### PR TITLE
Verify manifests against digests when known.

### DIFF
--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -3,8 +3,10 @@ package image
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime"
 
+	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -48,5 +50,14 @@ func manifestSchema2FromManifestList(src types.ImageSource, manblob []byte) (gen
 	if err != nil {
 		return nil, err
 	}
+
+	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
+	if err != nil {
+		return nil, fmt.Errorf("Error computing manifest digest: %v", err)
+	}
+	if !matches {
+		return nil, fmt.Errorf("Manifest image does not match selected manifest digest %s", targetManifestDigest)
+	}
+
 	return manifestInstanceFromBlob(src, manblob, mt)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -99,6 +99,9 @@ type BlobInfo struct {
 // This is primarily useful for copying images around; for examining their properties, Image (below)
 // is usually more useful.
 // Each ImageSource should eventually be closed by calling Close().
+//
+// WARNING: Various methods which return an object identified by digest generally do not
+// validate that the returned data actually matches that digest; this is the caller’s responsibility.
 type ImageSource interface {
 	// Reference returns the reference used to set up this source, _as specified by the user_
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.


### PR DESCRIPTION
In particular, when copying from a digested reference, and when choosing a manifest from a manifest list (previously this was a way to bypass signatures!)
