### PR TITLE
ostree: do not commit special files

### DIFF
--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -119,7 +119,7 @@ func (d *ostreeImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
 }
 
-func fixUsermodeFiles(dir string) error {
+func fixFiles(dir string, usermode bool) error {
 	entries, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return err
@@ -127,15 +127,23 @@ func fixUsermodeFiles(dir string) error {
 
 	for _, info := range entries {
 		fullpath := filepath.Join(dir, info.Name())
-		if info.IsDir() {
-			if err := os.Chmod(dir, info.Mode()|0700); err != nil {
+		if info.Mode()&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
+			if err := os.Remove(fullpath); err != nil {
 				return err
 			}
-			err = fixUsermodeFiles(fullpath)
+			continue
+		}
+		if info.IsDir() {
+			if usermode {
+				if err := os.Chmod(fullpath, info.Mode()|0700); err != nil {
+					return err
+				}
+			}
+			err = fixFiles(fullpath, usermode)
 			if err != nil {
 				return err
 			}
-		} else if info.Mode().IsRegular() {
+		} else if usermode && (info.Mode().IsRegular() || (info.Mode()&os.ModeSymlink) != 0) {
 			if err := os.Chmod(fullpath, info.Mode()|0600); err != nil {
 				return err
 			}
@@ -160,13 +168,16 @@ func (d *ostreeImageDestination) importBlob(blob *blobToImport) error {
 		if err := archive.UntarPath(blob.BlobPath, destinationPath); err != nil {
 			return err
 		}
+		if err := fixFiles(destinationPath, false); err != nil {
+			return err
+		}
 	} else {
 		os.MkdirAll(destinationPath, 0755)
 		if err := exec.Command("tar", "-C", destinationPath, "--no-same-owner", "--no-same-permissions", "--delay-directory-restore", "-xf", blob.BlobPath).Run(); err != nil {
 			return err
 		}
 
-		if err := fixUsermodeFiles(destinationPath); err != nil {
+		if err := fixFiles(destinationPath, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The issue was just fixed in atomic with the current implementation that
doesn't use Skopeo yet.

Apparently there are some images that contain special files and OSTree
doesn't allow to commit these special files.

Closes: https://github.com/projectatomic/atomic/issues/943

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>