### PR TITLE
copy: fix panic on error

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -153,7 +153,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	}
 	src, err := image.FromUnparsedImage(unparsedImage)
 	if err != nil {
-		retErr = errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(srcRef))
+		return errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(srcRef))
 	}
 	unparsedImage = nil
 	defer func() {


### PR DESCRIPTION
The following change caused a panic https://github.com/containers/image/commit/cdb838d9ac5776d3b3cc5d7593d2d4d849fa4fbf#diff-5f78baafa6d34438aba66ed64f4b16d5R156

@mtrmac @erikh PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>