### PR TITLE
Implement OCI image source

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type config struct {
@@ -84,7 +85,9 @@ func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) 
 	// need to happen within the ImageSource.
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, "application/json":
 		return manifestSchema1FromManifest(manblob)
-	case manifest.DockerV2Schema2MediaType:
+	case manifest.DockerV2Schema2MediaType, imgspecv1.MediaTypeImageManifest:
+		// FIXME: OCI v1 is compatible with Docker Schema2, "docker_schema2.go" is good enough for reading images, but this will
+		// need to be modified for write support due to differing MIME types.
 		return manifestSchema2FromManifest(src, manblob)
 	case manifest.DockerV2ListMediaType:
 		return manifestSchema2FromManifestList(src, manblob)

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -1,0 +1,93 @@
+package layout
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ociImageSource struct {
+	ref ociReference
+}
+
+// newImageSource returns an ImageSource for reading from an existing directory.
+func newImageSource(ref ociReference) types.ImageSource {
+	return &ociImageSource{ref: ref}
+}
+
+// Reference returns the reference used to set up this source.
+func (s *ociImageSource) Reference() types.ImageReference {
+	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *ociImageSource) Close() {
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+func (s *ociImageSource) GetManifest() ([]byte, string, error) {
+	descriptorPath := s.ref.descriptorPath(s.ref.tag)
+	data, err := ioutil.ReadFile(descriptorPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	desc := imgspecv1.Descriptor{}
+	err = json.Unmarshal(data, &desc)
+	if err != nil {
+		return nil, "", err
+	}
+
+	manifestPath, err := s.ref.blobPath(desc.Digest)
+	if err != nil {
+		return nil, "", err
+	}
+	m, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return m, manifest.GuessMIMEType(m), nil
+}
+
+func (s *ociImageSource) GetTargetManifest(digest string) ([]byte, string, error) {
+	manifestPath, err := s.ref.blobPath(digest)
+	if err != nil {
+		return nil, "", err
+	}
+
+	m, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return m, manifest.GuessMIMEType(m), nil
+}
+
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+func (s *ociImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
+	path, err := s.ref.blobPath(digest)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, 0, nil
+	}
+	fi, err := r.Stat()
+	if err != nil {
+		return nil, 0, nil
+	}
+	return r, fi.Size(), nil
+}
+
+func (s *ociImageSource) GetSignatures() ([][]byte, error) {
+	return [][]byte{}, nil
+}

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
 	"github.com/containers/image/types"
 )
 
@@ -169,7 +170,8 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	return nil, errors.New("Full Image support not implemented for oci: image names")
+	src := newImageSource(ref)
+	return image.FromSource(src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
@@ -177,7 +179,7 @@ func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) 
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return nil, errors.New("Reading images not implemented for oci: image names")
+	return newImageSource(ref), nil
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -213,7 +213,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
 	_, err := ref.NewImageSource(nil, nil)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {


### PR DESCRIPTION
fix #141 .

Test with skopeo:
```sh
# skopeo copy docker://hello-world:latest oci:hello-world-oci
Getting image source signatures
Copying blob sha256:c04b14da8d1441880ed3fe6106fb2cc6fa1c9661846ac0266b8a5ec8edf37b7c
 0 B / 974 B [-----------------------------------------------------------------]
Copying config sha256:c54a2cc56cbb2f04003c1cd4507e118af7c0d340fe7e2720f70976c4b75237dc
 0 B / 1.44 KB [---------------------------------------------------------------]
Writing manifest to image destination
Storing signatures

# skopeo copy oci:hello-world-oci oci:hello-world-oci-2                                            Getting image source signatures
Copying blob sha256:c04b14da8d1441880ed3fe6106fb2cc6fa1c9661846ac0266b8a5ec8edf37b7c
 0 B / 974 B [-----------------------------------------------------------------]
Copying config sha256:c54a2cc56cbb2f04003c1cd4507e118af7c0d340fe7e2720f70976c4b75237dc
 0 B / 1.44 KB [---------------------------------------------------------------]
Writing manifest to image destination
Storing signatures

# tree hello-world-oci-2/
hello-world-oci-2/
|-- blobs
|   `-- sha256
|       |-- c04b14da8d1441880ed3fe6106fb2cc6fa1c9661846ac0266b8a5ec8edf37b7c
|       |-- c54a2cc56cbb2f04003c1cd4507e118af7c0d340fe7e2720f70976c4b75237dc
|       `-- f422e18dae1e99251df03310818cfa7e9c7a7d4fb0227787f7924c9bc8146b4a
|-- oci-layout
`-- refs
    `-- latest
```

Signed-off-by: Ye Yin <eyniy@qq.com>