### PR TITLE
*: pluggable transports

### DIFF
--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -10,9 +10,14 @@ import (
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 // Transport is an ImageTransport for directory paths.
 var Transport = dirTransport{}

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -5,9 +5,14 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 // Transport is an ImageTransport for images managed by a local Docker daemon.
 var Transport = daemonTransport{}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -6,9 +6,14 @@ import (
 
 	"github.com/containers/image/docker/policyconfiguration"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 // Transport is an ImageTransport for Docker registry-hosted images.
 var Transport = dockerTransport{}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -54,7 +54,7 @@ func GuessMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest, imgspecv1.MediaTypeImageManifestList: // A recognized type.
+	case DockerV2Schema2MediaType, DockerV2ListMediaType: // A recognized type.
 		return meta.MediaType
 	}
 	// this is the only way the function can return DockerV2Schema1MediaType, and recognizing that is essential for stripping the JWS signatures = computing the correct manifest digest.

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -9,10 +9,15 @@ import (
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 // Transport is an ImageTransport for OCI directories.
 var Transport = ociTransport{}

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -8,9 +8,14 @@ import (
 	"github.com/containers/image/docker/policyconfiguration"
 	"github.com/containers/image/docker/reference"
 	genericImage "github.com/containers/image/image"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 // Transport is an ImageTransport for OpenShift registry-hosted images.
 var Transport = openshiftTransport{}

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -122,10 +122,8 @@ func (m *policyTransportsMap) UnmarshalJSON(data []byte) error {
 	// So, use a temporary map of pointers-to-slices and convert.
 	tmpMap := map[string]*PolicyTransportScopes{}
 	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		transport, ok := transports.KnownTransports[key]
-		if !ok {
-			return nil
-		}
+		// transport can be nil
+		transport := transports.Get(key)
 		// paranoidUnmarshalJSONObject detects key duplication for us, check just to be safe.
 		if _, ok := tmpMap[key]; ok {
 			return nil
@@ -155,7 +153,7 @@ func (m *PolicyTransportScopes) UnmarshalJSON(data []byte) error {
 }
 
 // policyTransportScopesWithTransport is a way to unmarshal a PolicyTransportScopes
-// while validating using a specific ImageTransport.
+// while validating using a specific ImageTransport if not nil.
 type policyTransportScopesWithTransport struct {
 	transport types.ImageTransport
 	dest      *PolicyTransportScopes
@@ -174,7 +172,7 @@ func (m *policyTransportScopesWithTransport) UnmarshalJSON(data []byte) error {
 		if _, ok := tmpMap[key]; ok {
 			return nil
 		}
-		if key != "" {
+		if key != "" && m.transport != nil {
 			if err := m.transport.ValidatePolicyConfigurationScope(key); err != nil {
 				return nil
 			}

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/containers/image/directory"
 	"github.com/containers/image/docker"
+	// this import is needed  where we use the "atomic" transport in TestPolicyUnmarshalJSON
+	_ "github.com/containers/image/openshift"
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,6 +246,11 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 					xNewPRSignedByKeyData(SBKeyTypeSignedByGPGKeys, []byte("RHatomic"), NewPRMMatchRepository()),
 				},
 			},
+			"unknown": {
+				"registry.access.redhat.com/rhel7": []PolicyRequirement{
+					xNewPRSignedByKeyData(SBKeyTypeSignedByGPGKeys, []byte("RHatomic"), NewPRMMatchRepository()),
+				},
+			},
 		},
 	}
 	validJSON, err := json.Marshal(validPolicy)
@@ -269,9 +276,6 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 		func(v mSI) { v["transports"] = []string{} },
 		// "default" is an invalid PolicyRequirements
 		func(v mSI) { v["default"] = PolicyRequirements{} },
-		// A key in "transports" is an invalid transport name
-		func(v mSI) { x(v, "transports")["this is unknown"] = x(v, "transports")["docker"] },
-		func(v mSI) { x(v, "transports")[""] = x(v, "transports")["docker"] },
 	}
 	for _, fn := range breakFns {
 		err = tryUnmarshalModifiedPolicy(t, &p, validJSON, fn)

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -9,11 +9,16 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/storage"
 	"github.com/opencontainers/go-digest"
 	ddigest "github.com/opencontainers/go-digest"
 )
+
+func init() {
+	transports.Register(Transport)
+}
 
 var (
 	// Transport is an ImageTransport that uses either a default

--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -1,0 +1,31 @@
+package alltransports
+
+import (
+	"strings"
+
+	// register all known transports
+	// NOTE: Make sure docs/policy.json.md is updated when adding or updating
+	// a transport.
+	_ "github.com/containers/image/directory"
+	_ "github.com/containers/image/docker"
+	_ "github.com/containers/image/docker/daemon"
+	_ "github.com/containers/image/oci/layout"
+	_ "github.com/containers/image/openshift"
+	_ "github.com/containers/image/storage"
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+)
+
+// ParseImageName converts a URL-like image name to a types.ImageReference.
+func ParseImageName(imgName string) (types.ImageReference, error) {
+	parts := strings.SplitN(imgName, ":", 2)
+	if len(parts) != 2 {
+		return nil, errors.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
+	}
+	transport := transports.Get(parts[0])
+	if transport == nil {
+		return nil, errors.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
+	}
+	return transport.ParseReference(parts[1])
+}

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -1,16 +1,12 @@
-package transports
+package alltransports
 
 import (
 	"testing"
 
+	"github.com/containers/image/transports"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestKnownTransports(t *testing.T) {
-	assert.NotNil(t, KnownTransports) // Ensure that the initialization has actually been run
-	assert.True(t, len(KnownTransports) > 1)
-}
 
 func TestParseImageName(t *testing.T) {
 	// This primarily tests error handling, TestImageNameHandling is a table-driven
@@ -36,11 +32,12 @@ func TestImageNameHandling(t *testing.T) {
 		{"docker-daemon", "busybox:latest", "busybox:latest"},
 		{"oci", "/etc:sometag", "/etc:sometag"},
 		// "atomic" not tested here because it depends on per-user configuration for the default cluster.
+		// "containers-storage" not tested here because it needs to initialize various directories on the fs.
 	} {
 		fullInput := c.transport + ":" + c.input
 		ref, err := ParseImageName(fullInput)
 		require.NoError(t, err, fullInput)
-		s := ImageName(ref)
+		s := transports.ImageName(ref)
 		assert.Equal(t, c.transport+":"+c.roundtrip, s, fullInput)
 	}
 }

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -2,52 +2,61 @@ package transports
 
 import (
 	"fmt"
-	"strings"
+	"sync"
 
-	"github.com/containers/image/directory"
-	"github.com/containers/image/docker"
-	"github.com/containers/image/docker/daemon"
-	ociLayout "github.com/containers/image/oci/layout"
-	"github.com/containers/image/openshift"
-	"github.com/containers/image/storage"
 	"github.com/containers/image/types"
-	"github.com/pkg/errors"
 )
 
-// KnownTransports is a registry of known ImageTransport instances.
-var KnownTransports map[string]types.ImageTransport
+// knownTransports is a registry of known ImageTransport instances.
+type knownTransports struct {
+	transports map[string]types.ImageTransport
+	mu         sync.Mutex
+}
+
+func (kt *knownTransports) Get(k string) types.ImageTransport {
+	kt.mu.Lock()
+	t := kt.transports[k]
+	kt.mu.Unlock()
+	return t
+}
+
+func (kt *knownTransports) Remove(k string) {
+	kt.mu.Lock()
+	delete(kt.transports, k)
+	kt.mu.Unlock()
+}
+
+func (kt *knownTransports) Add(t types.ImageTransport) {
+	kt.mu.Lock()
+	defer kt.mu.Unlock()
+	name := t.Name()
+	if t := kt.transports[name]; t != nil {
+		panic(fmt.Sprintf("Duplicate image transport name %s", name))
+	}
+	kt.transports[name] = t
+}
+
+var kt *knownTransports
 
 func init() {
-	KnownTransports = make(map[string]types.ImageTransport)
-	// NOTE: Make sure docs/policy.json.md is updated when adding or updating
-	// a transport.
-	for _, t := range []types.ImageTransport{
-		directory.Transport,
-		docker.Transport,
-		daemon.Transport,
-		ociLayout.Transport,
-		openshift.Transport,
-		storage.Transport,
-	} {
-		name := t.Name()
-		if _, ok := KnownTransports[name]; ok {
-			panic(fmt.Sprintf("Duplicate image transport name %s", name))
-		}
-		KnownTransports[name] = t
+	kt = &knownTransports{
+		transports: make(map[string]types.ImageTransport),
 	}
 }
 
-// ParseImageName converts a URL-like image name to a types.ImageReference.
-func ParseImageName(imgName string) (types.ImageReference, error) {
-	parts := strings.SplitN(imgName, ":", 2)
-	if len(parts) != 2 {
-		return nil, errors.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
-	}
-	transport, ok := KnownTransports[parts[0]]
-	if !ok {
-		return nil, errors.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
-	}
-	return transport.ParseReference(parts[1])
+// Get returns the transport specified by name or nil when unavailable.
+func Get(name string) types.ImageTransport {
+	return kt.Get(name)
+}
+
+// Delete deletes a transport from the registered transports.
+func Delete(name string) {
+	kt.Remove(name)
+}
+
+// Register registers a transport.
+func Register(t types.ImageTransport) {
+	kt.Add(t)
 }
 
 // ImageName converts a types.ImageReference into an URL-like image name, which MUST be such that


### PR DESCRIPTION
Close #125 

As discussed in #125, this patch creates a new subpkg to import transports independently. projectatomic/docker would greatly benefit from this as it needs just the docker transport (right now).

Those will be the stats in projectatomic/docker + this PR:
```
Showing  76 changed files  with 1,715 additions and 6,770 deletions.
```

@mtrmac PTAL (far from being ready, just a start...)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>