### PR TITLE
storage: improve handling of references with digests

### DIFF
--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -30,7 +29,6 @@ var (
 	// ErrPathNotAbsolute is returned when a graph root is not an absolute
 	// path name.
 	ErrPathNotAbsolute = errors.New("path name is not absolute")
-	idRegexp           = regexp.MustCompile("^(sha256:)?([0-9a-fA-F]{64})$")
 )
 
 // StoreTransport is an ImageTransport that uses a storage.Store to parse
@@ -100,9 +98,12 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 				return nil, err
 			}
 		}
-		sum, err = digest.Parse("sha256:" + refInfo[1])
-		if err != nil {
-			return nil, err
+		sum, err = digest.Parse(refInfo[1])
+		if err != nil || sum.Validate() != nil {
+			sum, err = digest.Parse("sha256:" + refInfo[1])
+			if err != nil || sum.Validate() != nil {
+				return nil, err
+			}
 		}
 	} else { // Coverage: len(refInfo) is always 1 or 2
 		// Anything else: store specified in a form we don't

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -286,7 +286,7 @@ func verboseName(name reference.Named) string {
 	name = reference.TagNameOnly(name)
 	tag := ""
 	if tagged, ok := name.(reference.NamedTagged); ok {
-		tag = tagged.Tag()
+		tag = ":" + tagged.Tag()
 	}
-	return name.Name() + ":" + tag
+	return name.Name() + tag
 }

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -34,10 +34,10 @@ func TestTransportParseStoreReference(t *testing.T) {
 		{"busybox:notlatest", "docker.io/library/busybox:notlatest", ""},                   // Valid single-component name, explicit tag
 		{"docker.io/library/busybox:notlatest", "docker.io/library/busybox:notlatest", ""}, // Valid single-component name, everything explicit
 
-		{"UPPERCASEISINVALID@" + sha256digestHex, "", ""},                                                                  // Invalid name in name@ID
-		{"busybox@ab", "", ""},                                                                                             // Invalid ID in name@ID
-		{"busybox@", "", ""},                                                                                               // Empty ID in name@ID
-		{"busybox@sha256:" + sha256digestHex, "", ""},                                                                      // This (a digested docker/docker reference format) is also invalid, since it's an invalid ID in name@ID
+		{"UPPERCASEISINVALID@" + sha256digestHex, "", ""}, // Invalid name in name@ID
+		{"busybox@ab", "", ""},                            // Invalid ID in name@ID
+		{"busybox@", "", ""},                              // Empty ID in name@ID
+		{"busybox@sha256:" + sha256digestHex, "docker.io/library/busybox:latest", sha256digestHex},                         // Valid two-component name, with ID using "sha256:" prefix
 		{"@" + sha256digestHex, "", sha256digestHex},                                                                       // Valid two-component name, with ID only
 		{"busybox@" + sha256digestHex, "docker.io/library/busybox:latest", sha256digestHex},                                // Valid two-component name, implicit tag
 		{"busybox:notlatest@" + sha256digestHex, "docker.io/library/busybox:notlatest", sha256digestHex},                   // Valid two-component name, explicit tag


### PR DESCRIPTION
This PR changes the way we parse references in the "storage" transport to correctly accept references that include an ID that has a "sha256:" prefix.  It defaults to adding the fully-expanded version of a reference's string value as the image's name, and adds a check to ensure that when attempting to read an image using a reference that included both a name and an ID, that the image we located using the ID actually has the specified name.