### PR TITLE
Integrate github.com/fzipp/gocyclo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
   go:
     - 1.7
   install: make deps
-  script: make .gitvalidation && make validate && make test && make test-skopeo
+  script: make .gitvalidation && make validate && make test && make test-root-storage && make test-skopeo 
   dist: trusty
   os:
     - linux

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,14 @@ deps:
 	go get -u $(BUILDFLAGS) github.com/golang/lint/golint
 	go get $(BUILDFLAGS) github.com/vbatts/git-validation
 
+gocyclo:
+	go get github.com/fzipp/gocyclo
+	@out=$$(gocyclo -over 15 . | grep -v vendor); \
+	if [ -n "$$(gocyclo -over 15 . | grep -v vendor)" ]; then \
+		echo "$$out"; \
+		exit 1; \
+	fi
+
 test:
 	@go test $(BUILDFLAGS) -cover ./...
 
@@ -35,7 +43,7 @@ test-skopeo:
 		$(SUDO) make check && \
 		rm -rf $${skopeo_path}
 
-validate: lint
+validate: lint gocyclo
 	@go vet ./...
 	@test -z "$$(gofmt -s -l . | tee /dev/stderr)"
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ gocyclo:
 test:
 	@go test $(BUILDFLAGS) -cover ./...
 
+test-root-storage:
+	@sudo -E `which go` test -v ./storage
+
 # This is not run as part of (make all), but Travis CI does run this.
 # Demonstarting a working version of skopeo (possibly with modified SKOPEO_REPO/SKOPEO_BRANCH, e.g.
 #    make test-skopeo SKOPEO_REPO=runcom/skopeo-1 SKOPEO_BRANCH=oci-3 SUDO=sudo

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ deps:
 	go get $(BUILDFLAGS) github.com/vbatts/git-validation
 
 gocyclo:
-	go get github.com/fzipp/gocyclo
+	@echo Fetching/Running github.com/fzipp/gocyclo...
+	@go get github.com/fzipp/gocyclo
 	@out=$$(gocyclo -over 15 . | grep -v vendor); \
 	if [ -n "$$(gocyclo -over 15 . | grep -v vendor)" ]; then \
 		echo "$$out"; \
@@ -44,10 +45,12 @@ test-skopeo:
 		rm -rf $${skopeo_path}
 
 validate: lint gocyclo
+	@echo Running go vet...
 	@go vet ./...
 	@test -z "$$(gofmt -s -l . | tee /dev/stderr)"
 
 lint:
+	@echo Running golint...
 	@out="$$(golint ./...)"; \
 	if [ -n "$$(golint ./...)" ]; then \
 		echo "$$out"; \

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -248,6 +248,33 @@ func (s *dockerImageSource) getOneSignature(url *url.URL) (signature []byte, mis
 	}
 }
 
+func getManifest(c *dockerClient, ref dockerReference, headers map[string][]string) ([]byte, string, error) {
+	reference, err := ref.tagOrDigest()
+	if err != nil {
+		return nil, "", err
+	}
+
+	getURL := fmt.Sprintf(manifestURL, ref.ref.RemoteName(), reference)
+	get, err := c.makeRequest("GET", getURL, headers, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	defer get.Body.Close()
+	manifestBody, err := ioutil.ReadAll(get.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	switch get.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, "", errors.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry", ref.ref)
+	default:
+		return nil, "", errors.Errorf("Failed to delete %v: %s (%v)", ref.ref, manifestBody, get.Status)
+	}
+
+	return manifestBody, get.Header.Get("Docker-Content-Digest"), nil
+}
+
 // deleteImage deletes the named image from the registry, if supported.
 func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
 	c, err := newDockerClient(ctx, ref, true)
@@ -260,31 +287,12 @@ func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
 	headers := make(map[string][]string)
 	headers["Accept"] = []string{manifest.DockerV2Schema2MediaType}
 
-	reference, err := ref.tagOrDigest()
+	manifestBody, digest, err := getManifest(c, ref, headers)
 	if err != nil {
 		return err
-	}
-	getURL := fmt.Sprintf(manifestURL, ref.ref.RemoteName(), reference)
-	get, err := c.makeRequest("GET", getURL, headers, nil)
-	if err != nil {
-		return err
-	}
-	defer get.Body.Close()
-	manifestBody, err := ioutil.ReadAll(get.Body)
-	if err != nil {
-		return err
-	}
-	switch get.StatusCode {
-	case http.StatusOK:
-	case http.StatusNotFound:
-		return errors.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry", ref.ref)
-	default:
-		return errors.Errorf("Failed to delete %v: %s (%v)", ref.ref, manifestBody, get.Status)
 	}
 
-	digest := get.Header.Get("Docker-Content-Digest")
 	deleteURL := fmt.Sprintf(manifestURL, ref.ref.RemoteName(), digest)
-
 	// When retrieving the digest from a registry >= 2.3 use the following header:
 	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
 	delete, err := c.makeRequest("DELETE", deleteURL, headers, nil)

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -354,7 +354,7 @@ func NewPRSignedByKeyData(keyType sbKeyType, keyData []byte, signedIdentity Poli
 // Compile-time check that prSignedBy implements json.Unmarshaler.
 var _ json.Unmarshaler = (*prSignedBy)(nil)
 
-func (pr *prSignedBy) getPR(tmp prSignedBy) error {
+func (pr *prSignedBy) getPR(tmp prSignedBy, gotKeyPath, gotKeyData bool) error {
 	var res *prSignedBy
 	var err error
 	switch {
@@ -418,7 +418,7 @@ func (pr *prSignedBy) UnmarshalJSON(data []byte) error {
 		tmp.SignedIdentity = si
 	}
 
-	return getPR(tmp)
+	return pr.getPR(tmp, gotKeyPath, gotKeyData)
 }
 
 // IsValid returns true iff kt is a recognized value


### PR DESCRIPTION
this is integration of a validation tool called gocyclo, which you can
find more information on [here](https://github.com/fzipp/gocyclo).

Please stop me if this is an unwelcome patch, but I personally have found it to
literally excavate large chunks of ugly code into manageable parts, and I think
it would behoove the project to incorporate it into its test/CI cycle to
encourage creating more modular code.

gocyclo counts the number of branches/loops and basically provides a safe
metric for the complexity and length of a given function.

I'll be taking the time in this PR to reorganize the offending functions:

Calculated with `gocyclo -over 15 .`

```
44 storage TestWriteRead storage/storage_test.go:230:1
32 storage (*storageImageDestination).PutBlob storage/storage_image.go:137:1
30 copy Image copy/copy.go:98:1
22 storage TestDuplicateBlob storage/storage_test.go:752:1
21 signature (*prSignedBy).UnmarshalJSON signature/policy_config.go:358:1
20 storage (*storageImageDestination).Commit storage/storage_image.go:311:1
19 signature (*prSignedBy).isSignatureAuthorAccepted signature/policy_eval_signedby.go:18:1
19 storage (storageTransport).ValidatePolicyConfigurationScope storage/storage_transport.go:220:1
18 openshift validateAuthInfo openshift/openshift-copies.go:373:1
17 docker deleteImage docker/docker_image_src.go:252:1
17 docker (*dockerClient).ping docker/docker_client.go:436:1
17 openshift (*openshiftClient).doRequest openshift/openshift.go:72:1
16 docker TestGetAuthFailsOnBadInput docker/docker_client_test.go:330:1
16 docker (*dockerClient).setupRequestAuth docker/docker_client.go:240:1
16 signature (*PolicyContext).GetSignaturesWithAcceptedAuthor signature/policy_eval.go:176:1
```

Please let me know what you think, I'll start executing immediately but I'm
happy to stop if instructed.
