### PR TITLE
Fix top-level source example in godoc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,29 +1,29 @@
 // Package image provides libraries and commands to interact with containers images.
 //
-//    package main
+// 	package main
 //
-//    import (
-//    	"fmt"
+// 	import (
+// 		"fmt"
 //
-//    	"github.com/containers/image/docker"
-//    )
+// 		"github.com/containers/image/docker"
+// 	)
 //
-//    func main() {
-//    	ref, err := docker.ParseReference("fedora")
-//    	if err != nil {
-//    		panic(err)
-//    	}
-//    	img, err := ref.NewImage(nil)
-//    	if err != nil {
-//    		panic(err)
-//    	}
-//      defer img.Close()
-//    	b, _, err := img.Manifest()
-//    	if err != nil {
-//    		panic(err)
-//    	}
-//    	fmt.Printf("%s", string(b))
-//    }
+// 	func main() {
+// 		ref, err := docker.ParseReference("//fedora")
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		img, err := ref.NewImage(nil)
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		defer img.Close()
+// 		b, _, err := img.Manifest()
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		fmt.Printf("%s", string(b))
+// 	}
 //
 // TODO(runcom)
 package image


### PR DESCRIPTION
This won't pass just yet.

I gofmt'd the source too, but the `//` syntax requirement that exists now was
throwing off the original example which would just panic.
