### PR TITLE
oci/layout: fix deps

### DIFF
--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -153,7 +152,7 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 	if err != nil {
 		return err
 	}
-	desc := imgspec.Descriptor{}
+	desc := imgspecv1.Descriptor{}
 	desc.Digest = digest
 	// TODO(runcom): beaware and add support for OCI manifest list
 	desc.MediaType = mt


### PR DESCRIPTION
will need a skopeo re-vendor of opencontainers/image-spec

This is fixing CI:
```
$ make deps
go get -t ./...
# github.com/containers/image/oci/layout
oci/layout/oci_dest.go:156: undefined: specs.Descriptor
make: *** [deps] Error 2
The command "make deps" failed and exited with 2 during .
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>