### PR TITLE
docker: move dockerClient to an interface

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -32,6 +32,11 @@ const (
 	blobUploadURL = "%s/blobs/uploads/"
 )
 
+type client interface {
+	makeRequest(method, url string, headers map[string][]string, stream io.Reader) (*http.Response, error)
+	makeRequestToResolvedURL(method, url string, headers map[string][]string, stream io.Reader) (*http.Response, error)
+}
+
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
 	registry        string

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -15,7 +15,7 @@ import (
 
 type dockerImageDestination struct {
 	ref reference.Named
-	c   *dockerClient
+	c   client
 }
 
 // NewImageDestination creates a new ImageDestination for the specified image and connection specification.

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -25,7 +25,7 @@ func (e errFetchManifest) Error() string {
 
 type dockerImageSource struct {
 	ref reference.Named
-	c   *dockerClient
+	c   client
 }
 
 // newDockerImageSource is the same as NewImageSource, only it returns the more specific *dockerImageSource type.


### PR DESCRIPTION
This should be a less opinionated change based on https://github.com/containers/image/pull/30.

Unit testing `docker_image_src.go` and `docker_image_dest_go` should be easier after this as we can mock up the entire client (along the line of https://github.com/containers/image/pull/30/commits/d5cbfe903f3384129e042b3f55a505f17e87f170).

This change goes along with https://github.com/containers/image/pull/42 where we set the actual client in the `dockerClient` struct - thus, allowing more fine grained unit tests like the ones expressed in https://github.com/containers/image/pull/30/commits/d5cbfe903f3384129e042b3f55a505f17e87f170#r69351589. Arguably I think the same unit tests can be done with just #42 because we can mock the entire client there as well.

@mtrmac PTAL, eventually using Go `httptest` package is what we'll end up - but this ease the burden of having to setup an `httptest` server everytime with different settings and handlers and just mocking the whole makeRequest\* game. We can still use `httptest` in a `docker_client_test.go` to test authentication, ping, https/http detection and what not.

Signed-off-by: Antonio Murdaca runcom@redhat.com
