### PR TITLE
*: fix the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ SKOPEO_REPO = projectatomic/skopeo
 SKOPEO_BRANCH = master
 # Set SUDO=sudo to run container integration tests using sudo.
 SUDO =
-BUILDFLAGS = -tags "btrfs_noversion libdm_no_deferred_remove"
+BUILDTAGS   = btrfs_noversion libdm_no_deferred_remove
+BUILDFLAGS := -tags "$(BUILDTAGS)"
 
 all: deps .gitvalidation test validate
 
@@ -30,7 +31,7 @@ test-skopeo:
 		git clone -b $(SKOPEO_BRANCH) https://github.com/$(SKOPEO_REPO) $${skopeo_path} && \
 		rm -rf $${vendor_path} && cp -r . $${vendor_path} && \
 		cd $${skopeo_path} && \
-		make binary-local test-all-local && \
+		make BUILDTAGS="$(BUILDTAGS)" binary-local test-all-local && \
 		$(SUDO) make check && \
 		rm -rf $${skopeo_path}
 

--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	// "docker/distribution/digest" requires us to load the algorithms that we
+	// want to use into the binary (it calls .Available).
+	_ "crypto/sha256"
 	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
 )
@@ -55,7 +58,7 @@ type Canonical interface {
 func ParseNamed(s string) (Named, error) {
 	named, err := distreference.ParseNamed(s)
 	if err != nil {
-		return nil, errors.Errorf("Error parsing reference: %q is not a valid repository/tag", s)
+		return nil, errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", s)
 	}
 	r, err := WithName(named.Name())
 	if err != nil {

--- a/docker/reference/reference_test.go
+++ b/docker/reference/reference_test.go
@@ -3,6 +3,7 @@ package reference
 import (
 	"testing"
 
+	_ "crypto/sha256"
 	"github.com/docker/distribution/digest"
 )
 


### PR DESCRIPTION
There has been a change in upstream (docker/distribution), where they
now require users of the digest library to load algorithms into the
binary (in other words they do .Available checks on crypto algorithms).

This fixes the unit test failures with "unsupported digest algorithm".

Since skopeo now also has containers/storage we have to pass it our
BUILDTAGS otherwise you'll get build failures in the CI.

Fixes #189 
Signed-off-by: Aleksa Sarai <asarai@suse.de>