### PR TITLE
Fix for image spec

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -17,6 +17,21 @@ import (
 	"github.com/pkg/errors"
 )
 
+var manifestMIMETypes = []string{
+	// TODO(runcom): we'll add OCI as part of another PR here
+	manifest.DockerV2Schema2MediaType,
+	manifest.DockerV2Schema1SignedMediaType,
+	manifest.DockerV2Schema1MediaType,
+}
+
+func supportedManifestMIMETypesMap() map[string]bool {
+	m := make(map[string]bool, len(manifestMIMETypes))
+	for _, mt := range manifestMIMETypes {
+		m[mt] = true
+	}
+	return m
+}
+
 type dockerImageDestination struct {
 	ref dockerReference
 	c   *dockerClient
@@ -47,12 +62,7 @@ func (d *dockerImageDestination) Close() {
 }
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
-		// TODO(runcom): we'll add OCI as part of another PR here
-		manifest.DockerV2Schema2MediaType,
-		manifest.DockerV2Schema1SignedMediaType,
-		manifest.DockerV2Schema1MediaType,
-	}
+	return manifestMIMETypes
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -39,6 +39,17 @@ func newImageSource(ctx *types.SystemContext, ref dockerReference, requestedMani
 	if requestedManifestMIMETypes == nil {
 		requestedManifestMIMETypes = manifest.DefaultRequestedManifestMIMETypes
 	}
+	supportedMIMEs := supportedManifestMIMETypesMap()
+	acceptableRequestedMIMEs := false
+	for _, mtrequested := range requestedManifestMIMETypes {
+		if supportedMIMEs[mtrequested] {
+			acceptableRequestedMIMEs = true
+			break
+		}
+	}
+	if !acceptableRequestedMIMEs {
+		requestedManifestMIMETypes = manifest.DefaultRequestedManifestMIMETypes
+	}
 	return &dockerImageSource{
 		ref: ref,
 		requestedManifestMIMETypes: requestedManifestMIMETypes,

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -190,7 +190,7 @@ func (m *manifestSchema2) convertToManifestOCI1() (types.Image, error) {
 		if m.LayersDescriptors[idx].MediaType == manifest.DockerV2Schema2ForeignLayerMediaType {
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributable
 		} else {
-			layers[idx].MediaType = imgspecv1.MediaTypeImageLayer
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerGzip
 		}
 	}
 

--- a/image/fixtures/oci1.json
+++ b/image/fixtures/oci1.json
@@ -1,6 +1,5 @@
 {
    "schemaVersion": 2,
-   "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "size": 5940,

--- a/image/fixtures/schema2-to-oci1.json
+++ b/image/fixtures/schema2-to-oci1.json
@@ -1,0 +1,29 @@
+{
+	"schemaVersion": 2,
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"size": 5940,
+		"digest": "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f"
+	},
+	"layers": [{
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"size": 51354364,
+		"digest": "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb"
+	}, {
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"size": 150,
+		"digest": "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c"
+	}, {
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"size": 11739507,
+		"digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
+	}, {
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"size": 8841833,
+		"digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
+	}, {
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"size": 291,
+		"digest": "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa"
+	}]
+}

--- a/image/oci.go
+++ b/image/oci.go
@@ -15,7 +15,6 @@ type manifestOCI1 struct {
 	src               types.ImageSource // May be nil if configBlob is not nil
 	configBlob        []byte            // If set, corresponds to contents of ConfigDescriptor.
 	SchemaVersion     int               `json:"schemaVersion"`
-	MediaType         string            `json:"mediaType"`
 	ConfigDescriptor  descriptor        `json:"config"`
 	LayersDescriptors []descriptor      `json:"layers"`
 }
@@ -29,12 +28,11 @@ func manifestOCI1FromManifest(src types.ImageSource, manifest []byte) (genericMa
 }
 
 // manifestOCI1FromComponents builds a new manifestOCI1 from the supplied data:
-func manifestOCI1FromComponents(config descriptor, configBlob []byte, layers []descriptor) genericManifest {
+func manifestOCI1FromComponents(config descriptor, src types.ImageSource, configBlob []byte, layers []descriptor) genericManifest {
 	return &manifestOCI1{
-		src:               nil,
+		src:               src,
 		configBlob:        configBlob,
 		SchemaVersion:     2,
-		MediaType:         imgspecv1.MediaTypeImageManifest,
 		ConfigDescriptor:  config,
 		LayersDescriptors: layers,
 	}
@@ -45,7 +43,7 @@ func (m *manifestOCI1) serialize() ([]byte, error) {
 }
 
 func (m *manifestOCI1) manifestMIMEType() string {
-	return m.MediaType
+	return imgspecv1.MediaTypeImageManifest
 }
 
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -34,7 +34,7 @@ func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
 		MediaType: imgspecv1.MediaTypeImageConfig,
 		Size:      5940,
 		Digest:    "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
-	}, configBlob, []descriptor{
+	}, nil, configBlob, []descriptor{
 		{
 			MediaType: imgspecv1.MediaTypeImageLayer,
 			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -36,27 +36,27 @@ func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
 		Digest:    "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
 	}, nil, configBlob, []descriptor{
 		{
-			MediaType: imgspecv1.MediaTypeImageLayer,
+			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
 			Size:      51354364,
 		},
 		{
-			MediaType: imgspecv1.MediaTypeImageLayer,
+			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
 			Size:      150,
 		},
 		{
-			MediaType: imgspecv1.MediaTypeImageLayer,
+			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
 			Size:      11739507,
 		},
 		{
-			MediaType: imgspecv1.MediaTypeImageLayer,
+			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
 			Size:      8841833,
 		},
 		{
-			MediaType: imgspecv1.MediaTypeImageLayer,
+			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
 			Size:      291,
 		},

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -59,36 +59,3 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
 }
-
-func TestPutManifestUnrecognizedMediaType(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
-	defer os.RemoveAll(tmpDir)
-	dirRef, ok := ref.(ociReference)
-	require.True(t, ok)
-
-	ociDest, err := dirRef.NewImageDestination(nil)
-	require.NoError(t, err)
-
-	m := `{"name":"puerapuliae/busybox","tag":"latest","architecture":"amd64","fsLayers":[{"blobSum":"sha256:04f18047a28f8dea4a3b3872a2ad345cbb6f0eae28d99a60d3df844d6eaae571"},{"blobSum":"sha256:04f18047a28f8dea4a3b3872a2ad345cbb6f0eae28d99a60d3df844d6eaae571"}],"history":[{"v1Compatibility":"{\"id\":\"b46e47334e74d687019107dbec32559dd598db58fe90d2a0c5473bda8b59829d\",\"comment\":\"Imported from -\",\"created\":\"2015-07-03T07:56:02.57018886Z\",\"container_config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.6.2\",\"config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":9356886}\n"},{"v1Compatibility":"{\"id\":\"b46e47334e74d687019107dbec32559dd598db58fe90d2a0c5473bda8b59829d\",\"comment\":\"Imported from -\",\"created\":\"2015-07-03T07:56:02.57018886Z\",\"container_config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.6.2\",\"config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":9356886}\n"}],"signatures":[{"header":{"jwk":{"crv":"P-256","kid":"SVJ4:Q6G3:SXTN:H6LT:7PXH:DHUZ:SGTB:5TMV:YPIV:UPHY:MRHO:PN6V","kty":"EC","x":"qrSsA2UAKEFlDhLk12zoWpnHgYcTNfEOWGZU46pzhfk","y":"RtD_vGFtagPlheiunLvZL02LOssnu7DqShuBwc6Ml44"},"alg":"ES256"},"signature":"YzfU_rKQLWqG74uilltTiV3O92lfEjaG5wJkVt_dCtjH_C5AeghfQttnbtceJOyiaU7xP2yEnjdultutsxkQKQ","protected":"eyJmb3JtYXRMZW5ndGgiOjI4NDgsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wOS0xMFQwODoyMDowOFoifQ"}]}`
-
-	err = ociDest.PutManifest([]byte(m))
-	require.Error(t, err)
-	assert.Equal(t, `unrecognized manifest media type ""`, err.Error())
-}
-
-// regression test for projectatomic/skopeo#198
-func TestPutManifestDockerV2Schema1Signed(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
-	defer os.RemoveAll(tmpDir)
-	dirRef, ok := ref.(ociReference)
-	require.True(t, ok)
-
-	ociDest, err := dirRef.NewImageDestination(nil)
-	require.NoError(t, err)
-
-	m := `{"name":"puerapuliae/busybox","tag":"latest","architecture":"amd64","fsLayers":[{"blobSum":"sha256:04f18047a28f8dea4a3b3872a2ad345cbb6f0eae28d99a60d3df844d6eaae571"},{"blobSum":"sha256:04f18047a28f8dea4a3b3872a2ad345cbb6f0eae28d99a60d3df844d6eaae571"}],"history":[{"v1Compatibility":"{\"id\":\"b46e47334e74d687019107dbec32559dd598db58fe90d2a0c5473bda8b59829d\",\"comment\":\"Imported from -\",\"created\":\"2015-07-03T07:56:02.57018886Z\",\"container_config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.6.2\",\"config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":9356886}\n"},{"v1Compatibility":"{\"id\":\"b46e47334e74d687019107dbec32559dd598db58fe90d2a0c5473bda8b59829d\",\"comment\":\"Imported from -\",\"created\":\"2015-07-03T07:56:02.57018886Z\",\"container_config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.6.2\",\"config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":9356886}\n"}],"schemaVersion":1,"signatures":[{"header":{"jwk":{"crv":"P-256","kid":"SVJ4:Q6G3:SXTN:H6LT:7PXH:DHUZ:SGTB:5TMV:YPIV:UPHY:MRHO:PN6V","kty":"EC","x":"qrSsA2UAKEFlDhLk12zoWpnHgYcTNfEOWGZU46pzhfk","y":"RtD_vGFtagPlheiunLvZL02LOssnu7DqShuBwc6Ml44"},"alg":"ES256"},"signature":"YzfU_rKQLWqG74uilltTiV3O92lfEjaG5wJkVt_dCtjH_C5AeghfQttnbtceJOyiaU7xP2yEnjdultutsxkQKQ","protected":"eyJmb3JtYXRMZW5ndGgiOjI4NDgsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wOS0xMFQwODoyMDowOFoifQ"}]}`
-
-	err = ociDest.PutManifest([]byte(m))
-	require.Error(t, err)
-	assert.Equal(t, `can't create an OCI manifest from Docker V2 schema 1 manifest`, err.Error())
-}

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -20,7 +20,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"golang.org/x/net/http2"
-	"k8s.io/client-go/pkg/util/homedir"
+	"k8s.io/client-go/util/homedir"
 )
 
 // restTLSClientConfig is a modified copy of k8s.io/kubernets/pkg/client/restclient.TLSClientConfig.

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -20,7 +20,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"golang.org/x/net/http2"
-	"k8s.io/kubernetes/pkg/util/homedir"
+	"k8s.io/client-go/pkg/util/homedir"
 )
 
 // restTLSClientConfig is a modified copy of k8s.io/kubernets/pkg/client/restclient.TLSClientConfig.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -83,8 +83,8 @@ func newStore(t *testing.T) storage.Store {
 		GraphRoot:          root,
 		GraphDriverName:    "vfs",
 		GraphDriverOptions: []string{},
-		UidMap:             uidmap,
-		GidMap:             gidmap,
+		UIDMap:             uidmap,
+		GIDMap:             gidmap,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
https://github.com/opencontainers/image-spec/pull/411 removed the `MediaType` field in `Manifest[List]` causing builds error here. Fix that by teaching docker v2s2 to convert to OCI and remove that ugly manifest conversion in OCI image destination.

@mtrmac @cyphar PTAL