### PR TITLE
Guess MIME type from content if Content-Type is unexpected.

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -65,7 +65,12 @@ func (i *genericImage) Manifest() ([]byte, string, error) {
 			return nil, "", err
 		}
 		i.cachedManifest = m
-		if mt == "" {
+		if mt == "" || mt == "text/plain" {
+			// Crane registries can return "text/plain".
+			// This makes no real sense, but it happens
+			// because requests for manifests are
+			// redirected to a content distribution
+			// network which is configured that way.
 			mt = manifest.GuessMIMEType(i.cachedManifest)
 		}
 		i.cachedManifestMIMEType = mt


### PR DESCRIPTION
When interacting with docker registries presented by Crane using a content distribution network, the Content-Type returned from queries is not under the control of Crane -- it simply redirects the client
to the relevant location on the CDN.

This works fine for 'docker pull', and since the file content describes which manifest schema it uses it is relatively easy to do the right thing.

Crane: https://github.com/pulp/crane