### PR TITLE
Add signature.DefaultPolicy()

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -147,3 +147,12 @@ type ImageInspectInfo struct {
 	Os            string
 	Layers        []string
 }
+
+// SystemContext allows parametrizing access to implicitly-accessed resources,
+// like configuration files in /etc and users' login state in their home directory.
+// Various components can share the same field only if their semantics is exactly
+// the same; if in doubt, add a new field.
+// It is always OK to pass nil instead of a SystemContext.
+type SystemContext struct {
+	SignaturePolicyPath string // If not "", overrides the system's default path for signature.Policy configuration.
+}


### PR DESCRIPTION
This is the API most applications should use to get the policy for the current host.

Also adds a `types.SystemContext` per discussions in https://github.com/containers/image/pull/41 and elsewhere, to make the functions testable and usable in special situations like chroots.

(Though, `signature.DefaultPolicy()` with an override is not that different from `signature.NewPolicyFromFile()`.)
