### PR TITLE
ImageDestination.PutBlob returns digest and size

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -137,7 +137,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		if err != nil {
 			return fmt.Errorf("Error preparing to verify blob %s: %v", digest, err)
 		}
-		if err := dest.PutBlob(digest, blobSize, digestingReader); err != nil {
+		if _, _, err := dest.PutBlob(digestingReader, digest, blobSize); err != nil {
 			return fmt.Errorf("Error writing blob: %v", err)
 		}
 		if digestingReader.validationFailed { // Coverage: This should never happen.

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -1,11 +1,12 @@
 package directory
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/containers/image/types"
 )
@@ -33,16 +34,16 @@ func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }
 
-// PutBlob writes contents of stream as a blob identified by digest.
+// PutBlob writes contents of stream and returns its computed digest and size.
+// A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dirImageDestination) PutBlob(digest string, expectedSize int64, stream io.Reader) error {
-	blobPath := d.ref.layerPath(digest)
-	blobFile, err := ioutil.TempFile(filepath.Dir(blobPath), filepath.Base(blobPath))
+func (d *dirImageDestination) PutBlob(stream io.Reader, digest string, expectedSize int64) (string, int64, error) {
+	blobFile, err := ioutil.TempFile(d.ref.path, "dir-put-blob")
 	if err != nil {
-		return err
+		return "", -1, err
 	}
 	succeeded := false
 	defer func() {
@@ -52,24 +53,29 @@ func (d *dirImageDestination) PutBlob(digest string, expectedSize int64, stream 
 		}
 	}()
 
-	size, err := io.Copy(blobFile, stream)
+	h := sha256.New()
+	tee := io.TeeReader(stream, h)
+
+	size, err := io.Copy(blobFile, tee)
 	if err != nil {
-		return err
+		return "", -1, err
 	}
+	computedDigest := hex.EncodeToString(h.Sum(nil))
 	if expectedSize != -1 && size != expectedSize {
-		return fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", digest, expectedSize, size)
+		return "", -1, fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", computedDigest, expectedSize, size)
 	}
 	if err := blobFile.Sync(); err != nil {
-		return err
+		return "", -1, err
 	}
 	if err := blobFile.Chmod(0644); err != nil {
-		return err
+		return "", -1, err
 	}
+	blobPath := d.ref.layerPath(computedDigest)
 	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
-		return nil
+		return "", -1, err
 	}
 	succeeded = true
-	return nil
+	return "sha256:" + computedDigest, size, nil
 }
 
 func (d *dirImageDestination) PutManifest(manifest []byte) error {

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -2,6 +2,8 @@ package directory
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -53,15 +55,18 @@ func TestGetPutBlob(t *testing.T) {
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	err = dest.PutBlob(digest, int64(len(blob)), bytes.NewReader(blob))
+	d, size, err := dest.PutBlob(bytes.NewReader(blob), digest, int64(9))
 	assert.NoError(t, err)
 	err = dest.Commit()
 	assert.NoError(t, err)
+	assert.Equal(t, int64(9), size)
+	hash := sha256.Sum256(blob)
+	assert.Equal(t, "sha256:"+hex.EncodeToString(hash[:]), d)
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
 	defer src.Close()
-	rc, size, err := src.GetBlob(digest)
+	rc, size, err := src.GetBlob(d)
 	assert.NoError(t, err)
 	defer rc.Close()
 	b, err := ioutil.ReadAll(rc)
@@ -108,7 +113,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	err = dest.PutBlob(blobDigest, -1, reader)
+	_, _, err = dest.PutBlob(reader, blobDigest, -1)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
 	err = dest.Commit()

--- a/oci/oci_dest_test.go
+++ b/oci/oci_dest_test.go
@@ -48,7 +48,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	err = dest.PutBlob(blobDigest, -1, reader)
+	_, _, err = dest.PutBlob(reader, blobDigest, -1)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
 	err = dest.Commit()

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -342,13 +342,14 @@ func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 	}
 }
 
-// PutBlob writes contents of stream as a blob identified by digest.
+// PutBlob writes contents of stream and returns its computed digest and size.
+// A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *openshiftImageDestination) PutBlob(digest string, expectedSize int64, stream io.Reader) error {
-	return d.docker.PutBlob(digest, expectedSize, stream)
+func (d *openshiftImageDestination) PutBlob(stream io.Reader, digest string, expectedSize int64) (string, int64, error) {
+	return d.docker.PutBlob(stream, digest, expectedSize)
 }
 
 func (d *openshiftImageDestination) PutManifest(m []byte) error {

--- a/types/types.go
+++ b/types/types.go
@@ -119,12 +119,13 @@ type ImageDestination interface {
 	Reference() ImageReference
 	// Close removes resources associated with an initialized ImageDestination, if any.
 	Close()
-	// PutBlob writes contents of stream as a blob identified by digest.
+	// PutBlob writes contents of stream and returns its computed digest and size.
+	// A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 	// The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 	// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 	// to any other readers for download using the supplied digest.
 	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-	PutBlob(digest string, expectedSize int64, stream io.Reader) error
+	PutBlob(stream io.Reader, digest string, expectedSize int64) (string, int64, error)
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	PutManifest([]byte) error
 	PutSignatures(signatures [][]byte) error


### PR DESCRIPTION
This patch is a WIP to discuss about changing the signature of `PutBlob`. I'll fix the other types if we get consensus on this.

Basically, while working on `docker save --format oci` (https://github.com/runcom/docker/commits/oci-save-load), I noticed the `PutBlob` interface is really awful since it requires callers to provide their own _digest_. This isn't ensuring that the digest file name is the same as the one from the stream and the OCI image specification requires this (also).

Here I'm basically changing `PutBlob` to return the computed digest from the given stream (and also the size of the blob being saved).

I've noticed in `copy/copy.go` there's something (I've already forgotten) about _digest verification_ also but I feel this change is needed to have a consisted usage of the library.

Does this interface make any sense? Does this break anything around signatures? @mtrmac  

Signed-off-by: Antonio Murdaca <runcom@redhat.com>