### PR TITLE
docker/image_dest: ask for pull action in token scope

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -42,7 +42,7 @@ type dockerImageDestination struct {
 
 // newImageDestination creates a new ImageDestination for the specified image reference.
 func newImageDestination(ctx *types.SystemContext, ref dockerReference) (types.ImageDestination, error) {
-	c, err := newDockerClient(ctx, ref, true, "push")
+	c, err := newDockerClient(ctx, ref, true, "pull,push")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After PR #202, PutBlob() now goes through an initial HasBlob()
which may require authentication in order to perform the check;
in such case a push-only scoped token will fail with:
```
service="registry.docker.io",scope="repository:<name>:pull",error="insufficient_scope"
```

This fixes the above case by changing the scope of the token
requested for uploads, allowing pull+push.

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>