### PR TITLE
Add ImageDestination.SupportsSignatures

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -114,7 +114,11 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 			return fmt.Errorf("Error reading signatures: %v", err)
 		}
 		sigs = s
-		// FIXME: Fail early if we can detect that RemoveSignatures should be used.
+	}
+	if len(sigs) != 0 {
+		if err := dest.SupportsSignatures(); err != nil {
+			return fmt.Errorf("Can not copy signatures: %v", err)
+		}
 	}
 
 	blobDigests, err := src.BlobDigests()

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -34,6 +34,12 @@ func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }
 
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (d *dirImageDestination) SupportsSignatures() error {
+	return nil
+}
+
 // PutBlob writes contents of stream and returns its computed digest and size.
 // A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -135,6 +135,8 @@ func TestGetPutSignatures(t *testing.T) {
 		[]byte("sig1"),
 		[]byte("sig2"),
 	}
+	err = dest.SupportsSignatures()
+	assert.NoError(t, err)
 	err = dest.PutSignatures(signatures)
 	assert.NoError(t, err)
 	err = dest.Commit()

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -51,6 +51,12 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	}
 }
 
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (d *dockerImageDestination) SupportsSignatures() error {
+	return fmt.Errorf("Pushing signatures to a Docker Registry is not supported")
+}
+
 // PutBlob writes contents of stream and returns its computed digest and size.
 // A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.

--- a/oci/oci_dest.go
+++ b/oci/oci_dest.go
@@ -35,6 +35,19 @@ func (d *ociImageDestination) Reference() types.ImageReference {
 func (d *ociImageDestination) Close() {
 }
 
+func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
+	return []string{
+		imgspecv1.MediaTypeImageManifest,
+		manifest.DockerV2Schema2MIMEType,
+	}
+}
+
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (d *ociImageDestination) SupportsSignatures() error {
+	return fmt.Errorf("Pushing signatures for OCI images is not supported")
+}
+
 // PutBlob writes contents of stream and returns its computed digest and size.
 // A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
@@ -174,13 +187,6 @@ func ensureDirectoryExists(path string) error {
 // ensureParentDirectoryExists ensures the parent of the supplied path exists.
 func ensureParentDirectoryExists(path string) error {
 	return ensureDirectoryExists(filepath.Dir(path))
-}
-
-func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
-		imgspecv1.MediaTypeImageManifest,
-		manifest.DockerV2Schema2MIMEType,
-	}
 }
 
 func (d *ociImageDestination) PutSignatures(signatures [][]byte) error {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -342,6 +342,12 @@ func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 	}
 }
 
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (d *openshiftImageDestination) SupportsSignatures() error {
+	return nil
+}
+
 // PutBlob writes contents of stream and returns its computed digest and size.
 // A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 // The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.

--- a/types/types.go
+++ b/types/types.go
@@ -119,6 +119,14 @@ type ImageDestination interface {
 	Reference() ImageReference
 	// Close removes resources associated with an initialized ImageDestination, if any.
 	Close()
+
+	// SupportedManifestMIMETypes tells which manifest mime types the destination supports
+	// If an empty slice or nil it's returned, then any mime type can be tried to upload
+	SupportedManifestMIMETypes() []string
+	// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+	// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+	SupportsSignatures() error
+
 	// PutBlob writes contents of stream and returns its computed digest and size.
 	// A digest can be optionally provided if known, the specific image destination can decide to play with it or not.
 	// The length of stream is expected to be expectedSize; if expectedSize == -1, it is not known.
@@ -134,9 +142,6 @@ type ImageDestination interface {
 	// - Uploaded data MAY be visible to others before Commit() is called
 	// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 	Commit() error
-	// SupportedManifestMIMETypes tells which manifest mime types the destination supports
-	// If an empty slice or nil it's returned, then any mime type can be tried to upload
-	SupportedManifestMIMETypes() []string
 }
 
 // Image is the primary API for inspecting properties of images.


### PR DESCRIPTION
This allows `copy.go` to bail early, without transferring any large blobs.

(This is an attribute of an `ImageDestination` and not an `ImageTransport` because supporting signatures may depend on the individual destination, e.g. depending on server version or whether a sigstore lookaside has been configured for that destination.)

Also reorders the `ImageDestination` methods in some cases, to separate basic management / capability query / upload groups.
