### PR TITLE
Restore a check for unknown digest in daemonImageDestination.PutBlob

### DIFF
--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -147,6 +147,10 @@ func (d *daemonImageDestination) AcceptsForeignLayerURLs() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *daemonImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+	if inputInfo.Digest.String() == "" {
+		return types.BlobInfo{}, errors.Errorf(`Can not stream a blob with unknown digest to "docker-daemon:"`)
+	}
+
 	if ok, size, err := d.HasBlob(inputInfo); err == nil && ok {
 		return types.BlobInfo{Digest: inputInfo.Digest, Size: size}, nil
 	}


### PR DESCRIPTION
This was inadvertently removed during the `HasBlob` addition, but the code below still relies on having a valid value.

(Well, it _could_ be recomputed, we already have the copy code for the `inputInfo.Size` case; this is just the very minimal fix.)
