### PR TITLE
Revert "provide better error when key not found"

### DIFF
--- a/signature/mechanism.go
+++ b/signature/mechanism.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/mtrmac/gpgme"
-	"github.com/pkg/errors"
 )
 
 // SigningMechanism abstracts a way to sign binary blobs and verify their signatures.
@@ -77,9 +76,6 @@ func (m gpgSigningMechanism) ImportKeysFromBytes(blob []byte) ([]string, error) 
 func (m gpgSigningMechanism) Sign(input []byte, keyIdentity string) ([]byte, error) {
 	key, err := m.ctx.GetKey(keyIdentity, true)
 	if err != nil {
-		if e, ok := err.(gpgme.Error); ok && e.Code() == gpgme.ErrorEOF {
-			return nil, errors.Errorf("key %q not found", keyIdentity)
-		}
 		return nil, err
 	}
 	inputData, err := gpgme.NewDataBytes(input)


### PR DESCRIPTION
This reverts commit 7f87ae0ac78aa57de3b554540ac014920fa5634b.

With https://github.com/mtrmac/gpgme/pull/1 this is no longer necessary.

(A future rerunning of `hack/vendor.sh` in skopeo will pick up both the updated `mtrmac/gpgme` and `containers/image`; there is no rush.)