### PR TITLE
Create test-pristine target used to align dev and CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,11 @@
   sudo: required
   notifications:
     email: false
+  services:
+    - docker
   go:
     - 1.7
-  install: make deps
-  script: make .gitvalidation && make validate && make test && make test-skopeo
+  script: make test-pristine
   dist: trusty
   os:
     - linux
-  addons:
-    apt:
-      packages:
-        - btrfs-tools
-        - libdevmapper-dev
-        - libgpgme11-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang
+
+ENV SRCPATH /go/src/github.com/containers/image
+ENV DOCKER_VERSION 1.13.0
+ENV DOCKER_PATH docker-${DOCKER_VERSION}.tgz
+
+# needed because if the tests run as root the tests that test permissions will fail.
+RUN useradd -d /home/gouser -m -s /bin/bash gouser
+
+# NOTE: iptables and psmisc are required by docker.
+RUN apt-get update -qq && apt-get install -y sudo iptables psmisc btrfs-tools libdevmapper-dev libgpgme11-dev
+
+RUN wget -q https://get.docker.com/builds/Linux/x86_64/${DOCKER_PATH}
+RUN tar -xpf ${DOCKER_PATH} --strip-components=1 -C /usr/bin
+RUN gpasswd -a gouser root
+
+# dind is required for the skopeo tests
+COPY dind /dind
+RUN chmod +x /dind
+
+COPY . ${SRCPATH}
+WORKDIR ${SRCPATH}
+RUN make deps
+RUN chown -R gouser:gouser ${SRCPATH}
+
+CMD sh -c "cd ${SRCPATH} && bash docker-test.sh"
+ENTRYPOINT ["/dind"]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ deps:
 	go get -u $(BUILDFLAGS) github.com/golang/lint/golint
 	go get $(BUILDFLAGS) github.com/vbatts/git-validation
 
+docker-build:
+	docker build -t containers/image:test .
+
+test-pristine: docker-build
+	docker run --privileged -e TRAVIS_COMMIT_RANGE=$(TRAVIS_COMMIT_RANGE) -e TRAVIS_BRANCH=$(TRAVIS_BRANCH) -e TRAVIS_COMMIT=$(TRAVIS_COMMIT) -e TRAVIS=$(TRAVIS) -it containers/image:test
+
 test:
 	@go test $(BUILDFLAGS) -cover ./...
 

--- a/dind
+++ b/dind
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privileged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+export container=docker
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+	mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and --privileged mode might break.'
+	}
+fi
+
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+	mount -t tmpfs none /tmp
+fi
+
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run a command or a shell?'

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash	
+
+set -eu
+
+dockerd -s vfs &
+sleep 5
+
+# explanation of sudo flags:
+# -H: rewrite $HOME to target user $HOME (because -E)
+# -E: persist environment
+# -u: user to use
+sudo -H -E -u gouser -- sh -c "PATH=\"/go/bin:${PATH}\" make .gitvalidation validate test test-skopeo"
+
+status=$?
+
+killall dockerd
+wait
+exit $status


### PR DESCRIPTION
This is a Dockerfile + make targets to enable pristine environment testing,
which will help with isolating dependency problems. In the event the CI and
developer's workstation do not align, they can quickly recreate (theoretically
at least) the problem by running `make test-pristine`.

Hope this is useful. Thanks.
