### PR TITLE
docker: remove silly error checks

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -342,17 +342,10 @@ func getAuth(ctx *types.SystemContext, registry string) (string, string, error) 
 	return "", "", nil
 }
 
-type apiErr struct {
-	Code    string
-	Message string
-	Detail  interface{}
-}
-
 type pingResponse struct {
 	WWWAuthenticate string
 	APIVersion      string
 	scheme          string
-	errors          []apiErr
 }
 
 func (c *dockerClient) ping() (*pingResponse, error) {
@@ -372,16 +365,6 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		pr.WWWAuthenticate = resp.Header.Get("WWW-Authenticate")
 		pr.APIVersion = resp.Header.Get("Docker-Distribution-Api-Version")
 		pr.scheme = scheme
-		if resp.StatusCode == http.StatusUnauthorized {
-			type APIErrors struct {
-				Errors []apiErr
-			}
-			errs := &APIErrors{}
-			if err := json.NewDecoder(resp.Body).Decode(errs); err != nil {
-				return nil, err
-			}
-			pr.errors = errs.Errors
-		}
 		return pr, nil
 	}
 	pr, err := ping("https")


### PR DESCRIPTION
Fully fix https://github.com/projectatomic/docker/issues/214 - checked directly with `docker`.
I'm not even sure why we had that check on `ping` - `errors` from `PingResult` isn't used anywhere also. Should be pretty safe to dump this code to me.

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>