### PR TITLE
docker/docker_image.go: Add func for obtaining tag

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -32,6 +32,15 @@ func (i *Image) SourceRefFullName() string {
 	return i.src.ref.ref.FullName()
 }
 
+// GetTag returns an image's tag
+func (i *Image) GetTag() string {
+	tag, err := i.src.ref.tagOrDigest()
+	if err != nil {
+		fmt.Errorf("Error in determining image tag")
+	}
+	return tag
+}
+
 // GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
 func (i *Image) GetRepositoryTags() ([]string, error) {
 	url := fmt.Sprintf(tagsURL, i.src.ref.ref.RemoteName())


### PR DESCRIPTION
There is a small bug in skopeo where with schema2, the tag
field in not populated when performing an inspect.  Adding
this small func and calling in skopeo fixes that.