### PR TITLE
Validate directory paths in policy configuration scopes

### DIFF
--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -32,12 +32,16 @@ func (t dirTransport) ParseReference(reference string) (types.ImageReference, er
 // scope passed to this function will not be "", that value is always allowed.
 func (t dirTransport) ValidatePolicyConfigurationScope(scope string) error {
 	if !strings.HasPrefix(scope, "/") {
-		return fmt.Errorf("Invalid scope %s: must be an absolute path", scope)
+		return fmt.Errorf("Invalid scope %s: Must be an absolute path", scope)
 	}
 	// Refuse also "/", otherwise "/" and "" would have the same semantics,
 	// and "" could be unexpectedly shadowed by the "/" entry.
 	if scope == "/" {
 		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
+	}
+	cleaned := filepath.Clean(scope)
+	if cleaned != scope {
+		return fmt.Errorf(`Invalid scope %s: Uses non-canonical format, perhaps try %s`, scope, cleaned)
 	}
 	return nil
 }

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -30,6 +30,10 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 
 	for _, scope := range []string{
 		"relative/path",
+		"/double//slashes",
+		"/has/./dot",
+		"/has/dot/../dot",
+		"/trailing/slash/",
 		"/",
 	} {
 		err := Transport.ValidatePolicyConfigurationScope(scope)

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -58,6 +58,10 @@ func (t ociTransport) ValidatePolicyConfigurationScope(scope string) error {
 	if scope == "/" {
 		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
 	}
+	cleaned := filepath.Clean(dir)
+	if cleaned != dir {
+		return fmt.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+	}
 	return nil
 }
 

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -34,6 +34,10 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 	for _, scope := range []string{
 		"relative/path",
 		"/",
+		"/double//slashes",
+		"/has/./dot",
+		"/has/dot/../dot",
+		"/trailing/slash/",
 		"/etc:invalid'tag!value@",
 		"/path:with/colons",
 		"/path:with/colons/and:tag",


### PR DESCRIPTION
Use `filepath.Clean()` to verify that the paths are in a canonical format, to catch simple and easy to detect mistakes like double slashes etc.
