### PR TITLE
*: add SupportedImageDestinationMIMEType to types.ImageDestination

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -22,6 +22,10 @@ func (d *dirImageDestination) CanonicalDockerReference() (string, error) {
 	return "", fmt.Errorf("Can not determine canonical Docker reference for a local directory")
 }
 
+func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
+	return nil
+}
+
 func (d *dirImageDestination) PutManifest(manifest []byte) error {
 	return ioutil.WriteFile(manifestPath(d.dir), manifest, 0644)
 }

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -23,7 +23,7 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Image{Image: image.FromSource(s), src: s}, nil
+	return &Image{Image: image.FromSource(s, nil), src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -34,6 +34,14 @@ func NewDockerImageDestination(img, certPath string, tlsVerify bool) (types.Imag
 		tag: tag,
 		c:   c,
 	}, nil
+}
+
+func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
+	return []string{
+		// TODO(runcom): we'll add OCI and v2s2 as part of another PR here
+		manifest.DockerV2Schema1SignedMIMEType,
+		manifest.DockerV2Schema1MIMEType,
+	}
 }
 
 func (d *dockerImageDestination) CanonicalDockerReference() (string, error) {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -283,6 +283,13 @@ func NewOpenshiftImageDestination(imageName, certPath string, tlsVerify bool) (t
 	}, nil
 }
 
+func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
+	return []string{
+		manifest.DockerV2Schema1SignedMIMEType,
+		manifest.DockerV2Schema1MIMEType,
+	}
+}
+
 func (d *openshiftImageDestination) CanonicalDockerReference() (string, error) {
 	return d.client.canonicalDockerReference(), nil
 }

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -18,7 +18,7 @@ func dirImageMock(dir, intendedDockerReference string) types.Image {
 	return image.FromSource(&dirImageSourceMock{
 		ImageSource:             directory.NewDirImageSource(dir),
 		intendedDockerReference: intendedDockerReference,
-	})
+	}, nil)
 }
 
 // dirImageSourceMock inherits dirImageSource, but overrides its IntendedDockerReference method.

--- a/types/types.go
+++ b/types/types.go
@@ -34,6 +34,9 @@ type ImageDestination interface {
 	// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 	PutBlob(digest string, stream io.Reader) error
 	PutSignatures(signatures [][]byte) error
+	// SupportedManifestMIMETypes tells which manifest mime types the destination supports
+	// If an empty slice or nil it's returned, then any mime type can be tried to upload
+	SupportedManifestMIMETypes() []string
 }
 
 // Image is the primary API for inspecting properties of images.


### PR DESCRIPTION
This is an attempt to fix https://github.com/projectatomic/skopeo/pull/102#issuecomment-228747350 so we can move on with https://github.com/containers/image/pull/23 w/o breaking `skopeo copy` when working with the Atomic Registry.

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>