### PR TITLE
types: add DockerRegistryUserAgent to SystemContext

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -125,6 +125,9 @@ func (c *dockerClient) makeRequestToResolvedURL(method, url string, headers map[
 			req.Header.Add(n, hh)
 		}
 	}
+	if c.ctx != nil && c.ctx.DockerRegistryUserAgent != "" {
+		req.Header.Add("User-Agent", c.ctx.DockerRegistryUserAgent)
+	}
 	if c.wwwAuthenticate != "" {
 		if err := c.setupRequestAuth(req); err != nil {
 			return nil, err
@@ -317,7 +320,7 @@ type pingResponse struct {
 func (c *dockerClient) ping() (*pingResponse, error) {
 	ping := func(scheme string) (*pingResponse, error) {
 		url := fmt.Sprintf(baseURL, scheme, c.registry)
-		resp, err := c.client.Get(url)
+		resp, err := c.makeRequestToResolvedURL("GET", url, nil, nil, -1)
 		logrus.Debugf("Ping %s err %#v", url, err)
 		if err != nil {
 			return nil, err

--- a/types/types.go
+++ b/types/types.go
@@ -244,4 +244,6 @@ type SystemContext struct {
 	DockerInsecureSkipTLSVerify bool   // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig
+	// if not "", an User-Agent header is added to each request when contacting a registry.
+	DockerRegistryUserAgent string
 }


### PR DESCRIPTION
Package users may want to identify themselves with the registry for tracking purpose (as Docker engine is doing). This patch adds a new field to `types.SystemContext` called `DockerRegistryUserAgent` which if not empty is added as an `User-Agent` header to each request to the registry.

@mtrmac PTAL, this is needed for projectatomic/docker#200 and it's blocking it since docker's integration tests are failing w/o this. 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>