### PR TITLE
RFC WIP: Define the three return states of HaveBlob as true/false/error

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -354,7 +354,7 @@ type diffIDResult struct {
 func (ic *imageCopier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Digest, error) {
 	// Check if we already have a blob with this digest
 	haveBlob, extantBlobSize, err := ic.dest.HasBlob(srcInfo)
-	if err != nil && err != types.ErrBlobNotFound {
+	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error checking for blob %s at destination", srcInfo.Digest)
 	}
 	// If we already have a cached diffID for this blob, we don't need to compute it

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -95,6 +95,10 @@ func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
 }
 
+// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
+// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
+// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
+// it returns a non-nil error only on an unexpected failure.
 func (d *dirImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
@@ -102,7 +106,7 @@ func (d *dirImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) 
 	blobPath := d.ref.layerPath(info.Digest)
 	finfo, err := os.Stat(blobPath)
 	if err != nil && os.IsNotExist(err) {
-		return false, -1, types.ErrBlobNotFound
+		return false, -1, nil
 	}
 	if err != nil {
 		return false, -1, err

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -112,6 +112,10 @@ func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
 }
 
+// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
+// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
+// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
+// it returns a non-nil error only on an unexpected failure.
 func (d *ociImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
@@ -122,7 +126,7 @@ func (d *ociImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) 
 	}
 	finfo, err := os.Stat(blobPath)
 	if err != nil && os.IsNotExist(err) {
-		return false, -1, types.ErrBlobNotFound
+		return false, -1, nil
 	}
 	if err != nil {
 		return false, -1, err

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -371,6 +371,10 @@ func (d *openshiftImageDestination) PutBlob(stream io.Reader, inputInfo types.Bl
 	return d.docker.PutBlob(stream, inputInfo)
 }
 
+// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
+// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
+// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
+// it returns a non-nil error only on an unexpected failure.
 func (d *openshiftImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
 	return d.docker.HasBlob(info)
 }

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -290,6 +290,10 @@ func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobI
 	return s.putBlob(stream, blobinfo, true)
 }
 
+// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
+// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
+// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
+// it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) HasBlob(blobinfo types.BlobInfo) (bool, int64, error) {
 	if blobinfo.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
@@ -299,7 +303,7 @@ func (s *storageImageDestination) HasBlob(blobinfo types.BlobInfo) (bool, int64,
 			return true, blob.Size, nil
 		}
 	}
-	return false, -1, types.ErrBlobNotFound
+	return false, -1, nil
 }
 
 func (s *storageImageDestination) ReapplyBlob(blobinfo types.BlobInfo) (types.BlobInfo, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 // ImageTransport is a top-level namespace for ways to to store/load an image.
@@ -160,7 +159,10 @@ type ImageDestination interface {
 	// to any other readers for download using the supplied digest.
 	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 	PutBlob(stream io.Reader, inputInfo BlobInfo) (BlobInfo, error)
-	// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.  Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.  A false result will often be accompanied by an ErrBlobNotFound error.
+	// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
+	// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
+	// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
+	// it returns a non-nil error only on an unexpected failure.
 	HasBlob(info BlobInfo) (bool, int64, error)
 	// ReapplyBlob informs the image destination that a blob for which HasBlob previously returned true would have been passed to PutBlob if it had returned false.  Like HasBlob and unlike PutBlob, the digest can not be empty.  If the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree.
 	ReapplyBlob(info BlobInfo) (BlobInfo, error)
@@ -300,8 +302,3 @@ type ProgressProperties struct {
 	Artifact BlobInfo
 	Offset   uint64
 }
-
-var (
-	// ErrBlobNotFound can be returned by an ImageDestination's HasBlob() method
-	ErrBlobNotFound = errors.New("no such blob present")
-)


### PR DESCRIPTION
(WIP because this includes #202 and #203 just because I am lazy to do this several times.)

@runcom PTAL: I know in #63 you have explicitly asked for `ErrBlobNotFound` to be added, but it seems to me that just makes the uses of `HaveBlob` more complex. I can live with the current code if it is indeed is more idiomatic, or perhaps I am missing a cleaner way to use it.

The current interface can return `(haveBlob, _, err)`:
- `(true, nil)`: blob exists
- `(false, ErrBlobNotFound)`: blob does not exist or unknown
- `(false, `other non-nil`)`: unexpected error

i.e. `haveBlob` is equivalent to `err == nil`, which is both redundant and makes the interface unnecessarily difficult to use for the typical case where the caller wants to abort on an unexpected error, and then decide based on haveBlob:

```go
if err != nil && err != types.ErrBlobNotFound {
   return err
}
if haveBlob { … }
```

Insted, define the interface to be
- `(true, nil)`: blob exists
- `(false, nil)`: blob does not exist or unknown
- `(false, `non-`nil)`: unexpected error

which simplifies the “abort” conditional to a simple `err != nil`.

A possible alternative would be to eliminate the `haveBlob` bool instead, but that still requires two-clause checks for aborting, and semantically a blob not being present is not an error, it is a succesfully obtained return value.