### PR TITLE
Pre-layer copy hook

### DIFF
--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -82,6 +82,8 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 		}
 	}()
 
+	// the err below will overwrite the error above; there by preventing the
+	// panic error message when the function can no longer panic.
 	resp, err := c.ImageLoad(ctx, reader, true)
 	if err != nil {
 		err = errors.Wrap(err, "Error saving image to docker engine")
@@ -180,8 +182,11 @@ func (d *daemonImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	if err := d.sendFile(inputInfo.Digest.String(), inputInfo.Size, tee); err != nil {
 		return types.BlobInfo{}, err
 	}
-	d.blobs[inputInfo.Digest] = types.BlobInfo{Digest: digester.Digest(), Size: inputInfo.Size}
-	return types.BlobInfo{Digest: digester.Digest(), Size: inputInfo.Size}, nil
+
+	retval := types.BlobInfo{Digest: digester.Digest(), Size: inputInfo.Size}
+
+	d.blobs[inputInfo.Digest] = retval
+	return retval, nil
 }
 
 func (d *daemonImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
@@ -276,6 +281,7 @@ func (d *daemonImageDestination) sendFile(path string, expectedSize int64, strea
 	if err != nil {
 		return nil
 	}
+
 	logrus.Debugf("Sending as tar file %s", path)
 	if err := d.tar.WriteHeader(hdr); err != nil {
 		return err
@@ -312,6 +318,5 @@ func (d *daemonImageDestination) Commit() error {
 	d.committed = true // We may still fail, but we are done sending to imageLoadGoroutine.
 
 	logrus.Debugf("docker-daemon: Waiting for status")
-	err := <-d.statusChannel
-	return err
+	return <-d.statusChannel
 }

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -98,6 +98,7 @@ func (m *manifestSchema2) ConfigBlob() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		computedDigest := digest.FromBytes(blob)
 		if computedDigest != m.ConfigDescriptor.Digest {
 			return nil, errors.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.ConfigDescriptor.Digest)
@@ -152,9 +153,6 @@ func (m *manifestSchema2) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUp
 func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
 	copy := *m // NOTE: This is not a deep copy, it still shares slices etc.
 	if options.LayerInfos != nil {
-		if len(copy.LayersDescriptors) != len(options.LayerInfos) {
-			return nil, errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(copy.LayersDescriptors), len(options.LayerInfos))
-		}
 		copy.LayersDescriptors = make([]descriptor, len(options.LayerInfos))
 		for i, info := range options.LayerInfos {
 			copy.LayersDescriptors[i].Digest = info.Digest

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -98,6 +99,8 @@ func (m *manifestSchema2) ConfigBlob() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		fmt.Println(string(blob))
 
 		computedDigest := digest.FromBytes(blob)
 		if computedDigest != m.ConfigDescriptor.Digest {

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -402,10 +402,6 @@ func TestManifestSchema2UpdatedImage(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, layerInfos, res.LayerInfos())
-	_, err = original.UpdatedImage(types.ManifestUpdateOptions{
-		LayerInfos: append(layerInfos, layerInfos[0]),
-	})
-	assert.Error(t, err)
 
 	// ManifestMIMEType:
 	// Only smoke-test the valid conversions, detailed tests are below. (This also verifies that “original” is not affected.)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -54,7 +54,7 @@ func GuessMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest, imgspecv1.MediaTypeImageManifestList: // A recognized type.
+	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest: // A recognized type.
 		return meta.MediaType
 	}
 	// this is the only way the function can return DockerV2Schema1MediaType, and recognizing that is essential for stripping the JWS signatures = computing the correct manifest digest.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -22,7 +22,6 @@ func TestGuessMIMEType(t *testing.T) {
 		mimeType string
 	}{
 		{"ociv1.manifest.json", imgspecv1.MediaTypeImageManifest},
-		{"ociv1list.manifest.json", imgspecv1.MediaTypeImageManifestList},
 		{"v2s2.manifest.json", DockerV2Schema2MediaType},
 		{"v2list.manifest.json", DockerV2ListMediaType},
 		{"v2s1.manifest.json", DockerV2Schema1SignedMediaType},

--- a/test.go
+++ b/test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+
+	"github.com/containers/image/copy"
+	"github.com/containers/image/docker/daemon"
+	"github.com/containers/image/signature"
+	"github.com/containers/image/types"
+	"github.com/docker/distribution/reference"
+)
+
+func main() {
+	ref, err := daemon.ParseReference("docker.io/library/golang:latest")
+	if err != nil {
+		panic(err)
+	}
+
+	tgt, err := reference.ParseNamed("docker.io/erikh/test:latest")
+	if err != nil {
+		panic(err)
+	}
+
+	tgtRef, err := daemon.NewReference("", tgt)
+	if err != nil {
+		panic(err)
+	}
+
+	pc, err := signature.NewPolicyContext(&signature.Policy{
+		Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()},
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = copy.Image(pc, tgtRef, ref, &copy.Options{
+		LayerEditor: func(input []types.BlobInfo) []types.BlobInfo {
+			return input[:2]
+		},
+		RemoveSignatures: true,
+		ReportWriter:     os.Stdout,
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -225,8 +225,12 @@ type Image interface {
 
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
 type ManifestUpdateOptions struct {
-	LayerInfos       []BlobInfo // Complete BlobInfos (size+digest+urls) which should replace the originals, in order (the root layer first, and then successive layered layers)
+	// Complete BlobInfos (size+digest+urls) which should replace the originals, in
+	// order (the root layer first, and then successive layered layers)
+	LayerInfos []BlobInfo
+
 	ManifestMIMEType string
+
 	// The values below are NOT requests to modify the image; they provide optional context which may or may not be used.
 	InformationOnly ManifestUpdateInformation
 }


### PR DESCRIPTION
This is a proof-of-concept and still needs tests and other completeness changes
(like for things that are not docker). Please let me know if you'd like to
accept the feature so I know to continue work towards getting this fleshed out
in the other image systems, tests, etc.

erikh/box has a layer editor inside it that allows it to filter out layers as
necessary. This is made possible currently with some hand-rolled image code.
I'd love to move to containers/image but it has a very coarse copy
implementation.

This adds a simple hook that provides the source layer information to a hook in
the copier which returns bool on whether to proceed to continue to copy
(contrast with `filepath.Walk`).

Here is some example code that demonstrates how it can be used: in this case,
the `golang` image is pulled from the host docker, the first layer is clipped
off the top and pushed to a new image named `erikh/test`. The other layer
relationships have been removed and naturally the image is much smaller.

This has proven useful for building minimal images of containers in the past.

```golang
package main

import (
	"fmt"

	"github.com/containers/image/copy"
	"github.com/containers/image/docker/daemon"
	"github.com/containers/image/docker/reference"
	"github.com/containers/image/types"
)

func main() {
	ref, err := daemon.ParseReference("docker.io/library/golang:latest")
	if err != nil {
		panic(err)
	}

	img, err := ref.NewImage(nil)
	if err != nil {
		panic(err)
	}
	defer img.Close()

	tgtRef, _ := reference.ParseNamed("docker.io/erikh/test:latest")
	tgt, err := daemon.NewReference("", tgtRef)
	if err != nil {
		panic(err)
	}

	b, _, err := img.Manifest()
	if err != nil {
		panic(err)
	}
	fmt.Println(string(b))

	var i int
	err = copy.Image(nil, tgt, ref, &copy.Options{
		RemoveSignatures: true,
		LayerCopyHook: func(srcLayer types.BlobInfo) bool {
			i++
			return i < 2 // only the first layer
		},
	})

	if err != nil {
		panic(err)
	}
}
```
