### PR TITLE
Clean up Docker reference handling

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -1,12 +1,12 @@
 package directory
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type dirImageDestination struct {
@@ -18,8 +18,8 @@ func NewImageDestination(dir string) types.ImageDestination {
 	return &dirImageDestination{dir}
 }
 
-func (d *dirImageDestination) CanonicalDockerReference() (string, error) {
-	return "", fmt.Errorf("Can not determine canonical Docker reference for a local directory")
+func (d *dirImageDestination) CanonicalDockerReference() reference.Named {
+	return nil
 }
 
 func (d *dirImageDestination) SupportedManifestMIMETypes() []string {

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type dirImageSource struct {
@@ -18,11 +19,12 @@ func NewImageSource(dir string) types.ImageSource {
 	return &dirImageSource{dir}
 }
 
-// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-// May be "" if unknown.
-func (s *dirImageSource) IntendedDockerReference() string {
-	return ""
+// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
+// This can be used e.g. to determine which public keys are trusted for this image.
+// May be nil if unknown.
+func (s *dirImageSource) IntendedDockerReference() reference.Named {
+	return nil
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCanonicalDockerReference(t *testing.T) {
 	dest := NewImageDestination("/path/to/somewhere")
-	_, err := dest.CanonicalDockerReference()
-	assert.Error(t, err)
+	ref := dest.CanonicalDockerReference()
+	assert.Nil(t, ref)
 }
 
 func TestGetPutManifest(t *testing.T) {
@@ -85,7 +85,6 @@ func TestDelete(t *testing.T) {
 
 func TestIntendedDockerReference(t *testing.T) {
 	src := NewImageSource("/path/to/somewhere")
-	dr := src.IntendedDockerReference()
-	assert.Equal(t, "", dr)
-
+	ref := src.IntendedDockerReference()
+	assert.Nil(t, ref)
 }

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -15,13 +15,12 @@ import (
 
 type dockerImageDestination struct {
 	ref reference.Named
-	tag string
 	c   *dockerClient
 }
 
 // NewImageDestination creates a new ImageDestination for the specified image and connection specification.
 func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDestination, error) {
-	ref, tag, err := parseImageName(img)
+	ref, err := parseImageName(img)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +30,6 @@ func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDesti
 	}
 	return &dockerImageDestination{
 		ref: ref,
-		tag: tag,
 		c:   c,
 	}, nil
 }
@@ -46,7 +44,7 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 func (d *dockerImageDestination) CanonicalDockerReference() (string, error) {
-	return fmt.Sprintf("%s:%s", d.ref.Name(), d.tag), nil
+	return d.ref.String(), nil
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -43,8 +43,8 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	}
 }
 
-func (d *dockerImageDestination) CanonicalDockerReference() (string, error) {
-	return d.ref.String(), nil
+func (d *dockerImageDestination) CanonicalDockerReference() reference.Named {
+	return d.ref
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -49,11 +49,12 @@ func NewImageSource(img, certPath string, tlsVerify bool) (types.ImageSource, er
 	return newDockerImageSource(img, certPath, tlsVerify)
 }
 
-// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-// May be "" if unknown.
-func (s *dockerImageSource) IntendedDockerReference() string {
-	return s.ref.String()
+// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
+// This can be used e.g. to determine which public keys are trusted for this image.
+// May be nil if unknown.
+func (s *dockerImageSource) IntendedDockerReference() reference.Named {
+	return s.ref
 }
 
 // simplifyContentType drops parameters from a HTTP media type (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1)

--- a/docker/docker_utils.go
+++ b/docker/docker_utils.go
@@ -1,20 +1,32 @@
 package docker
 
-import "github.com/docker/docker/reference"
+import (
+	"fmt"
 
-// parseImageName converts a string into a reference and tag value.
-func parseImageName(img string) (reference.Named, string, error) {
+	"github.com/docker/docker/reference"
+)
+
+// parseImageName converts a string into a reference.
+// It is guaranteed that reference.IsNameOnly is false for the returned value.
+func parseImageName(img string) (reference.Named, error) {
 	ref, err := reference.ParseNamed(img)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	ref = reference.WithDefaultTag(ref)
-	var tag string
-	switch x := ref.(type) {
-	case reference.Canonical:
-		tag = x.Digest().String()
-	case reference.NamedTagged:
-		tag = x.Tag()
+	if reference.IsNameOnly(ref) { // Sanity check that we are fulfulling our contract
+		return nil, fmt.Errorf("Internal inconsistency: reference.IsNameOnly for reference %s (parsed from %s)", ref.String(), img)
 	}
-	return ref, tag, nil
+	return ref, nil
+}
+
+// tagOrDigest returns a tag or digest from a reference for which !reference.IsNameOnly.
+func tagOrDigest(ref reference.Named) (string, error) {
+	if ref, ok := ref.(reference.Canonical); ok {
+		return ref.Digest().String(), nil
+	}
+	if ref, ok := ref.(reference.NamedTagged); ok {
+		return ref.Tag(), nil
+	}
+	return "", fmt.Errorf("Internal inconsistency: Reference %s unexpectedly has neither a digest nor a tag", ref.String())
 }

--- a/image/image.go
+++ b/image/image.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 var (
@@ -50,10 +51,11 @@ func FromSource(src types.ImageSource, requestedManifestMIMETypes []string) type
 	return &genericImage{src: src, requestedManifestMIMETypes: requestedManifestMIMETypes}
 }
 
-// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-// May be "" if unknown.
-func (i *genericImage) IntendedDockerReference() string {
+// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
+// This can be used e.g. to determine which public keys are trusted for this image.
+// May be nil if unknown.
+func (i *genericImage) IntendedDockerReference() reference.Named {
 	return i.src.IntendedDockerReference()
 }
 

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type ociManifest struct {
@@ -53,8 +54,8 @@ func NewImageDestination(dest string) (types.ImageDestination, error) {
 	}, nil
 }
 
-func (d *ociImageDestination) CanonicalDockerReference() (string, error) {
-	return "", fmt.Errorf("Can not determine canonical Docker reference for an OCI image")
+func (d *ociImageDestination) CanonicalDockerReference() reference.Named {
+	return nil
 }
 
 func createManifest(m []byte) ([]byte, string, error) {

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/reference"
 	"github.com/containers/image/types"
-	distreference "github.com/docker/distribution/reference"
+	"github.com/docker/docker/reference"
 )
 
 // PolicyRequirementError is an explanatory text for rejecting a signature or an image.
@@ -132,11 +131,12 @@ func (pc *PolicyContext) Destroy() error {
 // FIXME? This feels like it should be provided by skopeo/reference.
 func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 	res := ref.FullName()
-	tagged, isTagged := ref.(distreference.Tagged)
-	digested, isDigested := ref.(distreference.Digested)
+	tagged, isTagged := ref.(reference.NamedTagged)
+	digested, isDigested := ref.(reference.Canonical)
 	// A github.com/distribution/reference value can have a tag and a digest at the same time!
 	// github.com/docker/reference does not handle that, so fail.
-	// FIXME? Should we support that?
+	// (Even if it were supported, the semantics of policy namespaces are unclear - should we drop
+	// the tag or the digest first?)
 	switch {
 	case isTagged && isDigested:
 		// Coverage: This should currently not happen, the way docker/reference sets up types,

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -135,11 +135,11 @@ func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 	tagged, isTagged := ref.(distreference.Tagged)
 	digested, isDigested := ref.(distreference.Digested)
 	// A github.com/distribution/reference value can have a tag and a digest at the same time!
-	// skopeo/reference does not handle that, so fail.
+	// github.com/docker/reference does not handle that, so fail.
 	// FIXME? Should we support that?
 	switch {
 	case isTagged && isDigested:
-		// Coverage: This should currently not happen, the way skopeo/reference sets up types,
+		// Coverage: This should currently not happen, the way docker/reference sets up types,
 		// isTagged and isDigested is mutually exclusive.
 		return "", fmt.Errorf("Names with both a tag and digest are not currently supported")
 	case isTagged:

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -254,74 +254,74 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	image := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
-	sigs, err := pc.GetSignaturesWithAcceptedAuthor(image)
+	img := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	image = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
-	image = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
-	image = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:twoAccepts")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:twoAccepts")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptReject")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptReject")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown2")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown2")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
@@ -332,8 +332,8 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
-	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
@@ -341,16 +341,16 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// mistakes only, anyway.
 
 	// Invalid IntendedDockerReference value
-	image = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
 
 	// Error reading signatures.
 	invalidSigDir := createInvalidSigDir(t)
 	defer os.RemoveAll(invalidSigDir)
-	image = dirImageMock(invalidSigDir, "testing/manifest:latest")
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(image)
+	img = dirImageMock(invalidSigDir, "testing/manifest:latest")
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
 }
@@ -383,54 +383,54 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	image := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
-	res, err := pc.IsRunningImageAllowed(image)
+	img := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	res, err := pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	image = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
-	image = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
-	image = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:twoAllows")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:twoAllows")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:allowDeny")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:allowDeny")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:reject")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:reject")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
-	image = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Unexpected state (context already destroyed)
@@ -438,16 +438,16 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	image = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
-	res, err = destroyedPC.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	res, err = destroyedPC.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
 	// implementations meddling with the state, or threads. This is for catching trivial programmer
 	// mistakes only, anyway.
 
 	// Invalid IntendedDockerReference value
-	image = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
-	res, err = pc.IsRunningImageAllowed(image)
+	img = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
+	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 }
 

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -82,7 +82,7 @@ func TestFullyExpandedDockerReference(t *testing.T) {
 			sha256Digest: sha256Digest,
 			"":           "",
 			// A github.com/distribution/reference value can have a tag and a digest at the same time!
-			// github.com/skopeo/reference handles that by dropping the tag. That is not obviously the
+			// github.com/docker/reference handles that by dropping the tag. That is not obviously the
 			// right thing to do, but it is at least reasonable, so test that we keep behaving reasonably.
 			// This test case should not be construed to make this an API promise.
 			":tag" + sha256Digest: sha256Digest,

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containers/image/directory"
+	"github.com/containers/image/image"
 	"github.com/docker/docker/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -198,7 +200,9 @@ func TestPolicyContextRequirementsForImage(t *testing.T) {
 			expected = policy.Default
 		}
 
-		reqs, err := pc.requirementsForImage(refImageMock(input))
+		inputRef, err := reference.ParseNamed(input)
+		require.NoError(t, err)
+		reqs, err := pc.requirementsForImage(refImageMock{inputRef})
 		require.NoError(t, err)
 		comment := fmt.Sprintf("case %s: %#v", input, reqs[0])
 		// Do not sue assert.Equal, which would do a deep contents comparison; we want to compare
@@ -208,8 +212,8 @@ func TestPolicyContextRequirementsForImage(t *testing.T) {
 		assert.True(t, len(reqs) == len(expected), comment)
 	}
 
-	// Invalid reference format
-	_, err = pc.requirementsForImage(refImageMock("UPPERCASEISINVALID"))
+	// Image without a Docker reference identity
+	_, err = pc.requirementsForImage(refImageMock{nil})
 	assert.Error(t, err)
 }
 
@@ -254,73 +258,73 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	img := dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
-	img = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
-	img = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:twoAccepts")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptReject")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:unknown2")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
@@ -332,7 +336,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -340,8 +344,11 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// implementations meddling with the state, or threads. This is for catching trivial programmer
 	// mistakes only, anyway.
 
-	// Invalid IntendedDockerReference value
-	img = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
+	// Image without a Docker reference identity
+	img = image.FromSource(&dirImageSourceMock{
+		ImageSource:             directory.NewImageSource("fixtures/dir-img-valid"),
+		intendedDockerReference: nil,
+	}, nil)
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -349,7 +356,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// Error reading signatures.
 	invalidSigDir := createInvalidSigDir(t)
 	defer os.RemoveAll(invalidSigDir)
-	img = dirImageMock(invalidSigDir, "testing/manifest:latest")
+	img = dirImageMock(t, invalidSigDir, "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -383,53 +390,53 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	img := dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	res, err := pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = dirImageMock("fixtures/dir-img-valid-2", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
-	img = dirImageMock("fixtures/dir-img-unsigned", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
-	img = dirImageMock("fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:twoAllows")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:allowDeny")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:reject")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
-	img = dirImageMock("fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
+	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
@@ -438,15 +445,18 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = dirImageMock("fixtures/dir-img-valid", "testing/manifest:latest")
+	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	res, err = destroyedPC.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
 	// implementations meddling with the state, or threads. This is for catching trivial programmer
 	// mistakes only, anyway.
 
-	// Invalid IntendedDockerReference value
-	img = dirImageMock("fixtures/dir-img-valid", "UPPERCASEISINVALID")
+	// Image without a Docker reference identity
+	img = image.FromSource(&dirImageSourceMock{
+		ImageSource:             directory.NewImageSource("fixtures/dir-img-valid"),
+		intendedDockerReference: nil,
+	}, nil)
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 }


### PR DESCRIPTION
This cleans up Docker reference handling, primarily to rely more on `docker/reference.Named` than on strings. Conceptually a part of #33 , but usable and better to review stand-alone.

See the individual commits for detailed comments; the last one is the most important/disruptive.

`test-skopeo` will fail, but succeeds with `SKOPEO_REPO=mtrmac/skopeo SKOPEO_BRANCH=docker-references`; see also https://github.com/projectatomic/skopeo/pull/143 .