### PR TITLE
Use docker/distribution/reference.ParseNormalizedNamed

### DIFF
--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -56,7 +56,7 @@ type Canonical interface {
 // returned.
 // If an error was encountered it is returned, along with a nil Reference.
 func ParseNamed(s string) (Named, error) {
-	named, err := distreference.ParseNamed(s)
+	named, err := distreference.ParseNormalizedNamed(s)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", s)
 	}


### PR DESCRIPTION
`docker/distribution/reference.ParseNamed` now (as of 6170ac53daed40ebbebc9fe5f482495d01f09f12) refuses input in a non-fully-explicit form; the new `ParseNormalizedNamed` accepts it and normalizes it into the fully explicit form.  (One would expect it to be the other way around…)

So, use `ParseNormalizedNamed` now.  This is a minimal fix for the failing tests.

Because `docker/distribution/reference` now does all the normalization, we can use it and drop our `docker/docker/reference` fork (which will go away upstream), at least in the short term.  (Longer-term we may need to reintroduce it again if `projectatomic/docker` decided to modify _that_.) But that’s more than just fixing the tests, so that will be a separate PR.
