### PR TITLE
oci: mv to oci-layout

### DIFF
--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -1,4 +1,4 @@
-package oci
+package layout
 
 import (
 	"crypto/sha256"

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -1,4 +1,4 @@
-package oci
+package layout
 
 import (
 	"fmt"

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -1,4 +1,4 @@
-package oci
+package layout
 
 import (
 	"errors"

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -1,4 +1,4 @@
-package oci
+package layout
 
 import (
 	"io/ioutil"

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -1,0 +1,1 @@
+package oci

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containers/image/directory"
 	"github.com/containers/image/docker"
-	"github.com/containers/image/oci"
+	ociLayout "github.com/containers/image/oci/layout"
 	"github.com/containers/image/openshift"
 	"github.com/containers/image/types"
 )
@@ -19,7 +19,7 @@ func init() {
 	for _, t := range []types.ImageTransport{
 		directory.Transport,
 		docker.Transport,
-		oci.Transport,
+		ociLayout.Transport,
 		openshift.Transport,
 	} {
 		name := t.Name()


### PR DESCRIPTION
Fix https://github.com/containers/image/issues/75

@mtrmac slightly different path than discussed but ... I believe same net result.

I had to ofc change the transport name - I expect to still use `oci` in skopeo though. (unless I'm missing something)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>