### PR TITLE
Rename sigstore-write to sigstore-staging

### DIFF
--- a/docker/fixtures/registries.d/internal-example.com.yaml
+++ b/docker/fixtures/registries.d/internal-example.com.yaml
@@ -5,7 +5,7 @@ docker:
         sigstore: http://registry.test.example.com/sigstore
     registry.test.example.com:8888:
         sigstore: http://registry.test.example.com:8889/sigstore
-        sigstore-write: https://registry.test.example.com:8889/sigstore/specialAPIserverWhichDoesntExist
+        sigstore-staging: https://registry.test.example.com:8889/sigstore/specialAPIserverWhichDoesntExist
     localhost:
         sigstore: file:///home/mitr/mydevelopment1
     localhost:8080:

--- a/docker/fixtures/registries.d/internet-user.yaml
+++ b/docker/fixtures/registries.d/internet-user.yaml
@@ -7,6 +7,6 @@ docker:
         sigstore: https://sigstore.centos.org/
     docker.io/centos/mybetaprooduct:
         sigstore: http://localhost:9999/mybetaWIP/sigstore
-        sigstore-write: file:///srv/mybetaWIP/sigstore
+        sigstore-staging: file:///srv/mybetaWIP/sigstore
     docker.io/centos/mybetaproduct:latest:
         sigstore: https://sigstore.centos.org/

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -34,8 +34,8 @@ type registryConfiguration struct {
 
 // registryNamespace defines lookaside locations for a single namespace.
 type registryNamespace struct {
-	SigStore      string `json:"sigstore"`       // For reading, and if SigStoreWrite is not present, for writing.
-	SigStoreWrite string `json:"sigstore-write"` // For writing only.
+	SigStore        string `json:"sigstore"`         // For reading, and if SigStoreStaging is not present, for writing.
+	SigStoreStaging string `json:"sigstore-staging"` // For writing only.
 }
 
 // signatureStorageBase is an "opaque" type representing a lookaside Docker signature storage.
@@ -175,9 +175,9 @@ func (config *registryConfiguration) signatureTopLevel(ref dockerReference, writ
 // ns.signatureTopLevel returns an URL string configured in ns for ref, for write access if “write”.
 // or "" if nothing has been configured.
 func (ns registryNamespace) signatureTopLevel(write bool) string {
-	if write && ns.SigStoreWrite != "" {
-		logrus.Debugf(`  Using %s`, ns.SigStoreWrite)
-		return ns.SigStoreWrite
+	if write && ns.SigStoreStaging != "" {
+		logrus.Debugf(`  Using %s`, ns.SigStoreStaging)
+		return ns.SigStoreStaging
 	}
 	if ns.SigStore != "" {
 		logrus.Debugf(`  Using %s`, ns.SigStore)

--- a/docker/lookaside_test.go
+++ b/docker/lookaside_test.go
@@ -168,15 +168,15 @@ func TestLoadAndMergeConfig(t *testing.T) {
 		Docker: map[string]registryNamespace{
 			"example.com":                    {SigStore: "https://sigstore.example.com"},
 			"registry.test.example.com":      {SigStore: "http://registry.test.example.com/sigstore"},
-			"registry.test.example.com:8888": {SigStore: "http://registry.test.example.com:8889/sigstore", SigStoreWrite: "https://registry.test.example.com:8889/sigstore/specialAPIserverWhichDoesntExist"},
+			"registry.test.example.com:8888": {SigStore: "http://registry.test.example.com:8889/sigstore", SigStoreStaging: "https://registry.test.example.com:8889/sigstore/specialAPIserverWhichDoesntExist"},
 			"localhost":                      {SigStore: "file:///home/mitr/mydevelopment1"},
 			"localhost:8080":                 {SigStore: "file:///home/mitr/mydevelopment2"},
 			"localhost/invalid/url/test":     {SigStore: ":emptyscheme"},
 			"docker.io/contoso":              {SigStore: "https://sigstore.contoso.com/fordocker"},
 			"docker.io/centos":               {SigStore: "https://sigstore.centos.org/"},
 			"docker.io/centos/mybetaprooduct": {
-				SigStore:      "http://localhost:9999/mybetaWIP/sigstore",
-				SigStoreWrite: "file:///srv/mybetaWIP/sigstore",
+				SigStore:        "http://localhost:9999/mybetaWIP/sigstore",
+				SigStoreStaging: "file:///srv/mybetaWIP/sigstore",
 			},
 			"docker.io/centos/mybetaproduct:latest": {SigStore: "https://sigstore.centos.org/"},
 		},
@@ -185,7 +185,7 @@ func TestLoadAndMergeConfig(t *testing.T) {
 
 func TestRegistryConfigurationSignaureTopLevel(t *testing.T) {
 	config := registryConfiguration{
-		DefaultDocker: &registryNamespace{SigStore: "=default", SigStoreWrite: "=default+w"},
+		DefaultDocker: &registryNamespace{SigStore: "=default", SigStoreStaging: "=default+w"},
 		Docker:        map[string]registryNamespace{},
 	}
 	for _, ns := range []string{
@@ -197,7 +197,7 @@ func TestRegistryConfigurationSignaureTopLevel(t *testing.T) {
 		"example.com/ns1/ns2/repo",
 		"example.com/ns1/ns2/repo:notlatest",
 	} {
-		config.Docker[ns] = registryNamespace{SigStore: ns, SigStoreWrite: ns + "+w"}
+		config.Docker[ns] = registryNamespace{SigStore: ns, SigStoreStaging: ns + "+w"}
 	}
 
 	for _, c := range []struct{ input, expected string }{
@@ -221,7 +221,7 @@ func TestRegistryConfigurationSignaureTopLevel(t *testing.T) {
 
 	config = registryConfiguration{
 		Docker: map[string]registryNamespace{
-			"unmatched": {SigStore: "a", SigStoreWrite: "b"},
+			"unmatched": {SigStore: "a", SigStoreStaging: "b"},
 		},
 	}
 	dr := dockerRefFromString(t, "//thisisnotmatched")
@@ -237,12 +237,12 @@ func TestRegistryNamespaceSignatureTopLevel(t *testing.T) {
 		forWriting bool
 		expected   string
 	}{
-		{registryNamespace{SigStoreWrite: "a", SigStore: "b"}, true, "a"},
-		{registryNamespace{SigStoreWrite: "a", SigStore: "b"}, false, "b"},
+		{registryNamespace{SigStoreStaging: "a", SigStore: "b"}, true, "a"},
+		{registryNamespace{SigStoreStaging: "a", SigStore: "b"}, false, "b"},
 		{registryNamespace{SigStore: "b"}, true, "b"},
 		{registryNamespace{SigStore: "b"}, false, "b"},
-		{registryNamespace{SigStoreWrite: "a"}, true, "a"},
-		{registryNamespace{SigStoreWrite: "a"}, false, ""},
+		{registryNamespace{SigStoreStaging: "a"}, true, "a"},
+		{registryNamespace{SigStoreStaging: "a"}, false, ""},
 		{registryNamespace{}, true, ""},
 		{registryNamespace{}, false, ""},
 	} {

--- a/docs/registries.d.md
+++ b/docs/registries.d.md
@@ -61,16 +61,16 @@ more general scopes is ignored.  For example, if _any_ configuration exists for
 A single configuration section is selected for a container image using the process
 described above.  The configuration section is a YAML mapping, with the following keys:
 
-- `sigstore-write` defines an URL of of the signature storage, used for editing it (adding or deleting signatures).
+- `sigstore-staging` defines an URL of of the signature storage, used for editing it (adding or deleting signatures).
 
    This key is optional; if it is missing, `sigstore` below is used.
 
 - `sigstore` defines an URL of the signature storage.
    This URL is used for reading existing signatures,
-   and if `sigstore-write` does not exist, also for adding or removing them.
+   and if `sigstore-staging` does not exist, also for adding or removing them.
 
    This key is optional; if it is missing, no signature storage is defined (no signatures
-   are download along with images, adding new signatures is impossible).
+   are download along with images, adding new signatures is possible only if `sigstore-staging` is defined).
 
 ## Examples
 
@@ -102,10 +102,10 @@ docker:
         sigstore: https://registry-sigstore.example.com
     registry.example.com/mydepartment:
         sigstore: https://sigstore.mydepartment.example.com
-        sigstore-write: file:///mnt/mydepartment/sigstore-staging
+        sigstore-staging: file:///mnt/mydepartment/sigstore-staging
     registry.example.com/mydepartment/myproject:mybranch:
         sigstore: http://localhost:4242/sigstore
-        sigstore-write: file:///home/useraccount/webroot/sigstore
+        sigstore-staging: file:///home/useraccount/webroot/sigstore
 ```
 
 ### A Global Default
@@ -115,5 +115,5 @@ without listing each domain individually. This is expected to rarely happen, usu
 
 ```yaml
 default-docker:
-    sigstore-write: file:///mnt/company/common-sigstore-staging
+    sigstore-staging: file:///mnt/company/common-sigstore-staging
 ```


### PR DESCRIPTION
This makes it much clearer how that URL is supposed to be used.

(And it could also clear the way to, in the future, have a write server. Perhaps.)
