### PR TITLE
manifest: remove ManifestList type

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -54,7 +54,7 @@ func GuessMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest, imgspecv1.MediaTypeImageManifestList: // A recognized type.
+	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest: // A recognized type.
 		return meta.MediaType
 	}
 	// this is the only way the function can return DockerV2Schema1MediaType, and recognizing that is essential for stripping the JWS signatures = computing the correct manifest digest.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -22,7 +22,6 @@ func TestGuessMIMEType(t *testing.T) {
 		mimeType string
 	}{
 		{"ociv1.manifest.json", imgspecv1.MediaTypeImageManifest},
-		{"ociv1list.manifest.json", imgspecv1.MediaTypeImageManifestList},
 		{"v2s2.manifest.json", DockerV2Schema2MediaType},
 		{"v2list.manifest.json", DockerV2ListMediaType},
 		{"v2s1.manifest.json", DockerV2Schema1SignedMediaType},


### PR DESCRIPTION
This was breaking in the latest version of the opencontainers manifest library.

I removed it because the type no longer exists, so I presumed the feature no longer exists, perhaps a hasty assumption. I'll research and fix this up if necessary, but it was a very small patch.