### PR TITLE
Don't fake a bad answer from memoryImage.Size()

### DIFF
--- a/image/memory.go
+++ b/image/memory.go
@@ -37,11 +37,7 @@ func (i *memoryImage) Close() {
 
 // Size returns the size of the image as stored, if known, or -1 if not.
 func (i *memoryImage) Size() (int64, error) {
-	s, err := i.serialize()
-	if err != nil {
-		return -1, err
-	}
-	return int64(len(s)), nil
+	return -1, nil
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.


### PR DESCRIPTION
Instead of returning a probably-wrong guess from memoryImage.Size() (per https://github.com/containers/image/pull/63#pullrequestreview-14982893), return -1, to indicate that we don't know the right answer.