### PR TITLE
Revert "manifest: remove not needed mediatype"

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -54,7 +54,7 @@ func GuessMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MediaType, DockerV2ListMediaType: // A recognized type.
+	case DockerV2Schema2MediaType, DockerV2ListMediaType, imgspecv1.MediaTypeImageManifest, imgspecv1.MediaTypeImageManifestList: // A recognized type.
 		return meta.MediaType
 	}
 	// this is the only way the function can return DockerV2Schema1MediaType, and recognizing that is essential for stripping the JWS signatures = computing the correct manifest digest.


### PR DESCRIPTION
This reverts commit 0a5f50db799793f161cfc4d8d4fb00c9aa37585e. ,
which broke tests.

Eventually we may need that commit (when updating `image-spec`?), but right now it seems unnecessary and this is the most obvious way to get tests working without having to think :)