### PR TITLE
API changes

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -91,6 +91,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		return fmt.Errorf("Error initializing source %s: %v", transports.ImageName(srcRef), err)
 	}
 	src := image.FromSource(rawSource)
+	defer src.Close()
 
 	// Please keep this policy check BEFORE reading any other information about the image.
 	if allowed, err := policyContext.IsRunningImageAllowed(src); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -169,5 +169,10 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	if err := dest.PutSignatures(sigs); err != nil {
 		return fmt.Errorf("Error writing signatures: %v", err)
 	}
+
+	if err := dest.Commit(); err != nil {
+		return fmt.Errorf("Error committing the finished image: %v", err)
+	}
+
 	return nil
 }

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -120,8 +120,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		return fmt.Errorf("Error parsing manifest: %v", err)
 	}
 	for _, digest := range blobDigests {
-		// TODO(mitr): do not ignore the size param returned here
-		stream, _, err := rawSource.GetBlob(digest)
+		stream, blobSize, err := rawSource.GetBlob(digest)
 		if err != nil {
 			return fmt.Errorf("Error reading blob %s: %v", digest, err)
 		}
@@ -136,7 +135,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		if err != nil {
 			return fmt.Errorf("Error preparing to verify blob %s: %v", digest, err)
 		}
-		if err := dest.PutBlob(digest, digestingReader); err != nil {
+		if err := dest.PutBlob(digest, blobSize, digestingReader); err != nil {
 			return fmt.Errorf("Error writing blob: %v", err)
 		}
 		if digestingReader.validationFailed { // Coverage: This should never happen.

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -86,6 +86,8 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	if err != nil {
 		return fmt.Errorf("Error initializing destination %s: %v", transports.ImageName(destRef), err)
 	}
+	defer dest.Close()
+
 	rawSource, err := srcRef.NewImageSource(ctx, dest.SupportedManifestMIMETypes())
 	if err != nil {
 		return fmt.Errorf("Error initializing source %s: %v", transports.ImageName(srcRef), err)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -160,7 +160,6 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		sigs = append(sigs, newSig)
 	}
 
-	// FIXME: We need to call PutManifest after PutBlob and before PutSignatures. This seems ugly; move to a "set properties" + "commit" model?
 	if err := dest.PutManifest(manifest); err != nil {
 		return fmt.Errorf("Error writing manifest: %v", err)
 	}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -25,6 +25,10 @@ func (d *dirImageDestination) Reference() types.ImageReference {
 	return d.ref
 }
 
+// Close removes resources associated with an initialized ImageDestination, if any.
+func (d *dirImageDestination) Close() {
+}
+
 func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -84,3 +84,11 @@ func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {
 	}
 	return nil
 }
+
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
+func (d *dirImageDestination) Commit() error {
+	return nil
+}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -29,10 +29,6 @@ func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }
 
-func (d *dirImageDestination) PutManifest(manifest []byte) error {
-	return ioutil.WriteFile(d.ref.manifestPath(), manifest, 0644)
-}
-
 // PutBlob writes contents of stream as a blob identified by digest.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
@@ -70,6 +66,10 @@ func (d *dirImageDestination) PutBlob(digest string, expectedSize int64, stream 
 	}
 	succeeded = true
 	return nil
+}
+
+func (d *dirImageDestination) PutManifest(manifest []byte) error {
+	return ioutil.WriteFile(d.ref.manifestPath(), manifest, 0644)
 }
 
 func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -13,6 +13,7 @@ type dirImageSource struct {
 }
 
 // newImageSource returns an ImageSource reading from an existing directory.
+// The caller must call .Close() on the returned ImageSource.
 func newImageSource(ref dirReference) types.ImageSource {
 	return &dirImageSource{ref}
 }
@@ -21,6 +22,10 @@ func newImageSource(ref dirReference) types.ImageSource {
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *dirImageSource) Reference() types.ImageReference {
 	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *dirImageSource) Close() {
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -37,6 +37,7 @@ func (s *dirImageSource) GetManifest() ([]byte, string, error) {
 	return m, "", err
 }
 
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *dirImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(digest))
 	if err != nil {

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -33,6 +33,7 @@ func TestGetPutManifest(t *testing.T) {
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
+	defer src.Close()
 	m, mt, err := src.GetManifest()
 	assert.NoError(t, err)
 	assert.Equal(t, man, m)
@@ -52,6 +53,7 @@ func TestGetPutBlob(t *testing.T) {
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
+	defer src.Close()
 	rc, size, err := src.GetBlob(digest)
 	assert.NoError(t, err)
 	defer rc.Close()
@@ -122,6 +124,7 @@ func TestGetPutSignatures(t *testing.T) {
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
+	defer src.Close()
 	sigs, err := src.GetSignatures()
 	assert.NoError(t, err)
 	assert.Equal(t, signatures, sigs)
@@ -133,6 +136,7 @@ func TestSourceReference(t *testing.T) {
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
+	defer src.Close()
 	ref2 := src.Reference()
 	assert.Equal(t, tmpDir, ref2.StringWithinTransport())
 }

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -48,7 +48,7 @@ func TestGetPutBlob(t *testing.T) {
 	blob := []byte("test-blob")
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
-	err = dest.PutBlob(digest, bytes.NewReader(blob))
+	err = dest.PutBlob(digest, int64(len(blob)), bytes.NewReader(blob))
 	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(nil, nil)
@@ -100,7 +100,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
-	err = dest.PutBlob(blobDigest, reader)
+	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
 

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -17,6 +17,7 @@ func TestDestinationReference(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	ref2 := dest.Reference()
 	assert.Equal(t, tmpDir, ref2.StringWithinTransport())
 }
@@ -28,6 +29,7 @@ func TestGetPutManifest(t *testing.T) {
 	man := []byte("test-manifest")
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	err = dest.PutManifest(man)
 	assert.NoError(t, err)
 
@@ -48,6 +50,7 @@ func TestGetPutBlob(t *testing.T) {
 	blob := []byte("test-blob")
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	err = dest.PutBlob(digest, int64(len(blob)), bytes.NewReader(blob))
 	assert.NoError(t, err)
 
@@ -100,6 +103,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
@@ -115,6 +119,7 @@ func TestGetPutSignatures(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	signatures := [][]byte{
 		[]byte("sig1"),
 		[]byte("sig2"),

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -32,6 +32,8 @@ func TestGetPutManifest(t *testing.T) {
 	defer dest.Close()
 	err = dest.PutManifest(man)
 	assert.NoError(t, err)
+	err = dest.Commit()
+	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(nil, nil)
 	require.NoError(t, err)
@@ -52,6 +54,8 @@ func TestGetPutBlob(t *testing.T) {
 	require.NoError(t, err)
 	defer dest.Close()
 	err = dest.PutBlob(digest, int64(len(blob)), bytes.NewReader(blob))
+	assert.NoError(t, err)
+	err = dest.Commit()
 	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(nil, nil)
@@ -107,6 +111,8 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
+	err = dest.Commit()
+	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
 	require.Error(t, err)
@@ -125,6 +131,8 @@ func TestGetPutSignatures(t *testing.T) {
 		[]byte("sig2"),
 	}
 	err = dest.PutSignatures(signatures)
+	assert.NoError(t, err)
+	err = dest.Commit()
 	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(nil, nil)

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -143,6 +143,7 @@ func (ref dirReference) NewImageSource(ctx *types.SystemContext, requestedManife
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
 func (ref dirReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ref), nil
 }

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -128,14 +128,16 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 }
 
 // NewImage returns a types.Image for this reference.
+// The caller must call .Close() on the returned Image.
 func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	src := newImageSource(ref)
 	return image.FromSource(src), nil
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func (ref dirReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
 	return newImageSource(ref), nil
 }

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -149,15 +149,17 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImage(nil)
+	img, err := ref.NewImage(nil)
 	assert.NoError(t, err)
+	defer img.Close()
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil, nil)
 	assert.NoError(t, err)
+	defer src.Close()
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -165,8 +165,9 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(nil)
 	assert.NoError(t, err)
+	defer dest.Close()
 }
 
 func TestReferenceDeleteImage(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -17,6 +17,7 @@
 //    	if err != nil {
 //    		panic(err)
 //    	}
+//      defer img.Close()
 //    	b, _, err := img.Manifest()
 //    	if err != nil {
 //    		panic(err)

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -18,6 +18,7 @@ type Image struct {
 
 // newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
+// The caller must call .Close() on the returned Image.
 func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error) {
 	s, err := newImageSource(ctx, ref, nil)
 	if err != nil {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -35,6 +35,10 @@ func (d *dockerImageDestination) Reference() types.ImageReference {
 	return d.ref
 }
 
+// Close removes resources associated with an initialized ImageDestination, if any.
+func (d *dockerImageDestination) Close() {
+}
+
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		// TODO(runcom): we'll add OCI as part of another PR here

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -140,3 +140,11 @@ func (d *dockerImageDestination) PutSignatures(signatures [][]byte) error {
 	}
 	return nil
 }
+
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
+func (d *dockerImageDestination) Commit() error {
+	return nil
+}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -96,6 +96,7 @@ func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
 	return manblob, simplifyContentType(res.Header.Get("Content-Type")), nil
 }
 
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *dockerImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
 	url := fmt.Sprintf(blobsURL, s.ref.ref.RemoteName(), digest)
 	logrus.Debugf("Downloading %s", url)
@@ -109,7 +110,7 @@ func (s *dockerImageSource) GetBlob(digest string) (io.ReadCloser, int64, error)
 	}
 	size, err := strconv.ParseInt(res.Header.Get("Content-Length"), 10, 64)
 	if err != nil {
-		size = 0
+		size = -1
 	}
 	return res.Body, size, nil
 }

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -29,8 +29,9 @@ type dockerImageSource struct {
 }
 
 // newImageSource creates a new ImageSource for the specified image reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func newImageSource(ctx *types.SystemContext, ref dockerReference, requestedManifestMIMETypes []string) (*dockerImageSource, error) {
 	c, err := newDockerClient(ctx, ref.ref.Hostname())
 	if err != nil {
@@ -50,6 +51,10 @@ func newImageSource(ctx *types.SystemContext, ref dockerReference, requestedMani
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *dockerImageSource) Reference() types.ImageReference {
 	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *dockerImageSource) Close() {
 }
 
 // simplifyContentType drops parameters from a HTTP media type (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1)

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -116,13 +116,15 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 }
 
 // NewImage returns a types.Image for this reference.
+// The caller must call .Close() on the returned Image.
 func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	return newImage(ctx, ref)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func (ref dockerReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
 	return newImageSource(ctx, ref, requestedManifestMIMETypes)
 }

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -130,6 +130,7 @@ func (ref dockerReference) NewImageSource(ctx *types.SystemContext, requestedMan
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
 func (ref dockerReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ctx, ref)
 }

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -160,15 +160,17 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImage(nil)
+	img, err := ref.NewImage(nil)
 	assert.NoError(t, err)
+	defer img.Close()
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil, nil)
 	assert.NoError(t, err)
+	defer src.Close()
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -176,8 +176,9 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(nil)
 	assert.NoError(t, err)
+	defer dest.Close()
 }
 
 func TestReferenceTagOrDigest(t *testing.T) {

--- a/image/image.go
+++ b/image/image.go
@@ -37,6 +37,12 @@ type genericImage struct {
 }
 
 // FromSource returns a types.Image implementation for source.
+// The caller must call .Close() on the returned Image.
+//
+// FromSource “takes ownership” of the input ImageSource and will call src.Close()
+// when the image is closed.  (This does not prevent callers from using both the
+// Image and ImageSource objects simultaneously, but it means that they only need to
+// the Image.)
 func FromSource(src types.ImageSource) types.Image {
 	return &genericImage{src: src}
 }
@@ -45,6 +51,11 @@ func FromSource(src types.ImageSource) types.Image {
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (i *genericImage) Reference() types.ImageReference {
 	return i.src.Reference()
+}
+
+// Close removes resources associated with an initialized Image, if any.
+func (i *genericImage) Close() {
+	i.src.Close()
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -187,3 +187,11 @@ func (d *ociImageDestination) PutSignatures(signatures [][]byte) error {
 	}
 	return nil
 }
+
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
+func (d *ociImageDestination) Commit() error {
+	return nil
+}

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -115,11 +115,11 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 }
 
 // PutBlob writes contents of stream as a blob identified by digest.
+// The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
-func (d *ociImageDestination) PutBlob(digest string, stream io.Reader) error {
+func (d *ociImageDestination) PutBlob(digest string, expectedSize int64, stream io.Reader) error {
 	blobPath, err := d.ref.blobPath(digest)
 	if err != nil {
 		return err
@@ -139,8 +139,12 @@ func (d *ociImageDestination) PutBlob(digest string, stream io.Reader) error {
 		}
 	}()
 
-	if _, err := io.Copy(blobFile, stream); err != nil {
+	size, err := io.Copy(blobFile, stream)
+	if err != nil {
 		return err
+	}
+	if expectedSize != -1 && size != expectedSize {
+		return fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", digest, expectedSize, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return err

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -41,6 +41,10 @@ func (d *ociImageDestination) Reference() types.ImageReference {
 	return d.ref
 }
 
+// Close removes resources associated with an initialized ImageDestination, if any.
+func (d *ociImageDestination) Close() {
+}
+
 // PutBlob writes contents of stream as a blob identified by digest.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available

--- a/oci/oci_dest_test.go
+++ b/oci/oci_dest_test.go
@@ -51,6 +51,8 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
+	err = dest.Commit()
+	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
 	require.Error(t, err)

--- a/oci/oci_dest_test.go
+++ b/oci/oci_dest_test.go
@@ -47,6 +47,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
+	defer dest.Close()
 	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())

--- a/oci/oci_dest_test.go
+++ b/oci/oci_dest_test.go
@@ -47,7 +47,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
-	err = dest.PutBlob(blobDigest, reader)
+	err = dest.PutBlob(blobDigest, -1, reader)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
 

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -179,6 +179,7 @@ func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManife
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
 func (ref ociReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ref), nil
 }

--- a/oci/oci_transport.go
+++ b/oci/oci_transport.go
@@ -165,13 +165,15 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 }
 
 // NewImage returns a types.Image for this reference.
+// The caller must call .Close() on the returned Image.
 func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	return nil, errors.New("Full Image support not implemented for oci: image names")
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
 	return nil, errors.New("Reading images not implemented for oci: image names")
 }

--- a/oci/oci_transport_test.go
+++ b/oci/oci_transport_test.go
@@ -219,8 +219,9 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(nil)
 	assert.NoError(t, err)
+	defer dest.Close()
 }
 
 func TestReferenceDeleteImage(t *testing.T) {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -384,12 +384,12 @@ func (d *openshiftImageDestination) PutManifest(m []byte) error {
 }
 
 // PutBlob writes contents of stream as a blob identified by digest.
+// The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
-func (d *openshiftImageDestination) PutBlob(digest string, stream io.Reader) error {
-	return d.docker.PutBlob(digest, stream)
+func (d *openshiftImageDestination) PutBlob(digest string, expectedSize int64, stream io.Reader) error {
+	return d.docker.PutBlob(digest, expectedSize, stream)
 }
 
 func (d *openshiftImageDestination) PutSignatures(signatures [][]byte) error {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -458,6 +458,14 @@ sigExists:
 	return nil
 }
 
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
+func (d *openshiftImageDestination) Commit() error {
+	return d.docker.Commit()
+}
+
 // These structs are subsets of github.com/openshift/origin/pkg/image/api/v1 and its dependencies.
 type imageStream struct {
 	Status imageStreamStatus `json:"status,omitempty"`

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -216,6 +216,7 @@ func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
 	return s.docker.GetManifest()
 }
 
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *openshiftImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, 0, err

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -179,8 +179,9 @@ type openshiftImageSource struct {
 }
 
 // newImageSource creates a new ImageSource for the specified reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
 	client, err := newOpenshiftClient(ref)
 	if err != nil {
@@ -198,6 +199,14 @@ func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedM
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *openshiftImageSource) Reference() types.ImageReference {
 	return s.client.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *openshiftImageSource) Close() {
+	if s.docker != nil {
+		s.docker.Close()
+		s.docker = nil
+	}
 }
 
 func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -330,6 +330,11 @@ func (d *openshiftImageDestination) Reference() types.ImageReference {
 	return d.client.ref
 }
 
+// Close removes resources associated with an initialized ImageDestination, if any.
+func (d *openshiftImageDestination) Close() {
+	d.docker.Close()
+}
+
 func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		manifest.DockerV2Schema1SignedMIMEType,

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -168,6 +168,7 @@ func (ref openshiftReference) NewImageSource(ctx *types.SystemContext, requested
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
 func (ref openshiftReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ctx, ref)
 }

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -154,13 +154,15 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 }
 
 // NewImage returns a types.Image for this reference.
+// The caller must call .Close() on the returned Image.
 func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	return nil, errors.New("Full Image support not implemented for atomic: image names")
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// The caller must call .Close() on the returned ImageSource.
 func (ref openshiftReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
 	return newImageSource(ctx, ref, requestedManifestMIMETypes)
 }

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -172,6 +172,7 @@ func TestPolicyContextRequirementsForImageRef(t *testing.T) {
 }
 
 // pcImageMock returns a types.Image for a directory, claiming a specified dockerReference and implementing PolicyConfigurationIdentity/PolicyConfigurationNamespaces.
+// The caller must call .Close() on the returned Image.
 func pcImageMock(t *testing.T, dir, dockerReference string) types.Image {
 	ref, err := reference.ParseNamed(dockerReference)
 	require.NoError(t, err)
@@ -222,6 +223,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 
 	// Success
 	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
@@ -229,65 +231,76 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// Two signatures
 	// FIXME? Use really different signatures for this?
 	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
 	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
 	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
@@ -300,6 +313,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -311,6 +325,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	invalidSigDir := createInvalidSigDir(t)
 	defer os.RemoveAll(invalidSigDir)
 	img = pcImageMock(t, invalidSigDir, "testing/manifest:latest")
+	defer img.Close()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -347,52 +362,62 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 
 	// Success
 	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer img.Close()
 	res, err := pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
 	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
 	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
 	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
 	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	defer img.Close()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
@@ -402,6 +427,7 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
 	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer img.Close()
 	res, err = destroyedPC.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -56,6 +56,9 @@ type refImageMock struct{ reference.Named }
 func (ref refImageMock) Reference() types.ImageReference {
 	return refImageReferenceMock{ref.Named}
 }
+func (ref refImageMock) Close() {
+	panic("unexpected call to a mock function")
+}
 func (ref refImageMock) Manifest() ([]byte, string, error) {
 	panic("unexpected call to a mock function")
 }
@@ -259,6 +262,9 @@ func TestParseDockerReferences(t *testing.T) {
 type forbiddenImageMock struct{}
 
 func (ref forbiddenImageMock) Reference() types.ImageReference {
+	panic("unexpected call to a mock function")
+}
+func (ref forbiddenImageMock) Close() {
 	panic("unexpected call to a mock function")
 }
 func (ref forbiddenImageMock) Manifest() ([]byte, string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -98,8 +98,7 @@ type ImageSource interface {
 	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown.
 	// It may use a remote (= slow) service.
 	GetManifest() ([]byte, string, error)
-	// Note: Calling GetBlob() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
-	// the second return value is the size of the blob. If not known 0 is returned
+	// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 	GetBlob(digest string) (io.ReadCloser, int64, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)


### PR DESCRIPTION
These are various API changes which will be needed for `docker-daemon:`, splitting them for independent review and so that they may be merged early while I work on the `docker-daemon:` transport:

- Add `ImageSource.Close` and `Image.Close`
- Define size -1 as "unknown" in `GetBlob`
- Add an `expectedSize` parameter to `PutBlob`
- Commit to a fixed `PutBlob`→`PutManifest``PutSignatures` ordering in `ImageDestination`
- Add `ImageDestination.Close`
- Add `ImageDestination.Commit`

See the individual commits for more detailed comments.