### PR TITLE
Use tags when pushing to dockerImageDestination

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -165,14 +165,17 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {
-	// FIXME: This only allows upload by digest, not creating a tag.  See the
-	// corresponding comment in openshift.NewImageDestination.
 	digest, err := manifest.Digest(m)
 	if err != nil {
 		return err
 	}
 	d.manifestDigest = digest
-	url := fmt.Sprintf(manifestURL, d.ref.ref.RemoteName(), digest)
+
+	reference, err := d.ref.tagOrDigest()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf(manifestURL, d.ref.ref.RemoteName(), reference)
 
 	headers := map[string][]string{}
 	mimeType := manifest.GuessMIMEType(m)

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -354,8 +354,6 @@ func (d *openshiftImageDestination) PutBlob(stream io.Reader, inputInfo types.Bl
 
 func (d *openshiftImageDestination) PutManifest(m []byte) error {
 	// FIXME? Can this eventually just call d.docker.PutManifest()?
-	// Right now we need this as a skeleton to attach signatures to, and
-	// to workaround our inability to change tags when uploading v2s1 manifests.
 
 	// Note: This does absolutely no kind/version checking or conversions.
 	manifestDigest, err := manifest.Digest(m)


### PR DESCRIPTION
Not pushing to a tag makes the image impossible to pull with a tag.

This is not really correct because we keep the Name and Tag in schema1 manifests unmodified, and older registry versions (in particular OpenShift 1.1) do inspect those fields.  But, it is better than nothing,
and for OpenShift manifest uploads via the Docker API ( #95 ) a tag is required.

_Recent_ versions of registry, both docker/distribution and OpenShift, AFAICS completely ignore the tag in schema1 manifests; so that should work fine.