### PR TITLE
Add JSON schema for the JSON embedded inside signatures

### DIFF
--- a/docs/atomic-signature-embedded-json.json
+++ b/docs/atomic-signature-embedded-json.json
@@ -1,0 +1,66 @@
+{
+    "title": "JSON embedded in an atomic container signature",
+    "description": "This schema is a supplement to atomic-signature.md in this directory.\n\nConsumers of the JSON MUST use the processing rules documented in atomic-signature.md, especially the requirements for the 'critical' subjobject.\n\nWhenever this schema and atomic-signature.md, or the github.com/containers/image/signature implementation, differ,\nit is the atomic-signature.md document, or the github.com/containers/image/signature implementation, which governs.\n\nUsers are STRONGLY RECOMMENDED to use the github.com/containeres/image/signature implementation instead of writing\ntheir own, ESPECIALLY when consuming signatures, so that the policy.json format can be shared by all image consumers.\n",
+    "type": "object",
+    "required": [
+        "critical",
+        "optional"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "critical": {
+            "type": "object",
+            "required": [
+                "type",
+                "image",
+                "identity"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "atomic container signature"
+                    ]
+                },
+                "image": {
+                    "type": "object",
+                    "required": [
+                        "docker-manifest-digest"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "docker-manifest-digest": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "identity": {
+                    "type": "object",
+                    "required": [
+                        "docker-reference"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "docker-reference": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "optional": {
+            "type": "object",
+            "description": "All members are optional, but if they are included, they must be valid.",
+            "additionalProperties": true,
+            "properties": {
+                "creator": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -1,6 +1,6 @@
 // Note: Consider the API unstable until the code supports at least three different image formats or transports.
 
-// NOTE: Keep this in sync with docs/atomic-signature.md!
+// NOTE: Keep this in sync with docs/atomic-signature.md and docs/atomic-signature-embedded.json!
 
 package signature
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -29,3 +29,5 @@ gopkg.in/cheggaaa/pb.v1 d7e6ca3010b6f084d8056847f55d7f572f180678
 gopkg.in/yaml.v2 a3f3340b5840cee44f372bddb5880fcbc419b46a
 k8s.io/client-go bcde30fb7eaed76fd98a36b4120321b94995ffb6
 github.com/xeipuuv/gojsonschema master
+github.com/xeipuuv/gojsonreference master
+github.com/xeipuuv/gojsonpointer master


### PR DESCRIPTION
This schema is a supplement to `docs/atomic-signature.md`, added by #251 ; this PR therefore depends on and includes #251.

Also adds some tests for the schema. See individual commit messages for details.

Quoting `description` inside the schema:
> Consumers of the JSON MUST use the processing rules documented in `atomic-signature.md`, especially the requirements for the `critical` subjobject.
>
> Whenever this schema and `atomic-signature.md`, or the `github.com/containers/image/signature` implementation, differ, it is the `atomic-signature.md` document, or the `github.com/containers/image/signature` implementation, which governs.
>
> Users are STRONGLY RECOMMENDED to use the `github.com/containeres/image/signature` implementation instead of writing their own, ESPECIALLY when consuming signatures, so that the `policy.json` format can be shared by all image consumers.