### PR TITLE
WIP:  Use the "default" policy section for unidentified images

### DIFF
--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -157,8 +157,7 @@ func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 func (pc *PolicyContext) requirementsForImage(image types.Image) (PolicyRequirements, error) {
 	ref := image.IntendedDockerReference()
 	if ref == nil {
-		// FIXME: Tell the user which image this is.
-		return nil, fmt.Errorf("Can not determine policy for an image with no known Docker reference identity")
+		return pc.Policy.Default, nil
 	}
 	ref = reference.WithDefaultTag(ref) // This should not be needed, but if we did receive a name-only reference, this is a reasonable thing to do.
 

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -212,9 +212,11 @@ func TestPolicyContextRequirementsForImage(t *testing.T) {
 		assert.True(t, len(reqs) == len(expected), comment)
 	}
 
-	// Image without a Docker reference identity
-	_, err = pc.requirementsForImage(refImageMock{nil})
-	assert.Error(t, err)
+	// Image without a Docker reference identity, e.g. local directories
+	reqs, err := pc.requirementsForImage(refImageMock{nil})
+	assert.NoError(t, err)
+	assert.True(t, &(reqs[0]) == &policy.Default[0])
+	assert.True(t, len(reqs) == len(policy.Default))
 }
 
 func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
@@ -344,14 +346,14 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// implementations meddling with the state, or threads. This is for catching trivial programmer
 	// mistakes only, anyway.
 
-	// Image without a Docker reference identity
+	// Image without a Docker reference identity, e.g. local directories (rejected per default policy)
 	img = image.FromSource(&dirImageSourceMock{
 		ImageSource:             directory.NewImageSource("fixtures/dir-img-valid"),
 		intendedDockerReference: nil,
 	}, nil)
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
-	assert.Error(t, err)
-	assert.Nil(t, sigs)
+	require.NoError(t, err)
+	assert.Empty(t, sigs)
 
 	// Error reading signatures.
 	invalidSigDir := createInvalidSigDir(t)

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -8,7 +8,8 @@ package signature
 
 // Policy defines requirements for considering a signature valid.
 type Policy struct {
-	// Default applies to any image which does not have a matching policy in Specific.
+	// Default applies to any image which does not have a matching policy in Specific,
+	// and to images with unspecified identity, e.g. local directories (dir:…).
 	Default PolicyRequirements `json:"default"`
 	// Specific applies to images matching scope, the map key.
 	// Scope is hostname[/zero/or/more/namespaces[/repository[:tag|@digest]]]; note that in order to be


### PR DESCRIPTION
This is a placeholder for the discussion in https://github.com/projectatomic/skopeo/pull/97 ; real implementation will be different, I just didn’t want to close that one with nothing to point to.