### PR TITLE
Add support for digest references to signature enforcement

### DIFF
--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -69,7 +69,10 @@
                 {
                     "type": "signedBy",
                     "keyType": "signedByGPGKeys",
-                    "keyPath": "/keys/RH-key-signing-key-gpg-keyring"
+                    "keyPath": "/keys/RH-key-signing-key-gpg-keyring",
+                    "signedIdentity": {
+                        "type": "matchRepoDigestOrExact"
+                    }
                 }
             ],
             "bogus/key-data-example": [

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -105,7 +105,7 @@ func (ref pcImageReferenceMock) DeleteImage(ctx *types.SystemContext) error {
 
 func TestPolicyContextRequirementsForImageRef(t *testing.T) {
 	ktGPG := SBKeyTypeGPGKeys
-	prm := NewPRMMatchExact()
+	prm := NewPRMMatchRepoDigestOrExact()
 
 	policy := &Policy{
 		Default:    PolicyRequirements{NewPRReject()},

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -36,6 +36,29 @@ func (prm *prmMatchExact) matchesDockerReference(image types.UnparsedImage, sign
 	return signature.String() == intended.String()
 }
 
+func (prm *prmMatchRepoDigestOrExact) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
+	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
+	if err != nil {
+		return false
+	}
+
+	// Do not add default tags: image.Reference().DockerReference() should contain it already, and signatureDockerReference should be exact; so, verify that now.
+	if reference.IsNameOnly(signature) {
+		return false
+	}
+	switch intended.(type) {
+	case reference.NamedTagged: // Includes the case when intended has both a tag and a digest.
+		return signature.String() == intended.String()
+	case reference.Canonical:
+		// We don’t actually compare the manifest digest against the signature here; that happens prSignedBy.in UnparsedImage.Manifest.
+		// Becase UnparsedImage.Manifest verifies the intended.Digest() against the manifest, and prSignedBy verifies the signature digest against the manifest,
+		// we know that signature digest matches intended.Digest() (but intended.Digest() and signature digest may use different algorithms)
+		return signature.Name() == intended.Name()
+	default: // !reference.IsNameOnly(intended)
+		return false
+	}
+}
+
 func (prm *prmMatchRepository) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
 	if err != nil {

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -116,14 +116,21 @@ type prmCommon struct {
 type prmTypeIdentifier string
 
 const (
-	prmTypeMatchExact      prmTypeIdentifier = "matchExact"
-	prmTypeMatchRepository prmTypeIdentifier = "matchRepository"
-	prmTypeExactReference  prmTypeIdentifier = "exactReference"
-	prmTypeExactRepository prmTypeIdentifier = "exactRepository"
+	prmTypeMatchExact             prmTypeIdentifier = "matchExact"
+	prmTypeMatchRepoDigestOrExact prmTypeIdentifier = "matchRepoDigestOrExact"
+	prmTypeMatchRepository        prmTypeIdentifier = "matchRepository"
+	prmTypeExactReference         prmTypeIdentifier = "exactReference"
+	prmTypeExactRepository        prmTypeIdentifier = "exactRepository"
 )
 
 // prmMatchExact is a PolicyReferenceMatch with type = prmMatchExact: the two references must match exactly.
 type prmMatchExact struct {
+	prmCommon
+}
+
+// prmMatchRepoDigestOrExact is a PolicyReferenceMatch with type = prmMatchExactOrDigest: the two references must match exactly,
+// except that digest references are also accepted if the repository name matches (regardless of tag/digest) and the signature applies to the referenced digest
+type prmMatchRepoDigestOrExact struct {
 	prmCommon
 }
 


### PR DESCRIPTION
This adds `signedIdentity` `type:` `matchRepoDigestOrExact`, and makes it the default.
    
With `matchRepoDigestOrExact`, Tag references require a signature with a matching repo:tag (`Exact`), digest references require a signature with a matching repo (and any tag [or digest]; `RepoDigest`), with the digest itself still being validated in `image.UnparsedImage`, independently of signature processing.

Rationale from  https://github.com/mtrmac/image/commit/6e18d3010b10708245f42db5612dd303dfb4769a#commitcomment-19557682 for not doing a digest check in the identity matching component:
> I have implemented the digest check in here—and thrown it away, it really does not make sense to me here. If a single `PolicyReferenceMatch` implementation does a more strict digest check than the one in `UnparsedImage.Manifest`, why should any of the other `PolicyReferenceMatch` implementations be weaker?  So, this digest comparison should take place in a shared code path, e.g. `prSignedBy`.
> 
> But then, a strict digest equality check really only helps if we are worried about signatures with weak digest algorithms—and if a digest algorithm becomes so weak that we would not want to trust signatures which use that manifest digest algorithm, we should _always_ reject such signatures just because they use a weak algorithm, not only when the user uses an explicit digest reference with a stronger digest algorithm. (In fact it is a fairly good bet that some users would continue to use weak algorithms in digest references long after the signatures are generated with a stronger one.)
    
Users can still opt into strict checking by specifying `matchExact` in `signedIdentity`.

I am not entirely happy with the `matchRepoDigestOrExact` name, but it’s difficult to be both precise and short, and, ultimately, when this is the default, most users won’t see it.  Suggestions for improvement definitely welcome, though.

This is an alternative to #129 , and fixes #99.