### PR TITLE
Add manifest update infrastructure

### DIFF
--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -15,6 +15,8 @@ type descriptor struct {
 
 type manifestSchema2 struct {
 	src               types.ImageSource
+	SchemaVersion     int          `json:"schemaVersion"`
+	MediaType         string       `json:"mediaType"`
 	ConfigDescriptor  descriptor   `json:"config"`
 	LayersDescriptors []descriptor `json:"layers"`
 }
@@ -65,4 +67,9 @@ func (m *manifestSchema2) ImageInspectInfo() (*types.ImageInspectInfo, error) {
 		Architecture:  v1.Architecture,
 		Os:            v1.OS,
 	}, nil
+}
+
+func (m *manifestSchema2) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
+	copy := *m
+	return json.Marshal(copy)
 }

--- a/image/image.go
+++ b/image/image.go
@@ -108,6 +108,7 @@ type genericManifest interface {
 	ConfigInfo() types.BlobInfo
 	LayerInfos() []types.BlobInfo
 	ImageInspectInfo() (*types.ImageInspectInfo, error) // The caller will need to fill in Layers
+	UpdatedManifest(types.ManifestUpdateOptions) ([]byte, error)
 }
 
 // getParsedManifest parses the manifest into a data structure, cleans it up, and returns it.
@@ -172,4 +173,14 @@ func (i *genericImage) LayerInfos() ([]types.BlobInfo, error) {
 		return nil, err
 	}
 	return m.LayerInfos(), nil
+}
+
+// UpdatedManifest returns the image's manifest modified according to updateOptions.
+// This does not change the state of the Image object.
+func (i *genericImage) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
+	m, err := i.getParsedManifest()
+	if err != nil {
+		return nil, err
+	}
+	return m.UpdatedManifest(options)
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -95,3 +95,21 @@ func MatchesDigest(manifest []byte, expectedDigest string) (bool, error) {
 	}
 	return expectedDigest == actualDigest, nil
 }
+
+// AddDummyV2S1Signature adds an JWS signature with a temporary key (i.e. useless) to a v2s1 manifest.
+// This is useful to make the manifest acceptable to a Docker Registry (even though nothing needs or wants the JWS signature).
+func AddDummyV2S1Signature(manifest []byte) ([]byte, error) {
+	key, err := libtrust.GenerateECP256PrivateKey()
+	if err != nil {
+		return nil, err // Coverage: This can fail only if rand.Reader fails.
+	}
+
+	js, err := libtrust.NewJSONSignature(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if err := js.Sign(key); err != nil { // Coverage: This can fail basically only if rand.Reader fails.
+		return nil, err
+	}
+	return js.PrettySignature("signatures")
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/libtrust"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,4 +103,21 @@ func TestMatchesDigest(t *testing.T) {
 	res, err = MatchesDigest([]byte{}, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	assert.True(t, res)
 	assert.NoError(t, err)
+}
+
+func TestAddDummyV2S1Signature(t *testing.T) {
+	manifest, err := ioutil.ReadFile("fixtures/v2s1-unsigned.manifest.json")
+	require.NoError(t, err)
+
+	signedManifest, err := AddDummyV2S1Signature(manifest)
+	require.NoError(t, err)
+
+	sig, err := libtrust.ParsePrettySignature(signedManifest, "signatures")
+	require.NoError(t, err)
+	signaturePayload, err := sig.Payload()
+	require.NoError(t, err)
+	assert.Equal(t, manifest, signaturePayload)
+
+	_, err = AddDummyV2S1Signature([]byte("}this is invalid JSON"))
+	assert.Error(t, err)
 }

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -77,6 +77,9 @@ func (ref refImageMock) LayerInfos() ([]types.BlobInfo, error) {
 func (ref refImageMock) Inspect() (*types.ImageInspectInfo, error) {
 	panic("unexpected call to a mock function")
 }
+func (ref refImageMock) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
+	panic("unexpected call to a mock function")
+}
 func (ref refImageMock) GetRepositoryTags() ([]string, error) {
 	panic("unexpected call to a mock function")
 }
@@ -286,6 +289,9 @@ func (ref forbiddenImageMock) LayerInfos() ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref forbiddenImageMock) Inspect() (*types.ImageInspectInfo, error) {
+	panic("unexpected call to a mock function")
+}
+func (ref forbiddenImageMock) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref forbiddenImageMock) GetRepositoryTags() ([]string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -175,6 +175,13 @@ type Image interface {
 	LayerInfos() ([]BlobInfo, error)
 	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 	Inspect() (*ImageInspectInfo, error)
+	// UpdatedManifest returns the image's manifest modified according to options.
+	// This does not change the state of the Image object.
+	UpdatedManifest(options ManifestUpdateOptions) ([]byte, error)
+}
+
+// ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
+type ManifestUpdateOptions struct {
 }
 
 // ImageInspectInfo is a set of metadata describing Docker images, primarily their manifest and configuration.


### PR DESCRIPTION
@runcom PTAL

This is a subset of #93, preparing to be able to modify manifests. Does nothing so far, but will be shared by #93, pushing to Docker tags, and schema conversions.

See individual commits for a bit more description.