### PR TITLE
Require ImageDestination.PutBlob to fail and delete data on error in source stream

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/containers/image/types"
 )
@@ -31,18 +32,38 @@ func (d *dirImageDestination) PutManifest(manifest []byte) error {
 	return ioutil.WriteFile(d.ref.manifestPath(), manifest, 0644)
 }
 
+// PutBlob writes contents of stream as a blob identified by digest.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 func (d *dirImageDestination) PutBlob(digest string, stream io.Reader) error {
-	layerFile, err := os.Create(d.ref.layerPath(digest))
+	blobPath := d.ref.layerPath(digest)
+	blobFile, err := ioutil.TempFile(filepath.Dir(blobPath), filepath.Base(blobPath))
 	if err != nil {
 		return err
 	}
-	defer layerFile.Close()
-	if _, err := io.Copy(layerFile, stream); err != nil {
+	succeeded := false
+	defer func() {
+		blobFile.Close()
+		if !succeeded {
+			os.Remove(blobFile.Name())
+		}
+	}()
+
+	if _, err := io.Copy(blobFile, stream); err != nil {
 		return err
 	}
-	if err := layerFile.Sync(); err != nil {
+	if err := blobFile.Sync(); err != nil {
 		return err
 	}
+	if err := blobFile.Chmod(0644); err != nil {
+		return err
+	}
+	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
+		return nil
+	}
+	succeeded = true
 	return nil
 }
 

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -58,6 +59,52 @@ func TestGetPutBlob(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, blob, b)
 	assert.Equal(t, int64(len(blob)), size)
+}
+
+// readerFromFunc allows implementing Reader by any function, e.g. a closure.
+type readerFromFunc func([]byte) (int, error)
+
+func (fn readerFromFunc) Read(p []byte) (int, error) {
+	return fn(p)
+}
+
+// TestPutBlobDigestFailure simulates behavior on digest verification failure.
+func TestPutBlobDigestFailure(t *testing.T) {
+	const digestErrorString = "Simulated digest error"
+	const blobDigest = "test-digest"
+
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	dirRef, ok := ref.(dirReference)
+	require.True(t, ok)
+	blobPath := dirRef.layerPath(blobDigest)
+
+	firstRead := true
+	reader := readerFromFunc(func(p []byte) (int, error) {
+		_, err := os.Lstat(blobPath)
+		require.Error(t, err)
+		require.True(t, os.IsNotExist(err))
+		if firstRead {
+			if len(p) > 0 {
+				firstRead = false
+			}
+			for i := 0; i < len(p); i++ {
+				p[i] = 0xAA
+			}
+			return len(p), nil
+		}
+		return 0, fmt.Errorf(digestErrorString)
+	})
+
+	dest, err := ref.NewImageDestination("", true)
+	require.NoError(t, err)
+	err = dest.PutBlob(blobDigest, reader)
+	assert.Error(t, err)
+	assert.Contains(t, digestErrorString, err.Error())
+
+	_, err = os.Lstat(blobPath)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
 }
 
 func TestGetPutSignatures(t *testing.T) {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -74,6 +74,11 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 	return nil
 }
 
+// PutBlob writes contents of stream as a blob identified by digest.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error {
 	checkURL := fmt.Sprintf(blobsURL, d.ref.ref.RemoteName(), digest)
 

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -110,22 +110,41 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 	return ioutil.WriteFile(descriptorPath, data, 0644)
 }
 
+// PutBlob writes contents of stream as a blob identified by digest.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 func (d *ociImageDestination) PutBlob(digest string, stream io.Reader) error {
 	blobPath := d.ref.blobPath(digest)
 	if err := ensureParentDirectoryExists(blobPath); err != nil {
 		return err
 	}
-	blob, err := os.Create(blobPath)
+	blobFile, err := ioutil.TempFile(filepath.Dir(blobPath), filepath.Base(blobPath))
 	if err != nil {
 		return err
 	}
-	defer blob.Close()
-	if _, err := io.Copy(blob, stream); err != nil {
+	succeeded := false
+	defer func() {
+		blobFile.Close()
+		if !succeeded {
+			os.Remove(blobFile.Name())
+		}
+	}()
+
+	if _, err := io.Copy(blobFile, stream); err != nil {
 		return err
 	}
-	if err := blob.Sync(); err != nil {
+	if err := blobFile.Sync(); err != nil {
 		return err
 	}
+	if err := blobFile.Chmod(0644); err != nil {
+		return err
+	}
+	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
+		return nil
+	}
+	succeeded = true
 	return nil
 }
 

--- a/oci/oci_dest_test.go
+++ b/oci/oci_dest_test.go
@@ -1,0 +1,56 @@
+package oci
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readerFromFunc allows implementing Reader by any function, e.g. a closure.
+type readerFromFunc func([]byte) (int, error)
+
+func (fn readerFromFunc) Read(p []byte) (int, error) {
+	return fn(p)
+}
+
+// TestPutBlobDigestFailure simulates behavior on digest verification failure.
+func TestPutBlobDigestFailure(t *testing.T) {
+	const digestErrorString = "Simulated digest error"
+	const blobDigest = "test-digest"
+
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	dirRef, ok := ref.(ociReference)
+	require.True(t, ok)
+	blobPath := dirRef.blobPath(blobDigest)
+
+	firstRead := true
+	reader := readerFromFunc(func(p []byte) (int, error) {
+		_, err := os.Lstat(blobPath)
+		require.Error(t, err)
+		require.True(t, os.IsNotExist(err))
+		if firstRead {
+			if len(p) > 0 {
+				firstRead = false
+			}
+			for i := 0; i < len(p); i++ {
+				p[i] = 0xAA
+			}
+			return len(p), nil
+		}
+		return 0, fmt.Errorf(digestErrorString)
+	})
+
+	dest, err := ref.NewImageDestination("", true)
+	require.NoError(t, err)
+	err = dest.PutBlob(blobDigest, reader)
+	assert.Error(t, err)
+	assert.Contains(t, digestErrorString, err.Error())
+
+	_, err = os.Lstat(blobPath)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -368,6 +368,11 @@ func (d *openshiftImageDestination) PutManifest(m []byte) error {
 	return nil
 }
 
+// PutBlob writes contents of stream as a blob identified by digest.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 func (d *openshiftImageDestination) PutBlob(digest string, stream io.Reader) error {
 	return d.docker.PutBlob(digest, stream)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -104,6 +104,10 @@ type ImageDestination interface {
 	Reference() ImageReference
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	PutManifest([]byte) error
+	// PutBlob writes contents of stream as a blob identified by digest.
+	// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+	// to any other readers for download using the supplied digest.
+	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 	// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 	PutBlob(digest string, stream io.Reader) error
 	PutSignatures(signatures [][]byte) error


### PR DESCRIPTION
This is necessary to prevent using layers which have been tampered with.

To implement this, `dir:` and `oci:` now store data into temporary files, and `Rename()` when all data is successfully copied and validated.

We do not do anything extra for `docker:`, hoping that the mandatory `digest=` parameter in the API call is sufficient.
