### PR TITLE
oci: remove MIME type autodetection

### DIFF
--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -54,7 +53,7 @@ func (s *ociImageSource) GetManifest() ([]byte, string, error) {
 		return nil, "", err
 	}
 
-	return m, manifest.GuessMIMEType(m), nil
+	return m, desc.MediaType, nil
 }
 
 func (s *ociImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
@@ -68,7 +67,11 @@ func (s *ociImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string
 		return nil, "", err
 	}
 
-	return m, manifest.GuessMIMEType(m), nil
+	// XXX: GetTargetManifest means that we don't have the context of what
+	//      mediaType the manifest has. In OCI this means that we don't know
+	//      what reference it came from, so we just *assume* that its
+	//      MediaTypeImageManifest.
+	return m, imgspecv1.MediaTypeImageManifest, nil
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.


### PR DESCRIPTION
OCI JSON blobs no longer contain a mediaType (since 1.0.0-rc4), which
breaks the auto-detection code for MIME types. However, it doesn't make
sense for us to be "auto-detecting" the MIME type of a manifest when the
OCI transport *already knows the mediaType* from the reference. So
instead just return the already-computed mediaType from the descriptor.

Unfortunately, this doesn't work for GetTargetManifest, in which case we
just default to the only valid value at the moment. In future we should
extend this logic to read `/index.json` and figure out what descriptor
referenced the manifest (though any such logic would be questionable
without running a full index on all blobs in the source image).

This is part of fixing projectatomic/skopeo#305.
Signed-off-by: Aleksa Sarai <asarai@suse.de>