### PR TITLE
Update name/tag embedded into schema1 manifests

### DIFF
--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -55,6 +56,9 @@ func (f fakeImageSource) OCIConfig() (*v1.Image, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) LayerInfos() []types.BlobInfo {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) Inspect() (*types.ImageInspectInfo, error) {

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -135,6 +135,27 @@ func (m *manifestSchema1) LayerInfos() []types.BlobInfo {
 	return layers
 }
 
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	// This is a bit convoluted: We can’t just have a "get embedded docker reference" method
+	// and have the “does it conflict” logic in the generic copy code, because the manifest does not actually
+	// embed a full docker/distribution reference, but only the repo name and tag (without the host name).
+	// So we would have to provide a “return repo without host name, and tag” getter for the generic code,
+	// which would be very awkward.  Instead, we do the matching here in schema1-specific code, and all the
+	// generic copy code needs to know about is reference.Named and that a manifest may need updating
+	// for some destinations.
+	name := reference.Path(ref)
+	var tag string
+	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
+		tag = tagged.Tag()
+	} else {
+		tag = ""
+	}
+	return m.Name != name || m.Tag != tag
+}
+
 func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
 	v1 := &v1Image{}
 	if err := json.Unmarshal([]byte(m.History[0].V1Compatibility), v1); err != nil {

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -194,6 +194,14 @@ func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (typ
 			copy.FSLayers[(len(options.LayerInfos)-1)-i].BlobSum = info.Digest
 		}
 	}
+	if options.EmbeddedDockerReference != nil {
+		copy.Name = reference.Path(options.EmbeddedDockerReference)
+		if tagged, isTagged := options.EmbeddedDockerReference.(reference.NamedTagged); isTagged {
+			copy.Tag = tagged.Tag()
+		} else {
+			copy.Tag = ""
+		}
+	}
 
 	switch options.ManifestMIMEType {
 	case "": // No conversion, OK

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -138,6 +139,13 @@ func (m *manifestSchema2) LayerInfos() []types.BlobInfo {
 		})
 	}
 	return blobs
+}
+
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestSchema2) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	return false
 }
 
 func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -188,6 +188,7 @@ func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (typ
 			copy.LayersDescriptors[i].URLs = info.URLs
 		}
 	}
+	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1 to schema2, but we really don't care.
 
 	switch options.ManifestMIMEType {
 	case "": // No conversion, OK

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -242,6 +242,20 @@ func TestManifestSchema2LayerInfo(t *testing.T) {
 	}
 }
 
+func TestManifestSchema2EmbeddedDockerReferenceConflicts(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema2FromFixture(t, unusedImageSource{}, "schema2.json"),
+		manifestSchema2FromComponentsLikeFixture(nil),
+	} {
+		for _, name := range []string{"busybox", "example.com:5555/ns/repo:tag"} {
+			ref, err := reference.ParseNormalizedNamed(name)
+			require.NoError(t, err)
+			conflicts := m.EmbeddedDockerReferenceConflicts(ref)
+			assert.False(t, conflicts)
+		}
+	}
+}
+
 func TestManifestSchema2ImageInspectInfo(t *testing.T) {
 	configJSON, err := ioutil.ReadFile("fixtures/schema2-config.json")
 	require.NoError(t, err)

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -421,6 +421,19 @@ func TestManifestSchema2UpdatedImage(t *testing.T) {
 	})
 	assert.Error(t, err)
 
+	// EmbeddedDockerReference:
+	// … is ignored
+	embeddedRef, err := reference.ParseNormalizedNamed("busybox")
+	require.NoError(t, err)
+	res, err = original.UpdatedImage(types.ManifestUpdateOptions{
+		EmbeddedDockerReference: embeddedRef,
+	})
+	require.NoError(t, err)
+	nonEmbeddedRef, err := reference.ParseNormalizedNamed("notbusybox:notlatest")
+	require.NoError(t, err)
+	conflicts := res.EmbeddedDockerReferenceConflicts(nonEmbeddedRef)
+	assert.False(t, conflicts)
+
 	// ManifestMIMEType:
 	// Only smoke-test the valid conversions, detailed tests are below. (This also verifies that “original” is not affected.)
 	for _, mime := range []string{

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -3,6 +3,7 @@ package image
 import (
 	"time"
 
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/pkg/strslice"
 	"github.com/containers/image/types"
@@ -72,6 +73,10 @@ type genericManifest interface {
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []types.BlobInfo
+	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+	// It returns false if the manifest does not embed a Docker reference.
+	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+	EmbeddedDockerReferenceConflicts(ref reference.Named) bool
 	imageInspectInfo() (*types.ImageInspectInfo, error) // To be called by inspectManifest
 	// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
 	// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute

--- a/image/oci.go
+++ b/image/oci.go
@@ -154,6 +154,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 			copy.LayersDescriptors[i].Size = info.Size
 		}
 	}
+	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1, but we really don't care.
 
 	switch options.ManifestMIMEType {
 	case "": // No conversion, OK

--- a/image/oci.go
+++ b/image/oci.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -105,6 +106,13 @@ func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
 		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size})
 	}
 	return blobs
+}
+
+// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+// It returns false if the manifest does not embed a Docker reference.
+// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+func (m *manifestOCI1) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
+	return false
 }
 
 func (m *manifestOCI1) imageInspectInfo() (*types.ImageInspectInfo, error) {

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -207,6 +207,20 @@ func TestManifestOCI1LayerInfo(t *testing.T) {
 	}
 }
 
+func TestManifestOCI1EmbeddedDockerReferenceConflicts(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestOCI1FromFixture(t, unusedImageSource{}, "oci1.json"),
+		manifestOCI1FromComponentsLikeFixture(nil),
+	} {
+		for _, name := range []string{"busybox", "example.com:5555/ns/repo:tag"} {
+			ref, err := reference.ParseNormalizedNamed(name)
+			require.NoError(t, err)
+			conflicts := m.EmbeddedDockerReferenceConflicts(ref)
+			assert.False(t, conflicts)
+		}
+	}
+}
+
 func TestManifestOCI1ImageInspectInfo(t *testing.T) {
 	configJSON, err := ioutil.ReadFile("fixtures/oci1-config.json")
 	require.NoError(t, err)

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -302,6 +302,19 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 	})
 	assert.Error(t, err)
 
+	// EmbeddedDockerReference:
+	// … is ignored
+	embeddedRef, err := reference.ParseNormalizedNamed("busybox")
+	require.NoError(t, err)
+	res, err = original.UpdatedImage(types.ManifestUpdateOptions{
+		EmbeddedDockerReference: embeddedRef,
+	})
+	require.NoError(t, err)
+	nonEmbeddedRef, err := reference.ParseNormalizedNamed("notbusybox:notlatest")
+	require.NoError(t, err)
+	conflicts := res.EmbeddedDockerReferenceConflicts(nonEmbeddedRef)
+	assert.False(t, conflicts)
+
 	// ManifestMIMEType:
 	// Only smoke-test the valid conversions, detailed tests are below. (This also verifies that “original” is not affected.)
 	for _, mime := range []string{

--- a/types/types.go
+++ b/types/types.go
@@ -249,8 +249,9 @@ type Image interface {
 
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
 type ManifestUpdateOptions struct {
-	LayerInfos       []BlobInfo // Complete BlobInfos (size+digest+urls) which should replace the originals, in order (the root layer first, and then successive layered layers)
-	ManifestMIMEType string
+	LayerInfos              []BlobInfo // Complete BlobInfos (size+digest+urls) which should replace the originals, in order (the root layer first, and then successive layered layers)
+	EmbeddedDockerReference reference.Named
+	ManifestMIMEType        string
 	// The values below are NOT requests to modify the image; they provide optional context which may or may not be used.
 	InformationOnly ManifestUpdateInformation
 }

--- a/types/types.go
+++ b/types/types.go
@@ -226,6 +226,10 @@ type Image interface {
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []BlobInfo
+	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+	// It returns false if the manifest does not embed a Docker reference.
+	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
+	EmbeddedDockerReferenceConflicts(ref reference.Named) bool
 	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 	Inspect() (*ImageInspectInfo, error)
 	// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.


### PR DESCRIPTION
FIXME: Actually handle the manifest-embedded tags in schema 1. Without that, this is a fairly broken implementation (though might be better than nothing I suppose).

**EDIT** When pushing a schema1 image, update the name/tag embedded in the manifest. Recent registry versions ignore the fields, but older ones require them to match the registry/tag used to upload the image.