### PR TITLE
Transport-abstracted signature policy

### DIFF
--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -56,6 +56,26 @@ func (ref dirReference) DockerReference() reference.Named {
 	return nil
 }
 
+// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+// This MUST reflect user intent, not e.g. after processing of third-party redirects or aliases;
+// The value SHOULD be fully explicit about its semantics, with no hidden defaults, AND canonical
+// (i.e. various references with exactly the same semantics should return the same configuration identity)
+// It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
+// not required/guaranteed that it will be a valid input to Transport().ParseReference().
+// Returns "" if configuration identities for these references are not supported.
+func (ref dirReference) PolicyConfigurationIdentity() string {
+	return ""
+}
+
+// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+// for if explicit configuration for PolicyConfigurationIdentity() is not set.  The list will be processed
+// in order, terminating on first match, and an implicit "" is always checked at the end.
+// It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
+// and each following element to be a prefix of the element preceding it.
+func (ref dirReference) PolicyConfigurationNamespaces() []string {
+	return nil
+}
+
 // NewImage returns a types.Image for this reference.
 func (ref dirReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	src := newImageSource(ref)

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -73,6 +73,18 @@ func TestReferenceDockerReference(t *testing.T) {
 	assert.Nil(t, ref.DockerReference())
 }
 
+func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, "", ref.PolicyConfigurationIdentity())
+}
+
+func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, ref.PolicyConfigurationNamespaces())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -19,6 +19,24 @@ func TestTransportParseReference(t *testing.T) {
 	testNewReference(t, Transport.ParseReference)
 }
 
+func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
+	for _, scope := range []string{
+		"/etc",
+		"/this/does/not/exist",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.NoError(t, err, scope)
+	}
+
+	for _, scope := range []string{
+		"relative/path",
+		"/",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.Error(t, err, scope)
+	}
+}
+
 func TestNewReference(t *testing.T) {
 	testNewReference(t, NewReference)
 }

--- a/directory/explicitfilepath/path.go
+++ b/directory/explicitfilepath/path.go
@@ -1,0 +1,55 @@
+package explicitfilepath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ResolvePathToFullyExplicit returns the input path converted to an absolute, no-symlinks, cleaned up path.
+// To do so, all elements of the input path must exist; as a special case, the final component may be
+// a non-existent name (but not a symlink pointing to a non-existent name)
+// This is intended as a a helper for implementations of types.ImageReference.PolicyConfigurationIdentity etc.
+func ResolvePathToFullyExplicit(path string) (string, error) {
+	switch _, err := os.Lstat(path); {
+	case err == nil:
+		return resolveExistingPathToFullyExplicit(path)
+	case os.IsNotExist(err):
+		parent, file := filepath.Split(path)
+		resolvedParent, err := resolveExistingPathToFullyExplicit(parent)
+		if err != nil {
+			return "", err
+		}
+		if file == "." || file == ".." {
+			// Coverage: This can happen, but very rarely: if we have successfully resolved the parent, both "." and ".." in it should have been resolved as well.
+			// This can still happen if there is a filesystem race condition, causing the Lstat() above to fail but the later resolution to succeed.
+			// We do not care to promise anything if such filesystem race conditions can happen, but we definitely don't want to return "."/".." components
+			// in the resulting path, and especially not at the end.
+			return "", fmt.Errorf("Unexpectedly missing special filename component in %s", path)
+		}
+		resolvedPath := filepath.Join(resolvedParent, file)
+		// As a sanity check, ensure that there are no "." or ".." components.
+		cleanedResolvedPath := filepath.Clean(resolvedPath)
+		if cleanedResolvedPath != resolvedPath {
+			// Coverage: This should never happen.
+			return "", fmt.Errorf("Internal inconsistency: Path %s resolved to %s still cleaned up to %s", path, resolvedPath, cleanedResolvedPath)
+		}
+		return resolvedPath, nil
+	default: // err != nil, unrecognized
+		return "", err
+	}
+}
+
+// resolveExistingPathToFullyExplicit is the same as ResolvePathToFullyExplicit,
+// but without the special case for missing final component.
+func resolveExistingPathToFullyExplicit(path string) (string, error) {
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return "", err // Coverage: This can fail only if os.Getwd() fails.
+	}
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}

--- a/directory/explicitfilepath/path_test.go
+++ b/directory/explicitfilepath/path_test.go
@@ -1,0 +1,173 @@
+package explicitfilepath
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type pathResolvingTestCase struct {
+	setup    func(*testing.T, string) string
+	expected string
+}
+
+var testCases = []pathResolvingTestCase{
+	{ // A straightforward subdirectory hierarchy
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2/dir3"), 0755)
+			require.NoError(t, err)
+			return "dir1/dir2/dir3"
+		},
+		"dir1/dir2/dir3",
+	},
+	{ // Missing component
+		func(t *testing.T, top string) string {
+			return "thisismissing/dir2"
+		},
+		"",
+	},
+	{ // Symlink on the path
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2"), 0755)
+			require.NoError(t, err)
+			err = os.Symlink("dir1", filepath.Join(top, "link1"))
+			require.NoError(t, err)
+			return "link1/dir2"
+		},
+		"dir1/dir2",
+	},
+	{ // Trailing symlink
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2"), 0755)
+			require.NoError(t, err)
+			err = os.Symlink("dir2", filepath.Join(top, "dir1/link2"))
+			require.NoError(t, err)
+			return "dir1/link2"
+		},
+		"dir1/dir2",
+	},
+	{ // Symlink pointing nowhere, as a non-final component
+		func(t *testing.T, top string) string {
+			err := os.Symlink("thisismissing", filepath.Join(top, "link1"))
+			require.NoError(t, err)
+			return "link1/dir2"
+		},
+		"",
+	},
+	{ // Trailing symlink pointing nowhere (but note that a missing non-symlink would be accepted)
+		func(t *testing.T, top string) string {
+			err := os.Symlink("thisismissing", filepath.Join(top, "link1"))
+			require.NoError(t, err)
+			return "link1"
+		},
+		"",
+	},
+	{ // Relative components in a path
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2/dir3"), 0755)
+			require.NoError(t, err)
+			return "dir1/./dir2/../dir2/dir3"
+		},
+		"dir1/dir2/dir3",
+	},
+	{ // Trailing relative components
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2"), 0755)
+			require.NoError(t, err)
+			return "dir1/dir2/.."
+		},
+		"dir1",
+	},
+	{ // Relative components in symlink
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2"), 0755)
+			require.NoError(t, err)
+			err = os.Symlink("../dir1/dir2", filepath.Join(top, "dir1/link2"))
+			require.NoError(t, err)
+			return "dir1/link2"
+		},
+		"dir1/dir2",
+	},
+	{ // Relative component pointing "into" a symlink
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "dir1/dir2/dir3"), 0755)
+			require.NoError(t, err)
+			err = os.Symlink("dir3", filepath.Join(top, "dir1/dir2/link3"))
+			require.NoError(t, err)
+			return "dir1/dir2/link3/../.."
+		},
+		"dir1",
+	},
+	{ // Unreadable directory
+		func(t *testing.T, top string) string {
+			err := os.MkdirAll(filepath.Join(top, "unreadable/dir2"), 0755)
+			require.NoError(t, err)
+			err = os.Chmod(filepath.Join(top, "unreadable"), 000)
+			require.NoError(t, err)
+			return "unreadable/dir2"
+		},
+		"",
+	},
+}
+
+func testPathsAreSameFile(t *testing.T, path1, path2, description string) {
+	fi1, err := os.Stat(path1)
+	require.NoError(t, err)
+	fi2, err := os.Stat(path2)
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(fi1, fi2), description)
+}
+
+func runPathResolvingTestCase(t *testing.T, f func(string) (string, error), c pathResolvingTestCase, suffix string) {
+	topDir, err := ioutil.TempDir("", "pathResolving")
+	defer func() {
+		// Clean up after the "Unreadable directory" case; os.RemoveAll just fails.
+		_ = os.Chmod(filepath.Join(topDir, "unreadable"), 0755) // Ignore errors, especially if this does not exist.
+		os.RemoveAll(topDir)
+	}()
+
+	input := c.setup(t, topDir) + suffix // Do not call filepath.Join() on input, it calls filepath.Clean() internally!
+	description := fmt.Sprintf("%s vs. %s%s", input, c.expected, suffix)
+
+	fullOutput, err := ResolvePathToFullyExplicit(topDir + "/" + input)
+	if c.expected == "" {
+		assert.Error(t, err, description)
+	} else {
+		require.NoError(t, err, input)
+		fullExpected := topDir + "/" + c.expected + suffix
+		assert.Equal(t, fullExpected, fullOutput)
+
+		// Either the two paths resolve to the same existing file, or to the same name in the same existing parent.
+		if _, err := os.Lstat(fullExpected); err == nil {
+			testPathsAreSameFile(t, fullOutput, fullExpected, description)
+		} else {
+			require.True(t, os.IsNotExist(err))
+			_, err := os.Stat(fullOutput)
+			require.Error(t, err)
+			require.True(t, os.IsNotExist(err))
+
+			parentExpected, fileExpected := filepath.Split(fullExpected)
+			parentOutput, fileOutput := filepath.Split(fullOutput)
+			assert.Equal(t, fileExpected, fileOutput)
+			testPathsAreSameFile(t, parentOutput, parentExpected, description)
+		}
+	}
+}
+
+func TestResolvePathToFullyExplicit(t *testing.T) {
+	for _, c := range testCases {
+		runPathResolvingTestCase(t, ResolvePathToFullyExplicit, c, "")
+		runPathResolvingTestCase(t, ResolvePathToFullyExplicit, c, "/trailing")
+	}
+}
+
+func TestResolveExistingPathToFullyExplicit(t *testing.T) {
+	for _, c := range testCases {
+		runPathResolvingTestCase(t, resolveExistingPathToFullyExplicit, c, "")
+	}
+}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -23,6 +23,17 @@ func (t dockerTransport) ParseReference(reference string) (types.ImageReference,
 	return ParseReference(reference)
 }
 
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+// scope passed to this function will not be "", that value is always allowed.
+func (t dockerTransport) ValidatePolicyConfigurationScope(scope string) error {
+	// FIXME? We could be verifying the various character set and length restrictions
+	// from docker/distribution/reference.regexp.go, but other than that there
+	// are few semantically invalid strings.
+	return nil
+}
+
 // dockerReference is an ImageReference for Docker images.
 type dockerReference struct {
 	ref reference.Named // By construction we know that !reference.IsNameOnly(ref)

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containers/image/docker/policyconfiguration"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 )
@@ -77,6 +78,30 @@ func (ref dockerReference) StringWithinTransport() string {
 // not e.g. after redirect or alias processing), or nil if unknown/not applicable.
 func (ref dockerReference) DockerReference() reference.Named {
 	return ref.ref
+}
+
+// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+// This MUST reflect user intent, not e.g. after processing of third-party redirects or aliases;
+// The value SHOULD be fully explicit about its semantics, with no hidden defaults, AND canonical
+// (i.e. various references with exactly the same semantics should return the same configuration identity)
+// It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
+// not required/guaranteed that it will be a valid input to Transport().ParseReference().
+// Returns "" if configuration identities for these references are not supported.
+func (ref dockerReference) PolicyConfigurationIdentity() string {
+	res, err := policyconfiguration.DockerReferenceIdentity(ref.ref)
+	if res == "" || err != nil { // Coverage: Should never happen, NewReference above should refuse values which could cause a failure.
+		panic(fmt.Sprintf("Internal inconsistency: policyconfiguration.DockerReferenceIdentity returned %#v, %v", res, err))
+	}
+	return res
+}
+
+// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+// for if explicit configuration for PolicyConfigurationIdentity() is not set.  The list will be processed
+// in order, terminating on first match, and an implicit "" is always checked at the end.
+// It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
+// and each following element to be a prefix of the element preceding it.
+func (ref dockerReference) PolicyConfigurationNamespaces() []string {
+	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
 
 // NewImage returns a types.Image for this reference.

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -22,6 +22,19 @@ func TestTransportParseReference(t *testing.T) {
 	testParseReference(t, Transport.ParseReference)
 }
 
+func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
+	for _, scope := range []string{
+		"docker.io/library/busybox" + sha256digest,
+		"docker.io/library/busybox:notlatest",
+		"docker.io/library/busybox",
+		"docker.io/library",
+		"docker.io",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.NoError(t, err, scope)
+	}
+}
+
 func TestParseReference(t *testing.T) {
 	testParseReference(t, ParseReference)
 }

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -126,6 +126,24 @@ func TestReferenceDockerReference(t *testing.T) {
 	}
 }
 
+func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/busybox:latest", ref.PolicyConfigurationIdentity())
+}
+
+func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"docker.io/library/busybox",
+		"docker.io/library",
+		"docker.io",
+	}, ref.PolicyConfigurationNamespaces())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)

--- a/docker/policyconfiguration/naming.go
+++ b/docker/policyconfiguration/naming.go
@@ -1,0 +1,57 @@
+package policyconfiguration
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/reference"
+)
+
+// DockerReferenceIdentity returns a string representation of the reference, suitable for policy lookup,
+// as a backend for ImageReference.PolicyConfigurationIdentity.
+// The reference must satisfy !reference.IsNameOnly().
+func DockerReferenceIdentity(ref reference.Named) (string, error) {
+	res := ref.FullName()
+	tagged, isTagged := ref.(reference.NamedTagged)
+	digested, isDigested := ref.(reference.Canonical)
+	switch {
+	case isTagged && isDigested: // This should not happen, docker/reference.ParseNamed drops the tag.
+		return "", fmt.Errorf("Unexpected Docker reference %s with both a name and a digest", ref.String())
+	case !isTagged && !isDigested: // This should not happen, the caller is expected to ensure !reference.IsNameOnly()
+		return "", fmt.Errorf("Internal inconsistency: Docker reference %s with neither a tag nor a digest", ref.String())
+	case isTagged:
+		res = res + ":" + tagged.Tag()
+	case isDigested:
+		res = res + "@" + digested.Digest().String()
+	default: // Coverage: The above was supposed to be exhaustive.
+		return "", errors.New("Internal inconsistency, unexpected default branch")
+	}
+	return res, nil
+}
+
+// DockerReferenceNamespaces returns a list of other policy configuration namespaces to search,
+// as a backend for ImageReference.PolicyConfigurationIdentity.
+// The reference must satisfy !reference.IsNameOnly().
+func DockerReferenceNamespaces(ref reference.Named) []string {
+	// Look for a match of the repository, and then of the possible parent
+	// namespaces. Note that this only happens on the expanded host names
+	// and repository names, i.e. "busybox" is looked up as "docker.io/library/busybox",
+	// then in its parent "docker.io/library"; in none of "busybox",
+	// un-namespaced "library" nor in "" supposedly implicitly representing "library/".
+	//
+	// ref.FullName() == ref.Hostname() + "/" + ref.RemoteName(), so the last
+	// iteration matches the host name (for any namespace).
+	res := []string{}
+	name := ref.FullName()
+	for {
+		res = append(res, name)
+
+		lastSlash := strings.LastIndex(name, "/")
+		if lastSlash == -1 {
+			break
+		}
+		name = name[:lastSlash]
+	}
+	return res
+}

--- a/docker/policyconfiguration/naming_test.go
+++ b/docker/policyconfiguration/naming_test.go
@@ -1,0 +1,91 @@
+package policyconfiguration
+
+import (
+	"strings"
+	"testing"
+
+	"fmt"
+
+	"github.com/docker/docker/reference"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDockerReference tests DockerReferenceIdentity and DockerReferenceNamespaces simulatenously
+// to ensure they are consistent.
+func TestDockerReference(t *testing.T) {
+	sha256Digest := "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	// Test both that DockerReferenceIdentity returns the expected value (fullName+suffix),
+	// and that DockerReferenceNamespaces starts with the expected value (fullName), i.e. that the two functions are
+	// consistent.
+	for inputName, expectedNS := range map[string][]string{
+		"example.com/ns/repo": {"example.com/ns/repo", "example.com/ns", "example.com"},
+		"example.com/repo":    {"example.com/repo", "example.com"},
+		"localhost/ns/repo":   {"localhost/ns/repo", "localhost/ns", "localhost"},
+		// Note that "localhost" is special here: notlocalhost/repo is parsed as docker.io/notlocalhost.repo:
+		"localhost/repo":         {"localhost/repo", "localhost"},
+		"notlocalhost/repo":      {"docker.io/notlocalhost/repo", "docker.io/notlocalhost", "docker.io"},
+		"docker.io/ns/repo":      {"docker.io/ns/repo", "docker.io/ns", "docker.io"},
+		"docker.io/library/repo": {"docker.io/library/repo", "docker.io/library", "docker.io"},
+		"docker.io/repo":         {"docker.io/library/repo", "docker.io/library", "docker.io"},
+		"ns/repo":                {"docker.io/ns/repo", "docker.io/ns", "docker.io"},
+		"library/repo":           {"docker.io/library/repo", "docker.io/library", "docker.io"},
+		"repo":                   {"docker.io/library/repo", "docker.io/library", "docker.io"},
+	} {
+		for inputSuffix, mappedSuffix := range map[string]string{
+			":tag":       ":tag",
+			sha256Digest: sha256Digest,
+			// A github.com/distribution/reference value can have a tag and a digest at the same time!
+			// github.com/docker/reference handles that by dropping the tag. That is not obviously the
+			// right thing to do, but it is at least reasonable, so test that we keep behaving reasonably.
+			// This test case should not be construed to make this an API promise.
+			":tag" + sha256Digest: sha256Digest,
+		} {
+			fullInput := inputName + inputSuffix
+			ref, err := reference.ParseNamed(fullInput)
+			require.NoError(t, err, fullInput)
+
+			identity, err := DockerReferenceIdentity(ref)
+			require.NoError(t, err, fullInput)
+			assert.Equal(t, expectedNS[0]+mappedSuffix, identity, fullInput)
+
+			ns := DockerReferenceNamespaces(ref)
+			require.NotNil(t, ns, fullInput)
+			require.Len(t, ns, len(expectedNS), fullInput)
+			moreSpecific := identity
+			for i := range expectedNS {
+				assert.Equal(t, ns[i], expectedNS[i], fmt.Sprintf("%s item %d", fullInput, i))
+				assert.True(t, strings.HasPrefix(moreSpecific, ns[i]))
+				moreSpecific = ns[i]
+			}
+		}
+	}
+}
+
+// refWithTagAndDigest is a reference.NamedTagged and reference.Canonical at the same time.
+type refWithTagAndDigest struct{ reference.Canonical }
+
+func (ref refWithTagAndDigest) Tag() string {
+	return "notLatest"
+}
+
+func TestDockerReferenceIdentity(t *testing.T) {
+	// TestDockerReference above has tested the core of the functionality, this tests only the failure cases.
+
+	// Neither a tag nor digest
+	parsed, err := reference.ParseNamed("busybox")
+	require.NoError(t, err)
+	id, err := DockerReferenceIdentity(parsed)
+	assert.Equal(t, "", id)
+	assert.Error(t, err)
+
+	// A github.com/distribution/reference value can have a tag and a digest at the same time!
+	parsed, err = reference.ParseNamed("busybox@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	refDigested, ok := parsed.(reference.Canonical)
+	require.True(t, ok)
+	tagDigestRef := refWithTagAndDigest{refDigested}
+	id, err = DockerReferenceIdentity(tagDigestRef)
+	assert.Equal(t, "", id)
+	assert.Error(t, err)
+}

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -75,6 +75,26 @@ func (ref ociReference) DockerReference() reference.Named {
 	return nil
 }
 
+// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+// This MUST reflect user intent, not e.g. after processing of third-party redirects or aliases;
+// The value SHOULD be fully explicit about its semantics, with no hidden defaults, AND canonical
+// (i.e. various references with exactly the same semantics should return the same configuration identity)
+// It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
+// not required/guaranteed that it will be a valid input to Transport().ParseReference().
+// Returns "" if configuration identities for these references are not supported.
+func (ref ociReference) PolicyConfigurationIdentity() string {
+	return ""
+}
+
+// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+// for if explicit configuration for PolicyConfigurationIdentity() is not set.  The list will be processed
+// in order, terminating on first match, and an implicit "" is always checked at the end.
+// It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
+// and each following element to be a prefix of the element preceding it.
+func (ref ociReference) PolicyConfigurationNamespaces() []string {
+	return nil
+}
+
 // NewImage returns a types.Image for this reference.
 func (ref ociReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	return nil, errors.New("Full Image support not implemented for oci: image names")

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 )
@@ -27,8 +28,14 @@ func (t ociTransport) ParseReference(reference string) (types.ImageReference, er
 // ociReference is an ImageReference for OCI directory paths.
 type ociReference struct {
 	// Note that the interpretation of paths below depends on the underlying filesystem state, which may change under us at any time!
-	dir string // As specified by the user. May be relative, contain symlinks, etc.
-	tag string
+	// Either of the paths may point to a different, or no, inode over time.  resolvedDir may contain symbolic links, and so on.
+
+	// Generally we follow the intent of the user, and use the "dir" member for filesystem operations (e.g. the user can use a relative path to avoid
+	// being exposed to symlinks and renames in the parent directories to the working directory).
+	// (But in general, we make no attempt to be completely safe against concurrent hostile filesystem modifications.)
+	dir         string // As specified by the user. May be relative, contain symlinks, etc.
+	resolvedDir string // Absolute path with no symlinks, at least at the time of its creation. Primarily used for policy namespaces.
+	tag         string
 }
 
 var refRegexp = regexp.MustCompile(`^([A-Za-z0-9._-]+)+$`)
@@ -47,12 +54,24 @@ func ParseReference(reference string) (types.ImageReference, error) {
 			return nil, fmt.Errorf("Invalid tag %s", tag)
 		}
 	}
-	return NewReference(dir, tag), nil
+	return NewReference(dir, tag)
 }
 
 // NewReference returns an OCI reference for a directory and a tag.
-func NewReference(dir, tag string) types.ImageReference {
-	return ociReference{dir: dir, tag: tag}
+//
+// We do not expose an API supplying the resolvedDir; we could, but recomputing it
+// is generally cheap enough that we prefer being confident about the properties of resolvedDir.
+func NewReference(dir, tag string) (types.ImageReference, error) {
+	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(dir)
+	if err != nil {
+		return nil, err
+	}
+	// This is necessary to prevent directory paths returned by PolicyConfigurationNamespaces
+	// from being ambiguous with values of PolicyConfigurationIdentity.
+	if strings.Contains(resolved, ":") {
+		return nil, fmt.Errorf("Invalid OCI reference %s:%s: path %s contains a colon", dir, tag, resolved)
+	}
+	return ociReference{dir: dir, resolvedDir: resolved, tag: tag}, nil
 }
 
 func (ref ociReference) Transport() types.ImageTransport {
@@ -83,7 +102,7 @@ func (ref ociReference) DockerReference() reference.Named {
 // not required/guaranteed that it will be a valid input to Transport().ParseReference().
 // Returns "" if configuration identities for these references are not supported.
 func (ref ociReference) PolicyConfigurationIdentity() string {
-	return ""
+	return fmt.Sprintf("%s:%s", ref.resolvedDir, ref.tag)
 }
 
 // PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
@@ -92,7 +111,19 @@ func (ref ociReference) PolicyConfigurationIdentity() string {
 // It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
 // and each following element to be a prefix of the element preceding it.
 func (ref ociReference) PolicyConfigurationNamespaces() []string {
-	return nil
+	res := []string{}
+	path := ref.resolvedDir
+	for {
+		lastSlash := strings.LastIndex(path, "/")
+		// Note that we do not include "/"; it is redundant with the default "" global default.
+		// FIXME: Reject "/" when parsing configurations.
+		if lastSlash == -1 || path == "/" {
+			break
+		}
+		res = append(res, path)
+		path = path[:lastSlash]
+	}
+	return res
 }
 
 // NewImage returns a types.Image for this reference.

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containers/image/types"
@@ -49,12 +50,8 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 		}
 	}
 
-	ref, err := fn(tmpDir + "/with:colons:and:tag")
-	require.NoError(t, err)
-	ociRef, ok := ref.(ociReference)
-	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/with:colons:and", ociRef.dir)
-	assert.Equal(t, "tag", ociRef.tag)
+	_, err = fn(tmpDir + "/with:multiple:colons:and:tag")
+	assert.Error(t, err)
 
 	_, err = fn(tmpDir + ":invalid'tag!value@")
 	assert.Error(t, err)
@@ -67,11 +64,18 @@ func TestNewReference(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	ref := NewReference(tmpDir, tagValue)
+	ref, err := NewReference(tmpDir, tagValue)
+	require.NoError(t, err)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	assert.Equal(t, tmpDir, ociRef.dir)
 	assert.Equal(t, tagValue, ociRef.tag)
+
+	_, err = NewReference(tmpDir+"/thisparentdoesnotexist/something", tagValue)
+	assert.Error(t, err)
+
+	_, err = NewReference(tmpDir+"/has:colon", tagValue)
+	assert.Error(t, err)
 }
 
 // refToTempOCI creates a temporary directory and returns an reference to it.
@@ -80,7 +84,8 @@ func TestNewReference(t *testing.T) {
 func refToTempOCI(t *testing.T) (ref types.ImageReference, tmpDir string) {
 	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
 	require.NoError(t, err)
-	ref = NewReference(tmpDir, "tagValue")
+	ref, err = NewReference(tmpDir, "tagValue")
+	require.NoError(t, err)
 	return ref, tmpDir
 }
 
@@ -98,7 +103,6 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 	for _, c := range []struct{ input, result string }{
 		{"/dir1:notlatest", "/dir1:notlatest"}, // Explicit tag
 		{"/dir2", "/dir2:latest"},              // Default tag
-		{"/dir3:with:colons:and:tag", "/dir3:with:colons:and:tag"},
 	} {
 		ref, err := ParseReference(tmpDir + c.input)
 		require.NoError(t, err, c.input)
@@ -121,13 +125,50 @@ func TestReferenceDockerReference(t *testing.T) {
 func TestReferencePolicyConfigurationIdentity(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	assert.Equal(t, "", ref.PolicyConfigurationIdentity())
+
+	assert.Equal(t, tmpDir+":tagValue", ref.PolicyConfigurationIdentity())
+	// A non-canonical path.  Test just one, the various other cases are
+	// tested in explicitfilepath.ResolvePathToFullyExplicit.
+	ref, err := NewReference(tmpDir+"/.", "tag2")
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+":tag2", ref.PolicyConfigurationIdentity())
+
+	// "/" as a corner case.
+	ref, err = NewReference("/", "tag3")
+	require.NoError(t, err)
+	assert.Equal(t, "/:tag3", ref.PolicyConfigurationIdentity())
 }
 
 func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	assert.Nil(t, ref.PolicyConfigurationNamespaces())
+	// We don't really know enough to make a full equality test here.
+	ns := ref.PolicyConfigurationNamespaces()
+	require.NotNil(t, ns)
+	assert.True(t, len(ns) >= 2)
+	assert.Equal(t, tmpDir, ns[0])
+	assert.Equal(t, filepath.Dir(tmpDir), ns[1])
+
+	// Test with a known path which should exist. Test just one non-canonical
+	// path, the various other cases are tested in explicitfilepath.ResolvePathToFullyExplicit.
+	//
+	// It would be nice to test a deeper hierarchy, but it is not obvious what
+	// deeper path is always available in the various distros, AND is not likely
+	// to contains a symbolic link.
+	for _, path := range []string{"/etc/skel", "/etc/skel/./."} {
+		_, err := os.Lstat(path)
+		require.NoError(t, err)
+		ref, err := NewReference(path, "sometag")
+		require.NoError(t, err)
+		ns := ref.PolicyConfigurationNamespaces()
+		require.NotNil(t, ns)
+		assert.Equal(t, []string{"/etc/skel", "/etc"}, ns)
+	}
+
+	// "/" as a corner case.
+	ref, err := NewReference("/", "tag3")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, ref.PolicyConfigurationNamespaces())
 }
 
 func TestReferenceNewImage(t *testing.T) {

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -118,6 +118,18 @@ func TestReferenceDockerReference(t *testing.T) {
 	assert.Nil(t, ref.DockerReference())
 }
 
+func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, "", ref.PolicyConfigurationIdentity())
+}
+
+func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, ref.PolicyConfigurationNamespaces())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -19,6 +19,30 @@ func TestTransportParseReference(t *testing.T) {
 	testParseReference(t, Transport.ParseReference)
 }
 
+func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
+	for _, scope := range []string{
+		"/etc",
+		"/etc:notlatest",
+		"/this/does/not/exist",
+		"/this/does/not/exist:notlatest",
+		"/:strangecornercase",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.NoError(t, err, scope)
+	}
+
+	for _, scope := range []string{
+		"relative/path",
+		"/",
+		"/etc:invalid'tag!value@",
+		"/path:with/colons",
+		"/path:with/colons/and:tag",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.Error(t, err, scope)
+	}
+}
+
 func TestParseReference(t *testing.T) {
 	testParseReference(t, ParseReference)
 }

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -71,6 +71,24 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 	// but that is untested because it depends on per-user configuration.
 }
 
+func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com:8443/ns/stream:notlatest", ref.PolicyConfigurationIdentity())
+}
+
+func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"registry.example.com:8443/ns/stream",
+		"registry.example.com:8443/ns",
+		"registry.example.com:8443",
+	}, ref.PolicyConfigurationNamespaces())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
 	require.NoError(t, err)

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -17,6 +17,27 @@ func TestTransportName(t *testing.T) {
 	assert.Equal(t, "atomic", Transport.Name())
 }
 
+func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
+	for _, scope := range []string{
+		"registry.example.com/ns/stream" + sha256digest,
+		"registry.example.com/ns/stream:notlatest",
+		"registry.example.com/ns/stream",
+		"registry.example.com/ns",
+		"registry.example.com",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.NoError(t, err, scope)
+	}
+
+	for _, scope := range []string{
+		"registry.example.com/too/deep/hierarchy",
+		"registry.example.com/ns/stream:tag1:tag2",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.Error(t, err, scope)
+	}
+}
+
 // Transport.ParseReference, ParseReference untested because they depend
 // on per-user configuration.
 var testBaseURL *url.URL

--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -5,6 +5,13 @@
         }
     ],
     "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
         "docker": {
             "example.com/playground": [
                 {

--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -4,81 +4,83 @@
             "type": "reject"
         }
     ],
-    "specific": {
-        "example.com/playground": [
-            {
-                "type": "insecureAcceptAnything"
-            }
-        ],
-        "example.com/production": [
-            {
-                "type": "signedBy",
-                "keyType": "GPGKeys",
-                "keyPath": "/keys/employee-gpg-keyring"
-            }
-        ],
-        "example.com/hardened": [
-            {
-                "type": "signedBy",
-                "keyType": "GPGKeys",
-                "keyPath": "/keys/employee-gpg-keyring",
-                "signedIdentity": {
-                    "type": "matchRepository"
+    "transports": {
+        "docker": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
                 }
-            },
-            {
-                "type": "signedBy",
-                "keyType": "signedByGPGKeys",
-                "keyPath": "/keys/public-key-signing-gpg-keyring",
-                "signedIdentity": {
-                    "type": "matchExact"
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
                 }
-            },
-            {
-                "type": "signedBaseLayer",
-                "baseLayerIdentity": {
-                    "type": "exactRepository",
-                    "dockerRepository": "registry.access.redhat.com/rhel7/rhel"
+            ],
+            "example.com/hardened": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                },
+                {
+                    "type": "signedBy",
+                    "keyType": "signedByGPGKeys",
+                    "keyPath": "/keys/public-key-signing-gpg-keyring",
+                    "signedIdentity": {
+                        "type": "matchExact"
+                    }
+                },
+                {
+                    "type": "signedBaseLayer",
+                    "baseLayerIdentity": {
+                        "type": "exactRepository",
+                        "dockerRepository": "registry.access.redhat.com/rhel7/rhel"
+                    }
                 }
-            }
-        ],
-        "example.com/hardened-x509": [
-            {
-                "type": "signedBy",
-                "keyType": "X509Certificates",
-                "keyPath": "/keys/employee-cert-file",
-                "signedIdentity": {
-                    "type": "matchRepository"
+            ],
+            "example.com/hardened-x509": [
+                {
+                    "type": "signedBy",
+                    "keyType": "X509Certificates",
+                    "keyPath": "/keys/employee-cert-file",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                },
+                {
+                    "type": "signedBy",
+                    "keyType": "signedByX509CAs",
+                    "keyPath": "/keys/public-key-signing-ca-file"
                 }
-            },
-            {
-                "type": "signedBy",
-                "keyType": "signedByX509CAs",
-                "keyPath": "/keys/public-key-signing-ca-file"
-            }
-        ],
-        "registry.access.redhat.com": [
-            {
-                "type": "signedBy",
-                "keyType": "signedByGPGKeys",
-                "keyPath": "/keys/RH-key-signing-key-gpg-keyring"
-            }
-        ],
-        "bogus/key-data-example": [
-            {
-                "type": "signedBy",
-                "keyType": "signedByGPGKeys",
-                "keyData": "bm9uc2Vuc2U="
-            }
-        ],
-        "bogus/signed-identity-example": [
-            {
-                "type": "signedBaseLayer",
-                "baseLayerIdentity": {
-                    "type": "exactReference",
-                    "dockerReference": "registry.access.redhat.com/rhel7/rhel:latest"
+            ],
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "signedByGPGKeys",
+                    "keyPath": "/keys/RH-key-signing-key-gpg-keyring"
                 }
-            }
-        ]
+            ],
+            "bogus/key-data-example": [
+                {
+                    "type": "signedBy",
+                    "keyType": "signedByGPGKeys",
+                    "keyData": "bm9uc2Vuc2U="
+                }
+            ],
+            "bogus/signed-identity-example": [
+                {
+                    "type": "signedBaseLayer",
+                    "baseLayerIdentity": {
+                        "type": "exactReference",
+                        "dockerReference": "registry.access.redhat.com/rhel7/rhel:latest"
+                    }
+                }
+            ]
+        }
     }
 }

--- a/signature/json.go
+++ b/signature/json.go
@@ -59,7 +59,7 @@ func stringField(m map[string]interface{}, fieldName string) (string, error) {
 // (including duplicated keys, unrecognized keys, and non-matching types). Uses fieldResolver to
 // determine the destination for a field value, which should return a pointer to the destination if valid, or nil if the key is rejected.
 //
-// The fieldResolver approach is useful for decoding the Policy.Specific map; using it for structs is a bit lazy,
+// The fieldResolver approach is useful for decoding the Policy.Transports map; using it for structs is a bit lazy,
 // we could use reflection to automate this. Later?
 func paranoidUnmarshalJSONObject(data []byte, fieldResolver func(string) interface{}) error {
 	seenKeys := map[string]struct{}{}

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/containers/image/transports"
 	"github.com/docker/docker/reference"
 )
 
@@ -88,8 +89,8 @@ func (m *policyTransportsMap) UnmarshalJSON(data []byte) error {
 	// So, use a temporary map of pointers-to-slices and convert.
 	tmpMap := map[string]*PolicyTransportScopes{}
 	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		if key != "docker" {
-			return nil // Only accept this one for now
+		if _, ok := transports.KnownTransports[key]; !ok {
+			return nil
 		}
 		// paranoidUnmarshalJSONObject detects key duplication for us, check just to be safe.
 		if _, ok := tmpMap[key]; ok {

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -14,6 +14,9 @@ import (
 var policyFixtureContents = &Policy{
 	Default: PolicyRequirements{NewPRReject()},
 	Transports: map[string]PolicyTransportScopes{
+		"dir": {
+			"": PolicyRequirements{NewPRInsecureAcceptAnything()},
+		},
 		"docker": {
 			"example.com/playground": {
 				NewPRInsecureAcceptAnything(),
@@ -168,6 +171,11 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 				},
 				"registry.access.redhat.com": []PolicyRequirement{
 					xNewPRSignedByKeyData(SBKeyTypeSignedByGPGKeys, []byte("RH"), NewPRMMatchRepository()),
+				},
+			},
+			"atomic": {
+				"registry.access.redhat.com/rhel7": []PolicyRequirement{
+					xNewPRSignedByKeyData(SBKeyTypeSignedByGPGKeys, []byte("RHatomic"), NewPRMMatchRepository()),
 				},
 			},
 		},

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -23,7 +23,8 @@ func dirImageMock(t *testing.T, dir, dockerReference string) types.Image {
 
 // dirImageMockWithRef returns a types.Image for a directory, claiming a specified ref.
 func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) types.Image {
-	srcRef := directory.NewReference(dir)
+	srcRef, err := directory.NewReference(dir)
+	require.NoError(t, err)
 	src, err := srcRef.NewImageSource("", true)
 	require.NoError(t, err)
 	return image.FromSource(&dirImageSourceMock{

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -28,6 +28,12 @@ func (ref nameOnlyImageReferenceMock) StringWithinTransport() string {
 func (ref nameOnlyImageReferenceMock) DockerReference() reference.Named {
 	panic("unexpected call to a mock function")
 }
+func (ref nameOnlyImageReferenceMock) PolicyConfigurationIdentity() string {
+	panic("unexpected call to a mock function")
+}
+func (ref nameOnlyImageReferenceMock) PolicyConfigurationNamespaces() []string {
+	panic("unexpected call to a mock function")
+}
 func (ref nameOnlyImageReferenceMock) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -120,6 +120,9 @@ func (name nameImageTransportMock) Name() string {
 func (name nameImageTransportMock) ParseReference(reference string) (types.ImageReference, error) {
 	panic("unexpected call to a mock function")
 }
+func (name nameImageTransportMock) ValidatePolicyConfigurationScope(scope string) error {
+	panic("unexpected call to a mock function")
+}
 
 type prmTableTest struct {
 	imageRef, sigRef string

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -95,6 +95,12 @@ func (ref refImageReferenceMock) StringWithinTransport() string {
 func (ref refImageReferenceMock) DockerReference() reference.Named {
 	return ref.Named
 }
+func (ref refImageReferenceMock) PolicyConfigurationIdentity() string {
+	panic("unexpected call to a mock function")
+}
+func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
+	panic("unexpected call to a mock function")
+}
 func (ref refImageReferenceMock) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -8,17 +8,21 @@ package signature
 
 // Policy defines requirements for considering a signature valid.
 type Policy struct {
-	// Default applies to any image which does not have a matching policy in Specific.
-	Default PolicyRequirements `json:"default"`
-	// Specific applies to images matching scope, the map key.
-	// Scope is hostname[/zero/or/more/namespaces[/repository[:tag|@digest]]]; note that in order to be
-	// unambiguous, this must use a fully expanded format, e.g. "docker.io/library/busybox" or
-	// "docker.io/library", not "busybox" or "library".
-	// FIXME: Scope syntax - should it be namespaced docker:something ? Or, in the worst case, a composite object (we couldn't use a JSON map)
-	// Most specific scope wins, duplication is prohibited (hard failure).
-	// Defaults to an empty map if not specified.
-	Specific map[string]PolicyRequirements `json:"specific"`
+	// Default applies to any image which does not have a matching policy in Transports.
+	// Note that this can happen even if a matching PolicyTransportScopes exists in Transports
+	// if the image matches none of the scopes.
+	Default    PolicyRequirements               `json:"default"`
+	Transports map[string]PolicyTransportScopes `json:"transports"`
 }
+
+// PolicyTransportScopes defines policies for images for a specific transport,
+// for various scopes, the map keys.
+// Scopes are defined by the transport (types.ImageReference.PolicyConfigurationIdentity etc.);
+// there is one scope precisely matching to a single image, and namespace scopes as prefixes
+// of the single-image scope. (e.g. hostname[/zero[/or[/more[/namespaces[/individualimage]]]]])
+// The empty scope, if exists, is considered a parent namespace of all other scopes.
+// Most specific scope wins, duplication is prohibited (hard failure).
+type PolicyTransportScopes map[string]PolicyRequirements
 
 // PolicyRequirements is a set of requirements applying to a set of images; each of them must be satisfied (though perhaps each by a different signature).
 // Must not be empty, frequently will only contain a single element.

--- a/types/types.go
+++ b/types/types.go
@@ -49,6 +49,22 @@ type ImageReference interface {
 	// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
 	DockerReference() reference.Named
 
+	// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+	// This MUST reflect user intent, not e.g. after processing of third-party redirects or aliases;
+	// The value SHOULD be fully explicit about its semantics, with no hidden defaults, AND canonical
+	// (i.e. various references with exactly the same semantics should return the same configuration identity)
+	// It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
+	// not required/guaranteed that it will be a valid input to Transport().ParseReference().
+	// Returns "" if configuration identities for these references are not supported.
+	PolicyConfigurationIdentity() string
+
+	// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+	// for if explicit configuration for PolicyConfigurationIdentity() is not set.  The list will be processed
+	// in order, terminating on first match, and an implicit "" is always checked at the end.
+	// It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
+	// and each following element to be a prefix of the element preceding it.
+	PolicyConfigurationNamespaces() []string
+
 	// NewImage returns a types.Image for this reference.
 	NewImage(certPath string, tlsVerify bool) (Image, error)
 	// NewImageSource returns a types.ImageSource for this reference.

--- a/types/types.go
+++ b/types/types.go
@@ -24,6 +24,11 @@ type ImageTransport interface {
 	Name() string
 	// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
 	ParseReference(reference string) (ImageReference, error)
+	// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+	// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+	// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+	// scope passed to this function will not be "", that value is always allowed.
+	ValidatePolicyConfigurationScope(scope string) error
 }
 
 // ImageReference is an abstracted way to refer to an image location, namespaced within an ImageTransport.


### PR DESCRIPTION
@runcom PTAL . This is by no means finished, but shows the direction I’m planning to use, early feedback on the API would help me avoid a dead end.  Start with `types.go` I think, I will comment more on the code.