### PR TITLE
When failing to write to http/https sigstore, suggest sigstore-staging:

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -262,6 +262,8 @@ func (d *dockerImageDestination) putOneSignature(url *url.URL, signature []byte)
 		}
 		return nil
 
+	case "http", "https":
+		return fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location.", url.Scheme, url.String())
 	default:
 		return fmt.Errorf("Unsupported scheme when writing signature to %s", url.String())
 	}
@@ -279,6 +281,8 @@ func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error
 		}
 		return false, err
 
+	case "http", "https":
+		return false, fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location.", url.Scheme, url.String())
 	default:
 		return false, fmt.Errorf("Unsupported scheme when deleting signature from %s", url.String())
 	}


### PR DESCRIPTION
This will make it easier for the user to figure out how to proceed.

As pointed out in https://github.com/projectatomic/atomic/issues/644#issuecomment-248969687 (though note that _that_ error message comes from `atomic`, not `containers/image`).