### PR TITLE
Add support for the X-Registry-Supports-Signatures API extension

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -18,8 +18,10 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/homedir"
+	"github.com/docker/distribution/registry/client"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -32,19 +34,37 @@ const (
 	dockerCfgFileName = "config.json"
 	dockerCfgObsolete = ".dockercfg"
 
-	resolvedPingV2URL = "%s://%s/v2/"
-	resolvedPingV1URL = "%s://%s/v1/_ping"
-	tagsPath          = "/v2/%s/tags/list"
-	manifestPath      = "/v2/%s/manifests/%s"
-	blobsPath         = "/v2/%s/blobs/%s"
-	blobUploadPath    = "/v2/%s/blobs/uploads/"
+	resolvedPingV2URL       = "%s://%s/v2/"
+	resolvedPingV1URL       = "%s://%s/v1/_ping"
+	tagsPath                = "/v2/%s/tags/list"
+	manifestPath            = "/v2/%s/manifests/%s"
+	blobsPath               = "/v2/%s/blobs/%s"
+	blobUploadPath          = "/v2/%s/blobs/uploads/"
+	extensionsSignaturePath = "/extensions/v2/%s/signatures/%s"
 
 	minimumTokenLifetimeSeconds = 60
+
+	extensionSignatureSchemaVersion = 2        // extensionSignature.Version
+	extensionSignatureTypeAtomic    = "atomic" // extensionSignature.Type
 )
 
 // ErrV1NotSupported is returned when we're trying to talk to a
 // docker V1 registry.
 var ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
+
+// extensionSignature and extensionSignatureList come from github.com/openshift/origin/pkg/dockerregistry/server/signaturedispatcher.go:
+// signature represents a Docker image signature.
+type extensionSignature struct {
+	Version int    `json:"schemaVersion"` // Version specifies the schema version
+	Name    string `json:"name"`          // Name must be in "sha256:<digest>@signatureName" format
+	Type    string `json:"type"`          // Type is optional, of not set it will be defaulted to "AtomicImageV1"
+	Content []byte `json:"content"`       // Content contains the signature
+}
+
+// signatureList represents list of Docker image signatures.
+type extensionSignatureList struct {
+	Signatures []extensionSignature `json:"signatures"`
+}
 
 type bearerToken struct {
 	Token     string    `json:"token"`
@@ -64,8 +84,9 @@ type dockerClient struct {
 	scope         authScope
 	// The following members are detected registry properties:
 	// They are set after a successful detectProperties(), and never change afterwards.
-	scheme     string // Empty value also used to indicate detectProperties() has not yet succeeded.
-	challenges []challenge
+	scheme             string // Empty value also used to indicate detectProperties() has not yet succeeded.
+	challenges         []challenge
+	supportsSignatures bool
 	// The following members are private state for setupRequestAuth, both are valid if token != nil.
 	token           *bearerToken
 	tokenExpiration time.Time
@@ -421,6 +442,7 @@ func (c *dockerClient) detectProperties() error {
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme
+		c.supportsSignatures = resp.Header.Get("X-Registry-Supports-Signatures") == "1"
 		return nil
 	}
 	err := ping("https")
@@ -456,6 +478,30 @@ func (c *dockerClient) detectProperties() error {
 		}
 	}
 	return err
+}
+
+// getExtensionsSignatures returns signatures from the X-Registry-Supports-Signatures API extension,
+// using the original data structures.
+func (c *dockerClient) getExtensionsSignatures(ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
+	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
+	res, err := c.makeRequest("GET", path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, client.HandleErrorResponse(res)
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedBody extensionSignatureList
+	if err := json.Unmarshal(body, &parsedBody); err != nil {
+		return nil, errors.Wrapf(err, "Error decoding signature list")
+	}
+	return &parsedBody, nil
 }
 
 func getDefaultConfigDir(confPath string) string {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -40,8 +40,8 @@ func (i *Image) SourceRefFullName() string {
 
 // GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
 func (i *Image) GetRepositoryTags() ([]string, error) {
-	url := fmt.Sprintf(tagsURL, reference.Path(i.src.ref.ref))
-	res, err := i.src.c.makeRequest("GET", url, nil, nil)
+	path := fmt.Sprintf(tagsPath, reference.Path(i.src.ref.ref))
+	res, err := i.src.c.makeRequest("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -70,7 +70,10 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 func (d *dockerImageDestination) SupportsSignatures() error {
-	return errors.Errorf("Pushing signatures to a Docker Registry is not supported")
+	if d.c.signatureBase == nil {
+		return errors.Errorf("Pushing signatures to a Docker Registry is not supported, and there is no applicable signature storage configured")
+	}
+	return nil
 }
 
 // ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.


### PR DESCRIPTION
This is provided by the OpenShift-integrated registry. This is equivalent to the atomic: transport (in the “openshift”) subpackage, but    it requires less code and notably does not require an OpenShift login     context to be configured.
    
See https://github.com/openshift/origin/pull/12504 and     https://github.com/openshift/openshift-docs/pull/3556 for more     information on this API extension.
    
To preserve compatibility, we always check for a configured lookaside     sigstore first; if that is set up, we use the lookaside and ignore the     registry-native signature storage.  Usually the user would not bother to    set up the lookaside, and use the native mechanism.
    
See the individual commits for more details.

NOTE: This includes tests using the recording mechanism proposed in #254. They are in separate commits, so they can be dropped if that mechanism is rejected or controversial and would block merging this.