### PR TITLE
Update openshift

### DIFF
--- a/docker/wwwauthenticate.go
+++ b/docker/wwwauthenticate.go
@@ -1,0 +1,159 @@
+package docker
+
+// Based on github.com/docker/distribution/registry/client/auth/authchallenge.go, primarily stripping unnecessary dependencies.
+
+import (
+	"net/http"
+	"strings"
+)
+
+// challenge carries information from a WWW-Authenticate response header.
+// See RFC 7235.
+type challenge struct {
+	// Scheme is the auth-scheme according to RFC 7235
+	Scheme string
+
+	// Parameters are the auth-params according to RFC 7235
+	Parameters map[string]string
+}
+
+// Octet types from RFC 7230.
+type octetType byte
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+func parseAuthHeader(header http.Header) []challenge {
+	challenges := []challenge{}
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		if v != "" {
+			challenges = append(challenges, challenge{Scheme: v, Parameters: p})
+		}
+	}
+	return challenges
+}
+
+// NOTE: This is not a fully compliant parser per RFC 7235:
+// Most notably it does not support more than one challenge within a single header
+// Some of the whitespace parsing also seems noncompliant.
+// But it is clearly better than what we used to have…
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	s = "," + skipSpace(s)
+	for strings.HasPrefix(s, ",") {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s[1:]))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/docker/wwwauthenticate_test.go
+++ b/docker/wwwauthenticate_test.go
@@ -1,0 +1,45 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This is just a smoke test for the common expected header formats,
+// by no means comprehensive.
+func TestParseValueAndParams(t *testing.T) {
+	for _, c := range []struct {
+		input  string
+		scope  string
+		params map[string]string
+	}{
+		{
+			`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/busybox:pull"`,
+			"bearer",
+			map[string]string{
+				"realm":   "https://auth.docker.io/token",
+				"service": "registry.docker.io",
+				"scope":   "repository:library/busybox:pull",
+			},
+		},
+		{
+			`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/busybox:pull,push"`,
+			"bearer",
+			map[string]string{
+				"realm":   "https://auth.docker.io/token",
+				"service": "registry.docker.io",
+				"scope":   "repository:library/busybox:pull,push",
+			},
+		},
+		{
+			`Bearer realm="http://127.0.0.1:5000/openshift/token"`,
+			"bearer",
+			map[string]string{"realm": "http://127.0.0.1:5000/openshift/token"},
+		},
+	} {
+		scope, params := parseValueAndParams(c.input)
+		assert.Equal(t, c.scope, scope, c.input)
+		assert.Equal(t, c.params, params, c.input)
+	}
+}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -290,6 +290,10 @@ func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 func (d *openshiftImageDestination) PutManifest(m []byte) error {
+	// FIXME? Can this eventually just call d.docker.PutManifest()?
+	// Right now we need this as a skeleton to attach signatures to, and
+	// to workaround our inability to change tags when uploading v2s1 manifests.
+
 	// Note: This does absolutely no kind/version checking or conversions.
 	manifestDigest, err := manifest.Digest(m)
 	if err != nil {
@@ -327,7 +331,7 @@ func (d *openshiftImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 
-	return d.docker.PutManifest(m)
+	return nil
 }
 
 func (d *openshiftImageDestination) PutBlob(digest string, stream io.Reader) error {


### PR DESCRIPTION
This is a WIP alternative to https://github.com/projectatomic/skopeo/pull/145 :

- Dealing with the `stream` reuse problem in a bit cleaner way.
- Uses a mostly-correct `docker/distribution` parser for the `WWW-Authenticate` header

In addition to that, also updates OpenShift manifest upload so that it works against recent updates.

WIP because this pulls in way too much of `docker/distribution`, and skopeo’s `hack/vendor.sh` for some reason does not pull enough dependencies for this to actually build.