### PR TITLE
[WIP] verify signature for untagged references

### DIFF
--- a/docs/policy.json.md
+++ b/docs/policy.json.md
@@ -146,13 +146,25 @@ This requirement requires an image to be signed with an expected identity, or ac
     "keyType": "GPGKeys", /* The only currently supported value */
     "keyPath": "/path/to/local/keyring/file",
     "keyData": "base64-encoded-keyring-data",
-    "signedIdentity": identity_requirement
+    "signedIdentity": identity_requirement,
+    "referencesByDigest": refs_by_digest_requirement
 }
 ```
 <!-- Later: other keyType values -->
 
 Exactly one of `keyPath` and `keyData` must be present, containing a GPG keyring of one or more public keys.  Only signatures made by these keys are accepted.
 
+The `referencesByDigest` field controls whether an reference with a digest should be taken into consideration when checking signatures or be rejected altogheter.
+One of the following alternatives are supported:
+
+- References by digest are allowed (default). In this case, the digest should match the one from the signature for the verification to be successful.
+  ```json
+  {"referencesByDigest: allow"}
+  ```
+- References by digest are rejected and no signature verification is performed.
+  ```json
+  {"referencesByDigest: reject"}
+  ```
 The `signedIdentity` field, a JSON object, specifies what image identity the signature claims about the image.
 One of the following alternatives are supported:
 
@@ -257,27 +269,3 @@ selectively allow individual transports and scopes as desired.
     "default": [{"type": "insecureAcceptAnything"}]
 }
 ```
-
-### A _temporary_ work-around to allow accessing any image by digest
-
-Usually, identities in signatures use the _repository_`:`_tag_ format,
-which is not matched when pulling a specific image using a digest.
-To allow such operations, a policy may set `signedIdentity` to `matchRepository`, similar
-to the following fragment:
-
-```json
-            "hostname:5000/allow/pull/by/tag": [
-                {
-                    "type": "signedBy",
-                    "keyType": "GPGKeys",
-                    "keyPath": "/path/to/some.gpg"
-                    "signedIdentity": {
-                        "type": "matchRepository"
-                    }
-                }
-            ]
-```
-
-*Warning*: This completely turns off tag matching for the signature check in question,
-allowing also pulls by tag to accept signatures for any other tag.
-A more granular solution for this situation will be provided in the future ( https://github.com/containers/image/issues/99 ).

--- a/signature/docker.go
+++ b/signature/docker.go
@@ -35,7 +35,7 @@ func VerifyDockerManifestSignature(unverifiedSignature, unverifiedManifest []byt
 			}
 			return nil
 		},
-		validateSignedDockerReference: func(signedDockerReference string) error {
+		validateSignedDockerReference: func(signedDockerReference, digest string) error {
 			if signedDockerReference != expectedDockerReference {
 				return InvalidSignatureError{msg: fmt.Sprintf("Docker reference %s does not match %s",
 					signedDockerReference, expectedDockerReference)}

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -70,7 +70,10 @@ type PolicyReferenceMatch interface {
 	// matchesDockerReference decides whether a specific image identity is accepted for an image
 	// (or, usually, for the image's Reference().DockerReference()).  Note that
 	// image.Reference().DockerReference() may be nil.
-	matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool
+	//
+	// TODO(runcom): document byDigest
+	// TODO(runcom): document digest
+	matchesDockerReference(image types.UnparsedImage, signatureDockerReference, signatureManifstDigest string, byDigest bool) bool
 }
 
 // PolicyContext encapsulates a policy and possible cached state

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -69,8 +69,8 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(image types.UnparsedImage, sig [
 			// not be reachable.
 			return PolicyRequirementError(fmt.Sprintf("Signature by key %s is not accepted", keyIdentity))
 		},
-		validateSignedDockerReference: func(ref string) error {
-			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
+		validateSignedDockerReference: func(ref, digest string) error {
+			if !pr.SignedIdentity.matchesDockerReference(image, ref, digest, pr.ReferencesByDigest == SBKeyTypeUntaggedReferenceAllow) {
 				return PolicyRequirementError(fmt.Sprintf("Signature for identity %s is not accepted", ref))
 			}
 			return nil

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -54,7 +54,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Successful validation, with KeyData and KeyPath
-	pr, err := NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err := NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err := pr.isSignatureAuthorAccepted(testImage, testImageSig)
 	assertSARAccepted(t, sar, parsedSig, err, Signature{
@@ -64,7 +64,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 
 	keyData, err := ioutil.ReadFile("fixtures/public-key.gpg")
 	require.NoError(t, err)
-	pr, err = NewPRSignedByKeyData(ktGPG, keyData, prm)
+	pr, err = NewPRSignedByKeyData(ktGPG, keyData, prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(testImage, testImageSig)
 	assertSARAccepted(t, sar, parsedSig, err, Signature{
@@ -101,7 +101,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	assertSARRejected(t, sar, parsedSig, err)
 
 	// Invalid KeyPath
-	pr, err = NewPRSignedByKeyPath(ktGPG, "/this/does/not/exist", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "/this/does/not/exist", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	// Pass nil pointers to, kind of, test that the return value does not depend on the parameters.
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(nil, nil)
@@ -110,14 +110,14 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	// Errors initializing the temporary GPG directory and mechanism are not obviously easy to reach.
 
 	// KeyData has no public keys.
-	pr, err = NewPRSignedByKeyData(ktGPG, []byte{}, prm)
+	pr, err = NewPRSignedByKeyData(ktGPG, []byte{}, prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	// Pass nil pointers to, kind of, test that the return value does not depend on the parameters.
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(nil, nil)
 	assertSARRejectedPolicyRequirement(t, sar, parsedSig, err)
 
 	// A signature which does not GPG verify
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	// Pass a nil pointer to, kind of, test that the return value does not depend on the image parmater..
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(nil, []byte("invalid signature"))
@@ -126,7 +126,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	// A valid signature using an unknown key.
 	// (This is (currently?) rejected through the "mech.Verify fails" path, not the "!identityFound" path,
 	// because we use a temporary directory and only import the trusted keys.)
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sig, err := ioutil.ReadFile("fixtures/unknown-key.signature")
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	assertSARRejected(t, sar, parsedSig, err)
 
 	// A valid signature of an invalid JSON.
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sig, err = ioutil.ReadFile("fixtures/invalid-blob.signature")
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	// A valid signature with a rejected identity.
 	nonmatchingPRM, err := NewPRMExactReference("this/doesnt:match")
 	require.NoError(t, err)
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", nonmatchingPRM)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", nonmatchingPRM, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(testImage, testImageSig)
 	assertSARRejectedPolicyRequirement(t, sar, parsedSig, err)
@@ -157,7 +157,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	defer image.Close()
 	sig, err = ioutil.ReadFile("fixtures/dir-img-no-manifest/signature-1")
 	require.NoError(t, err)
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(image, sig)
 	assertSARRejected(t, sar, parsedSig, err)
@@ -167,7 +167,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	defer image.Close()
 	sig, err = ioutil.ReadFile("fixtures/dir-img-manifest-digest-error/signature-1")
 	require.NoError(t, err)
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(image, sig)
 	assertSARRejected(t, sar, parsedSig, err)
@@ -177,7 +177,7 @@ func TestPRSignedByIsSignatureAuthorAccepted(t *testing.T) {
 	defer image.Close()
 	sig, err = ioutil.ReadFile("fixtures/dir-img-modified-manifest/signature-1")
 	require.NoError(t, err)
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	sar, parsedSig, err = pr.isSignatureAuthorAccepted(image, sig)
 	assertSARRejectedPolicyRequirement(t, sar, parsedSig, err)
@@ -207,7 +207,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// A simple success case: single valid signature.
 	image := dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	defer image.Close()
-	pr, err := NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err := NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err := pr.isRunningImageAllowed(image)
 	assertRunningAllowed(t, allowed, err)
@@ -217,7 +217,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	defer os.RemoveAll(invalidSigDir)
 	image = dirImageMock(t, invalidSigDir, "testing/manifest:latest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningRejected(t, allowed, err)
@@ -225,7 +225,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// No signatures
 	image = dirImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningRejectedPolicyRequirement(t, allowed, err)
@@ -233,7 +233,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// 1 invalid signature: use dir-img-valid, but a non-matching Docker reference
 	image = dirImageMock(t, "fixtures/dir-img-valid", "testing/manifest:notlatest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningRejectedPolicyRequirement(t, allowed, err)
@@ -241,7 +241,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// 2 valid signatures
 	image = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningAllowed(t, allowed, err)
@@ -249,7 +249,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// One invalid, one valid signature (in this order)
 	image = dirImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningAllowed(t, allowed, err)
@@ -257,7 +257,7 @@ func TestPRSignedByIsRunningImageAllowed(t *testing.T) {
 	// 2 invalid signatures: use dir-img-valid-2, but a non-matching Docker reference
 	image = dirImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:notlatest")
 	defer image.Close()
-	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm)
+	pr, err = NewPRSignedByKeyPath(ktGPG, "fixtures/public-key.gpg", prm, SBKeyTypeUntaggedReferenceAllow)
 	require.NoError(t, err)
 	allowed, err = pr.isRunningImageAllowed(image)
 	assertRunningRejectedPolicyRequirement(t, allowed, err)

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -196,11 +196,11 @@ func TestPRMMatchExactMatchesDockerReference(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		res := prm.matchesDockerReference(refImageMock{imageRef}, test.sigRef)
+		res := prm.matchesDockerReference(refImageMock{imageRef}, test.sigRef, "", false)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 	// Even if they are signed with an empty string as a reference, unidentified images are rejected.
-	res := prm.matchesDockerReference(refImageMock{nil}, "")
+	res := prm.matchesDockerReference(refImageMock{nil}, "", "", false)
 	assert.False(t, res, `unidentified vs. ""`)
 }
 
@@ -213,11 +213,11 @@ func TestPRMMatchRepositoryMatchesDockerReference(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		res := prm.matchesDockerReference(refImageMock{imageRef}, test.sigRef)
+		res := prm.matchesDockerReference(refImageMock{imageRef}, test.sigRef, "", false)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 	// Even if they are signed with an empty string as a reference, unidentified images are rejected.
-	res := prm.matchesDockerReference(refImageMock{nil}, "")
+	res := prm.matchesDockerReference(refImageMock{nil}, "", "", false)
 	assert.False(t, res, `unidentified vs. ""`)
 }
 
@@ -267,7 +267,7 @@ func TestPRMExactReferenceMatchesDockerReference(t *testing.T) {
 		// Do not use NewPRMExactReference, we want to also test the case with an invalid DockerReference,
 		// even though NewPRMExactReference should never let it happen.
 		prm := prmExactReference{DockerReference: test.imageRef}
-		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef)
+		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef, "", false)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 }
@@ -277,7 +277,7 @@ func TestPRMExactRepositoryMatchesDockerReference(t *testing.T) {
 		// Do not use NewPRMExactRepository, we want to also test the case with an invalid DockerReference,
 		// even though NewPRMExactRepository should never let it happen.
 		prm := prmExactRepository{DockerRepository: test.imageRef}
-		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef)
+		res := prm.matchesDockerReference(forbiddenImageMock{}, test.sigRef, "", false)
 		assert.Equal(t, test.result, res, fmt.Sprintf("%s vs. %s", test.imageRef, test.sigRef))
 	}
 }

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -79,7 +79,17 @@ type prSignedBy struct {
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.
 	// Defaults to "match-exact" if not specified.
 	SignedIdentity PolicyReferenceMatch `json:"signedIdentity"`
+
+	// ReferencesByDigest specifies whether the signature is valid when the reference isn't tagged (e.g. canonical).
+	ReferencesByDigest sbUntaggedReferenceMatch `json:"referencesByDigest"`
 }
+
+type sbUntaggedReferenceMatch string
+
+const (
+	SBKeyTypeUntaggedReferenceAllow  sbUntaggedReferenceMatch = "allow"
+	SBKeyTypeUntaggedReferenceReject sbUntaggedReferenceMatch = "reject"
+)
 
 // sbKeyType are the allowed values for prSignedBy.KeyType
 type sbKeyType string
@@ -140,6 +150,27 @@ type prmExactReference struct {
 
 // prmExactRepository is a PolicyReferenceMatch with type = prmExactRepository: matches a specified repository, with any tag.
 type prmExactRepository struct {
+	prmCommon
+	DockerRepository string `json:"dockerRepository"`
+}
+
+// TODO(runcom): document stuff below
+
+const (
+	prmTypeUntaggedProhibit       prmTypeIdentifier = "prohibit"
+	prmTypeUntaggedMatchAnyTag    prmTypeIdentifier = "matchAnyTag"
+	prmTypeUntaggedMatchPrecisely prmTypeIdentifier = "matchPrecisely"
+)
+
+type prmUntaggedProhibit struct {
+	prmCommon
+}
+
+type prmUntaggedMatchAnyTag struct {
+	prmCommon
+}
+
+type prmUntaggedMatchPrecisely struct {
 	prmCommon
 	DockerRepository string `json:"dockerRepository"`
 }

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -161,7 +161,7 @@ func (s privateSignature) sign(mech SigningMechanism, keyIdentity string) ([]byt
 // named members of this struct are more explicit.
 type signatureAcceptanceRules struct {
 	validateKeyIdentity                func(string) error
-	validateSignedDockerReference      func(string) error
+	validateSignedDockerReference      func(string, string) error
 	validateSignedDockerManifestDigest func(string) error
 }
 
@@ -183,7 +183,7 @@ func verifyAndExtractSignature(mech SigningMechanism, unverifiedSignature []byte
 	if err := rules.validateSignedDockerManifestDigest(unmatchedSignature.DockerManifestDigest); err != nil {
 		return nil, err
 	}
-	if err := rules.validateSignedDockerReference(unmatchedSignature.DockerReference); err != nil {
+	if err := rules.validateSignedDockerReference(unmatchedSignature.DockerReference, unmatchedSignature.DockerManifestDigest); err != nil {
 		return nil, err
 	}
 	signature := unmatchedSignature.Signature // Policy OK.

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -157,7 +157,7 @@ func TestSign(t *testing.T) {
 			}
 			return nil
 		},
-		validateSignedDockerReference: func(signedDockerReference string) error {
+		validateSignedDockerReference: func(signedDockerReference, signedManifestDigest string) error {
 			if signedDockerReference != sig.DockerReference {
 				return fmt.Errorf("Unexpected signedDockerReference")
 			}
@@ -199,7 +199,7 @@ func TestVerifyAndExtractSignature(t *testing.T) {
 			}
 			return nil
 		},
-		validateSignedDockerReference: func(signedDockerReference string) error {
+		validateSignedDockerReference: func(signedDockerReference, signedManifestDigest string) error {
 			recorded.signedDockerReference = signedDockerReference
 			if signedDockerReference != wanted.signedDockerReference {
 				return fmt.Errorf("signedDockerReference mismatch")


### PR DESCRIPTION
Fix #99

Hopefully the last piece needed for projectatomic/docker#200. This will allow us by default to pull an untagged reference (e.g. by digest) when the signature is valid for a tag.

This is still WIP - I would like feedback on the direction I'm going.

Signed-off-by: Antonio Murdaca runcom@redhat.com
