### PR TITLE
[RFC] types: ImageSource: support getting a specific manifest

### DIFF
--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -26,7 +26,7 @@ func (s *dirImageSource) IntendedDockerReference() string {
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes
-func (s *dirImageSource) GetManifest(_ []string) ([]byte, string, error) {
+func (s *dirImageSource) GetManifest(_ []string, _ string) ([]byte, string, error) {
 	m, err := ioutil.ReadFile(manifestPath(s.dir))
 	if err != nil {
 		return nil, "", err

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -27,7 +27,7 @@ func TestGetPutManifest(t *testing.T) {
 	assert.NoError(t, err)
 
 	src := NewDirImageSource(tmpDir)
-	m, mt, err := src.GetManifest(nil)
+	m, mt, err := src.GetManifest(nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, man, m)
 	assert.Equal(t, "", mt)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -71,8 +71,11 @@ func simplifyContentType(contentType string) string {
 	return mimeType
 }
 
-func (s *dockerImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {
-	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
+func (s *dockerImageSource) GetManifest(mimetypes []string, reference string) ([]byte, string, error) {
+	if reference == "" {
+		reference = s.tag
+	}
+	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), reference)
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1
 	// TODO(runcom) NO, switch on the resulter manifest like Docker is doing
 	headers := make(map[string][]string)

--- a/image/image.go
+++ b/image/image.go
@@ -52,7 +52,10 @@ func (i *genericImage) IntendedDockerReference() string {
 // NOTE: It is essential for signature verification that Manifest returns the manifest from which BlobDigests is computed.
 func (i *genericImage) Manifest() ([]byte, string, error) {
 	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest([]string{manifest.DockerV2Schema1SignedMIMEType, manifest.DockerV2Schema1MIMEType})
+		m, mt, err := i.src.GetManifest([]string{
+			manifest.DockerV2Schema1SignedMIMEType,
+			manifest.DockerV2Schema1MIMEType,
+		}, "")
 		if err != nil {
 			return nil, "", err
 		}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -193,11 +193,11 @@ func (s *openshiftImageSource) IntendedDockerReference() string {
 	return s.client.canonicalDockerReference()
 }
 
-func (s *openshiftImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {
+func (s *openshiftImageSource) GetManifest(mimetypes []string, reference string) ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, "", err
 	}
-	return s.docker.GetManifest(mimetypes)
+	return s.docker.GetManifest(mimetypes, reference)
 }
 
 func (s *openshiftImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -14,8 +14,9 @@ type ImageSource interface {
 	// May be "" if unknown.
 	IntendedDockerReference() string
 	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown. The slice parameter indicates the supported mime types the manifest should be when getting it.
+	// The string parameter indicates the reference to be looking for when getting a manifest.
 	// It may use a remote (= slow) service.
-	GetManifest([]string) ([]byte, string, error)
+	GetManifest([]string, string) ([]byte, string, error)
 	// Note: Calling GetBlob() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
 	// the second return value is the size of the blob. If not known 0 is returned
 	GetBlob(digest string) (io.ReadCloser, int64, error)


### PR DESCRIPTION
This is in preparation to support manifests list:
- add the possibility to select manifest by reference (tag or digest) when getting a manifest from an `ImageSource`

The interface does not seems that bad to me but I'd like to know if you're ok with it. This is basically needed because after getting a manifest list, we need to select a manifest digest from the manifest list for a given platform (we'll start with supporting the current runtime the library is used on at first and then we can expand to let users specify platform specs) and fetch it (by digest) and then convert it to either v2s1 or v2s2 to be used with the `genericManifest` interface.

This is basically the same as `GetBlob` which lets you specify a digest - because the image repository is the smallest unit we work on - not the actual digest or tag - when dealing with registries.

/cc @mtrmac 

Signed-off-by: Antonio Murdaca runcom@redhat.com
