### PR TITLE
Layer compression

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -40,6 +40,11 @@ func (d *dirImageDestination) SupportsSignatures() error {
 	return nil
 }
 
+// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
+func (d *dirImageDestination) ShouldCompressLayers() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -56,6 +56,8 @@ func TestGetPutBlob(t *testing.T) {
 	dest, err := ref.NewImageDestination(nil)
 	require.NoError(t, err)
 	defer dest.Close()
+	compress := dest.ShouldCompressLayers()
+	assert.False(t, compress)
 	info, err := dest.PutBlob(bytes.NewReader(blob), types.BlobInfo{Digest: digest, Size: int64(9)})
 	assert.NoError(t, err)
 	err = dest.Commit()

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -62,6 +62,11 @@ func (d *dockerImageDestination) SupportsSignatures() error {
 	return fmt.Errorf("Pushing signatures to a Docker Registry is not supported")
 }
 
+// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
+func (d *dockerImageDestination) ShouldCompressLayers() bool {
+	return true
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/image/types"
@@ -71,5 +72,14 @@ func (m *manifestSchema2) ImageInspectInfo() (*types.ImageInspectInfo, error) {
 
 func (m *manifestSchema2) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
 	copy := *m
+	if options.LayerInfos != nil {
+		if len(copy.LayersDescriptors) != len(options.LayerInfos) {
+			return nil, fmt.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(copy.LayersDescriptors), len(options.LayerInfos))
+		}
+		for i, info := range options.LayerInfos {
+			copy.LayersDescriptors[i].Digest = info.Digest
+			copy.LayersDescriptors[i].Size = info.Size
+		}
+	}
 	return json.Marshal(copy)
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -49,6 +49,11 @@ func (d *ociImageDestination) SupportsSignatures() error {
 	return fmt.Errorf("Pushing signatures for OCI images is not supported")
 }
 
+// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
+func (d *ociImageDestination) ShouldCompressLayers() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -337,6 +337,11 @@ func (d *openshiftImageDestination) SupportsSignatures() error {
 	return nil
 }
 
+// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
+func (d *openshiftImageDestination) ShouldCompressLayers() bool {
+	return true
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/types/types.go
+++ b/types/types.go
@@ -133,6 +133,8 @@ type ImageDestination interface {
 	// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 	// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 	SupportsSignatures() error
+	// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
+	ShouldCompressLayers() bool
 
 	// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.

--- a/types/types.go
+++ b/types/types.go
@@ -184,6 +184,7 @@ type Image interface {
 
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
 type ManifestUpdateOptions struct {
+	LayerInfos []BlobInfo // Complete BlobInfos (size+digest) which should replace the originals, in order (the root layer first, and then successive layered layers)
 }
 
 // ImageInspectInfo is a set of metadata describing Docker images, primarily their manifest and configuration.


### PR DESCRIPTION
@runcom PTAL

This integrates #90 , and builds on it to compress layers in `copy.go` if they are uncompressed and the destination prefers compressed ones.

If any layer is modified, we need corresponding updates to the manifest; hence `types.Image.UpdatedManifest`. I don’t particularly _like_ that interface, but it works for now, and it seems possible to extend it to the other anticipated uses (1) updating a tag when pushing schema1, 2) conversion to a different MIME type).  Any better ideas would be welcome. (Of course, an ugly interface is not a show-stopper; we can clean this up later after the uses are better knkown.)

This seems to work fine, though the schema1 manifest updates will need a closer look. And tests, I suppose?