### PR TITLE
Change sigstore layout

### DIFF
--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/types"
 	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/types"
 )
 
 // systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.
@@ -64,8 +64,8 @@ func configuredSignatureStorageBase(ctx *types.SystemContext, ref dockerReferenc
 		return nil, errors.Wrapf(err, "Invalid signature storage URL %s", topLevel)
 	}
 	// FIXME? Restrict to explicitly supported schemes?
-	repo := ref.ref.Name()        // Note that this is without a tag or digest.
-	if path.Clean(repo) != repo { // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
+	repo := reference.Path(ref.ref) // Note that this is without a tag or digest.
+	if path.Clean(repo) != repo {   // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
 		return nil, errors.Errorf("Unexpected path elements in Docker reference %s for signature storage", ref.ref.String())
 	}
 	url.Path = url.Path + "/" + repo

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -195,6 +195,6 @@ func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest
 		return nil
 	}
 	url := *base
-	url.Path = fmt.Sprintf("%s@%s/signature-%d", url.Path, manifestDigest.String(), index+1)
+	url.Path = fmt.Sprintf("%s@%s=%s/signature-%d", url.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
 	return &url
 }

--- a/docker/lookaside_test.go
+++ b/docker/lookaside_test.go
@@ -252,26 +252,27 @@ func TestRegistryNamespaceSignatureTopLevel(t *testing.T) {
 }
 
 func TestSignatureStorageBaseSignatureStorageURL(t *testing.T) {
-	const md = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	const mdInput = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	const mdMapped = "sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-	assert.True(t, signatureStorageURL(nil, md, 0) == nil)
+	assert.True(t, signatureStorageURL(nil, mdInput, 0) == nil)
 	for _, c := range []struct {
 		base     string
 		index    int
 		expected string
 	}{
-		{"file:///tmp", 0, "file:///tmp@" + md + "/signature-1"},
-		{"file:///tmp", 1, "file:///tmp@" + md + "/signature-2"},
-		{"https://localhost:5555/root", 0, "https://localhost:5555/root@" + md + "/signature-1"},
-		{"https://localhost:5555/root", 1, "https://localhost:5555/root@" + md + "/signature-2"},
-		{"http://localhost:5555/root", 0, "http://localhost:5555/root@" + md + "/signature-1"},
-		{"http://localhost:5555/root", 1, "http://localhost:5555/root@" + md + "/signature-2"},
+		{"file:///tmp", 0, "file:///tmp@" + mdMapped + "/signature-1"},
+		{"file:///tmp", 1, "file:///tmp@" + mdMapped + "/signature-2"},
+		{"https://localhost:5555/root", 0, "https://localhost:5555/root@" + mdMapped + "/signature-1"},
+		{"https://localhost:5555/root", 1, "https://localhost:5555/root@" + mdMapped + "/signature-2"},
+		{"http://localhost:5555/root", 0, "http://localhost:5555/root@" + mdMapped + "/signature-1"},
+		{"http://localhost:5555/root", 1, "http://localhost:5555/root@" + mdMapped + "/signature-2"},
 	} {
 		url, err := url.Parse(c.base)
 		require.NoError(t, err)
 		expectedURL, err := url.Parse(c.expected)
 		require.NoError(t, err)
-		res := signatureStorageURL(url, md, c.index)
+		res := signatureStorageURL(url, mdInput, c.index)
 		assert.Equal(t, expectedURL, res, c.expected)
 	}
 }

--- a/docker/lookaside_test.go
+++ b/docker/lookaside_test.go
@@ -46,7 +46,7 @@ func TestConfiguredSignatureStorageBase(t *testing.T) {
 		dockerRefFromString(t, "//example.com/my/project"), false)
 	assert.NoError(t, err)
 	require.NotNil(t, base)
-	assert.Equal(t, "https://sigstore.example.com/example.com/my/project", (*url.URL)(base).String())
+	assert.Equal(t, "https://sigstore.example.com/my/project", (*url.URL)(base).String())
 }
 
 func TestRegistriesDirPath(t *testing.T) {


### PR DESCRIPTION
This

* Changes the file name to use `=` instead of `:`, to avoid a Windows reserved character. Fixes #187 .
* Removes the host name from the path, per the conversation around #120 .