### PR TITLE
docker/image_dest: do not deref possibly-nil results

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -132,7 +132,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	tee := io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter))
 	res, err = d.c.makeRequestToResolvedURL("PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, true)
 	if err != nil {
-		logrus.Debugf("Error uploading layer chunked, response %#v", *res)
+		logrus.Debugf("Error uploading layer chunked, response %#v", res)
 		return types.BlobInfo{}, err
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
This avoids dereferencing a nil result when an error is
encountered on PATCH request.

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>