### PR TITLE
Fix dockerClient use with nil SystemContext

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -332,7 +332,7 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		return pr, nil
 	}
 	pr, err := ping("https")
-	if err != nil && c.ctx.DockerInsecureSkipTLSVerify {
+	if err != nil && c.ctx != nil && c.ctx.DockerInsecureSkipTLSVerify {
 		pr, err = ping("http")
 	}
 	return pr, err


### PR DESCRIPTION
This does not manifest with skopeo because skopeo usually uses `contextFromGlobalOptions()` which is never `nil`, but it still is a violation of the documented API (and breaks the copy-lookalike I use for quick debugging).