### PR TITLE
docker: add an option to disable V1 ping

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -372,6 +372,10 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		pr, err = ping("http")
 	}
 	if err != nil {
+		err = fmt.Errorf("pinging docker registry returned %+v", err)
+		if c.ctx.DockerDisableV1Ping {
+			return nil, err
+		}
 		// best effort to understand if we're talking to a V1 registry
 		pingV1 := func(scheme string) bool {
 			url := fmt.Sprintf(baseURLV1, scheme, c.registry)
@@ -393,8 +397,6 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		}
 		if isV1 {
 			err = ErrV1NotSupported
-		} else {
-			err = fmt.Errorf("pinging docker registry returned %+v", err)
 		}
 	}
 	return pr, err

--- a/types/types.go
+++ b/types/types.go
@@ -276,4 +276,8 @@ type SystemContext struct {
 	DockerAuthConfig *DockerAuthConfig
 	// if not "", an User-Agent header is added to each request when contacting a registry.
 	DockerRegistryUserAgent string
+	// if true, a V1 ping attempt isn't done to give users a better error. Default is false.
+	// Note that this field is used mainly to integrate containers/image into projectatomic/docker
+	// in order to not break any existing docker's integration tests.
+	DockerDisableV1Ping bool
 }


### PR DESCRIPTION
This is needed for the `projectatomic/docker` integration - otherwise if `dockerd` runs with `--disable-legacy-registry=true` and we ping V1, we're breaking that flag usage. Docker will set `DockerDisableV1Ping` to `true` if the daemon flag is set to true.

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>