### PR TITLE
image: schema2: add no-conversion for schema2 configs

### DIFF
--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -153,7 +153,7 @@ func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (typ
 	}
 
 	switch options.ManifestMIMEType {
-	case "": // No conversion, OK
+	case "", manifest.DockerV2Schema2MediaType: // No conversion, OK
 	case manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema1MediaType:
 		return copy.convertToManifestSchema1(options.InformationOnly.Destination)
 	default:


### PR DESCRIPTION
Previously, if a Docker Schema2 configuration was being "converted" to a
Schema2 configuration then it would cause errors even though the
conversion should be a simple copy. Fix this by just adding a dummy
conversion (just like in schema1).

Fixes: #168
Signed-off-by: Aleksa Sarai <asarai@suse.de>