### PR TITLE
Rename type insecureAcceptAnything to accept

### DIFF
--- a/docs/policy.json.md
+++ b/docs/policy.json.md
@@ -110,12 +110,12 @@ in that case some requirements may apply only to some signatures, but each signa
 
 The following requirement objects are supported:
 
-### `insecureAcceptAnything`
+### `accept`
 
 A simple requirement with the following syntax
 
 ```json
-{"type":"insecureAcceptAnything"}
+{"type":"accept"}
 ```
 
 This requirement accepts any image (but note that other requirements in the array still apply).
@@ -209,14 +209,14 @@ selectively allow individual transports and scopes as desired.
         "docker": {
             /* Allow installing images from a specific repository namespace, without cryptographic verification.
                This namespace includes images like openshift/hello-openshift and openshift/origin. */
-            "docker.io/openshift": [{"type": "insecureAcceptAnything"}],
+            "docker.io/openshift": [{"type": "accept"}],
             /* Similarly, allow installing the “official” busybox images.  Note how the fully expanded
                form, with the explicit /library/, must be used. */
-            "docker.io/library/busybox": [{"type": "insecureAcceptAnything"}]
+            "docker.io/library/busybox": [{"type": "accept"}]
             /* Other docker: images use the global default policy and are rejected */
         },
         "dir": {
-            "": [{"type": "insecureAcceptAnything"}] /* Allow any images originating in local directories */
+            "": [{"type": "accept"}] /* Allow any images originating in local directories */
         },
         "atomic": {
             /* The common case: using a known key for a repository or set of repositories */
@@ -254,7 +254,7 @@ selectively allow individual transports and scopes as desired.
 
 ```json
 {
-    "default": [{"type": "insecureAcceptAnything"}]
+    "default": [{"type": "accept"}]
 }
 ```
 

--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -8,14 +8,14 @@
         "dir": {
             "": [
                 {
-                    "type": "insecureAcceptAnything"
+                    "type": "accept"
                 }
             ]
         },
         "docker": {
             "example.com/playground": [
                 {
-                    "type": "insecureAcceptAnything"
+                    "type": "accept"
                 }
             ],
             "example.com/production": [

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -247,7 +247,7 @@ func newPRInsecureAcceptAnything() *prInsecureAcceptAnything {
 	return &prInsecureAcceptAnything{prCommon{Type: prTypeInsecureAcceptAnything}}
 }
 
-// NewPRInsecureAcceptAnything returns a new "insecureAcceptAnything" PolicyRequirement.
+// NewPRInsecureAcceptAnything returns a new "accept" PolicyRequirement.
 func NewPRInsecureAcceptAnything() PolicyRequirement {
 	return newPRInsecureAcceptAnything()
 }

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -42,7 +42,7 @@ type prCommon struct {
 type prTypeIdentifier string
 
 const (
-	prTypeInsecureAcceptAnything prTypeIdentifier = "insecureAcceptAnything"
+	prTypeInsecureAcceptAnything prTypeIdentifier = "accept"
 	prTypeReject                 prTypeIdentifier = "reject"
 	prTypeSignedBy               prTypeIdentifier = "signedBy"
 	prTypeSignedBaseLayer        prTypeIdentifier = "signedBaseLayer"


### PR DESCRIPTION
insecureAcceptAnything does not describe policy very well to the end user. I would be happy with "permissive" or "accept" or possibly other strings.

Signed-off-by: Aaron Weitekamp aweiteka@redhat.com
