### PR TITLE
*: move to opencontainers/go-digest

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -59,7 +59,7 @@ func newDigestingReader(source io.Reader, expectedDigest digest.Digest) (*digest
 	}
 	return &digestingReader{
 		source:           source,
-		digester:         digestAlgorithm.New(),
+		digester:         digestAlgorithm.Digester(),
 		expectedDigest:   expectedDigest,
 		validationFailed: false,
 	}, nil

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +69,7 @@ func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 		}
 	}()
 
-	digester := digest.Canonical.New()
+	digester := digest.Canonical.Digester()
 	tee := io.TeeReader(stream, digester.Hash())
 
 	size, err := io.Copy(blobFile, tee)

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 // Transport is an ImageTransport for directory paths.

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -14,8 +14,8 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
 	"github.com/docker/engine-api/client"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -170,7 +170,7 @@ func (d *daemonImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 		logrus.Debugf("… streaming done")
 	}
 
-	digester := digest.Canonical.New()
+	digester := digest.Canonical.Digester()
 	tee := io.TeeReader(stream, digester.Hash())
 	if err := d.sendFile(inputInfo.Digest.String(), inputInfo.Size, tee); err != nil {
 		return types.BlobInfo{}, err

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
 	"github.com/docker/engine-api/client"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -6,7 +6,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 // Transport is an ImageTransport for images managed by a local Docker daemon.
@@ -51,7 +51,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 
 	// digest:hexstring is structurally the same as a reponame:tag (meaning docker.io/library/reponame:tag).
 	// reference.ParseIDOrReference interprets such strings as digests.
-	if dgst, err := digest.ParseDigest(refString); err == nil {
+	if dgst, err := digest.Parse(refString); err == nil {
 		// The daemon explicitly refuses to tag images with a reponame equal to digest.Canonical - but _only_ this digest name.
 		// Other digest references are ambiguous, so refuse them.
 		if dgst.Algorithm() != digest.Canonical {

--- a/docker/daemon/daemon_transport_test.go
+++ b/docker/daemon/daemon_transport_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,7 +108,7 @@ var validNamedReferenceTestCases = []struct{ input, dockerRef, stringWithinTrans
 
 func TestNewReference(t *testing.T) {
 	// An ID reference.
-	id, err := digest.ParseDigest(sha256digest)
+	id, err := digest.Parse(sha256digest)
 	require.NoError(t, err)
 	ref, err := NewReference(id, nil)
 	require.NoError(t, err)

--- a/docker/daemon/daemon_types.go
+++ b/docker/daemon/daemon_types.go
@@ -1,6 +1,6 @@
 package daemon
 
-import "github.com/docker/distribution/digest"
+import "github.com/opencontainers/go-digest"
 
 // Various data structures.
 

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -128,7 +128,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 		return types.BlobInfo{}, errors.Wrap(err, "Error determining upload URL")
 	}
 
-	digester := digest.Canonical.New()
+	digester := digest.Canonical.Digester()
 	sizeCounter := &sizeCounter{}
 	tee := io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter))
 	res, err = d.c.makeRequestToResolvedURL("PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, true)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -13,8 +13,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/client"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/distribution/digest"
 	"github.com/ghodss/yaml"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 
 	"github.com/Sirupsen/logrus"

--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -4,14 +4,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	// "docker/distribution/digest" requires us to load the algorithms that we
+	// "opencontainers/go-digest" requires us to load the algorithms that we
 	// want to use into the binary (it calls .Available).
 	_ "crypto/sha256"
 
-	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -131,7 +130,7 @@ func (r *taggedRef) Tag() string {
 	return r.namedRef.Named.(distreference.NamedTagged).Tag()
 }
 func (r *canonicalRef) Digest() digest.Digest {
-	return r.namedRef.Named.(distreference.Canonical).Digest()
+	return digest.Digest(r.namedRef.Named.(distreference.Canonical).Digest())
 }
 
 // WithDefaultTag adds a default tag to a reference if it only has a repo name.
@@ -159,7 +158,7 @@ func ParseIDOrReference(idOrRef string) (digest.Digest, Named, error) {
 	if err := validateID(idOrRef); err == nil {
 		idOrRef = "sha256:" + idOrRef
 	}
-	if dgst, err := digest.ParseDigest(idOrRef); err == nil {
+	if dgst, err := digest.Parse(idOrRef); err == nil {
 		return dgst, nil, nil
 	}
 	ref, err := ParseNamed(idOrRef)

--- a/docker/reference/reference_test.go
+++ b/docker/reference/reference_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	_ "crypto/sha256"
-	"github.com/docker/distribution/digest"
 )
 
 func TestValidateReferenceName(t *testing.T) {
@@ -269,8 +268,5 @@ func TestInvalidReferenceComponents(t *testing.T) {
 	}
 	if _, err := WithTag(ref, "-foo"); err == nil {
 		t.Fatal("Expected WithName to detect invalid tag")
-	}
-	if _, err := WithDigest(ref, digest.Digest("foo")); err == nil {
-		t.Fatal("Expected WithName to detect invalid digest")
 	}
 }

--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -3,8 +3,8 @@ package image
 import (
 	"time"
 
-	"github.com/docker/distribution/digest"
 	"github.com/docker/engine-api/types/strslice"
+	"github.com/opencontainers/go-digest"
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"

--- a/image/oci.go
+++ b/image/oci.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/manifest/fixtures_info_test.go
+++ b/manifest/fixtures_info_test.go
@@ -1,6 +1,6 @@
 package manifest
 
-import "github.com/docker/distribution/digest"
+import "github.com/opencontainers/go-digest"
 
 const (
 	// TestV2S2ManifestDigest is the Docker manifest digest of "v2s2.manifest.json"

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -3,8 +3,8 @@ package manifest
 import (
 	"encoding/json"
 
-	"github.com/docker/distribution/digest"
 	"github.com/docker/libtrust"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -5,11 +5,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/distribution/digest"
 	"github.com/docker/libtrust"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	digestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 )
 
 func TestGuessMIMEType(t *testing.T) {
@@ -61,7 +65,7 @@ func TestDigest(t *testing.T) {
 
 	actualDigest, err = Digest([]byte{})
 	require.NoError(t, err)
-	assert.Equal(t, digest.Digest(digest.DigestSha256EmptyTar), actualDigest)
+	assert.Equal(t, digest.Digest(digestSha256EmptyTar), actualDigest)
 }
 
 func TestMatchesDigest(t *testing.T) {
@@ -98,7 +102,7 @@ func TestMatchesDigest(t *testing.T) {
 	assert.False(t, res)
 	assert.Error(t, err)
 
-	res, err = MatchesDigest([]byte{}, digest.Digest(digest.DigestSha256EmptyTar))
+	res, err = MatchesDigest([]byte{}, digest.Digest(digestSha256EmptyTar))
 	assert.True(t, res)
 	assert.NoError(t, err)
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -80,7 +80,7 @@ func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 		}
 	}()
 
-	digester := digest.Canonical.New()
+	digester := digest.Canonical.Digester()
 	tee := io.TeeReader(stream, digester.Hash())
 
 	size, err := io.Copy(blobFile, tee)

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/image/version"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/signature/docker.go
+++ b/signature/docker.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/containers/image/manifest"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 // SignDockerManifest returns a signature for manifest as the specified dockerReference,

--- a/signature/fixtures_info_test.go
+++ b/signature/fixtures_info_test.go
@@ -1,6 +1,6 @@
 package signature
 
-import "github.com/docker/distribution/digest"
+import "github.com/opencontainers/go-digest"
 
 const (
 	// TestImageManifestDigest is the Docker manifest digest of "image.manifest.json"

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 func (pr *prSignedBy) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/containers/image/version"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 const (

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/storage"
-	ddigest "github.com/docker/distribution/digest"
+	ddigest "github.com/opencontainers/go-digest"
 )
 
 var (
@@ -150,10 +150,10 @@ func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobI
 	// Set up to read the whole blob (the initial snippet, plus the rest)
 	// while digesting it with either the default, or the passed-in digest,
 	// if one was specified.
-	hasher := ddigest.Canonical.New()
+	hasher := ddigest.Canonical.Digester()
 	if digest.Validate() == nil {
 		if a := digest.Algorithm(); a.Available() {
-			hasher = a.New()
+			hasher = a.Digester()
 		}
 	}
 	hash := ""

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/storage"
-	ddigest "github.com/docker/distribution/digest"
+	ddigest "github.com/opencontainers/go-digest"
 )
 
 var (

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -11,8 +11,8 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/storage"
-	"github.com/docker/distribution/digest"
-	ddigest "github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
+	ddigest "github.com/opencontainers/go-digest"
 )
 
 var (
@@ -95,7 +95,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 				return nil, err
 			}
 		}
-		sum, err = digest.ParseDigest("sha256:" + refInfo[1])
+		sum, err = digest.Parse("sha256:" + refInfo[1])
 		if err != nil {
 			return nil, err
 		}
@@ -266,7 +266,7 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 		if err != nil {
 			return err
 		}
-		_, err = ddigest.ParseDigest("sha256:" + scopeInfo[1])
+		_, err = ddigest.Parse("sha256:" + scopeInfo[1])
 		if err != nil {
 			return err
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/containers/image/docker/reference"
-	"github.com/docker/distribution/digest"
+	"github.com/opencontainers/go-digest"
 )
 
 // ImageTransport is a top-level namespace for ways to to store/load an image.


### PR DESCRIPTION
Upstream docker moved to [`opencontainers/go-digest`](https://github.com/opencontainers/go-digest) - this patch tries to adapt our code to use OCI digest pkg (but currently running in GOPATH weirdness as always...if anyone has any idea about why this is failing, pls let me know, can't seem to figure out why uses the vendor directory from docker/distribution). Seems like there's no easy way out of this situation according to https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/edit other than vendoring (but this is a library!).

According to https://github.com/opencontainers/go-digest#usage also we need to add ` _ "crypto/sha256"` as an `import` wherever we use that pkg (I'll update that later).

Signed-off-by: Antonio Murdaca <runcom@redhat.com>