### PR TITLE
docker: use registry and system CAs

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -87,6 +87,64 @@ func newTransport() *http.Transport {
 	return tr
 }
 
+func setupCertificates(dir string, tlsc *tls.Config) error {
+	if dir == "" {
+		return nil
+	}
+	fs, err := ioutil.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	for _, f := range fs {
+		fullPath := filepath.Join(dir, f.Name())
+		if strings.HasSuffix(f.Name(), ".crt") {
+			systemPool, err := tlsconfig.SystemCertPool()
+			if err != nil {
+				return fmt.Errorf("unable to get system cert pool: %v", err)
+			}
+			tlsc.RootCAs = systemPool
+			logrus.Debugf("crt: %s", fullPath)
+			data, err := ioutil.ReadFile(fullPath)
+			if err != nil {
+				return err
+			}
+			tlsc.RootCAs.AppendCertsFromPEM(data)
+		}
+		if strings.HasSuffix(f.Name(), ".cert") {
+			certName := f.Name()
+			keyName := certName[:len(certName)-5] + ".key"
+			logrus.Debugf("cert: %s", fullPath)
+			if !hasFile(fs, keyName) {
+				return fmt.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
+			}
+			cert, err := tls.LoadX509KeyPair(filepath.Join(dir, certName), filepath.Join(dir, keyName))
+			if err != nil {
+				return err
+			}
+			tlsc.Certificates = append(tlsc.Certificates, cert)
+		}
+		if strings.HasSuffix(f.Name(), ".key") {
+			keyName := f.Name()
+			certName := keyName[:len(keyName)-4] + ".cert"
+			logrus.Debugf("key: %s", fullPath)
+			if !hasFile(fs, certName) {
+				return fmt.Errorf("missing client certificate %s for key %s", certName, keyName)
+			}
+		}
+	}
+	return nil
+}
+
+func hasFile(files []os.FileInfo, name string) bool {
+	for _, f := range files {
+		if f.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
 // newDockerClient returns a new dockerClient instance for refHostname (a host a specified in the Docker image reference, not canonicalized to dockerRegistry)
 // “write” specifies whether the client will be used for "write" access (in particular passed to lookaside.go:toplevelFromSection)
 func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) (*dockerClient, error) {
@@ -102,13 +160,10 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) 
 	if ctx != nil && (ctx.DockerCertPath != "" || ctx.DockerInsecureSkipTLSVerify) {
 		tlsc := &tls.Config{}
 
-		if ctx.DockerCertPath != "" {
-			cert, err := tls.LoadX509KeyPair(filepath.Join(ctx.DockerCertPath, "cert.pem"), filepath.Join(ctx.DockerCertPath, "key.pem"))
-			if err != nil {
-				return nil, fmt.Errorf("Error loading x509 key pair: %s", err)
-			}
-			tlsc.Certificates = append(tlsc.Certificates, cert)
+		if err := setupCertificates(ctx.DockerCertPath, tlsc); err != nil {
+			return nil, err
 		}
+
 		tlsc.InsecureSkipVerify = ctx.DockerInsecureSkipTLSVerify
 		tr.TLSClientConfig = tlsc
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -270,8 +270,11 @@ type SystemContext struct {
 	RegistriesDirPath string
 
 	// === docker.Transport overrides ===
-	DockerCertPath              string // If not "", a directory containing "cert.pem" and "key.pem" used when talking to a Docker Registry
-	DockerInsecureSkipTLSVerify bool   // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
+	// If not "", a directory containing a CA certificate (ending with ".crt"),
+	// a client certificate (ending with ".cert") and a client ceritificate key
+	// (ending with ".key") used when talking to a Docker Registry.
+	DockerCertPath              string
+	DockerInsecureSkipTLSVerify bool // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig
 	// if not "", an User-Agent header is added to each request when contacting a registry.


### PR DESCRIPTION
This works as docker does upstream (by reading CAs as well from `/etc/docker/certs.d/`, here we just read from the input context).

This is also needed by the `projectatomic/docker` integration of `containers/image`.

For `skopeo copy` we'll likely do something like `--[src|dest]-cert` as we did for credentials - other skopeo commands would be unaffected except for the naming conventions around certs names and suffixes.

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>