### PR TITLE
types,docker: add DockerAuthConfig

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -52,7 +52,7 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) 
 	if registry == dockerHostname {
 		registry = dockerRegistry
 	}
-	username, password, err := getAuth(ref.ref.Hostname())
+	username, password, err := getAuth(ctx, ref.ref.Hostname())
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,10 @@ func (c *dockerClient) getBearerToken(realm, service, scope string) (string, err
 	return tokenStruct.Token, nil
 }
 
-func getAuth(registry string) (string, string, error) {
+func getAuth(ctx *types.SystemContext, registry string) (string, string, error) {
+	if ctx != nil && ctx.DockerAuthConfig != nil {
+		return ctx.DockerAuthConfig.Username, ctx.DockerAuthConfig.Password, nil
+	}
 	// TODO(runcom): get this from *cli.Context somehow
 	//if username != "" && password != "" {
 	//return username, password, nil

--- a/types/types.go
+++ b/types/types.go
@@ -205,6 +205,12 @@ type ImageInspectInfo struct {
 	Layers        []string
 }
 
+// DockerAuthConfig contains authorization information for connecting to a registry.
+type DockerAuthConfig struct {
+	Username string
+	Password string
+}
+
 // SystemContext allows parametrizing access to implicitly-accessed resources,
 // like configuration files in /etc and users' login state in their home directory.
 // Various components can share the same field only if their semantics is exactly
@@ -228,4 +234,6 @@ type SystemContext struct {
 	// === docker.Transport overrides ===
 	DockerCertPath              string // If not "", a directory containing "cert.pem" and "key.pem" used when talking to a Docker Registry
 	DockerInsecureSkipTLSVerify bool   // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
+	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
+	DockerAuthConfig *DockerAuthConfig
 }


### PR DESCRIPTION
The automatic credentials retrieval built into containers/image doesn't play at all with external credentials store. Furthermore, we need a way to pass credentials to containers/image from docker/docker (projectatomic/docker#200). This also fixes a bunch of docker's integration tests in projectatomic/docker#200.

This patch just gives precedence to any `ctx.DockerAuthConfig` field before diving deep into the system to lookup credentials into `~/.docker/config.json`. So no real behavior change in skopeo so far. We'll need to tackle #111, at which point we'll made the automatic retrieval optional as per https://github.com/containers/image/pull/41#issuecomment-233338484.

Close #41 
Close projectatomic/skopeo#106

This is also needed by kubernetes-incubator/cri-o#8 since there it's k8s itself to provide those credentials and we need to honor that (instead of looking on the system).

@mtrmac PTAL this is blocking projectatomic/docker#200 as said also. 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>