### PR TITLE
Provide large file progress reporting hooks to copy operations

### DIFF
--- a/copy/progress_reader.go
+++ b/copy/progress_reader.go
@@ -1,0 +1,28 @@
+package copy
+
+import (
+	"io"
+	"time"
+
+	"github.com/containers/image/types"
+)
+
+// progressReader is a reader that reports its progress on an interval.
+type progressReader struct {
+	source   io.Reader
+	channel  chan types.ProgressProperties
+	interval time.Duration
+	artifact types.BlobInfo
+	lastTime time.Time
+	offset   uint64
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.source.Read(p)
+	r.offset += uint64(n)
+	if time.Since(r.lastTime) > r.interval {
+		r.channel <- types.ProgressProperties{Artifact: r.artifact, Offset: r.offset}
+		r.lastTime = time.Now()
+	}
+	return n, err
+}

--- a/types/types.go
+++ b/types/types.go
@@ -294,6 +294,13 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 }
 
+// ProgressProperties is used to pass information from the copy code to a monitor which
+// can use the real-time information to produce output or react to changes.
+type ProgressProperties struct {
+	Artifact BlobInfo
+	Offset   uint64
+}
+
 var (
 	// ErrBlobNotFound can be returned by an ImageDestination's HasBlob() method
 	ErrBlobNotFound = errors.New("no such blob present")


### PR DESCRIPTION
Again, including the other commits for ease of getting things to compile; there
is an example at the end. Only the last commit is relevant in this PR.

This provides a hook and an interval timer for progressed copy operations, such
as image packaging. It only covers the docker endpoints for now and is
untested, again, as a proof of concept for approval.

Users can specify a function which is called at each interval as long as the
copy is progressing. This function is passed the current byte offset of the
copy operation. They can use this to calculate sizes, or percentages, or the
phase of the moon at the time the current byte is downloading. Resolution of
the timer is completely independent.

Here's some code that works with this: it reports byte offsets every 100ms
during both download and upload operations during this layer edit.

Thank you again for the consideration.

```go
package main

import (
	"fmt"
	"time"

	"github.com/containers/image/copy"
	"github.com/containers/image/docker/daemon"
	"github.com/containers/image/docker/reference"
	"github.com/containers/image/types"
)

func main() {
	ref, err := daemon.ParseReference("docker.io/library/golang:latest")
	if err != nil {
		panic(err)
	}

	copyCtx := &types.SystemContext{
		CopyHook: func(offset uint64) {
			fmt.Println(offset)
		},
		CopyHookInterval: 100 * time.Millisecond,
	}

	img, err := ref.NewImage(copyCtx)
	if err != nil {
		panic(err)
	}
	defer img.Close()

	tgtRef, _ := reference.ParseNamed("docker.io/erikh/test:latest")
	tgt, err := daemon.NewReference("", tgtRef)
	if err != nil {
		panic(err)
	}

	b, _, err := img.Manifest()
	if err != nil {
		panic(err)
	}
	fmt.Println(string(b))

	var i int
	err = copy.Image(nil, tgt, ref, &copy.Options{
		SourceCtx:        copyCtx,
		DestinationCtx:   copyCtx,
		RemoveSignatures: true,
		LayerCopyHook: func(srcLayer types.BlobInfo) bool {
			i++
			return i < 2 // only the first layer
		},
	})

	if err != nil {
		panic(err)
	}
}
```
