### PR TITLE
[RFC] remove .docker/config.json parsing

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -18,8 +18,8 @@ type Image struct {
 
 // NewImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
-func NewImage(img, certPath string, tlsVerify bool) (types.Image, error) {
-	s, err := newDockerImageSource(img, certPath, tlsVerify)
+func NewImage(img, certPath string, tlsVerify bool, username, password string) (types.Image, error) {
+	s, err := newDockerImageSource(img, certPath, tlsVerify, username, password)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -19,12 +19,12 @@ type dockerImageDestination struct {
 }
 
 // NewImageDestination creates a new ImageDestination for the specified image and connection specification.
-func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDestination, error) {
+func NewImageDestination(img, certPath string, tlsVerify bool, username, password string) (types.ImageDestination, error) {
 	ref, err := parseImageName(img)
 	if err != nil {
 		return nil, err
 	}
-	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify)
+	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify, username, password)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -29,12 +29,12 @@ type dockerImageSource struct {
 }
 
 // newDockerImageSource is the same as NewImageSource, only it returns the more specific *dockerImageSource type.
-func newDockerImageSource(img, certPath string, tlsVerify bool) (*dockerImageSource, error) {
+func newDockerImageSource(img, certPath string, tlsVerify bool, username, password string) (*dockerImageSource, error) {
 	ref, err := parseImageName(img)
 	if err != nil {
 		return nil, err
 	}
-	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify)
+	c, err := newDockerClient(ref.Hostname(), certPath, tlsVerify, username, password)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,8 @@ func newDockerImageSource(img, certPath string, tlsVerify bool) (*dockerImageSou
 }
 
 // NewImageSource creates a new ImageSource for the specified image and connection specification.
-func NewImageSource(img, certPath string, tlsVerify bool) (types.ImageSource, error) {
-	return newDockerImageSource(img, certPath, tlsVerify)
+func NewImageSource(img, certPath string, tlsVerify bool, username, password string) (types.ImageSource, error) {
+	return newDockerImageSource(img, certPath, tlsVerify, username, password)
 }
 
 // IntendedDockerReference returns the Docker reference for this image, _as specified by the user_


### PR DESCRIPTION
This patch removes the parsing and credential retrieval from `~/.docker/config.json`.
Eventually I'll move the actual json parsing in skopeo according to https://github.com/projectatomic/skopeo/issues/106.

`containers/image` shouldn't depend nor rely on docker being installed on the system where we are actually running it. Higher level tooling should instead take care of this and the library should just accepts username/password to later attempt an authentication against a registry.

This work is being done as part of https://github.com/kubernetes/kubernetes/pull/25899 and https://github.com/mrunalp/ocid because we don't expect to have any docker daemon installed in the kubelet. /cc @mrunalp

@mtrmac I'm not sure username and password being passed as arguments is good. Eventually I'd expect to have an *Auth* struct containing useful information about authenticating against a given registry (see https://github.com/kubernetes/kubernetes/pull/25899/files#diff-b99b84f6471ccf2077dedc93530a51a2R401).

@mtrmac That said, if you have any better suggestion on how to achieve this w/o requiring a long list of arguments, I'll rework this patch. Right now, it's just taking username and password because those were what `getAuth` was actually providing.

@mtrmac I've also thought about having a generic _connection_ option struct to be passed to `NewImage...` methods so that we don't break any function definition in the future when adding other options.

The ocid part will then receive an AuthConfig struct from the Kubelet Runtime API and we'll pass those info down to containers/image to do pull and push. See https://github.com/mrunalp/ocid/blob/master/vendor/github.com/kubernetes/kubernetes/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L2130 for instance.

Lastly as said, the config.json parsing will be moved to skopeo (which is where, IMO, it belongs as a mean to integrate better with the host running skopeo; skopeo also has --username and --password flag which are used to override the whole parsing or to ignore the fact that the underlying host has docker installed)

Note: tests against skopeo are rightly failing - containers/image tests pass instead

Signed-off-by: Antonio Murdaca <runcom@redhat.com>