### PR TITLE
WIP do not merge: Dump HTTP operations

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/httpdump"
 	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/set"
@@ -648,7 +649,7 @@ func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method 
 		}
 	}
 	logrus.Debugf("%s %s", method, resolvedURL.Redacted())
-	res, err := c.client.Do(req)
+	res, err := httpdump.DoRequest(c.client, req)
 	if err != nil {
 		return nil, err
 	}
@@ -830,7 +831,7 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	authReq.Header.Add("User-Agent", c.userAgent)
 	authReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.Redacted())
-	res, err := c.client.Do(authReq)
+	res, err := httpdump.DoRequest(c.client, authReq)
 	if err != nil {
 		return nil, err
 	}
@@ -877,7 +878,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 	authReq.Header.Add("User-Agent", c.userAgent)
 
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.Redacted())
-	res, err := c.client.Do(authReq)
+	res, err := httpdump.DoRequest(c.client, authReq)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/httpdump"
 	"github.com/containers/image/v5/internal/imagesource/impl"
 	"github.com/containers/image/v5/internal/imagesource/stubs"
 	"github.com/containers/image/v5/internal/iolimits"
@@ -562,7 +563,7 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, sigURL *url.URL
 		if err != nil {
 			return nil, false, err
 		}
-		res, err := s.c.client.Do(req)
+		res, err := httpdump.DoRequest(s.c.client, req)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/httpdump/dump.go
+++ b/internal/httpdump/dump.go
@@ -1,0 +1,31 @@
+package httpdump
+
+import (
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DoRequest (c, req) is the same as c.Do(req), but it may log the
+// request and response at logrus trace level.
+func DoRequest(c *http.Client, req *http.Request) (*http.Response, error) {
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		if dro, err := httputil.DumpRequestOut(req, false); err != nil {
+			logrus.Tracef("===Can not log HTTP request: %v", err)
+		} else {
+			logrus.Tracef("===REQ===\n%s\n===REQ===\n", dro)
+		}
+	}
+	res, err := c.Do(req)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		if err != nil {
+			logrus.Tracef("===RES error: %v", err)
+		} else if dr, err := httputil.DumpResponse(res, false); err != nil {
+			logrus.Tracef("===Can not log HTTP response: %v", err)
+		} else {
+			logrus.Tracef("===RES===\n%s\n===RES===\n", dr)
+		}
+	}
+	return res, err
+}

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/containers/image/v5/internal/httpdump"
 	"github.com/containers/image/v5/internal/imagesource/impl"
 	"github.com/containers/image/v5/internal/imagesource/stubs"
 	"github.com/containers/image/v5/internal/manifest"
@@ -186,7 +187,7 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 			continue
 		}
 
-		resp, err := s.client.Do(req)
+		resp, err := httpdump.DoRequest(s.client, req)
 		if err != nil {
 			errWrap = fmt.Errorf("fetching %q failed %s: %w", u, err.Error(), errWrap)
 			continue

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/httpdump"
 	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/version"
 	"github.com/sirupsen/logrus"
@@ -95,7 +96,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 	}
 
 	logrus.Debugf("%s %s", method, requestURL.Redacted())
-	res, err := c.httpClient.Do(req)
+	res, err := httpdump.DoRequest(c.httpClient, req)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +105,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 	if err != nil {
 		return nil, err
 	}
-	logrus.Debugf("Got body: %s", body)
-	// FIXME: Just throwing this useful information away only to try to guess later...
-	logrus.Debugf("Got content-type: %s", res.Header.Get("Content-Type"))
+	// FIXME: Just throwing Content-Type away only to try to guess later...
 
 	var status status
 	statusValid := false


### PR DESCRIPTION
Quite often it has been useful to dump the full HTTP request and response headers, and sometimes fuill bodies, for debugging; we probably should make that possible either automatically at the “debug” log level, or when the user sets an option.

This is *by no means* a workable implementation for that, but I’ve written exactly this hack two or three times now, so right now I am at least recording it for posterity, expecting that rebasing it will be easier than rewriting it.

A real implementation should, I guess, wrap a `http.RoundTripper` or perhaps `http.Client` (or just `http.Client.Do`?), or perhaps using `net/http/httptrace` somehow.