### PR TITLE
Reference abstraction

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/containers/image/types"
-	"github.com/docker/docker/reference"
 )
 
 type dirImageDestination struct {
@@ -18,8 +17,10 @@ func newImageDestination(ref dirReference) types.ImageDestination {
 	return &dirImageDestination{ref}
 }
 
-func (d *dirImageDestination) CanonicalDockerReference() reference.Named {
-	return nil
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+func (d *dirImageDestination) Reference() types.ImageReference {
+	return d.ref
 }
 
 func (d *dirImageDestination) SupportedManifestMIMETypes() []string {

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -10,12 +10,12 @@ import (
 )
 
 type dirImageDestination struct {
-	dir string
+	ref dirReference
 }
 
-// NewImageDestination returns an ImageDestination for writing to an existing directory.
-func NewImageDestination(dir string) types.ImageDestination {
-	return &dirImageDestination{dir}
+// newImageDestination returns an ImageDestination for writing to an existing directory.
+func newImageDestination(ref dirReference) types.ImageDestination {
+	return &dirImageDestination{ref}
 }
 
 func (d *dirImageDestination) CanonicalDockerReference() reference.Named {
@@ -27,11 +27,11 @@ func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 func (d *dirImageDestination) PutManifest(manifest []byte) error {
-	return ioutil.WriteFile(manifestPath(d.dir), manifest, 0644)
+	return ioutil.WriteFile(manifestPath(d.ref.path), manifest, 0644)
 }
 
 func (d *dirImageDestination) PutBlob(digest string, stream io.Reader) error {
-	layerFile, err := os.Create(layerPath(d.dir, digest))
+	layerFile, err := os.Create(layerPath(d.ref.path, digest))
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (d *dirImageDestination) PutBlob(digest string, stream io.Reader) error {
 
 func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {
 	for i, sig := range signatures {
-		if err := ioutil.WriteFile(signaturePath(d.dir, i), sig, 0644); err != nil {
+		if err := ioutil.WriteFile(signaturePath(d.ref.path, i), sig, 0644); err != nil {
 			return err
 		}
 	}

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/containers/image/types"
-	"github.com/docker/docker/reference"
 )
 
 type dirImageSource struct {
@@ -19,12 +18,10 @@ func newImageSource(ref dirReference) types.ImageSource {
 	return &dirImageSource{ref}
 }
 
-// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-// This can be used e.g. to determine which public keys are trusted for this image.
-// May be nil if unknown.
-func (s *dirImageSource) IntendedDockerReference() reference.Named {
-	return nil
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (s *dirImageSource) Reference() types.ImageReference {
+	return s.ref
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -11,12 +11,12 @@ import (
 )
 
 type dirImageSource struct {
-	dir string
+	ref dirReference
 }
 
-// NewImageSource returns an ImageSource reading from an existing directory.
-func NewImageSource(dir string) types.ImageSource {
-	return &dirImageSource{dir}
+// newImageSource returns an ImageSource reading from an existing directory.
+func newImageSource(ref dirReference) types.ImageSource {
+	return &dirImageSource{ref}
 }
 
 // IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
@@ -29,7 +29,7 @@ func (s *dirImageSource) IntendedDockerReference() reference.Named {
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes
 func (s *dirImageSource) GetManifest(_ []string) ([]byte, string, error) {
-	m, err := ioutil.ReadFile(manifestPath(s.dir))
+	m, err := ioutil.ReadFile(manifestPath(s.ref.path))
 	if err != nil {
 		return nil, "", err
 	}
@@ -37,11 +37,11 @@ func (s *dirImageSource) GetManifest(_ []string) ([]byte, string, error) {
 }
 
 func (s *dirImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
-	r, err := os.Open(layerPath(s.dir, digest))
+	r, err := os.Open(layerPath(s.ref.path, digest))
 	if err != nil {
 		return nil, 0, nil
 	}
-	fi, err := os.Stat(layerPath(s.dir, digest))
+	fi, err := os.Stat(layerPath(s.ref.path, digest))
 	if err != nil {
 		return nil, 0, nil
 	}
@@ -51,7 +51,7 @@ func (s *dirImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
 func (s *dirImageSource) GetSignatures() ([][]byte, error) {
 	signatures := [][]byte{}
 	for i := 0; ; i++ {
-		signature, err := ioutil.ReadFile(signaturePath(s.dir, i))
+		signature, err := ioutil.ReadFile(signaturePath(s.ref.path, i))
 		if err != nil {
 			if os.IsNotExist(err) {
 				break

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCanonicalDockerReference(t *testing.T) {
-	destRef := NewReference("/etc")
-	dest, err := destRef.NewImageDestination("", true)
+func TestDestinationReference(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	dest, err := ref.NewImageDestination("", true)
 	require.NoError(t, err)
-	ref := dest.CanonicalDockerReference()
-	assert.Nil(t, ref)
+	ref2 := dest.Reference()
+	assert.Equal(t, tmpDir, ref2.StringWithinTransport())
 }
 
 func TestGetPutManifest(t *testing.T) {

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -11,22 +11,25 @@ import (
 )
 
 func TestCanonicalDockerReference(t *testing.T) {
-	dest := NewImageDestination("/path/to/somewhere")
+	destRef := NewReference("/etc")
+	dest, err := destRef.NewImageDestination("", true)
+	require.NoError(t, err)
 	ref := dest.CanonicalDockerReference()
 	assert.Nil(t, ref)
 }
 
 func TestGetPutManifest(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "put-manifest")
-	require.NoError(t, err)
+	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
 	man := []byte("test-manifest")
-	dest := NewImageDestination(tmpDir)
+	dest, err := ref.NewImageDestination("", true)
+	require.NoError(t, err)
 	err = dest.PutManifest(man)
 	assert.NoError(t, err)
 
-	src := NewImageSource(tmpDir)
+	src, err := ref.NewImageSource("", true)
+	require.NoError(t, err)
 	m, mt, err := src.GetManifest(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, man, m)
@@ -34,17 +37,18 @@ func TestGetPutManifest(t *testing.T) {
 }
 
 func TestGetPutBlob(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "put-blob")
-	require.NoError(t, err)
+	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
 	digest := "digest-test"
 	blob := []byte("test-blob")
-	dest := NewImageDestination(tmpDir)
+	dest, err := ref.NewImageDestination("", true)
+	require.NoError(t, err)
 	err = dest.PutBlob(digest, bytes.NewReader(blob))
 	assert.NoError(t, err)
 
-	src := NewImageSource(tmpDir)
+	src, err := ref.NewImageSource("", true)
+	require.NoError(t, err)
 	rc, size, err := src.GetBlob(digest)
 	assert.NoError(t, err)
 	defer rc.Close()
@@ -55,11 +59,11 @@ func TestGetPutBlob(t *testing.T) {
 }
 
 func TestGetPutSignatures(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "put-signatures")
-	require.NoError(t, err)
+	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest := NewImageDestination(tmpDir)
+	dest, err := ref.NewImageDestination("", true)
+	require.NoError(t, err)
 	signatures := [][]byte{
 		[]byte("sig1"),
 		[]byte("sig2"),
@@ -67,24 +71,27 @@ func TestGetPutSignatures(t *testing.T) {
 	err = dest.PutSignatures(signatures)
 	assert.NoError(t, err)
 
-	src := NewImageSource(tmpDir)
+	src, err := ref.NewImageSource("", true)
+	require.NoError(t, err)
 	sigs, err := src.GetSignatures()
 	assert.NoError(t, err)
 	assert.Equal(t, signatures, sigs)
 }
 
 func TestDelete(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "delete")
-	require.NoError(t, err)
+	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	src := NewImageSource(tmpDir)
+	src, err := ref.NewImageSource("", true)
+	require.NoError(t, err)
 	err = src.Delete()
 	assert.Error(t, err)
 }
 
 func TestIntendedDockerReference(t *testing.T) {
-	src := NewImageSource("/path/to/somewhere")
+	destRef := NewReference("/etc")
+	src, err := destRef.NewImageSource("", true)
+	require.NoError(t, err)
 	ref := src.IntendedDockerReference()
 	assert.Nil(t, ref)
 }

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -90,10 +90,12 @@ func TestDelete(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestIntendedDockerReference(t *testing.T) {
-	destRef := NewReference("/etc")
-	src, err := destRef.NewImageSource("", true)
+func TestSourceReference(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	src, err := ref.NewImageSource("", true)
 	require.NoError(t, err)
-	ref := src.IntendedDockerReference()
-	assert.Nil(t, ref)
+	ref2 := src.Reference()
+	assert.Equal(t, tmpDir, ref2.StringWithinTransport())
 }

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -1,0 +1,65 @@
+package directory
+
+import (
+	"github.com/containers/image/image"
+	"github.com/containers/image/types"
+)
+
+// Transport is an ImageTransport for directory paths.
+var Transport = dirTransport{}
+
+type dirTransport struct{}
+
+func (t dirTransport) Name() string {
+	return "dir"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (t dirTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return NewReference(reference), nil
+}
+
+// dirReference is an ImageReference for directory paths.
+type dirReference struct {
+	// Note that the interpretation of paths below depends on the underlying filesystem state, which may change under us at any time!
+	path string // As specified by the user. May be relative, contain symlinks, etc.
+}
+
+// There is no directory.ParseReference because it is rather pointless.
+// Callers who need a transport-independent interface will go through
+// dirTransport.ParseReference; callers who intentionally deal with directories
+// can use directory.NewReference.
+
+// NewReference returns a directory reference for a specified path.
+func NewReference(path string) types.ImageReference {
+	return dirReference{path: path}
+}
+
+func (ref dirReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+func (ref dirReference) StringWithinTransport() string {
+	return ref.path
+}
+
+// NewImage returns a types.Image for this reference.
+func (ref dirReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	src := newImageSource(ref)
+	return image.FromSource(src, nil), nil
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+func (ref dirReference) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	return newImageSource(ref), nil
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+func (ref dirReference) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	return newImageDestination(ref), nil
+}

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -3,6 +3,7 @@ package directory
 import (
 	"github.com/containers/image/image"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 // Transport is an ImageTransport for directory paths.
@@ -46,6 +47,13 @@ func (ref dirReference) Transport() types.ImageTransport {
 // WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
 func (ref dirReference) StringWithinTransport() string {
 	return ref.path
+}
+
+// DockerReference returns a Docker reference associated with this reference
+// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+func (ref dirReference) DockerReference() reference.Named {
+	return nil
 }
 
 // NewImage returns a types.Image for this reference.

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -67,6 +67,12 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 	assert.Equal(t, tmpDir, ref.StringWithinTransport())
 }
 
+func TestReferenceDockerReference(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, ref.DockerReference())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -1,0 +1,89 @@
+package directory
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportName(t *testing.T) {
+	assert.Equal(t, "dir", Transport.Name())
+}
+
+func TestTransportParseReference(t *testing.T) {
+	testNewReference(t, Transport.ParseReference)
+}
+
+func TestNewReference(t *testing.T) {
+	testNewReference(t, func(ref string) (types.ImageReference, error) {
+		return NewReference(ref), nil
+	})
+}
+
+// testNewReference is a test shared for Transport.ParseReference and NewReference.
+func testNewReference(t *testing.T, fn func(string) (types.ImageReference, error)) {
+	tmpDir, err := ioutil.TempDir("", "dir-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	for _, path := range []string{
+		"/",
+		"/etc",
+		tmpDir,
+		"relativepath",
+		tmpDir + "/thisdoesnotexist",
+	} {
+		ref, err := fn(path)
+		require.NoError(t, err, path)
+		dirRef, ok := ref.(dirReference)
+		require.True(t, ok)
+		assert.Equal(t, path, dirRef.path, path)
+	}
+}
+
+// refToTempDir creates a temporary directory and returns a reference to it.
+// The caller should
+//   defer os.RemoveAll(tmpDir)
+func refToTempDir(t *testing.T) (ref types.ImageReference, tmpDir string) {
+	tmpDir, err := ioutil.TempDir("", "dir-transport-test")
+	require.NoError(t, err)
+	ref = NewReference(tmpDir)
+	return ref, tmpDir
+}
+
+func TestReferenceTransport(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, Transport, ref.Transport())
+}
+
+func TestReferenceStringWithinTransport(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, tmpDir, ref.StringWithinTransport())
+}
+
+func TestReferenceNewImage(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImage("/this/doesn't/exist", true)
+	assert.NoError(t, err)
+}
+
+func TestReferenceNewImageSource(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImageSource("/this/doesn't/exist", true)
+	assert.NoError(t, err)
+}
+
+func TestReferenceNewImageDestination(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImageDestination("/this/doesn't/exist", true)
+	assert.NoError(t, err)
+}

--- a/doc.go
+++ b/doc.go
@@ -9,11 +9,15 @@
 //    )
 //
 //    func main() {
-//    	img, err := docker.NewImage("fedora", "", false)
+//    	ref, err := docker.ParseReference("fedora")
 //    	if err != nil {
 //    		panic(err)
 //    	}
-//    	b, err := img.Manifest()
+//    	img, err := ref.NewImage("", true)
+//    	if err != nil {
+//    		panic(err)
+//    	}
+//    	b, _, err := img.Manifest()
 //    	if err != nil {
 //    		panic(err)
 //    	}

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -16,10 +16,10 @@ type Image struct {
 	src *dockerImageSource
 }
 
-// NewImage returns a new Image interface type after setting up
+// newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
-func NewImage(img, certPath string, tlsVerify bool) (types.Image, error) {
-	s, err := newDockerImageSource(img, certPath, tlsVerify)
+func newImage(ref dockerReference, certPath string, tlsVerify bool) (types.Image, error) {
+	s, err := newImageSource(ref, certPath, tlsVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -28,12 +28,12 @@ func NewImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.
 func (i *Image) SourceRefFullName() string {
-	return i.src.ref.FullName()
+	return i.src.ref.ref.FullName()
 }
 
 // GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
 func (i *Image) GetRepositoryTags() ([]string, error) {
-	url := fmt.Sprintf(tagsURL, i.src.ref.RemoteName())
+	url := fmt.Sprintf(tagsURL, i.src.ref.ref.RemoteName())
 	res, err := i.src.c.makeRequest("GET", url, nil, nil)
 	if err != nil {
 		return nil, err

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/docker/reference"
 )
 
 type dockerImageDestination struct {
@@ -30,6 +29,12 @@ func newImageDestination(ref dockerReference, certPath string, tlsVerify bool) (
 	}, nil
 }
 
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+func (d *dockerImageDestination) Reference() types.ImageReference {
+	return d.ref
+}
+
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		// TODO(runcom): we'll add OCI as part of another PR here
@@ -37,10 +42,6 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 		manifest.DockerV2Schema1SignedMIMEType,
 		manifest.DockerV2Schema1MIMEType,
 	}
-}
-
-func (d *dockerImageDestination) CanonicalDockerReference() reference.Named {
-	return d.ref.ref
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -14,17 +14,13 @@ import (
 )
 
 type dockerImageDestination struct {
-	ref reference.Named
+	ref dockerReference
 	c   *dockerClient
 }
 
-// NewImageDestination creates a new ImageDestination for the specified image and connection specification.
-func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDestination, error) {
-	ref, err := parseImageName(img)
-	if err != nil {
-		return nil, err
-	}
-	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify)
+// newImageDestination creates a new ImageDestination for the specified image reference and connection specification.
+func newImageDestination(ref dockerReference, certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	c, err := newDockerClient(ref.ref.Hostname(), certPath, tlsVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +40,7 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 func (d *dockerImageDestination) CanonicalDockerReference() reference.Named {
-	return d.ref
+	return d.ref.ref
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {
@@ -54,7 +50,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf(manifestURL, d.ref.RemoteName(), digest)
+	url := fmt.Sprintf(manifestURL, d.ref.ref.RemoteName(), digest)
 
 	headers := map[string][]string{}
 	mimeType := manifest.GuessMIMEType(m)
@@ -78,7 +74,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 }
 
 func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error {
-	checkURL := fmt.Sprintf(blobsURL, d.ref.RemoteName(), digest)
+	checkURL := fmt.Sprintf(blobsURL, d.ref.ref.RemoteName(), digest)
 
 	logrus.Debugf("Checking %s", checkURL)
 	res, err := d.c.makeRequest("HEAD", checkURL, nil, nil)
@@ -93,7 +89,7 @@ func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error 
 	logrus.Debugf("... failed, status %d", res.StatusCode)
 
 	// FIXME? Chunked upload, progress reporting, etc.
-	uploadURL := fmt.Sprintf(blobUploadURL, d.ref.RemoteName())
+	uploadURL := fmt.Sprintf(blobUploadURL, d.ref.ref.RemoteName())
 	logrus.Debugf("Uploading %s", uploadURL)
 	res, err = d.c.makeRequest("POST", uploadURL, nil, nil)
 	if err != nil {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
-	"github.com/docker/docker/reference"
+	"github.com/containers/image/types"
 )
 
 type errFetchManifest struct {
@@ -39,12 +39,10 @@ func newImageSource(ref dockerReference, certPath string, tlsVerify bool) (*dock
 	}, nil
 }
 
-// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-// This can be used e.g. to determine which public keys are trusted for this image.
-// May be nil if unknown.
-func (s *dockerImageSource) IntendedDockerReference() reference.Named {
-	return s.ref.ref
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (s *dockerImageSource) Reference() types.ImageReference {
+	return s.ref
 }
 
 // simplifyContentType drops parameters from a HTTP media type (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
-	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 )
 
@@ -24,17 +23,13 @@ func (e errFetchManifest) Error() string {
 }
 
 type dockerImageSource struct {
-	ref reference.Named
+	ref dockerReference
 	c   *dockerClient
 }
 
-// newDockerImageSource is the same as NewImageSource, only it returns the more specific *dockerImageSource type.
-func newDockerImageSource(img, certPath string, tlsVerify bool) (*dockerImageSource, error) {
-	ref, err := parseImageName(img)
-	if err != nil {
-		return nil, err
-	}
-	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify)
+// newImageSource creates a new ImageSource for the specified image reference and connection specification.
+func newImageSource(ref dockerReference, certPath string, tlsVerify bool) (*dockerImageSource, error) {
+	c, err := newDockerClient(ref.ref.Hostname(), certPath, tlsVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -44,17 +39,12 @@ func newDockerImageSource(img, certPath string, tlsVerify bool) (*dockerImageSou
 	}, nil
 }
 
-// NewImageSource creates a new ImageSource for the specified image and connection specification.
-func NewImageSource(img, certPath string, tlsVerify bool) (types.ImageSource, error) {
-	return newDockerImageSource(img, certPath, tlsVerify)
-}
-
 // IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
 // This can be used e.g. to determine which public keys are trusted for this image.
 // May be nil if unknown.
 func (s *dockerImageSource) IntendedDockerReference() reference.Named {
-	return s.ref
+	return s.ref.ref
 }
 
 // simplifyContentType drops parameters from a HTTP media type (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1)
@@ -71,11 +61,11 @@ func simplifyContentType(contentType string) string {
 }
 
 func (s *dockerImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {
-	reference, err := tagOrDigest(s.ref)
+	reference, err := tagOrDigest(s.ref.ref)
 	if err != nil {
 		return nil, "", err
 	}
-	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), reference)
+	url := fmt.Sprintf(manifestURL, s.ref.ref.RemoteName(), reference)
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1
 	// TODO(runcom) NO, switch on the resulter manifest like Docker is doing
 	headers := make(map[string][]string)
@@ -97,7 +87,7 @@ func (s *dockerImageSource) GetManifest(mimetypes []string) ([]byte, string, err
 }
 
 func (s *dockerImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
-	url := fmt.Sprintf(blobsURL, s.ref.RemoteName(), digest)
+	url := fmt.Sprintf(blobsURL, s.ref.ref.RemoteName(), digest)
 	logrus.Debugf("Downloading %s", url)
 	res, err := s.c.makeRequest("GET", url, nil, nil)
 	if err != nil {
@@ -126,11 +116,11 @@ func (s *dockerImageSource) Delete() error {
 	headers := make(map[string][]string)
 	headers["Accept"] = []string{manifest.DockerV2Schema2MIMEType}
 
-	reference, err := tagOrDigest(s.ref)
+	reference, err := tagOrDigest(s.ref.ref)
 	if err != nil {
 		return err
 	}
-	getURL := fmt.Sprintf(manifestURL, s.ref.RemoteName(), reference)
+	getURL := fmt.Sprintf(manifestURL, s.ref.ref.RemoteName(), reference)
 	get, err := s.c.makeRequest("GET", getURL, headers, nil)
 	if err != nil {
 		return err
@@ -143,13 +133,13 @@ func (s *dockerImageSource) Delete() error {
 	switch get.StatusCode {
 	case http.StatusOK:
 	case http.StatusNotFound:
-		return fmt.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry.", s.ref)
+		return fmt.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry.", s.ref.ref)
 	default:
-		return fmt.Errorf("Failed to delete %v: %v (%v)", s.ref, body, get.Status)
+		return fmt.Errorf("Failed to delete %v: %v (%v)", s.ref.ref, body, get.Status)
 	}
 
 	digest := get.Header.Get("Docker-Content-Digest")
-	deleteURL := fmt.Sprintf(manifestURL, s.ref.RemoteName(), digest)
+	deleteURL := fmt.Sprintf(manifestURL, s.ref.ref.RemoteName(), digest)
 
 	// When retrieving the digest from a registry >= 2.3 use the following header:
 	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -72,6 +72,13 @@ func (ref dockerReference) StringWithinTransport() string {
 	return "//" + ref.ref.String()
 }
 
+// DockerReference returns a Docker reference associated with this reference
+// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+func (ref dockerReference) DockerReference() reference.Named {
+	return ref.ref
+}
+
 // NewImage returns a types.Image for this reference.
 func (ref dockerReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	return newImage(ref, certPath, tlsVerify)

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
+)
+
+// Transport is an ImageTransport for Docker references.
+var Transport = dockerTransport{}
+
+type dockerTransport struct{}
+
+func (t dockerTransport) Name() string {
+	return "docker"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (t dockerTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return ParseReference(reference)
+}
+
+// dockerReference is an ImageReference for Docker images.
+type dockerReference struct {
+	ref reference.Named // By construction we know that !reference.IsNameOnly(ref)
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.
+func ParseReference(refString string) (types.ImageReference, error) {
+	if !strings.HasPrefix(refString, "//") {
+		return nil, fmt.Errorf("docker: image reference %s does not start with //", refString)
+	}
+	ref, err := reference.ParseNamed(strings.TrimPrefix(refString, "//"))
+	if err != nil {
+		return nil, err
+	}
+	ref = reference.WithDefaultTag(ref)
+	return NewReference(ref)
+}
+
+// NewReference returns a Docker reference for a named reference. The reference must satisfy !reference.IsNameOnly().
+func NewReference(ref reference.Named) (types.ImageReference, error) {
+	if reference.IsNameOnly(ref) {
+		return nil, fmt.Errorf("Docker reference %s has neither a tag nor a digest", ref.String())
+	}
+	// A github.com/distribution/reference value can have a tag and a digest at the same time!
+	// docker/reference does not handle that, so fail.
+	// (Even if it were supported, the semantics of policy namespaces are unclear - should we drop
+	// the tag or the digest first?)
+	_, isTagged := ref.(reference.NamedTagged)
+	_, isDigested := ref.(reference.Canonical)
+	if isTagged && isDigested {
+		return nil, fmt.Errorf("Docker references with both a tag and digest are currently not supported")
+	}
+	return dockerReference{
+		ref: ref,
+	}, nil
+}
+
+func (ref dockerReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+func (ref dockerReference) StringWithinTransport() string {
+	return "//" + ref.ref.String()
+}
+
+// NewImage returns a types.Image for this reference.
+func (ref dockerReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	return newImage(ref, certPath, tlsVerify)
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+func (ref dockerReference) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	return newImageSource(ref, certPath, tlsVerify)
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+func (ref dockerReference) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	return newImageDestination(ref, certPath, tlsVerify)
+}

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -116,6 +116,16 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 	}
 }
 
+func TestReferenceDockerReference(t *testing.T) {
+	for _, c := range validReferenceTestCases {
+		ref, err := ParseReference("//" + c.input)
+		require.NoError(t, err, c.input)
+		dockerRef := ref.DockerReference()
+		require.NotNil(t, dockerRef, c.input)
+		assert.Equal(t, c.dockerRef, dockerRef.String(), c.input)
+	}
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -1,0 +1,138 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sha256digestHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	sha256digest    = "@sha256:" + sha256digestHex
+)
+
+func TestTransportName(t *testing.T) {
+	assert.Equal(t, "docker", Transport.Name())
+}
+
+func TestTransportParseReference(t *testing.T) {
+	testParseReference(t, Transport.ParseReference)
+}
+
+func TestParseReference(t *testing.T) {
+	testParseReference(t, ParseReference)
+}
+
+// testParseReference is a test shared for Transport.ParseReference and ParseReference.
+func testParseReference(t *testing.T, fn func(string) (types.ImageReference, error)) {
+	for _, c := range []struct{ input, expected string }{
+		{"busybox", ""},                                        // Missing // prefix
+		{"//busybox:notlatest", "busybox:notlatest"},           // Explicit tag
+		{"//busybox" + sha256digest, "busybox" + sha256digest}, // Explicit digest
+		{"//busybox", "busybox:latest"},                        // Default tag
+		// A github.com/distribution/reference value can have a tag and a digest at the same time!
+		// github.com/docker/reference handles that by dropping the tag. That is not obviously the
+		// right thing to do, but it is at least reasonable, so test that we keep behaving reasonably.
+		// This test case should not be construed to make this an API promise.
+		// FIXME? Instead work extra hard to reject such input?
+		{"//busybox:latest" + sha256digest, "busybox" + sha256digest}, // Both tag and digest
+		{"//docker.io/library/busybox:latest", "busybox:latest"},      // All implied values explicitly specified
+		{"//UPPERCASEISINVALID", ""},                                  // Invalid input
+	} {
+		ref, err := fn(c.input)
+		if c.expected == "" {
+			assert.Error(t, err, c.input)
+		} else {
+			require.NoError(t, err, c.input)
+			dockerRef, ok := ref.(dockerReference)
+			require.True(t, ok, c.input)
+			assert.Equal(t, c.expected, dockerRef.ref.String(), c.input)
+		}
+	}
+}
+
+// refWithTagAndDigest is a reference.NamedTagged and reference.Canonical at the same time.
+type refWithTagAndDigest struct{ reference.Canonical }
+
+func (ref refWithTagAndDigest) Tag() string {
+	return "notLatest"
+}
+
+// A common list of reference formats to test for the various ImageReference methods.
+var validReferenceTestCases = []struct{ input, dockerRef, stringWithinTransport string }{
+	{"busybox:notlatest", "busybox:notlatest", "//busybox:notlatest"},                // Explicit tag
+	{"busybox" + sha256digest, "busybox" + sha256digest, "//busybox" + sha256digest}, // Explicit digest
+	{"docker.io/library/busybox:latest", "busybox:latest", "//busybox:latest"},       // All implied values explicitly specified
+	{"example.com/ns/foo:bar", "example.com/ns/foo:bar", "//example.com/ns/foo:bar"}, // All values explicitly specified
+}
+
+func TestNewReference(t *testing.T) {
+	for _, c := range validReferenceTestCases {
+		parsed, err := reference.ParseNamed(c.input)
+		require.NoError(t, err)
+		ref, err := NewReference(parsed)
+		require.NoError(t, err, c.input)
+		dockerRef, ok := ref.(dockerReference)
+		require.True(t, ok, c.input)
+		assert.Equal(t, c.dockerRef, dockerRef.ref.String(), c.input)
+	}
+
+	// Neither a tag nor digest
+	parsed, err := reference.ParseNamed("busybox")
+	require.NoError(t, err)
+	_, err = NewReference(parsed)
+	assert.Error(t, err)
+
+	// A github.com/distribution/reference value can have a tag and a digest at the same time!
+	parsed, err = reference.ParseNamed("busybox" + sha256digest)
+	require.NoError(t, err)
+	refDigested, ok := parsed.(reference.Canonical)
+	require.True(t, ok)
+	tagDigestRef := refWithTagAndDigest{refDigested}
+	_, err = NewReference(tagDigestRef)
+	assert.Error(t, err)
+}
+
+func TestReferenceTransport(t *testing.T) {
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	assert.Equal(t, Transport, ref.Transport())
+}
+
+func TestReferenceStringWithinTransport(t *testing.T) {
+	for _, c := range validReferenceTestCases {
+		ref, err := ParseReference("//" + c.input)
+		require.NoError(t, err, c.input)
+		stringRef := ref.StringWithinTransport()
+		assert.Equal(t, c.stringWithinTransport, stringRef, c.input)
+		// Do one more round to verify that the output can be parsed, to an equal value.
+		ref2, err := Transport.ParseReference(stringRef)
+		require.NoError(t, err, c.input)
+		stringRef2 := ref2.StringWithinTransport()
+		assert.Equal(t, stringRef, stringRef2, c.input)
+	}
+}
+
+func TestReferenceNewImage(t *testing.T) {
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	_, err = ref.NewImage("", true)
+	assert.NoError(t, err)
+}
+
+func TestReferenceNewImageSource(t *testing.T) {
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	_, err = ref.NewImageSource("", true)
+	assert.NoError(t, err)
+}
+
+func TestReferenceNewImageDestination(t *testing.T) {
+	ref, err := ParseReference("//busybox")
+	require.NoError(t, err)
+	_, err = ref.NewImageDestination("", true)
+	assert.NoError(t, err)
+}

--- a/docker/docker_utils.go
+++ b/docker/docker_utils.go
@@ -6,20 +6,6 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// parseImageName converts a string into a reference.
-// It is guaranteed that reference.IsNameOnly is false for the returned value.
-func parseImageName(img string) (reference.Named, error) {
-	ref, err := reference.ParseNamed(img)
-	if err != nil {
-		return nil, err
-	}
-	ref = reference.WithDefaultTag(ref)
-	if reference.IsNameOnly(ref) { // Sanity check that we are fulfulling our contract
-		return nil, fmt.Errorf("Internal inconsistency: reference.IsNameOnly for reference %s (parsed from %s)", ref.String(), img)
-	}
-	return ref, nil
-}
-
 // tagOrDigest returns a tag or digest from a reference for which !reference.IsNameOnly.
 func tagOrDigest(ref reference.Named) (string, error) {
 	if ref, ok := ref.(reference.Canonical); ok {

--- a/image/image.go
+++ b/image/image.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/docker/reference"
 )
 
 var (
@@ -51,12 +50,10 @@ func FromSource(src types.ImageSource, requestedManifestMIMETypes []string) type
 	return &genericImage{src: src, requestedManifestMIMETypes: requestedManifestMIMETypes}
 }
 
-// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-// This can be used e.g. to determine which public keys are trusted for this image.
-// May be nil if unknown.
-func (i *genericImage) IntendedDockerReference() reference.Named {
-	return i.src.IntendedDockerReference()
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (i *genericImage) Reference() types.ImageReference {
+	return i.src.Reference()
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/docker/reference"
 )
 
 type ociManifest struct {
@@ -37,8 +36,10 @@ func newImageDestination(ref ociReference) types.ImageDestination {
 	return &ociImageDestination{ref: ref}
 }
 
-func (d *ociImageDestination) CanonicalDockerReference() reference.Named {
-	return nil
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+func (d *ociImageDestination) Reference() types.ImageReference {
+	return d.ref
 }
 
 func createManifest(m []byte) ([]byte, string, error) {

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -1,0 +1,83 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/containers/image/types"
+)
+
+// Transport is an ImageTransport for Docker references.
+var Transport = ociTransport{}
+
+type ociTransport struct{}
+
+func (t ociTransport) Name() string {
+	return "oci"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (t ociTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return ParseReference(reference)
+}
+
+// ociReference is an ImageReference for OCI directory paths.
+type ociReference struct {
+	// Note that the interpretation of paths below depends on the underlying filesystem state, which may change under us at any time!
+	dir string // As specified by the user. May be relative, contain symlinks, etc.
+	tag string
+}
+
+var refRegexp = regexp.MustCompile(`^([A-Za-z0-9._-]+)+$`)
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
+func ParseReference(reference string) (types.ImageReference, error) {
+	var dir, tag string
+	sep := strings.LastIndex(reference, ":")
+	if sep == -1 {
+		dir = reference
+		tag = "latest"
+	} else {
+		dir = reference[:sep]
+		tag = reference[sep+1:]
+		if !refRegexp.MatchString(tag) {
+			return nil, fmt.Errorf("Invalid tag %s", tag)
+		}
+	}
+	return NewReference(dir, tag), nil
+}
+
+// NewReference returns an OCI reference for a directory and a tag.
+func NewReference(dir, tag string) types.ImageReference {
+	return ociReference{dir: dir, tag: tag}
+}
+
+func (ref ociReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+func (ref ociReference) StringWithinTransport() string {
+	return fmt.Sprintf("%s:%s", ref.dir, ref.tag)
+}
+
+// NewImage returns a types.Image for this reference.
+func (ref ociReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	return nil, errors.New("Full Image support not implemented for oci: image names")
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+func (ref ociReference) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	return nil, errors.New("Reading images not implemented for oci: image names")
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+func (ref ociReference) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	return newImageDestination(ref), nil
+}

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 // Transport is an ImageTransport for Docker references.
@@ -65,6 +66,13 @@ func (ref ociReference) Transport() types.ImageTransport {
 // WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
 func (ref ociReference) StringWithinTransport() string {
 	return fmt.Sprintf("%s:%s", ref.dir, ref.tag)
+}
+
+// DockerReference returns a Docker reference associated with this reference
+// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+func (ref ociReference) DockerReference() reference.Named {
+	return nil
 }
 
 // NewImage returns a types.Image for this reference.

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -112,6 +112,12 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 	}
 }
 
+func TestReferenceDockerReference(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, ref.DockerReference())
+}
+
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -1,0 +1,134 @@
+package oci
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportName(t *testing.T) {
+	assert.Equal(t, "oci", Transport.Name())
+}
+
+func TestTransportParseReference(t *testing.T) {
+	testParseReference(t, Transport.ParseReference)
+}
+
+func TestParseReference(t *testing.T) {
+	testParseReference(t, ParseReference)
+}
+
+// testParseReference is a test shared for Transport.ParseReference and ParseReference.
+func testParseReference(t *testing.T, fn func(string) (types.ImageReference, error)) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	for _, path := range []string{
+		"/",
+		"/etc",
+		tmpDir,
+		"relativepath",
+		tmpDir + "/thisdoesnotexist",
+	} {
+		for _, tag := range []struct{ suffix, tag string }{
+			{":notlatest", "notlatest"},
+			{"", "latest"},
+		} {
+			input := path + tag.suffix
+			ref, err := fn(input)
+			require.NoError(t, err, input)
+			ociRef, ok := ref.(ociReference)
+			require.True(t, ok)
+			assert.Equal(t, path, ociRef.dir, input)
+			assert.Equal(t, tag.tag, ociRef.tag, input)
+		}
+	}
+
+	ref, err := fn(tmpDir + "/with:colons:and:tag")
+	require.NoError(t, err)
+	ociRef, ok := ref.(ociReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir+"/with:colons:and", ociRef.dir)
+	assert.Equal(t, "tag", ociRef.tag)
+
+	_, err = fn(tmpDir + ":invalid'tag!value@")
+	assert.Error(t, err)
+}
+
+func TestNewReference(t *testing.T) {
+	const tagValue = "tagValue"
+
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ref := NewReference(tmpDir, tagValue)
+	ociRef, ok := ref.(ociReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir, ociRef.dir)
+	assert.Equal(t, tagValue, ociRef.tag)
+}
+
+// refToTempOCI creates a temporary directory and returns an reference to it.
+// The caller should
+//   defer os.RemoveAll(tmpDir)
+func refToTempOCI(t *testing.T) (ref types.ImageReference, tmpDir string) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	ref = NewReference(tmpDir, "tagValue")
+	return ref, tmpDir
+}
+
+func TestReferenceTransport(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, Transport, ref.Transport())
+}
+
+func TestReferenceStringWithinTransport(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	for _, c := range []struct{ input, result string }{
+		{"/dir1:notlatest", "/dir1:notlatest"}, // Explicit tag
+		{"/dir2", "/dir2:latest"},              // Default tag
+		{"/dir3:with:colons:and:tag", "/dir3:with:colons:and:tag"},
+	} {
+		ref, err := ParseReference(tmpDir + c.input)
+		require.NoError(t, err, c.input)
+		stringRef := ref.StringWithinTransport()
+		assert.Equal(t, tmpDir+c.result, stringRef, c.input)
+		// Do one more round to verify that the output can be parsed, to an equal value.
+		ref2, err := Transport.ParseReference(stringRef)
+		require.NoError(t, err, c.input)
+		stringRef2 := ref2.StringWithinTransport()
+		assert.Equal(t, stringRef, stringRef2, c.input)
+	}
+}
+
+func TestReferenceNewImage(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImage("/this/doesn't/exist", true)
+	assert.Error(t, err)
+}
+
+func TestReferenceNewImageSource(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImageSource("/this/doesn't/exist", true)
+	assert.Error(t, err)
+}
+
+func TestReferenceNewImageDestination(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImageDestination("/this/doesn't/exist", true)
+	assert.NoError(t, err)
+}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -277,15 +277,17 @@ func newImageDestination(ref openshiftReference, certPath string, tlsVerify bool
 	}, nil
 }
 
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+func (d *openshiftImageDestination) Reference() types.ImageReference {
+	return d.client.ref
+}
+
 func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		manifest.DockerV2Schema1SignedMIMEType,
 		manifest.DockerV2Schema1MIMEType,
 	}
-}
-
-func (d *openshiftImageDestination) CanonicalDockerReference() reference.Named {
-	return d.client.ref.dockerReference
 }
 
 func (d *openshiftImageDestination) PutManifest(m []byte) error {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/image/version"
-	"github.com/docker/docker/reference"
 )
 
 // openshiftClient is configuration for dealing with a single image stream, for reading or writing.
@@ -171,12 +170,10 @@ func newImageSource(ref openshiftReference, certPath string, tlsVerify bool) (ty
 	}, nil
 }
 
-// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-// This can be used e.g. to determine which public keys are trusted for this image.
-// May be nil if unknown.
-func (s *openshiftImageSource) IntendedDockerReference() reference.Named {
-	return s.client.ref.dockerReference
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (s *openshiftImageSource) Reference() types.ImageReference {
+	return s.client.ref
 }
 
 func (s *openshiftImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -104,6 +104,13 @@ func (ref openshiftReference) StringWithinTransport() string {
 	return fmt.Sprintf("%s/%s:%s", ref.namespace, ref.stream, ref.tag)
 }
 
+// DockerReference returns a Docker reference associated with this reference
+// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+func (ref openshiftReference) DockerReference() reference.Named {
+	return ref.dockerReference
+}
+
 // NewImage returns a types.Image for this reference.
 func (ref openshiftReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
 	return nil, errors.New("Full Image support not implemented for atomic: image names")

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -1,0 +1,120 @@
+package openshift
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
+)
+
+// Transport is an ImageTransport for directory paths.
+var Transport = openshiftTransport{}
+
+type openshiftTransport struct{}
+
+func (t openshiftTransport) Name() string {
+	return "atomic"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (t openshiftTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return ParseReference(reference)
+}
+
+// openshiftReference is an ImageReference for OpenShift images.
+type openshiftReference struct {
+	baseURL         *url.URL
+	namespace       string
+	stream          string
+	tag             string
+	dockerReference reference.Named // Computed from the above in advance, so that later references can not fail.
+}
+
+// FIXME: Is imageName like this a good way to refer to OpenShift images?
+var imageNameRegexp = regexp.MustCompile("^([^:/]*)/([^:/]*):([^:/]*)$")
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OpenShift ImageReference.
+func ParseReference(reference string) (types.ImageReference, error) {
+	// Overall, this is modelled on openshift/origin/pkg/cmd/util/clientcmd.New().ClientConfig() and openshift/origin/pkg/client.
+	cmdConfig := defaultClientConfig()
+	logrus.Debugf("cmdConfig: %#v", cmdConfig)
+	restConfig, err := cmdConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	// REMOVED: SetOpenShiftDefaults (values are not overridable in config files, so hard-coded these defaults.)
+	logrus.Debugf("restConfig: %#v", restConfig)
+	baseURL, _, err := restClientFor(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("URL: %#v", *baseURL)
+
+	m := imageNameRegexp.FindStringSubmatch(reference)
+	if m == nil || len(m) != 4 {
+		return nil, fmt.Errorf("Invalid image reference %s, %#v", reference, m)
+	}
+
+	return NewReference(baseURL, m[1], m[2], m[3])
+}
+
+// NewReference returns an OpenShift reference for a base URL, namespace, stream and tag.
+func NewReference(baseURL *url.URL, namespace, stream, tag string) (types.ImageReference, error) {
+	// Precompute also dockerReference so that later references can not fail.
+	//
+	// This discards ref.baseURL.Path, which is unexpected for a “base URL”;
+	// but openshiftClient.doRequest actually completely overrides url.Path
+	// (and defaultServerURL rejects non-trivial Path values), so it is OK for
+	// us to ignore it as well.
+	//
+	// FIXME: This is, strictly speaking, a namespace conflict with images placed in a Docker registry running on the same host.
+	// Do we need to do something else, perhaps disambiguate (port number?) or namespace Docker and OpenShift separately?
+	dockerRef, err := reference.WithName(fmt.Sprintf("%s/%s/%s", baseURL.Host, namespace, stream))
+	if err != nil {
+		return nil, err
+	}
+	dockerRef, err = reference.WithTag(dockerRef, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return openshiftReference{
+		baseURL:         baseURL,
+		namespace:       namespace,
+		stream:          stream,
+		tag:             tag,
+		dockerReference: dockerRef,
+	}, nil
+}
+
+func (ref openshiftReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+func (ref openshiftReference) StringWithinTransport() string {
+	return fmt.Sprintf("%s/%s:%s", ref.namespace, ref.stream, ref.tag)
+}
+
+// NewImage returns a types.Image for this reference.
+func (ref openshiftReference) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	return nil, errors.New("Full Image support not implemented for atomic: image names")
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+func (ref openshiftReference) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	return newImageSource(ref, certPath, tlsVerify)
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+func (ref openshiftReference) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	return newImageDestination(ref, certPath, tlsVerify)
+}

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -49,6 +49,14 @@ func TestNewReference(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestReferenceDockerReference(t *testing.T) {
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	dockerRef := ref.DockerReference()
+	require.NotNil(t, dockerRef)
+	assert.Equal(t, "registry.example.com:8443/ns/stream:notlatest", dockerRef.String())
+}
+
 func TestReferenceTransport(t *testing.T) {
 	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
 	require.NoError(t, err)

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -1,0 +1,74 @@
+package openshift
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sha256digestHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	sha256digest    = "@sha256:" + sha256digestHex
+)
+
+func TestTransportName(t *testing.T) {
+	assert.Equal(t, "atomic", Transport.Name())
+}
+
+// Transport.ParseReference, ParseReference untested because they depend
+// on per-user configuration.
+var testBaseURL *url.URL
+
+func init() {
+	u, err := url.Parse("https://registry.example.com:8443")
+	if err != nil {
+		panic("Error initializing testBaseURL")
+	}
+	testBaseURL = u
+}
+
+func TestNewReference(t *testing.T) {
+	// Success
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	osRef, ok := ref.(openshiftReference)
+	require.True(t, ok)
+	assert.Equal(t, testBaseURL.String(), osRef.baseURL.String())
+	assert.Equal(t, "ns", osRef.namespace)
+	assert.Equal(t, "stream", osRef.stream)
+	assert.Equal(t, "notlatest", osRef.tag)
+	assert.Equal(t, "registry.example.com:8443/ns/stream:notlatest", osRef.dockerReference.String())
+
+	// Components creating an invalid Docker Reference name
+	_, err = NewReference(testBaseURL, "ns", "UPPERCASEISINVALID", "notlatest")
+	assert.Error(t, err)
+
+	_, err = NewReference(testBaseURL, "ns", "stream", "invalid!tag@value=")
+	assert.Error(t, err)
+}
+
+func TestReferenceTransport(t *testing.T) {
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	assert.Equal(t, Transport, ref.Transport())
+}
+
+func TestReferenceStringWithinTransport(t *testing.T) {
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	assert.Equal(t, "ns/stream:notlatest", ref.StringWithinTransport())
+	// We should do one more round to verify that the output can be parsed, to an equal value,
+	// but that is untested because it depends on per-user configuration.
+}
+
+func TestReferenceNewImage(t *testing.T) {
+	ref, err := NewReference(testBaseURL, "ns", "stream", "notlatest")
+	require.NoError(t, err)
+	_, err = ref.NewImage("", true)
+	assert.Error(t, err)
+}
+
+// openshfitReference.NewImageSource, openshfitReference.NewImageDestination untested because they depend
+// on per-user configuration when initializing httpClient.

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 )
@@ -157,8 +158,7 @@ func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 func (pc *PolicyContext) requirementsForImage(image types.Image) (PolicyRequirements, error) {
 	ref := image.Reference().DockerReference()
 	if ref == nil {
-		// FIXME: Tell the user which image this is.
-		return nil, fmt.Errorf("Can not determine policy for an image with no known Docker reference identity")
+		return nil, fmt.Errorf("Can not determine policy for image %s with no known Docker reference identity", transports.ImageName(image.Reference()))
 	}
 	ref = reference.WithDefaultTag(ref) // This should not be needed, but if we did receive a name-only reference, this is a reasonable thing to do.
 

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -70,8 +70,8 @@ type PolicyRequirement interface {
 // The type is public, but its implementation is private.
 type PolicyReferenceMatch interface {
 	// matchesDockerReference decides whether a specific image identity is accepted for an image
-	// (or, usually, for the image's IntendedDockerReference()).  Note that
-	// image.IntendedDockerReference() may be nil.
+	// (or, usually, for the image's Reference().DockerReference()).  Note that
+	// image.Reference().DockerReference() may be nil.
 	matchesDockerReference(image types.Image, signatureDockerReference string) bool
 }
 
@@ -155,7 +155,7 @@ func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 
 // requirementsForImage selects the appropriate requirements for image.
 func (pc *PolicyContext) requirementsForImage(image types.Image) (PolicyRequirements, error) {
-	ref := image.IntendedDockerReference()
+	ref := image.Reference().DockerReference()
 	if ref == nil {
 		// FIXME: Tell the user which image this is.
 		return nil, fmt.Errorf("Can not determine policy for an image with no known Docker reference identity")
@@ -222,7 +222,7 @@ func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(image types.Image) (sig
 		}
 	}()
 
-	logrus.Debugf("GetSignaturesWithAcceptedAuthor for image %s", image.IntendedDockerReference())
+	logrus.Debugf("GetSignaturesWithAcceptedAuthor for image %s", image.Reference().DockerReference())
 
 	reqs, err := pc.requirementsForImage(image)
 	if err != nil {
@@ -306,7 +306,7 @@ func (pc *PolicyContext) IsRunningImageAllowed(image types.Image) (res bool, fin
 		}
 	}()
 
-	logrus.Debugf("IsRunningImageAllowed for image %s", image.IntendedDockerReference())
+	logrus.Debugf("IsRunningImageAllowed for image %s", image.Reference().DockerReference())
 
 	reqs, err := pc.requirementsForImage(image)
 	if err != nil {

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -18,9 +18,17 @@ import (
 func dirImageMock(t *testing.T, dir, intendedDockerReference string) types.Image {
 	ref, err := reference.ParseNamed(intendedDockerReference)
 	require.NoError(t, err)
+	return dirImageMockWithRef(t, dir, ref)
+}
+
+// dirImageMockWithRef returns a types.Image for a directory, claiming a specified intendedDockerReference.
+func dirImageMockWithRef(t *testing.T, dir string, intendedDockerReference reference.Named) types.Image {
+	srcRef := directory.NewReference(dir)
+	src, err := srcRef.NewImageSource("", true)
+	require.NoError(t, err)
 	return image.FromSource(&dirImageSourceMock{
-		ImageSource:             directory.NewImageSource(dir),
-		intendedDockerReference: ref,
+		ImageSource:             src,
+		intendedDockerReference: intendedDockerReference,
 	}, nil)
 }
 

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -18,17 +18,17 @@ import (
 func dirImageMock(t *testing.T, dir, dockerReference string) types.Image {
 	ref, err := reference.ParseNamed(dockerReference)
 	require.NoError(t, err)
-	return dirImageMockWithRef(t, dir, ref)
+	return dirImageMockWithRef(t, dir, refImageReferenceMock{ref})
 }
 
-// dirImageMockWithRef returns a types.Image for a directory, claiming a specified dockerReference.
-func dirImageMockWithRef(t *testing.T, dir string, dockerReference reference.Named) types.Image {
+// dirImageMockWithRef returns a types.Image for a directory, claiming a specified ref.
+func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) types.Image {
 	srcRef := directory.NewReference(dir)
 	src, err := srcRef.NewImageSource("", true)
 	require.NoError(t, err)
 	return image.FromSource(&dirImageSourceMock{
 		ImageSource: src,
-		ref:         refImageReferenceMock{dockerReference},
+		ref:         ref,
 	}, nil)
 }
 

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -14,32 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// dirImageMock returns a types.Image for a directory, claiming a specified intendedDockerReference.
-func dirImageMock(t *testing.T, dir, intendedDockerReference string) types.Image {
-	ref, err := reference.ParseNamed(intendedDockerReference)
+// dirImageMock returns a types.Image for a directory, claiming a specified dockerReference.
+func dirImageMock(t *testing.T, dir, dockerReference string) types.Image {
+	ref, err := reference.ParseNamed(dockerReference)
 	require.NoError(t, err)
 	return dirImageMockWithRef(t, dir, ref)
 }
 
-// dirImageMockWithRef returns a types.Image for a directory, claiming a specified intendedDockerReference.
-func dirImageMockWithRef(t *testing.T, dir string, intendedDockerReference reference.Named) types.Image {
+// dirImageMockWithRef returns a types.Image for a directory, claiming a specified dockerReference.
+func dirImageMockWithRef(t *testing.T, dir string, dockerReference reference.Named) types.Image {
 	srcRef := directory.NewReference(dir)
 	src, err := srcRef.NewImageSource("", true)
 	require.NoError(t, err)
 	return image.FromSource(&dirImageSourceMock{
-		ImageSource:             src,
-		intendedDockerReference: intendedDockerReference,
+		ImageSource: src,
+		ref:         refImageReferenceMock{dockerReference},
 	}, nil)
 }
 
-// dirImageSourceMock inherits dirImageSource, but overrides its IntendedDockerReference method.
+// dirImageSourceMock inherits dirImageSource, but overrides its Reference method.
 type dirImageSourceMock struct {
 	types.ImageSource
-	intendedDockerReference reference.Named
+	ref types.ImageReference
 }
 
-func (d *dirImageSourceMock) IntendedDockerReference() reference.Named {
-	return d.intendedDockerReference
+func (d *dirImageSourceMock) Reference() types.ImageReference {
+	return d.ref
 }
 
 func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {

--- a/signature/policy_eval_simple.go
+++ b/signature/policy_eval_simple.go
@@ -2,7 +2,12 @@
 
 package signature
 
-import "github.com/containers/image/types"
+import (
+	"fmt"
+
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+)
 
 func (pr *prInsecureAcceptAnything) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	// prInsecureAcceptAnything semantics: Every image is allowed to run,
@@ -15,11 +20,9 @@ func (pr *prInsecureAcceptAnything) isRunningImageAllowed(image types.Image) (bo
 }
 
 func (pr *prReject) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
-	// FIXME? Name the image, or better the matched scope in Policy.Specific.
-	return sarRejected, nil, PolicyRequirementError("Any signatures for these images are rejected by policy.")
+	return sarRejected, nil, PolicyRequirementError(fmt.Sprintf("Any signatures for image %s are rejected by policy.", transports.ImageName(image.Reference())))
 }
 
 func (pr *prReject) isRunningImageAllowed(image types.Image) (bool, error) {
-	// FIXME? Name the image, or better the matched scope in Policy.Specific.
-	return false, PolicyRequirementError("Running these images is rejected by policy.")
+	return false, PolicyRequirementError(fmt.Sprintf("Running image %s is rejected by policy.", transports.ImageName(image.Reference())))
 }

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -1,32 +1,66 @@
 package signature
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
+)
+
+// nameOnlyImageMock is a mock of types.Image which only allows transports.ImageName to work
+type nameOnlyImageMock struct {
+	forbiddenImageMock
+}
+
+func (nameOnlyImageMock) Reference() types.ImageReference {
+	return nameOnlyImageReferenceMock("== StringWithinTransport mock")
+}
+
+// nameOnlyImageReferenceMock is a mock of types.ImageReference which only allows transports.ImageName to work, returning self.
+type nameOnlyImageReferenceMock string
+
+func (ref nameOnlyImageReferenceMock) Transport() types.ImageTransport {
+	return nameImageTransportMock("== Transport mock")
+}
+func (ref nameOnlyImageReferenceMock) StringWithinTransport() string {
+	return string(ref)
+}
+func (ref nameOnlyImageReferenceMock) DockerReference() reference.Named {
+	panic("unexpected call to a mock function")
+}
+func (ref nameOnlyImageReferenceMock) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref nameOnlyImageReferenceMock) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref nameOnlyImageReferenceMock) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	panic("unexpected call to a mock function")
+}
 
 func TestPRInsecureAcceptAnythingIsSignatureAuthorAccepted(t *testing.T) {
 	pr := NewPRInsecureAcceptAnything()
-	// Pass nil pointers to, kind of, test that the return value does not depend on the parameters.
-	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nil, nil)
+	// Pass nil signature to, kind of, test that the return value does not depend on it.
+	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nameOnlyImageMock{}, nil)
 	assertSARUnknown(t, sar, parsedSig, err)
 }
 
 func TestPRInsecureAcceptAnythingIsRunningImageAllowed(t *testing.T) {
 	pr := NewPRInsecureAcceptAnything()
-	// Pass a nil pointer to, kind of, test that the return value does not depend on the image.
-	res, err := pr.isRunningImageAllowed(nil)
+	res, err := pr.isRunningImageAllowed(nameOnlyImageMock{})
 	assertRunningAllowed(t, res, err)
 }
 
 func TestPRRejectIsSignatureAuthorAccepted(t *testing.T) {
 	pr := NewPRReject()
-	// Pass nil pointers to, kind of, test that the return value does not depend on the parameters.
-	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nil, nil)
+	// Pass nil signature to, kind of, test that the return value does not depend on it.
+	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nameOnlyImageMock{}, nil)
 	assertSARRejectedPolicyRequirement(t, sar, parsedSig, err)
 }
 
 func TestPRRejectIsRunningImageAllowed(t *testing.T) {
 	// This will obviously need to change after this is implemented.
 	pr := NewPRReject()
-	// Pass a nil pointer to, kind of, test that the return value does not depend on the image.
-	res, err := pr.isRunningImageAllowed(nil)
+	res, err := pr.isRunningImageAllowed(nameOnlyImageMock{})
 	assertRunningRejectedPolicyRequirement(t, res, err)
 }

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,6 +97,36 @@ func TestFullyExpandedDockerReference(t *testing.T) {
 			assert.Equal(t, fullName+mappedSuffix, expanded, fullInput)
 		}
 	}
+}
+
+// pcImageReferenceMock is a mock of types.ImageReference which returns itself in DockerReference
+type pcImageReferenceMock struct{ ref reference.Named }
+
+func (ref pcImageReferenceMock) Transport() types.ImageTransport {
+	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
+	if ref.ref == nil {
+		return nameImageTransportMock("== Transport mock")
+	}
+	panic("unexpected call to a mock function")
+}
+func (ref pcImageReferenceMock) StringWithinTransport() string {
+	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
+	if ref.ref == nil {
+		return "== StringWithinTransport for an image with no Docker support"
+	}
+	panic("unexpected call to a mock function")
+}
+func (ref pcImageReferenceMock) DockerReference() reference.Named {
+	return ref.ref
+}
+func (ref pcImageReferenceMock) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref pcImageReferenceMock) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref pcImageReferenceMock) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	panic("unexpected call to a mock function")
 }
 
 func TestPolicyContextRequirementsForImage(t *testing.T) {
@@ -215,6 +246,13 @@ func TestPolicyContextRequirementsForImage(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// pcImageMock returns a types.Image for a directory, claiming a specified dockerReference and implementing PolicyConfigurationIdentity/PolicyConfigurationNamespaces.
+func pcImageMock(t *testing.T, dir, dockerReference string) types.Image {
+	ref, err := reference.ParseNamed(dockerReference)
+	require.NoError(t, err)
+	return dirImageMockWithRef(t, dir, pcImageReferenceMock{ref})
+}
+
 func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	expectedSig := &Signature{
 		DockerManifestDigest: TestImageManifestDigest,
@@ -256,73 +294,73 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
-	img = dirImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
-	img = dirImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
@@ -334,7 +372,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -343,7 +381,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// mistakes only, anyway.
 
 	// Image without a Docker reference identity
-	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", nil)
+	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", pcImageReferenceMock{nil})
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -351,7 +389,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// Error reading signatures.
 	invalidSigDir := createInvalidSigDir(t)
 	defer os.RemoveAll(invalidSigDir)
-	img = dirImageMock(t, invalidSigDir, "testing/manifest:latest")
+	img = pcImageMock(t, invalidSigDir, "testing/manifest:latest")
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -385,53 +423,53 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	res, err := pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
-	img = dirImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
-	img = dirImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
-	img = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
+	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
@@ -440,7 +478,7 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	res, err = destroyedPC.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
@@ -448,7 +486,7 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	// mistakes only, anyway.
 
 	// Image without a Docker reference identity
-	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", nil)
+	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", pcImageReferenceMock{nil})
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 }

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -103,18 +103,12 @@ func TestFullyExpandedDockerReference(t *testing.T) {
 type pcImageReferenceMock struct{ ref reference.Named }
 
 func (ref pcImageReferenceMock) Transport() types.ImageTransport {
-	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
-	if ref.ref == nil {
-		return nameImageTransportMock("== Transport mock")
-	}
-	panic("unexpected call to a mock function")
+	// We use this in error messages, so sadly we must return something.
+	return nameImageTransportMock("== Transport mock")
 }
 func (ref pcImageReferenceMock) StringWithinTransport() string {
-	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
-	if ref.ref == nil {
-		return "== StringWithinTransport for an image with no Docker support"
-	}
-	panic("unexpected call to a mock function")
+	// We use this in error messages, so sadly we must return something.
+	return "== StringWithinTransport mock"
 }
 func (ref pcImageReferenceMock) DockerReference() reference.Named {
 	return ref.ref

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containers/image/directory"
-	"github.com/containers/image/image"
 	"github.com/docker/docker/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -345,10 +343,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// mistakes only, anyway.
 
 	// Image without a Docker reference identity
-	img = image.FromSource(&dirImageSourceMock{
-		ImageSource:             directory.NewImageSource("fixtures/dir-img-valid"),
-		intendedDockerReference: nil,
-	}, nil)
+	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", nil)
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -453,10 +448,7 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	// mistakes only, anyway.
 
 	// Image without a Docker reference identity
-	img = image.FromSource(&dirImageSourceMock{
-		ImageSource:             directory.NewImageSource("fixtures/dir-img-valid"),
-		intendedDockerReference: nil,
-	}, nil)
+	img = dirImageMockWithRef(t, "fixtures/dir-img-valid", nil)
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 }

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -3,16 +3,19 @@
 package signature
 
 import (
-	"github.com/docker/docker/reference"
+	"fmt"
+
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 // parseImageAndDockerReference converts an image and a reference string into two parsed entities, failing on any error and handling unidentified images.
 func parseImageAndDockerReference(image types.Image, s2 string) (reference.Named, reference.Named, error) {
 	r1 := image.Reference().DockerReference()
 	if r1 == nil {
-		// FIXME: Tell the user which image this is.
-		return nil, nil, PolicyRequirementError("Docker reference match attempted on an image with no known Docker reference identity")
+		return nil, nil, PolicyRequirementError(fmt.Sprintf("Docker reference match attempted on image %s with no known Docker reference identity",
+			transports.ImageName(image.Reference())))
 	}
 	r2, err := reference.ParseNamed(s2)
 	if err != nil {

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -9,7 +9,7 @@ import (
 
 // parseImageAndDockerReference converts an image and a reference string into two parsed entities, failing on any error and handling unidentified images.
 func parseImageAndDockerReference(image types.Image, s2 string) (reference.Named, reference.Named, error) {
-	r1 := image.IntendedDockerReference()
+	r1 := image.Reference().DockerReference()
 	if r1 == nil {
 		// FIXME: Tell the user which image this is.
 		return nil, nil, PolicyRequirementError("Docker reference match attempted on an image with no known Docker reference identity")
@@ -26,7 +26,7 @@ func (prm *prmMatchExact) matchesDockerReference(image types.Image, signatureDoc
 	if err != nil {
 		return false
 	}
-	// Do not add default tags: image.IntendedDockerReference() has it added already per its construction, and signatureDockerReference should be exact; so, verify that now.
+	// Do not add default tags: image.Reference().DockerReference() should contain it already, and signatureDockerReference should be exact; so, verify that now.
 	if reference.IsNameOnly(intended) || reference.IsNameOnly(signature) {
 		return false
 	}

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -50,11 +50,11 @@ func TestParseImageAndDockerReference(t *testing.T) {
 	}
 }
 
-// refImageMock is a mock of types.Image which returns itself in IntendedDockerReference.
+// refImageMock is a mock of types.Image which returns itself in Reference().DockerReference.
 type refImageMock struct{ reference.Named }
 
-func (ref refImageMock) IntendedDockerReference() reference.Named {
-	return ref.Named
+func (ref refImageMock) Reference() types.ImageReference {
+	return refImageReferenceMock{ref.Named}
 }
 func (ref refImageMock) Manifest() ([]byte, string, error) {
 	panic("unexpected call to a mock function")
@@ -72,6 +72,43 @@ func (ref refImageMock) Inspect() (*types.ImageInspectInfo, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageMock) GetRepositoryTags() ([]string, error) {
+	panic("unexpected call to a mock function")
+}
+
+// refImageReferenceMock is a mock of types.ImageReference which returns itself in DockerReference.
+type refImageReferenceMock struct{ reference.Named }
+
+func (ref refImageReferenceMock) Transport() types.ImageTransport {
+	// We use this in error messages, so sadly we must return something.
+	return nameImageTransportMock("== Transport mock")
+}
+func (ref refImageReferenceMock) StringWithinTransport() string {
+	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
+	if ref.Named == nil {
+		return "== StringWithinTransport for an image with no Docker support"
+	}
+	panic("unexpected call to a mock function")
+}
+func (ref refImageReferenceMock) DockerReference() reference.Named {
+	return ref.Named
+}
+func (ref refImageReferenceMock) NewImage(certPath string, tlsVerify bool) (types.Image, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref refImageReferenceMock) NewImageSource(certPath string, tlsVerify bool) (types.ImageSource, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref refImageReferenceMock) NewImageDestination(certPath string, tlsVerify bool) (types.ImageDestination, error) {
+	panic("unexpected call to a mock function")
+}
+
+// nameImageTransportMock is a mock of types.ImageTransport which returns itself in Name.
+type nameImageTransportMock string
+
+func (name nameImageTransportMock) Name() string {
+	return string(name)
+}
+func (name nameImageTransportMock) ParseReference(reference string) (types.ImageReference, error) {
 	panic("unexpected call to a mock function")
 }
 
@@ -203,10 +240,10 @@ func TestParseDockerReferences(t *testing.T) {
 	}
 }
 
-// forbiddenImageMock is a mock of types.Image which ensures IntendedDockerReference is not called
+// forbiddenImageMock is a mock of types.Image which ensures Reference is not called
 type forbiddenImageMock string
 
-func (ref forbiddenImageMock) IntendedDockerReference() reference.Named {
+func (ref forbiddenImageMock) Reference() types.ImageReference {
 	panic("unexpected call to a mock function")
 }
 func (ref forbiddenImageMock) Manifest() ([]byte, string, error) {

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -79,8 +79,11 @@ func (ref refImageMock) GetRepositoryTags() ([]string, error) {
 type refImageReferenceMock struct{ reference.Named }
 
 func (ref refImageReferenceMock) Transport() types.ImageTransport {
-	// We use this in error messages, so sadly we must return something.
-	return nameImageTransportMock("== Transport mock")
+	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
+	if ref.Named == nil {
+		return nameImageTransportMock("== Transport mock")
+	}
+	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) StringWithinTransport() string {
 	// We use this in error messages, so sadly we must return something. But right now we do so only when DockerReference is nil, so restrict to that.

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -244,7 +244,7 @@ func TestParseDockerReferences(t *testing.T) {
 }
 
 // forbiddenImageMock is a mock of types.Image which ensures Reference is not called
-type forbiddenImageMock string
+type forbiddenImageMock struct{}
 
 func (ref forbiddenImageMock) Reference() types.ImageReference {
 	panic("unexpected call to a mock function")
@@ -273,7 +273,7 @@ func TestPRMExactReferenceMatchesDockerReference(t *testing.T) {
 		// Do not use NewPRMExactReference, we want to also test the case with an invalid DockerReference,
 		// even though NewPRMExactReference should never let it happen.
 		prm := prmExactReference{DockerReference: test.imageRef}
-		res := prm.matchesDockerReference(forbiddenImageMock(""), test.sigRef)
+		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 }
@@ -283,7 +283,7 @@ func TestPRMExactRepositoryMatchesDockerReference(t *testing.T) {
 		// Do not use NewPRMExactRepository, we want to also test the case with an invalid DockerReference,
 		// even though NewPRMExactRepository should never let it happen.
 		prm := prmExactRepository{DockerRepository: test.imageRef}
-		res := prm.matchesDockerReference(forbiddenImageMock(""), test.sigRef)
+		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 }

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -1,0 +1,55 @@
+package transports
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/image/directory"
+	"github.com/containers/image/docker"
+	"github.com/containers/image/oci"
+	"github.com/containers/image/openshift"
+	"github.com/containers/image/types"
+)
+
+// KnownTransports is a registry of known ImageTransport instances.
+var KnownTransports map[string]types.ImageTransport
+
+func init() {
+	KnownTransports = make(map[string]types.ImageTransport)
+	for _, t := range []types.ImageTransport{
+		directory.Transport,
+		docker.Transport,
+		oci.Transport,
+		openshift.Transport,
+	} {
+		name := t.Name()
+		if _, ok := KnownTransports[name]; ok {
+			panic(fmt.Sprintf("Duplicate image transport name %s", name))
+		}
+		KnownTransports[name] = t
+	}
+}
+
+// ParseImageName converts a URL-like image name to a types.ImageReference.
+func ParseImageName(imgName string) (types.ImageReference, error) {
+	parts := strings.SplitN(imgName, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
+	}
+	transport, ok := KnownTransports[parts[0]]
+	if !ok {
+		return nil, fmt.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
+	}
+	return transport.ParseReference(parts[1])
+}
+
+// ImageName converts a types.ImageReference into an URL-like image name, which MUST be such that
+// ParseImageName(ImageName(reference)) returns an equivalent reference.
+//
+// This is the generally recommended way to refer to images in the UI.
+//
+// NOTE: The returned string is not promised to be equal to the original input to ParseImageName;
+// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
+func ImageName(ref types.ImageReference) string {
+	return ref.Transport().Name() + ":" + ref.StringWithinTransport()
+}

--- a/transports/transports_test.go
+++ b/transports/transports_test.go
@@ -1,0 +1,44 @@
+package transports
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnownTransports(t *testing.T) {
+	assert.NotNil(t, KnownTransports) // Ensure that the initialization has actually been run
+	assert.True(t, len(KnownTransports) > 1)
+}
+
+func TestParseImageName(t *testing.T) {
+	// This primarily tests error handling, TestImageNameHandling is a table-driven
+	// test for the expected values.
+	for _, name := range []string{
+		"",         // Empty
+		"busybox",  // No transport name
+		":busybox", // Empty transport name
+		"docker:",  // Empty transport reference
+	} {
+		_, err := ParseImageName(name)
+		assert.Error(t, err, name)
+	}
+}
+
+// A table-driven test summarizing the various transports' behavior.
+func TestImageNameHandling(t *testing.T) {
+	for _, c := range []struct{ transport, input, roundtrip string }{
+		{"dir", "/etc", "/etc"},
+		{"docker", "//busybox", "//busybox:latest"},
+		{"docker", "//busybox:notlatest", "//busybox:notlatest"}, // This also tests handling of multiple ":" characters
+		{"oci", "/etc:sometag", "/etc:sometag"},
+		// "atomic" not tested here because it depends on per-user configuration for the default cluster.
+	} {
+		fullInput := c.transport + ":" + c.input
+		ref, err := ParseImageName(fullInput)
+		require.NoError(t, err, fullInput)
+		s := ImageName(ref)
+		assert.Equal(t, c.transport+":"+c.roundtrip, s, fullInput)
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -58,11 +58,9 @@ type ImageReference interface {
 // This is primarily useful for copying images around; for examining their properties, Image (below)
 // is usually more useful.
 type ImageSource interface {
-	// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-	// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-	// This can be used e.g. to determine which public keys are trusted for this image.
-	// May be nil if unknown.
-	IntendedDockerReference() reference.Named
+	// Reference returns the reference used to set up this source, _as specified by the user_
+	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+	Reference() ImageReference
 	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown. The slice parameter indicates the supported mime types the manifest should be when getting it.
 	// It may use a remote (= slow) service.
 	GetManifest([]string) ([]byte, string, error)
@@ -92,12 +90,10 @@ type ImageDestination interface {
 
 // Image is the primary API for inspecting properties of images.
 type Image interface {
+	// Reference returns the reference used to set up this source, _as specified by the user_
+	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+	Reference() ImageReference
 	// ref to repository?
-	// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
-	// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
-	// This can be used e.g. to determine which public keys are trusted for this image.
-	// May be nil if unknown.
-	IntendedDockerReference() reference.Named
 	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 	// NOTE: It is essential for signature verification that Manifest returns the manifest from which BlobDigests is computed.
 	Manifest() ([]byte, string, error)

--- a/types/types.go
+++ b/types/types.go
@@ -77,9 +77,9 @@ type ImageSource interface {
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
 type ImageDestination interface {
-	// CanonicalDockerReference returns the Docker reference for this image (fully expanded, i.e. !reference.IsNameOnly, but
-	// reflecting user intent, not e.g. after redirect or alias processing), or nil if unknown.
-	CanonicalDockerReference() reference.Named
+	// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+	// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
+	Reference() ImageReference
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	PutManifest([]byte) error
 	// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.

--- a/types/types.go
+++ b/types/types.go
@@ -41,6 +41,11 @@ type ImageReference interface {
 	// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
 	StringWithinTransport() string
 
+	// DockerReference returns a Docker reference associated with this reference
+	// (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
+	// not e.g. after redirect or alias processing), or nil if unknown/not applicable.
+	DockerReference() reference.Named
+
 	// NewImage returns a types.Image for this reference.
 	NewImage(certPath string, tlsVerify bool) (Image, error)
 	// NewImageSource returns a types.ImageSource for this reference.

--- a/types/types.go
+++ b/types/types.go
@@ -17,6 +17,8 @@ import (
 // OTOH all images using the same transport should (apart from versions of the image format), be interoperable.
 // For example, several different ImageTransport implementations may be based on local filesystem paths,
 // but using completely different formats for the contents of that path (a single tar file, a directory containing tarballs, a fully expanded container filesystem, ...)
+//
+// See also transports.KnownTransports.
 type ImageTransport interface {
 	// Name returns the name of the transport, which must be unique among other transports.
 	Name() string
@@ -38,7 +40,8 @@ type ImageReference interface {
 	// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
 	// NOTE: The returned string is not promised to be equal to the original input to ParseReference;
 	// e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
-	// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
+	// WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix;
+	// instead, see transports.ImageName().
 	StringWithinTransport() string
 
 	// DockerReference returns a Docker reference associated with this reference


### PR DESCRIPTION
This is split from #33 to make the review process a bit less overwhelming.

Introduces `types.ImageTransport` and `types.ImageReference`, and reorganizes the code to work with `ImageReference` for image identity.

Does not change anything about the behavior, except for the last commit which takes advantage of the ability to get an `ImageReference` from a `types.Image` to improve some error messages.

See individual commits for detailed description and rationale.