### PR TITLE
Do not use HTTP for docker registries if ~SystemContext.DockerInsecureSkipTLSVerify

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -36,6 +36,7 @@ const (
 
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
+	ctx             *types.SystemContext
 	registry        string
 	username        string
 	password        string
@@ -85,6 +86,7 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) 
 	}
 
 	return &dockerClient{
+		ctx:           ctx,
 		registry:      registry,
 		username:      username,
 		password:      password,
@@ -332,14 +334,9 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		}
 		return pr, nil
 	}
-	scheme := "https"
-	pr, err := ping(scheme)
-	if err != nil {
-		scheme = "http"
-		pr, err = ping(scheme)
-		if err == nil {
-			return pr, nil
-		}
+	pr, err := ping("https")
+	if err != nil && c.ctx.DockerInsecureSkipTLSVerify {
+		pr, err = ping("http")
 	}
 	return pr, err
 }

--- a/types/types.go
+++ b/types/types.go
@@ -201,5 +201,5 @@ type SystemContext struct {
 
 	// === docker.Transport overrides ===
 	DockerCertPath              string // If not "", a directory containing "cert.pem" and "key.pem" used when talking to a Docker Registry
-	DockerInsecureSkipTLSVerify bool
+	DockerInsecureSkipTLSVerify bool   // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 }


### PR DESCRIPTION
Then document `SystemContext.DockerInsecureSkipTLSVerify` more precisely.

Also simplify `dockerClient.ping()` a bit.

Fixes #45 .