### PR TITLE
manifest: enable DockerV2List

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -112,6 +112,14 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	src := image.FromSource(rawSource)
 	defer src.Close()
 
+	multiImage, err := src.IsMultiImage()
+	if err != nil {
+		return err
+	}
+	if multiImage {
+		return fmt.Errorf("can not copy %s: manifest contains multiple images", transports.ImageName(srcRef))
+	}
+
 	// Please keep this policy check BEFORE reading any other information about the image.
 	if allowed, err := policyContext.IsRunningImageAllowed(src); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
 		return fmt.Errorf("Source image rejected: %v", err)

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -1,6 +1,7 @@
 package directory
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,6 +36,10 @@ func (s *dirImageSource) GetManifest() ([]byte, string, error) {
 		return nil, "", err
 	}
 	return m, "", err
+}
+
+func (s *dirImageSource) GetTargetManifest(digest string) ([]byte, string, error) {
+	return nil, "", fmt.Errorf("Getting target manifest not supported by dir:")
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).

--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -1,0 +1,52 @@
+package image
+
+import (
+	"encoding/json"
+	"errors"
+	"runtime"
+
+	"github.com/containers/image/types"
+)
+
+type platformSpec struct {
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	OSVersion    string   `json:"os.version,omitempty"`
+	OSFeatures   []string `json:"os.features,omitempty"`
+	Variant      string   `json:"variant,omitempty"`
+	Features     []string `json:"features,omitempty"`
+}
+
+// A manifestDescriptor references a platform-specific manifest.
+type manifestDescriptor struct {
+	descriptor
+	Platform platformSpec `json:"platform"`
+}
+
+type manifestList struct {
+	SchemaVersion int                  `json:"schemaVersion"`
+	MediaType     string               `json:"mediaType"`
+	Manifests     []manifestDescriptor `json:"manifests"`
+}
+
+func manifestSchema2FromManifestList(src types.ImageSource, manblob []byte) (genericManifest, error) {
+	list := manifestList{}
+	if err := json.Unmarshal(manblob, &list); err != nil {
+		return nil, err
+	}
+	var targetManifestDigest string
+	for _, d := range list.Manifests {
+		if d.Platform.Architecture == runtime.GOARCH && d.Platform.OS == runtime.GOOS {
+			targetManifestDigest = d.Digest
+			break
+		}
+	}
+	if targetManifestDigest == "" {
+		return nil, errors.New("no supported platform found in manifest list")
+	}
+	manblob, mt, err := src.GetTargetManifest(targetManifestDigest)
+	if err != nil {
+		return nil, err
+	}
+	return manifestInstanceFromBlob(src, manblob, mt)
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -30,6 +30,7 @@ var DefaultRequestedManifestMIMETypes = []string{
 	DockerV2Schema2MediaType,
 	DockerV2Schema1SignedMediaType,
 	DockerV2Schema1MediaType,
+	DockerV2ListMediaType,
 }
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -196,6 +196,13 @@ func (s *openshiftImageSource) Close() {
 	}
 }
 
+func (s *openshiftImageSource) GetTargetManifest(digest string) ([]byte, string, error) {
+	if err := s.ensureImageIsResolved(); err != nil {
+		return nil, "", err
+	}
+	return s.docker.GetTargetManifest(digest)
+}
+
 func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, "", err

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -12,6 +12,10 @@ type nameOnlyImageMock struct {
 	forbiddenImageMock
 }
 
+func (nameOnlyImageMock) IsMultiImage() (bool, error) {
+	panic("unexpected call to a mock function")
+}
+
 func (nameOnlyImageMock) Reference() types.ImageReference {
 	return nameOnlyImageReferenceMock("== StringWithinTransport mock")
 }

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -56,6 +56,9 @@ type refImageMock struct{ reference.Named }
 func (ref refImageMock) Reference() types.ImageReference {
 	return refImageReferenceMock{ref.Named}
 }
+func (ref refImageMock) IsMultiImage() (bool, error) {
+	panic("unexpected call to a mock function")
+}
 func (ref refImageMock) Close() {
 	panic("unexpected call to a mock function")
 }
@@ -267,6 +270,9 @@ func TestParseDockerReferences(t *testing.T) {
 // forbiddenImageMock is a mock of types.Image which ensures Reference is not called
 type forbiddenImageMock struct{}
 
+func (ref forbiddenImageMock) IsMultiImage() (bool, error) {
+	panic("unexpected call to a mock function")
+}
 func (ref forbiddenImageMock) Reference() types.ImageReference {
 	panic("unexpected call to a mock function")
 }

--- a/types/types.go
+++ b/types/types.go
@@ -106,6 +106,9 @@ type ImageSource interface {
 	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown.
 	// It may use a remote (= slow) service.
 	GetManifest() ([]byte, string, error)
+	// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest
+	// out of a manifest list.
+	GetTargetManifest(digest string) ([]byte, string, error)
 	// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 	GetBlob(digest string) (io.ReadCloser, int64, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
@@ -180,6 +183,8 @@ type Image interface {
 	// UpdatedManifest returns the image's manifest modified according to options.
 	// This does not change the state of the Image object.
 	UpdatedManifest(options ManifestUpdateOptions) ([]byte, error)
+	// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
+	IsMultiImage() (bool, error)
 }
 
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest


### PR DESCRIPTION
Related to https://github.com/containers/image/issues/114

Needed for projectatomic/docker#200 - w/o this pulling an image with a manifest list is broken into docker.
Rigth now, by not supporting the manifest list media type we always got the _single_ manifest for the amd64 arch instead of the whole manifest list and this broke docker because computing the digest for that single manifest isn't the same as the digest from the manifest list.

Also note that if you pull-by-digest a manifest list in docker you get back exactly the same manifest list digest (and not the one from the target manifest) which is confusing to me but still, it's how docker works.

@mtrmac PTAL - this is blocking

Signed-off-by: Antonio Murdaca <runcom@redhat.com>