### PR TITLE
Implement openshiftReference.NewImage

### DIFF
--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -1,12 +1,12 @@
 package openshift
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/containers/image/docker/policyconfiguration"
+	genericImage "github.com/containers/image/image"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/reference"
 )
@@ -121,7 +121,11 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 // NewImage returns a types.Image for this reference.
 // The caller must call .Close() on the returned Image.
 func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	return nil, errors.New("Full Image support not implemented for atomic: image names")
+	src, err := newImageSource(ctx, ref, nil)
+	if err != nil {
+		return nil, err
+	}
+	return genericImage.FromSource(src), nil
 }
 
 // NewImageSource returns a types.ImageSource for this reference,

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -114,14 +114,7 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 	}, ref.PolicyConfigurationNamespaces())
 }
 
-func TestReferenceNewImage(t *testing.T) {
-	ref, err := ParseReference("registry.example.com:8443/ns/stream:notlatest")
-	require.NoError(t, err)
-	_, err = ref.NewImage(nil)
-	assert.Error(t, err)
-}
-
-// openshiftReference.NewImageSource, openshiftReference.NewImageDestination untested because they depend
+// openshiftReference.NewImage, openshiftReference.NewImageSource, openshiftReference.NewImageDestination untested because they depend
 // on per-user configuration when initializing httpClient.
 
 func TestReferenceDeleteImage(t *testing.T) {


### PR DESCRIPTION
There is no reason not to, and it will allow `skopeo inspect atomic:` to work.