### PR TITLE
Refactor c/i/image

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -156,11 +156,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	}
 	canModifyManifest := len(sigs) == 0
 
-	writeReport("Getting image source configuration\n")
-	srcConfigInfo, err := src.ConfigInfo()
-	if err != nil {
-		return fmt.Errorf("Error parsing manifest: %v", err)
-	}
+	srcConfigInfo := src.ConfigInfo()
 	if srcConfigInfo.Digest != "" {
 		writeReport("Uploading blob %s\n", srcConfigInfo.Digest)
 		destConfigInfo, err := copyBlob(dest, rawSource, srcConfigInfo, false, reportWriter)
@@ -172,10 +168,7 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 		}
 	}
 
-	srcLayerInfos, err := src.LayerInfos()
-	if err != nil {
-		return fmt.Errorf("Error parsing manifest: %v", err)
-	}
+	srcLayerInfos := src.LayerInfos()
 	destLayerInfos := []types.BlobInfo{}
 	copiedLayers := map[string]types.BlobInfo{}
 	for _, srcLayer := range srcLayerInfos {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -112,17 +112,17 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	src := image.FromSource(rawSource)
 	defer src.Close()
 
+	// Please keep this policy check BEFORE reading any other information about the image.
+	if allowed, err := policyContext.IsRunningImageAllowed(src); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
+		return fmt.Errorf("Source image rejected: %v", err)
+	}
+
 	multiImage, err := src.IsMultiImage()
 	if err != nil {
 		return err
 	}
 	if multiImage {
 		return fmt.Errorf("can not copy %s: manifest contains multiple images", transports.ImageName(srcRef))
-	}
-
-	// Please keep this policy check BEFORE reading any other information about the image.
-	if allowed, err := policyContext.IsRunningImageAllowed(src); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
-		return fmt.Errorf("Source image rejected: %v", err)
 	}
 
 	writeReport("Getting image source manifest\n")

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -120,15 +120,14 @@ func Image(ctx *types.SystemContext, policyContext *signature.PolicyContext, des
 	if allowed, err := policyContext.IsRunningImageAllowed(unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
 		return fmt.Errorf("Source image rejected: %v", err)
 	}
-	src := image.FromUnparsedImage(unparsedImage)
+	src, err := image.FromUnparsedImage(unparsedImage)
+	if err != nil {
+		return fmt.Errorf("Error initializing image from source %s: %v", transports.ImageName(srcRef), err)
+	}
 	unparsedImage = nil
 	defer src.Close()
 
-	multiImage, err := src.IsMultiImage()
-	if err != nil {
-		return err
-	}
-	if multiImage {
+	if src.IsMultiImage() {
 		return fmt.Errorf("can not copy %s: manifest contains multiple images", transports.ImageName(srcRef))
 	}
 

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -133,7 +133,7 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	src := newImageSource(ref)
-	return image.FromSource(src), nil
+	return image.FromSource(src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -127,8 +127,10 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference.
+// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	src := newImageSource(ref)
 	return image.FromSource(src), nil

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -149,6 +149,15 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
+
+	dest, err := ref.NewImageDestination(nil)
+	require.NoError(t, err)
+	defer dest.Close()
+	err = dest.PutManifest([]byte(`{"schemaVersion":2}`))
+	assert.NoError(t, err)
+	err = dest.Commit()
+	assert.NoError(t, err)
+
 	img, err := ref.NewImage(nil)
 	assert.NoError(t, err)
 	defer img.Close()

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -24,7 +24,11 @@ func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error
 	if err != nil {
 		return nil, err
 	}
-	return &Image{Image: image.FromSource(s), src: s}, nil
+	img, err := image.FromSource(s)
+	if err != nil {
+		return nil, err
+	}
+	return &Image{Image: img, src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -115,8 +115,10 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
 
-// NewImage returns a types.Image for this reference.
+// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	return newImage(ctx, ref)
 }

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -56,6 +56,10 @@ func (m *manifestSchema1) serialize() ([]byte, error) {
 	return manifest.AddDummyV2S1Signature(unsigned)
 }
 
+func (m *manifestSchema1) manifestMIMEType() string {
+	return manifest.DockerV2Schema1SignedMediaType
+}
+
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 func (m *manifestSchema1) ConfigInfo() types.BlobInfo {
 	return types.BlobInfo{}
@@ -111,7 +115,7 @@ func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (typ
 			copy.FSLayers[(len(options.LayerInfos)-1)-i].BlobSum = info.Digest
 		}
 	}
-	return memoryImageFromManifest(&copy, manifest.DockerV2Schema1SignedMediaType), nil
+	return memoryImageFromManifest(&copy), nil
 }
 
 // fixManifestLayers, after validating the supplied manifest

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -33,6 +32,10 @@ func manifestSchema2FromManifest(src types.ImageSource, manifest []byte) (generi
 
 func (m *manifestSchema2) serialize() ([]byte, error) {
 	return json.Marshal(*m)
+}
+
+func (m *manifestSchema2) manifestMIMEType() string {
+	return m.MediaType
 }
 
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
@@ -92,5 +95,5 @@ func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (typ
 			copy.LayersDescriptors[i].Size = info.Size
 		}
 	}
-	return memoryImageFromManifest(&copy, manifest.DockerV2Schema2MediaType), nil
+	return memoryImageFromManifest(&copy), nil
 }

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -28,6 +29,10 @@ func manifestSchema2FromManifest(src types.ImageSource, manifest []byte) (generi
 		return nil, err
 	}
 	return &v2s2, nil
+}
+
+func (m *manifestSchema2) serialize() ([]byte, error) {
+	return json.Marshal(*m)
 }
 
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
@@ -74,9 +79,9 @@ func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
 	}, nil
 }
 
-// UpdatedManifest returns the image's manifest modified according to options.
-// This does not change the state of the Image object.
-func (m *manifestSchema2) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
+// UpdatedImage returns a types.Image modified according to options.
+// This does not change the state of the original Image object.
+func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
 	copy := *m
 	if options.LayerInfos != nil {
 		if len(copy.LayersDescriptors) != len(options.LayerInfos) {
@@ -87,5 +92,5 @@ func (m *manifestSchema2) UpdatedManifest(options types.ManifestUpdateOptions) (
 			copy.LayersDescriptors[i].Size = info.Size
 		}
 	}
-	return json.Marshal(copy)
+	return memoryImageFromManifest(&copy, manifest.DockerV2Schema2MediaType), nil
 }

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -30,10 +30,14 @@ func manifestSchema2FromManifest(src types.ImageSource, manifest []byte) (generi
 	return &v2s2, nil
 }
 
+// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 func (m *manifestSchema2) ConfigInfo() types.BlobInfo {
 	return types.BlobInfo{Digest: m.ConfigDescriptor.Digest, Size: m.ConfigDescriptor.Size}
 }
 
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
 func (m *manifestSchema2) LayerInfos() []types.BlobInfo {
 	blobs := []types.BlobInfo{}
 	for _, layer := range m.LayersDescriptors {
@@ -42,7 +46,7 @@ func (m *manifestSchema2) LayerInfos() []types.BlobInfo {
 	return blobs
 }
 
-func (m *manifestSchema2) Config() ([]byte, error) {
+func (m *manifestSchema2) config() ([]byte, error) {
 	rawConfig, _, err := m.src.GetBlob(m.ConfigDescriptor.Digest)
 	if err != nil {
 		return nil, err
@@ -52,8 +56,8 @@ func (m *manifestSchema2) Config() ([]byte, error) {
 	return config, err
 }
 
-func (m *manifestSchema2) ImageInspectInfo() (*types.ImageInspectInfo, error) {
-	config, err := m.Config()
+func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
+	config, err := m.config()
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +74,8 @@ func (m *manifestSchema2) ImageInspectInfo() (*types.ImageInspectInfo, error) {
 	}, nil
 }
 
+// UpdatedManifest returns the image's manifest modified according to options.
+// This does not change the state of the Image object.
 func (m *manifestSchema2) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
 	copy := *m
 	if options.LayerInfos != nil {

--- a/image/image.go
+++ b/image/image.go
@@ -88,14 +88,6 @@ func (i *genericImage) getParsedManifest() (genericManifest, error) {
 	return manifestInstanceFromBlob(i.src, manblob, mt)
 }
 
-func (i *genericImage) IsMultiImage() (bool, error) {
-	_, mt, err := i.Manifest()
-	if err != nil {
-		return false, err
-	}
-	return mt == manifest.DockerV2ListMediaType, nil
-}
-
 func (i *genericImage) Inspect() (*types.ImageInspectInfo, error) {
 	// TODO(runcom): unused version param for now, default to docker v2-1
 	m, err := i.getParsedManifest()
@@ -142,4 +134,12 @@ func (i *genericImage) UpdatedManifest(options types.ManifestUpdateOptions) ([]b
 		return nil, err
 	}
 	return m.UpdatedManifest(options)
+}
+
+func (i *genericImage) IsMultiImage() (bool, error) {
+	_, mt, err := i.Manifest()
+	if err != nil {
+		return false, err
+	}
+	return mt == manifest.DockerV2ListMediaType, nil
 }

--- a/image/image.go
+++ b/image/image.go
@@ -4,10 +4,6 @@
 package image
 
 import (
-	"errors"
-	"fmt"
-	"time"
-
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
@@ -81,32 +77,6 @@ func (i *genericImage) Manifest() ([]byte, string, error) {
 	return m, mt, nil
 }
 
-type config struct {
-	Labels map[string]string
-}
-
-type v1Image struct {
-	// Config is the configuration of the container received from the client
-	Config *config `json:"config,omitempty"`
-	// DockerVersion specifies version on which image is built
-	DockerVersion string `json:"docker_version,omitempty"`
-	// Created timestamp when image was created
-	Created time.Time `json:"created"`
-	// Architecture is the hardware that the image is build and runs on
-	Architecture string `json:"architecture,omitempty"`
-	// OS is the operating system used to build and run the image
-	OS string `json:"os,omitempty"`
-}
-
-// will support v1 one day...
-type genericManifest interface {
-	Config() ([]byte, error)
-	ConfigInfo() types.BlobInfo
-	LayerInfos() []types.BlobInfo
-	ImageInspectInfo() (*types.ImageInspectInfo, error) // The caller will need to fill in Layers
-	UpdatedManifest(types.ManifestUpdateOptions) ([]byte, error)
-}
-
 // getParsedManifest parses the manifest into a data structure, cleans it up, and returns it.
 // NOTE: The manifest may have been modified in the process; DO NOT reserialize and store the return value
 // if you want to preserve the original manifest; use the blob returned by Manifest() directly.
@@ -124,24 +94,6 @@ func (i *genericImage) IsMultiImage() (bool, error) {
 		return false, err
 	}
 	return mt == manifest.DockerV2ListMediaType, nil
-}
-
-func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
-	switch mt {
-	// "application/json" is a valid v2s1 value per https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md .
-	// This works for now, when nothing else seems to return "application/json"; if that were not true, the mapping/detection might
-	// need to happen within the ImageSource.
-	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, "application/json":
-		return manifestSchema1FromManifest(manblob)
-	case manifest.DockerV2Schema2MediaType:
-		return manifestSchema2FromManifest(src, manblob)
-	case manifest.DockerV2ListMediaType:
-		return manifestSchema2FromManifestList(src, manblob)
-	case "":
-		return nil, errors.New("could not guess manifest media type")
-	default:
-		return nil, fmt.Errorf("unsupported manifest media type %s", mt)
-	}
 }
 
 func (i *genericImage) Inspect() (*types.ImageInspectInfo, error) {

--- a/image/image.go
+++ b/image/image.go
@@ -12,23 +12,6 @@ import (
 	"github.com/containers/image/types"
 )
 
-// genericImage is a general set of utilities for working with container images,
-// whatever is their underlying location (i.e. dockerImageSource-independent).
-// Note the existence of skopeo/docker.Image: some instances of a `types.Image`
-// may not be a `genericImage` directly. However, most users of `types.Image`
-// do not care, and those who care about `skopeo/docker.Image` know they do.
-type genericImage struct {
-	src types.ImageSource
-	// private cache for Manifest(); nil if not yet known.
-	cachedManifest []byte
-	// private cache for the manifest media type w/o having to guess it
-	// this may be the empty string in case the MIME Type wasn't guessed correctly
-	// this field is valid only if cachedManifest is not nil
-	cachedManifestMIMEType string
-	// private cache for Signatures(); nil if not yet known.
-	cachedSignatures [][]byte
-}
-
 // FromSource returns a types.Image implementation for source.
 // The caller must call .Close() on the returned Image.
 //
@@ -36,30 +19,54 @@ type genericImage struct {
 // when the image is closed.  (This does not prevent callers from using both the
 // Image and ImageSource objects simultaneously, but it means that they only need to
 // the Image.)
+//
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
 func FromSource(src types.ImageSource) types.Image {
-	return &genericImage{src: src}
+	return FromUnparsedImage(UnparsedFromSource(src))
 }
 
-// Reference returns the reference used to set up this source, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-func (i *genericImage) Reference() types.ImageReference {
-	return i.src.Reference()
+// genericImage is a general set of utilities for working with container images,
+// whatever is their underlying location (i.e. dockerImageSource-independent).
+// Note the existence of skopeo/docker.Image: some instances of a `types.Image`
+// may not be a `genericImage` directly. However, most users of `types.Image`
+// do not care, and those who care about `skopeo/docker.Image` know they do.
+type genericImage struct {
+	*UnparsedImage
+	trueManifestMIMETypeSet bool   // A private cache for Manifest
+	trueManifestMIMEType    string // A private cache for Manifest, valid only if trueManifestMIMETypeSet
 }
 
-// Close removes resources associated with an initialized Image, if any.
-func (i *genericImage) Close() {
-	i.src.Close()
+// FromUnparsedImage returns a types.Image implementation for unparsed.
+// The caller must call .Close() on the returned Image.
+//
+// FromSource “takes ownership” of the input UnparsedImage and will call uparsed.Close()
+// when the image is closed.  (This does not prevent callers from using both the
+// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
+// keep a reference to the Image.)
+func FromUnparsedImage(unparsed *UnparsedImage) types.Image {
+	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
+	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
+	// this is the only UnparsedImage implementation around, anyway.
+
+	// Also, we do not explicitly implement types.Image.Close; we let the implementation fall through to
+	// unparsed.Close.
+
+	// NOTE: It is essential for signature verification that all parsing done in this object happens on the same manifest which is returned by unparsed.Manifest().
+	return &genericImage{
+		UnparsedImage:           unparsed,
+		trueManifestMIMETypeSet: false,
+		trueManifestMIMEType:    "",
+	}
 }
 
-// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
-// NOTE: It is essential for signature verification that Manifest returns the manifest from which ConfigInfo and LayerInfos is computed.
+// Manifest overrides the UnparsedImage.Manifest to add guessing and overrides, which we don't want to do before signature verification.
 func (i *genericImage) Manifest() ([]byte, string, error) {
-	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest()
-		if err != nil {
-			return nil, "", err
-		}
-		i.cachedManifest = m
+	m, mt, err := i.UnparsedImage.Manifest()
+	if err != nil {
+		return nil, "", err
+	}
+	if !i.trueManifestMIMETypeSet {
 		if mt == "" || mt == "text/plain" {
 			// Crane registries can return "text/plain".
 			// This makes no real sense, but it happens
@@ -68,21 +75,10 @@ func (i *genericImage) Manifest() ([]byte, string, error) {
 			// network which is configured that way.
 			mt = manifest.GuessMIMEType(i.cachedManifest)
 		}
-		i.cachedManifestMIMEType = mt
+		i.trueManifestMIMEType = mt
+		i.trueManifestMIMETypeSet = true
 	}
-	return i.cachedManifest, i.cachedManifestMIMEType, nil
-}
-
-// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
-func (i *genericImage) Signatures() ([][]byte, error) {
-	if i.cachedSignatures == nil {
-		sigs, err := i.src.GetSignatures()
-		if err != nil {
-			return nil, err
-		}
-		i.cachedSignatures = sigs
-	}
-	return i.cachedSignatures, nil
+	return m, mt, nil
 }
 
 type config struct {
@@ -114,7 +110,6 @@ type genericManifest interface {
 // getParsedManifest parses the manifest into a data structure, cleans it up, and returns it.
 // NOTE: The manifest may have been modified in the process; DO NOT reserialize and store the return value
 // if you want to preserve the original manifest; use the blob returned by Manifest() directly.
-// NOTE: It is essential for signature verification that the object is computed from the same manifest which is returned by Manifest().
 func (i *genericImage) getParsedManifest() (genericManifest, error) {
 	manblob, mt, err := i.Manifest()
 	if err != nil {
@@ -168,7 +163,6 @@ func (i *genericImage) Inspect() (*types.ImageInspectInfo, error) {
 }
 
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
-// NOTE: It is essential for signature verification that ConfigInfo is computed from the same manifest which is returned by Manifest().
 func (i *genericImage) ConfigInfo() (types.BlobInfo, error) {
 	m, err := i.getParsedManifest()
 	if err != nil {
@@ -179,7 +173,6 @@ func (i *genericImage) ConfigInfo() (types.BlobInfo, error) {
 
 // LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 // The Digest field is guaranteed to be provided; Size may be -1.
-// NOTE: It is essential for signature verification that LayerInfos is computed from the same manifest which is returned by Manifest().
 // WARNING: The list may contain duplicates, and they are semantically relevant.
 func (i *genericImage) LayerInfos() ([]types.BlobInfo, error) {
 	m, err := i.getParsedManifest()

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -26,12 +26,21 @@ type v1Image struct {
 	OS string `json:"os,omitempty"`
 }
 
+// genericManifest is an interface for parsing, modifying image manifests and related data.
+// Note that the public methods are intended to be a subset of types.Image
+// so that embedding a genericManifest into structs works.
 // will support v1 one day...
 type genericManifest interface {
-	Config() ([]byte, error)
+	config() ([]byte, error)
+	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 	ConfigInfo() types.BlobInfo
+	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+	// The Digest field is guaranteed to be provided; Size may be -1.
+	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []types.BlobInfo
-	ImageInspectInfo() (*types.ImageInspectInfo, error) // The caller will need to fill in Layers
+	imageInspectInfo() (*types.ImageInspectInfo, error) // The caller will need to fill in Layers
+	// UpdatedManifest returns the image's manifest modified according to options.
+	// This does not change the state of the Image object.
 	UpdatedManifest(types.ManifestUpdateOptions) ([]byte, error)
 }
 

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -1,0 +1,54 @@
+package image
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+)
+
+type config struct {
+	Labels map[string]string
+}
+
+type v1Image struct {
+	// Config is the configuration of the container received from the client
+	Config *config `json:"config,omitempty"`
+	// DockerVersion specifies version on which image is built
+	DockerVersion string `json:"docker_version,omitempty"`
+	// Created timestamp when image was created
+	Created time.Time `json:"created"`
+	// Architecture is the hardware that the image is build and runs on
+	Architecture string `json:"architecture,omitempty"`
+	// OS is the operating system used to build and run the image
+	OS string `json:"os,omitempty"`
+}
+
+// will support v1 one day...
+type genericManifest interface {
+	Config() ([]byte, error)
+	ConfigInfo() types.BlobInfo
+	LayerInfos() []types.BlobInfo
+	ImageInspectInfo() (*types.ImageInspectInfo, error) // The caller will need to fill in Layers
+	UpdatedManifest(types.ManifestUpdateOptions) ([]byte, error)
+}
+
+func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
+	switch mt {
+	// "application/json" is a valid v2s1 value per https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md .
+	// This works for now, when nothing else seems to return "application/json"; if that were not true, the mapping/detection might
+	// need to happen within the ImageSource.
+	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, "application/json":
+		return manifestSchema1FromManifest(manblob)
+	case manifest.DockerV2Schema2MediaType:
+		return manifestSchema2FromManifest(src, manblob)
+	case manifest.DockerV2ListMediaType:
+		return manifestSchema2FromManifestList(src, manblob)
+	case "":
+		return nil, errors.New("could not guess manifest media type")
+	default:
+		return nil, fmt.Errorf("unsupported manifest media type %s", mt)
+	}
+}

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -32,6 +32,7 @@ type v1Image struct {
 // will support v1 one day...
 type genericManifest interface {
 	serialize() ([]byte, error)
+	manifestMIMEType() string
 	config() ([]byte, error)
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 	ConfigInfo() types.BlobInfo

--- a/image/memory.go
+++ b/image/memory.go
@@ -14,14 +14,12 @@ import (
 // from a memoryImage.
 type memoryImage struct {
 	genericManifest
-	manifestMIMEType   string
 	serializedManifest []byte // A private cache for Manifest()
 }
 
-func memoryImageFromManifest(m genericManifest, mimeType string) types.Image {
+func memoryImageFromManifest(m genericManifest) types.Image {
 	return &memoryImage{
 		genericManifest:    m,
-		manifestMIMEType:   mimeType,
 		serializedManifest: nil,
 	}
 }
@@ -46,7 +44,7 @@ func (i *memoryImage) Manifest() ([]byte, string, error) {
 		}
 		i.serializedManifest = m
 	}
-	return i.serializedManifest, i.manifestMIMEType, nil
+	return i.serializedManifest, i.genericManifest.manifestMIMEType(), nil
 }
 
 // Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.

--- a/image/memory.go
+++ b/image/memory.go
@@ -1,0 +1,67 @@
+package image
+
+import (
+	"errors"
+
+	"github.com/containers/image/types"
+)
+
+// memoryImage is a mostly-implementation of types.Image assembled from data
+// created in memory, used primarily as a return value of types.Image.UpdatedImage
+// as a way to carry various structured information in a type-safe and easy-to-use way.
+// Note that this _only_ carries the immediate metadata; it is _not_ a stand-alone
+// collection of all related information, e.g. there is no way to get layer blobs
+// from a memoryImage.
+type memoryImage struct {
+	genericManifest
+	manifestMIMEType   string
+	serializedManifest []byte // A private cache for Manifest()
+}
+
+func memoryImageFromManifest(m genericManifest, mimeType string) types.Image {
+	return &memoryImage{
+		genericManifest:    m,
+		manifestMIMEType:   mimeType,
+		serializedManifest: nil,
+	}
+}
+
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (i *memoryImage) Reference() types.ImageReference {
+	// It would really be inappropriate to return the ImageReference of the image this was based on.
+	return nil
+}
+
+// Close removes resources associated with an initialized UnparsedImage, if any.
+func (i *memoryImage) Close() {
+}
+
+// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *memoryImage) Manifest() ([]byte, string, error) {
+	if i.serializedManifest == nil {
+		m, err := i.genericManifest.serialize()
+		if err != nil {
+			return nil, "", err
+		}
+		i.serializedManifest = m
+	}
+	return i.serializedManifest, i.manifestMIMEType, nil
+}
+
+// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *memoryImage) Signatures() ([][]byte, error) {
+	// Modifying an image invalidates signatures; a caller asking the updated image for signatures
+	// is probably confused.
+	return nil, errors.New("Internal error: Image.Signatures() is not supported for images modified in memory")
+}
+
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
+	return inspectManifest(i.genericManifest)
+}
+
+// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
+func (i *memoryImage) IsMultiImage() bool {
+	return false
+}

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -22,12 +22,12 @@ func FromSource(src types.ImageSource) (types.Image, error) {
 	return FromUnparsedImage(UnparsedFromSource(src))
 }
 
-// genericImage is a general set of utilities for working with container images,
+// sourcedImage is a general set of utilities for working with container images,
 // whatever is their underlying location (i.e. dockerImageSource-independent).
 // Note the existence of skopeo/docker.Image: some instances of a `types.Image`
-// may not be a `genericImage` directly. However, most users of `types.Image`
+// may not be a `sourcedImage` directly. However, most users of `types.Image`
 // do not care, and those who care about `skopeo/docker.Image` know they do.
-type genericImage struct {
+type sourcedImage struct {
 	*UnparsedImage
 	manifestBlob     []byte
 	manifestMIMEType string
@@ -71,7 +71,7 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 		return nil, err
 	}
 
-	return &genericImage{
+	return &sourcedImage{
 		UnparsedImage:    unparsed,
 		manifestBlob:     manifestBlob,
 		manifestMIMEType: manifestMIMEType,
@@ -80,11 +80,11 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 }
 
 // Manifest overrides the UnparsedImage.Manifest to use the fields which we have already fetched, after guessing and overrides.
-func (i *genericImage) Manifest() ([]byte, string, error) {
+func (i *sourcedImage) Manifest() ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }
 
-func (i *genericImage) Inspect() (*types.ImageInspectInfo, error) {
+func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
 	info, err := i.genericManifest.imageInspectInfo()
 	if err != nil {
 		return nil, err
@@ -97,6 +97,6 @@ func (i *genericImage) Inspect() (*types.ImageInspectInfo, error) {
 	return info, nil
 }
 
-func (i *genericImage) IsMultiImage() bool {
+func (i *sourcedImage) IsMultiImage() bool {
 	return i.manifestMIMEType == manifest.DockerV2ListMediaType
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -85,16 +85,7 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 }
 
 func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
-	info, err := i.genericManifest.imageInspectInfo()
-	if err != nil {
-		return nil, err
-	}
-	layers := i.LayerInfos()
-	info.Layers = make([]string, len(layers))
-	for i, layer := range layers {
-		info.Layers[i] = layer.Digest
-	}
-	return info, nil
+	return inspectManifest(i.genericManifest)
 }
 
 func (i *sourcedImage) IsMultiImage() bool {

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -1,0 +1,60 @@
+package image
+
+import "github.com/containers/image/types"
+
+// UnparsedImage implements types.UnparsedImage .
+type UnparsedImage struct {
+	src            types.ImageSource
+	cachedManifest []byte // A private cache for Manifest(); nil if not yet known.
+	// A private cache for Manifest(), may be the empty string if guessing failed.
+	// Valid iff cachedManifest is not nil.
+	cachedManifestMIMEType string
+	cachedSignatures       [][]byte // A private cache for Signatures(); nil if not yet known.
+}
+
+// UnparsedFromSource returns a types.UnparsedImage implementation for source.
+// The caller must call .Close() on the returned UnparsedImage.
+//
+// UnparsedFromSource “takes ownership” of the input ImageSource and will call src.Close()
+// when the image is closed.  (This does not prevent callers from using both the
+// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
+// keep a reference to the UnparsedImage.)
+func UnparsedFromSource(src types.ImageSource) *UnparsedImage {
+	return &UnparsedImage{src: src}
+}
+
+// Reference returns the reference used to set up this source, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+func (i *UnparsedImage) Reference() types.ImageReference {
+	return i.src.Reference()
+}
+
+// Close removes resources associated with an initialized UnparsedImage, if any.
+func (i *UnparsedImage) Close() {
+	i.src.Close()
+}
+
+// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *UnparsedImage) Manifest() ([]byte, string, error) {
+	if i.cachedManifest == nil {
+		m, mt, err := i.src.GetManifest()
+		if err != nil {
+			return nil, "", err
+		}
+		i.cachedManifest = m
+		i.cachedManifestMIMEType = mt
+	}
+	return i.cachedManifest, i.cachedManifestMIMEType, nil
+}
+
+// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *UnparsedImage) Signatures() ([][]byte, error) {
+	if i.cachedSignatures == nil {
+		sigs, err := i.src.GetSignatures()
+		if err != nil {
+			return nil, err
+		}
+		i.cachedSignatures = sigs
+	}
+	return i.cachedSignatures, nil
+}

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -164,8 +164,10 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference.
+// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	return nil, errors.New("Full Image support not implemented for oci: image names")
 }

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -118,8 +118,10 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.dockerReference)
 }
 
-// NewImage returns a types.Image for this reference.
+// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	src, err := newImageSource(ctx, ref, nil)
 	if err != nil {

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -127,7 +127,7 @@ func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, e
 	if err != nil {
 		return nil, err
 	}
-	return genericImage.FromSource(src), nil
+	return genericImage.FromSource(src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -54,14 +54,14 @@ type PolicyRequirement interface {
 	//   a container based on this image; use IsRunningImageAllowed instead.
 	// - Just because a signature is accepted does not automatically mean the contents of the
 	//   signature are authorized to run code as root, or to affect system or cluster configuration.
-	isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error)
+	isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error)
 
 	// isRunningImageAllowed returns true if the requirement allows running an image.
 	// If it returns false, err must be non-nil, and should be an PolicyRequirementError if evaluation
 	// succeeded but the result was rejection.
 	// WARNING: This validates signatures and the manifest, but does not download or validate the
 	// layers. Users must validate that the layers match their expected digests.
-	isRunningImageAllowed(image types.Image) (bool, error)
+	isRunningImageAllowed(image types.UnparsedImage) (bool, error)
 }
 
 // PolicyReferenceMatch specifies a set of image identities accepted in PolicyRequirement.
@@ -70,7 +70,7 @@ type PolicyReferenceMatch interface {
 	// matchesDockerReference decides whether a specific image identity is accepted for an image
 	// (or, usually, for the image's Reference().DockerReference()).  Note that
 	// image.Reference().DockerReference() may be nil.
-	matchesDockerReference(image types.Image, signatureDockerReference string) bool
+	matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool
 }
 
 // PolicyContext encapsulates a policy and possible cached state
@@ -174,7 +174,7 @@ func (pc *PolicyContext) requirementsForImageRef(ref types.ImageReference) Polic
 //   a container based on this image; use IsRunningImageAllowed instead.
 // - Just because a signature is accepted does not automatically mean the contents of the
 //   signature are authorized to run code as root, or to affect system or cluster configuration.
-func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(image types.Image) (sigs []*Signature, finalErr error) {
+func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(image types.UnparsedImage) (sigs []*Signature, finalErr error) {
 	if err := pc.changeState(pcReady, pcInUse); err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(image types.Image) (sig
 // succeeded but the result was rejection.
 // WARNING: This validates signatures and the manifest, but does not download or validate the
 // layers. Users must validate that the layers match their expected digests.
-func (pc *PolicyContext) IsRunningImageAllowed(image types.Image) (res bool, finalErr error) {
+func (pc *PolicyContext) IsRunningImageAllowed(image types.UnparsedImage) (res bool, finalErr error) {
 	if err := pc.changeState(pcReady, pcInUse); err != nil {
 		return false, err
 	}

--- a/signature/policy_eval_baselayer.go
+++ b/signature/policy_eval_baselayer.go
@@ -7,11 +7,11 @@ import (
 	"github.com/containers/image/types"
 )
 
-func (pr *prSignedBaseLayer) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prSignedBaseLayer) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	return sarUnknown, nil, nil
 }
 
-func (pr *prSignedBaseLayer) isRunningImageAllowed(image types.Image) (bool, error) {
+func (pr *prSignedBaseLayer) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
 	// FIXME? Reject this at policy parsing time already?
 	logrus.Errorf("signedBaseLayer not implemented yet!")
 	return false, PolicyRequirementError("signedBaseLayer not implemented yet!")

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containers/image/types"
 )
 
-func (pr *prSignedBy) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prSignedBy) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	switch pr.KeyType {
 	case SBKeyTypeGPGKeys:
 	case SBKeyTypeSignedByGPGKeys, SBKeyTypeX509Certificates, SBKeyTypeSignedByX509CAs:
@@ -97,7 +97,7 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(image types.Image, sig []byte) (
 	return sarAccepted, signature, nil
 }
 
-func (pr *prSignedBy) isRunningImageAllowed(image types.Image) (bool, error) {
+func (pr *prSignedBy) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
 	sigs, err := image.Signatures()
 	if err != nil {
 		return false, err

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -14,16 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// dirImageMock returns a types.Image for a directory, claiming a specified dockerReference.
-func dirImageMock(t *testing.T, dir, dockerReference string) types.Image {
+// dirImageMock returns a types.UnparsedImage for a directory, claiming a specified dockerReference.
+// The caller must call .Close() on the returned UnparsedImage.
+func dirImageMock(t *testing.T, dir, dockerReference string) types.UnparsedImage {
 	ref, err := reference.ParseNamed(dockerReference)
 	require.NoError(t, err)
 	return dirImageMockWithRef(t, dir, refImageReferenceMock{ref})
 }
 
-// dirImageMockWithRef returns a types.Image for a directory, claiming a specified ref.
-// The caller must call .Close() on the returned Image.
-func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) types.Image {
+// dirImageMockWithRef returns a types.UnparsedImage for a directory, claiming a specified ref.
+// The caller must call .Close() on the returned UnparsedImage.
+func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) types.UnparsedImage {
 	srcRef, err := directory.NewReference(dir)
 	require.NoError(t, err)
 	src, err := srcRef.NewImageSource(nil, nil)

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -29,7 +29,7 @@ func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) typ
 	require.NoError(t, err)
 	src, err := srcRef.NewImageSource(nil, nil)
 	require.NoError(t, err)
-	return image.FromSource(&dirImageSourceMock{
+	return image.UnparsedFromSource(&dirImageSourceMock{
 		ImageSource: src,
 		ref:         ref,
 	})

--- a/signature/policy_eval_simple.go
+++ b/signature/policy_eval_simple.go
@@ -9,20 +9,20 @@ import (
 	"github.com/containers/image/types"
 )
 
-func (pr *prInsecureAcceptAnything) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prInsecureAcceptAnything) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	// prInsecureAcceptAnything semantics: Every image is allowed to run,
 	// but this does not consider the signature as verified.
 	return sarUnknown, nil, nil
 }
 
-func (pr *prInsecureAcceptAnything) isRunningImageAllowed(image types.Image) (bool, error) {
+func (pr *prInsecureAcceptAnything) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
 	return true, nil
 }
 
-func (pr *prReject) isSignatureAuthorAccepted(image types.Image, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prReject) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	return sarRejected, nil, PolicyRequirementError(fmt.Sprintf("Any signatures for image %s are rejected by policy.", transports.ImageName(image.Reference())))
 }
 
-func (pr *prReject) isRunningImageAllowed(image types.Image) (bool, error) {
+func (pr *prReject) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
 	return false, PolicyRequirementError(fmt.Sprintf("Running image %s is rejected by policy.", transports.ImageName(image.Reference())))
 }

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -7,13 +7,9 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// nameOnlyImageMock is a mock of types.Image which only allows transports.ImageName to work
+// nameOnlyImageMock is a mock of types.UnparsedImage which only allows transports.ImageName to work
 type nameOnlyImageMock struct {
 	forbiddenImageMock
-}
-
-func (nameOnlyImageMock) IsMultiImage() (bool, error) {
-	panic("unexpected call to a mock function")
 }
 
 func (nameOnlyImageMock) Reference() types.ImageReference {

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -171,9 +171,9 @@ func TestPolicyContextRequirementsForImageRef(t *testing.T) {
 	}
 }
 
-// pcImageMock returns a types.Image for a directory, claiming a specified dockerReference and implementing PolicyConfigurationIdentity/PolicyConfigurationNamespaces.
+// pcImageMock returns a types.UnparsedImage for a directory, claiming a specified dockerReference and implementing PolicyConfigurationIdentity/PolicyConfigurationNamespaces.
 // The caller must call .Close() on the returned Image.
-func pcImageMock(t *testing.T, dir, dockerReference string) types.Image {
+func pcImageMock(t *testing.T, dir, dockerReference string) types.UnparsedImage {
 	ref, err := reference.ParseNamed(dockerReference)
 	require.NoError(t, err)
 	return dirImageMockWithRef(t, dir, pcImageReferenceMock{"docker", ref})

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -11,7 +11,7 @@ import (
 )
 
 // parseImageAndDockerReference converts an image and a reference string into two parsed entities, failing on any error and handling unidentified images.
-func parseImageAndDockerReference(image types.Image, s2 string) (reference.Named, reference.Named, error) {
+func parseImageAndDockerReference(image types.UnparsedImage, s2 string) (reference.Named, reference.Named, error) {
 	r1 := image.Reference().DockerReference()
 	if r1 == nil {
 		return nil, nil, PolicyRequirementError(fmt.Sprintf("Docker reference match attempted on image %s with no known Docker reference identity",
@@ -24,7 +24,7 @@ func parseImageAndDockerReference(image types.Image, s2 string) (reference.Named
 	return r1, r2, nil
 }
 
-func (prm *prmMatchExact) matchesDockerReference(image types.Image, signatureDockerReference string) bool {
+func (prm *prmMatchExact) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
 	if err != nil {
 		return false
@@ -36,7 +36,7 @@ func (prm *prmMatchExact) matchesDockerReference(image types.Image, signatureDoc
 	return signature.String() == intended.String()
 }
 
-func (prm *prmMatchRepository) matchesDockerReference(image types.Image, signatureDockerReference string) bool {
+func (prm *prmMatchRepository) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
 	if err != nil {
 		return false
@@ -57,7 +57,7 @@ func parseDockerReferences(s1, s2 string) (reference.Named, reference.Named, err
 	return r1, r2, nil
 }
 
-func (prm *prmExactReference) matchesDockerReference(image types.Image, signatureDockerReference string) bool {
+func (prm *prmExactReference) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseDockerReferences(prm.DockerReference, signatureDockerReference)
 	if err != nil {
 		return false
@@ -69,7 +69,7 @@ func (prm *prmExactReference) matchesDockerReference(image types.Image, signatur
 	return signature.String() == intended.String()
 }
 
-func (prm *prmExactRepository) matchesDockerReference(image types.Image, signatureDockerReference string) bool {
+func (prm *prmExactRepository) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseDockerReferences(prm.DockerRepository, signatureDockerReference)
 	if err != nil {
 		return false

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -50,14 +50,11 @@ func TestParseImageAndDockerReference(t *testing.T) {
 	}
 }
 
-// refImageMock is a mock of types.Image which returns itself in Reference().DockerReference.
+// refImageMock is a mock of types.UnparsedImage which returns itself in Reference().DockerReference.
 type refImageMock struct{ reference.Named }
 
 func (ref refImageMock) Reference() types.ImageReference {
 	return refImageReferenceMock{ref.Named}
-}
-func (ref refImageMock) IsMultiImage() (bool, error) {
-	panic("unexpected call to a mock function")
 }
 func (ref refImageMock) Close() {
 	panic("unexpected call to a mock function")
@@ -65,25 +62,7 @@ func (ref refImageMock) Close() {
 func (ref refImageMock) Manifest() ([]byte, string, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageMock) ManifestMatchesDigest(expectedDigest string) (bool, error) {
-	panic("unexpected call to a mock function")
-}
 func (ref refImageMock) Signatures() ([][]byte, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref refImageMock) ConfigInfo() (types.BlobInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref refImageMock) LayerInfos() ([]types.BlobInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref refImageMock) Inspect() (*types.ImageInspectInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref refImageMock) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref refImageMock) GetRepositoryTags() ([]string, error) {
 	panic("unexpected call to a mock function")
 }
 
@@ -267,12 +246,9 @@ func TestParseDockerReferences(t *testing.T) {
 	}
 }
 
-// forbiddenImageMock is a mock of types.Image which ensures Reference is not called
+// forbiddenImageMock is a mock of types.UnparsedImage which ensures Reference is not called
 type forbiddenImageMock struct{}
 
-func (ref forbiddenImageMock) IsMultiImage() (bool, error) {
-	panic("unexpected call to a mock function")
-}
 func (ref forbiddenImageMock) Reference() types.ImageReference {
 	panic("unexpected call to a mock function")
 }
@@ -282,25 +258,7 @@ func (ref forbiddenImageMock) Close() {
 func (ref forbiddenImageMock) Manifest() ([]byte, string, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref forbiddenImageMock) ManifestMatchesDigest(expectedDigest string) (bool, error) {
-	panic("unexpected call to a mock function")
-}
 func (ref forbiddenImageMock) Signatures() ([][]byte, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref forbiddenImageMock) ConfigInfo() (types.BlobInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref forbiddenImageMock) LayerInfos() ([]types.BlobInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref forbiddenImageMock) Inspect() (*types.ImageInspectInfo, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref forbiddenImageMock) UpdatedManifest(options types.ManifestUpdateOptions) ([]byte, error) {
-	panic("unexpected call to a mock function")
-}
-func (ref forbiddenImageMock) GetRepositoryTags() ([]string, error) {
 	panic("unexpected call to a mock function")
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -180,11 +180,11 @@ type UnparsedImage interface {
 type Image interface {
 	UnparsedImage
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
-	ConfigInfo() (BlobInfo, error)
+	ConfigInfo() BlobInfo
 	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfos() ([]BlobInfo, error)
+	LayerInfos() []BlobInfo
 	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 	Inspect() (*ImageInspectInfo, error)
 	// UpdatedManifest returns the image's manifest modified according to options.

--- a/types/types.go
+++ b/types/types.go
@@ -178,6 +178,7 @@ type UnparsedImage interface {
 // Image is the primary API for inspecting properties of images.
 // Each Image should eventually be closed by calling Close().
 type Image interface {
+	// Note that Reference may return nil in the return value of UpdatedImage!
 	UnparsedImage
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 	ConfigInfo() BlobInfo
@@ -187,9 +188,9 @@ type Image interface {
 	LayerInfos() []BlobInfo
 	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 	Inspect() (*ImageInspectInfo, error)
-	// UpdatedManifest returns the image's manifest modified according to options.
-	// This does not change the state of the Image object.
-	UpdatedManifest(options ManifestUpdateOptions) ([]byte, error)
+	// UpdatedImage returns a types.Image modified according to options.
+	// This does not change the state of the original Image object.
+	UpdatedImage(options ManifestUpdateOptions) (Image, error)
 	// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
 	IsMultiImage() bool
 }

--- a/types/types.go
+++ b/types/types.go
@@ -191,7 +191,7 @@ type Image interface {
 	// This does not change the state of the Image object.
 	UpdatedManifest(options ManifestUpdateOptions) ([]byte, error)
 	// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
-	IsMultiImage() (bool, error)
+	IsMultiImage() bool
 }
 
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest

--- a/types/types.go
+++ b/types/types.go
@@ -70,8 +70,10 @@ type ImageReference interface {
 	// and each following element to be a prefix of the element preceding it.
 	PolicyConfigurationNamespaces() []string
 
-	// NewImage returns a types.Image for this reference.
+	// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 	// The caller must call .Close() on the returned Image.
+	// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+	// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 	NewImage(ctx *SystemContext) (Image, error)
 	// NewImageSource returns a types.ImageSource for this reference,
 	// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
@@ -176,14 +178,11 @@ type UnparsedImage interface {
 // Image is the primary API for inspecting properties of images.
 // Each Image should eventually be closed by calling Close().
 type Image interface {
-	// NOTE: It is essential for signature verification that Manifest returns the manifest from which ConfigInfo and LayerInfos is computed.
 	UnparsedImage
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
-	// NOTE: It is essential for signature verification that ConfigInfo is computed from the same manifest which is returned by Manifest().
 	ConfigInfo() (BlobInfo, error)
 	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 	// The Digest field is guaranteed to be provided; Size may be -1.
-	// NOTE: It is essential for signature verification that LayerInfos is computed from the same manifest which is returned by Manifest().
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() ([]BlobInfo, error)
 	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.


### PR DESCRIPTION
@runcom PTAL.

This is a pretty big refactoring of `image/`, see individual commits for details.  The overall ideas:

- Signature verification happens on `UnparsedImage`, which structurally prevents interpreting too much before we know the image is admissible.
- `genericImage` becomes `sourcedImage`, a very thin layer over `UnparsedImage` and `genericManifest`
- Instead of `UpdatedManifest`, we now have `UpdatedImage`. This does not change much now, but will be a way to return also `config.json` and other objects.

I haven’t actually updated the schema conversion work to take advantage of `UpdatedImage` yet, but I expect it to help with the API shape noticeably.

Tests pass in https://github.com/mtrmac/skopeo/tree/image-refactor-test , although note that that includes https://github.com/mtrmac/image/commit/364c110ea3e5748cd8e748e3dd74df3b6d70373e as a defeat device for #115, not to be merged.