### PR TITLE
Remove dependencies on k8s.io/apimachinery

### DIFF
--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -20,7 +20,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"golang.org/x/net/http2"
-	"k8s.io/kubernetes/pkg/util/homedir"
+	"k8s.io/client-go/pkg/util/homedir"
 )
 
 // restTLSClientConfig is a modified copy of k8s.io/kubernets/pkg/client/restclient.TLSClientConfig.


### PR DESCRIPTION
Per https://github.com/containers/image/pull/207#issuecomment-274479683 , depending on the latest versions of `k8s.io` makes this code very difficult to use in `openshift/origin`. So, drop dependencies on `k8s.io/apimachinery/pkg/util/{error,net}` by inlining or copying the necessary parts.

(This leaves `k8s.io/pkg/util/homedir`, which seems not to cause issues right now.)