### PR TITLE
Reject duplicate JSON members when parsing signatures

### DIFF
--- a/signature/json.go
+++ b/signature/json.go
@@ -14,64 +14,6 @@ func (err jsonFormatError) Error() string {
 	return string(err)
 }
 
-// validateExactMapKeys returns an error if the keys of m are not exactly expectedKeys, which must be pairwise distinct
-func validateExactMapKeys(m map[string]interface{}, expectedKeys ...string) error {
-	if len(m) != len(expectedKeys) {
-		return jsonFormatError("Unexpected keys in a JSON object")
-	}
-
-	for _, k := range expectedKeys {
-		if _, ok := m[k]; !ok {
-			return jsonFormatError(fmt.Sprintf("Key %s missing in a JSON object", k))
-		}
-	}
-	// Assuming expectedKeys are pairwise distinct, we know m contains len(expectedKeys) different values in expectedKeys.
-	return nil
-}
-
-// int64Field returns a member fieldName of m, if it is an int64, or an error.
-func int64Field(m map[string]interface{}, fieldName string) (int64, error) {
-	untyped, ok := m[fieldName]
-	if !ok {
-		return -1, jsonFormatError(fmt.Sprintf("Field %s missing", fieldName))
-	}
-	f, ok := untyped.(float64)
-	if !ok {
-		return -1, jsonFormatError(fmt.Sprintf("Field %s is not a number", fieldName))
-	}
-	v := int64(f)
-	if float64(v) != f {
-		return -1, jsonFormatError(fmt.Sprintf("Field %s is not an integer", fieldName))
-	}
-	return v, nil
-}
-
-// mapField returns a member fieldName of m, if it is a JSON map, or an error.
-func mapField(m map[string]interface{}, fieldName string) (map[string]interface{}, error) {
-	untyped, ok := m[fieldName]
-	if !ok {
-		return nil, jsonFormatError(fmt.Sprintf("Field %s missing", fieldName))
-	}
-	v, ok := untyped.(map[string]interface{})
-	if !ok {
-		return nil, jsonFormatError(fmt.Sprintf("Field %s is not a JSON object", fieldName))
-	}
-	return v, nil
-}
-
-// stringField returns a member fieldName of m, if it is a string, or an error.
-func stringField(m map[string]interface{}, fieldName string) (string, error) {
-	untyped, ok := m[fieldName]
-	if !ok {
-		return "", jsonFormatError(fmt.Sprintf("Field %s missing", fieldName))
-	}
-	v, ok := untyped.(string)
-	if !ok {
-		return "", jsonFormatError(fmt.Sprintf("Field %s is not a string", fieldName))
-	}
-	return v, nil
-}
-
 // paranoidUnmarshalJSONObject unmarshals data as a JSON object, but failing on the slightest unexpected aspect
 // (including duplicated keys, unrecognized keys, and non-matching types). Uses fieldResolver to
 // determine the destination for a field value, which should return a pointer to the destination if valid, or nil if the key is rejected.

--- a/signature/json_test.go
+++ b/signature/json_test.go
@@ -2,8 +2,6 @@ package signature
 
 import (
 	"encoding/json"
-	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,91 +20,6 @@ func x(m mSI, fields ...string) mSI {
 		m = m[field].(map[string]interface{})
 	}
 	return m
-}
-
-func TestValidateExactMapKeys(t *testing.T) {
-	// Empty map and keys
-	err := validateExactMapKeys(mSI{})
-	assert.NoError(t, err)
-
-	// Success
-	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "b", "a")
-	assert.NoError(t, err)
-
-	// Extra map keys
-	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "a")
-	assert.Error(t, err)
-
-	// Extra expected keys
-	err = validateExactMapKeys(mSI{"a": 1}, "b", "a")
-	assert.Error(t, err)
-
-	// Unexpected key values
-	err = validateExactMapKeys(mSI{"a": 1}, "b")
-	assert.Error(t, err)
-}
-
-func TestInt64Field(t *testing.T) {
-	// Field not found
-	_, err := int64Field(mSI{"a": "x"}, "b")
-	assert.Error(t, err)
-
-	// Field has a wrong type
-	_, err = int64Field(mSI{"a": "string"}, "a")
-	assert.Error(t, err)
-
-	for _, value := range []float64{
-		0.5,         // Fractional input
-		math.Inf(1), // Infinity
-		math.NaN(),  // NaN
-	} {
-		_, err = int64Field(mSI{"a": value}, "a")
-		assert.Error(t, err, fmt.Sprintf("%f", value))
-	}
-
-	// Success
-	// The float64 type has 53 bits of effective precision, so ±1FFFFFFFFFFFFF is the
-	// range of integer values which can all be represented exactly (beyond that,
-	// some are representable if they are divisible by a high enough power of 2,
-	// but most are not).
-	for _, value := range []int64{0, 1, -1, 0x1FFFFFFFFFFFFF, -0x1FFFFFFFFFFFFF} {
-		testName := fmt.Sprintf("%d", value)
-		v, err := int64Field(mSI{"a": float64(value), "b": nil}, "a")
-		require.NoError(t, err, testName)
-		assert.Equal(t, value, v, testName)
-	}
-}
-
-func TestMapField(t *testing.T) {
-	// Field not found
-	_, err := mapField(mSI{"a": mSI{}}, "b")
-	assert.Error(t, err)
-
-	// Field has a wrong type
-	_, err = mapField(mSI{"a": 1}, "a")
-	assert.Error(t, err)
-
-	// Success
-	// FIXME? We can't use mSI as the type of child, that type apparently can't be converted to the raw map type.
-	child := map[string]interface{}{"b": mSI{}}
-	m, err := mapField(mSI{"a": child, "b": nil}, "a")
-	require.NoError(t, err)
-	assert.Equal(t, child, m)
-}
-
-func TestStringField(t *testing.T) {
-	// Field not found
-	_, err := stringField(mSI{"a": "x"}, "b")
-	assert.Error(t, err)
-
-	// Field has a wrong type
-	_, err = stringField(mSI{"a": 1}, "a")
-	assert.Error(t, err)
-
-	// Success
-	s, err := stringField(mSI{"a": "x", "b": nil}, "a")
-	require.NoError(t, err)
-	assert.Equal(t, "x", s)
 }
 
 // implementsUnmarshalJSON is a minimalistic type used to detect that

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -255,13 +255,8 @@ var _ json.Unmarshaler = (*prInsecureAcceptAnything)(nil)
 func (pr *prInsecureAcceptAnything) UnmarshalJSON(data []byte) error {
 	*pr = prInsecureAcceptAnything{}
 	var tmp prInsecureAcceptAnything
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type": &tmp.Type,
 	}); err != nil {
 		return err
 	}
@@ -290,13 +285,8 @@ var _ json.Unmarshaler = (*prReject)(nil)
 func (pr *prReject) UnmarshalJSON(data []byte) error {
 	*pr = prReject{}
 	var tmp prReject
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type": &tmp.Type,
 	}); err != nil {
 		return err
 	}
@@ -465,24 +455,15 @@ func (pr *prSignedBaseLayer) UnmarshalJSON(data []byte) error {
 	*pr = prSignedBaseLayer{}
 	var tmp prSignedBaseLayer
 	var baseLayerIdentity json.RawMessage
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		case "baseLayerIdentity":
-			return &baseLayerIdentity
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type":              &tmp.Type,
+		"baseLayerIdentity": &baseLayerIdentity,
 	}); err != nil {
 		return err
 	}
 
 	if tmp.Type != prTypeSignedBaseLayer {
 		return InvalidPolicyFormatError(fmt.Sprintf("Unexpected policy requirement type \"%s\"", tmp.Type))
-	}
-	if baseLayerIdentity == nil {
-		return InvalidPolicyFormatError(fmt.Sprintf("baseLayerIdentity not specified"))
 	}
 	bli, err := newPolicyReferenceMatchFromJSON(baseLayerIdentity)
 	if err != nil {
@@ -541,13 +522,8 @@ var _ json.Unmarshaler = (*prmMatchExact)(nil)
 func (prm *prmMatchExact) UnmarshalJSON(data []byte) error {
 	*prm = prmMatchExact{}
 	var tmp prmMatchExact
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type": &tmp.Type,
 	}); err != nil {
 		return err
 	}
@@ -576,13 +552,8 @@ var _ json.Unmarshaler = (*prmMatchRepoDigestOrExact)(nil)
 func (prm *prmMatchRepoDigestOrExact) UnmarshalJSON(data []byte) error {
 	*prm = prmMatchRepoDigestOrExact{}
 	var tmp prmMatchRepoDigestOrExact
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type": &tmp.Type,
 	}); err != nil {
 		return err
 	}
@@ -611,13 +582,8 @@ var _ json.Unmarshaler = (*prmMatchRepository)(nil)
 func (prm *prmMatchRepository) UnmarshalJSON(data []byte) error {
 	*prm = prmMatchRepository{}
 	var tmp prmMatchRepository
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type": &tmp.Type,
 	}); err != nil {
 		return err
 	}
@@ -656,15 +622,9 @@ var _ json.Unmarshaler = (*prmExactReference)(nil)
 func (prm *prmExactReference) UnmarshalJSON(data []byte) error {
 	*prm = prmExactReference{}
 	var tmp prmExactReference
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		case "dockerReference":
-			return &tmp.DockerReference
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type":            &tmp.Type,
+		"dockerReference": &tmp.DockerReference,
 	}); err != nil {
 		return err
 	}
@@ -704,15 +664,9 @@ var _ json.Unmarshaler = (*prmExactRepository)(nil)
 func (prm *prmExactRepository) UnmarshalJSON(data []byte) error {
 	*prm = prmExactRepository{}
 	var tmp prmExactRepository
-	if err := paranoidUnmarshalJSONObject(data, func(key string) interface{} {
-		switch key {
-		case "type":
-			return &tmp.Type
-		case "dockerRepository":
-			return &tmp.DockerRepository
-		default:
-			return nil
-		}
+	if err := paranoidUnmarshalJSONObjectExactFields(data, map[string]interface{}{
+		"type":             &tmp.Type,
+		"dockerRepository": &tmp.DockerRepository,
 	}); err != nil {
 		return err
 	}

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -297,8 +297,8 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 
 	// Various allowed modifications to the policy
 	allowedModificationFns := []func(mSI){
-		// Delete the map of specific policies
-		func(v mSI) { delete(v, "specific") },
+		// Delete the map of transport-specific scopes
+		func(v mSI) { delete(v, "transports") },
 		// Use an empty map of transport-specific scopes
 		func(v mSI) { v["transports"] = map[string]PolicyTransportScopes{} },
 	}

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -153,6 +153,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		func(v mSI) { x(v, "optional")["creator"] = 1 },
 		// Invalid "timestamp"
 		func(v mSI) { x(v, "optional")["timestamp"] = "unexpected" },
+		func(v mSI) { x(v, "optional")["timestamp"] = 0.5 }, // Fractional input
 	}
 	for _, fn := range breakFns {
 		err = tryUnmarshalModifiedSignature(t, &s, validJSON, fn)


### PR DESCRIPTION
Instead of relying on `json.Unmarshal` into a `map[string]interface{}`, and dealing with field presence and correct types manually, build a helper based on `paranoidUnmarshalJSONObjects` which verifies field presence automatically, relies on `json.Unmarshal` for enforcing types of unstructured values, and newly rejects JSON objects with duplicate members.

Besides the primary benefit, rejecting ambiguous signatures, this allows us to get rid of the infrastructure for safely manually parsing `map[string]interface{}`. The new `paranoidUnmarshalJSONObjectExactFields` can also be used to simplify `policy.json` parsing a bit.

Also includes one unrelated test bug fix.

See the individual commits for more details.