### PR TITLE
copy: progress fix

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -270,11 +270,7 @@ func copyBlob(dest types.ImageDestination, src types.ImageSource, srcInfo types.
 	bar.Start()
 	destStream = bar.NewProxyReader(destStream)
 
-	defer func() {
-		if err != nil {
-			fmt.Fprint(reportWriter, "\n")
-		}
-	}()
+	defer fmt.Fprint(reportWriter, "\n")
 
 	var inputInfo types.BlobInfo
 	if !canCompress || isCompressed || !dest.ShouldCompressLayers() {


### PR DESCRIPTION
Silly me, we always want the new line - even on error if some of the progress has already been read 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>