### PR TITLE
docker: remove client's timeout

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/types"
@@ -73,9 +72,7 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) 
 			TLSClientConfig: tlsc,
 		}
 	}
-	client := &http.Client{
-		Timeout: 1 * time.Minute,
-	}
+	client := &http.Client{}
 	if tr != nil {
 		client.Transport = tr
 	}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/docker"
@@ -57,7 +56,6 @@ func newOpenshiftClient(ref openshiftReference) (*openshiftClient, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	httpClient.Timeout = 1 * time.Minute
 
 	return &openshiftClient{
 		ref:         ref,


### PR DESCRIPTION
This timeout is a no sense I've added few months ago IIRC - for pushes that take more than 1 minute is idiotic to just cancel the request, imagine a big layer...

@mtrmac PTAL - this sort of stuff should be better handled through channels and context.Context, not just by adding a client's timeout.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>