### PR TITLE
Support run-time manifest type support (e.g. schema1/schema2) autodetection

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -182,7 +182,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	manifestUpdates := types.ManifestUpdateOptions{}
 	manifestUpdates.InformationOnly.Destination = dest
 
-	_, err = determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest)
+	_, _, err = determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest)
 	if err != nil {
 		return err
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -182,7 +182,8 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	manifestUpdates := types.ManifestUpdateOptions{}
 	manifestUpdates.InformationOnly.Destination = dest
 
-	if err := determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest); err != nil {
+	_, err = determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest)
+	if err != nil {
 		return err
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -186,6 +186,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 
 	canModifyManifest := len(sigs) == 0
 	manifestUpdates := types.ManifestUpdateOptions{}
+	manifestUpdates.InformationOnly.Destination = dest
 
 	if err := determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest); err != nil {
 		return err
@@ -215,7 +216,6 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		if !canModifyManifest {
 			return errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden")
 		}
-		manifestUpdates.InformationOnly.Destination = dest
 		pendingImage, err = src.UpdatedImage(manifestUpdates)
 		if err != nil {
 			return errors.Wrap(err, "Error creating an updated image manifest")

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/image"
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
@@ -21,11 +20,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
-
-// preferredManifestMIMETypes lists manifest MIME types in order of our preference, if we can't use the original manifest and need to convert.
-// Prefer v2s2 to v2s1 because v2s2 does not need to be changed when uploading to a different location.
-// Include v2s1 signed but not v2s1 unsigned, because docker/distribution requires a signature even if the unsigned MIME type is used.
-var preferredManifestMIMETypes = []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType}
 
 type digestingReader struct {
 	source           io.Reader
@@ -570,42 +564,4 @@ func compressGoroutine(dest *io.PipeWriter, src io.Reader) {
 	defer zipper.Close()
 
 	_, err = io.Copy(zipper, src) // Sets err to nil, i.e. causes dest.Close()
-}
-
-// determineManifestConversion updates manifestUpdates to convert manifest to a supported MIME type, if necessary and canModifyManifest.
-// Note that the conversion will only happen later, through src.UpdatedImage
-func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) error {
-	if len(destSupportedManifestMIMETypes) == 0 {
-		return nil // Anything goes
-	}
-	supportedByDest := map[string]struct{}{}
-	for _, t := range destSupportedManifestMIMETypes {
-		supportedByDest[t] = struct{}{}
-	}
-
-	_, srcType, err := src.Manifest()
-	if err != nil { // This should have been cached?!
-		return errors.Wrap(err, "Error reading manifest")
-	}
-	if _, ok := supportedByDest[srcType]; ok {
-		logrus.Debugf("Manifest MIME type %s is declared supported by the destination", srcType)
-		return nil
-	}
-
-	// OK, we should convert the manifest.
-	if !canModifyManifest {
-		logrus.Debugf("Manifest MIME type %s is not supported by the destination, but we can't modify the manifest, hoping for the best...")
-		return nil // Take our chances - FIXME? Or should we fail without trying?
-	}
-
-	var chosenType = destSupportedManifestMIMETypes[0] // This one is known to be supported.
-	for _, t := range preferredManifestMIMETypes {
-		if _, ok := supportedByDest[t]; ok {
-			chosenType = t
-			break
-		}
-	}
-	logrus.Debugf("Will convert manifest from MIME type %s to %s", srcType, chosenType)
-	manifestUpdates.ManifestMIMEType = chosenType
-	return nil
 }

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -236,24 +236,9 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	}
 
 	if options.SignBy != "" {
-		mech, err := signature.NewGPGSigningMechanism()
+		newSig, err := createSignature(dest, manifest, options.SignBy, reportWriter)
 		if err != nil {
-			return errors.Wrap(err, "Error initializing GPG")
-		}
-		defer mech.Close()
-		if err := mech.SupportsSigning(); err != nil {
-			return errors.Wrap(err, "Signing not supported")
-		}
-
-		dockerReference := dest.Reference().DockerReference()
-		if dockerReference == nil {
-			return errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(dest.Reference()))
-		}
-
-		writeReport("Signing manifest\n")
-		newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, options.SignBy)
-		if err != nil {
-			return errors.Wrap(err, "Error creating signature")
+			return err
 		}
 		sigs = append(sigs, newSig)
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -230,6 +230,11 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		return err
 	}
 
+	writeReport("Writing manifest to image destination\n")
+	if err := dest.PutManifest(manifest); err != nil {
+		return errors.Wrap(err, "Error writing manifest")
+	}
+
 	if options.SignBy != "" {
 		mech, err := signature.NewGPGSigningMechanism()
 		if err != nil {
@@ -251,11 +256,6 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 			return errors.Wrap(err, "Error creating signature")
 		}
 		sigs = append(sigs, newSig)
-	}
-
-	writeReport("Writing manifest to image destination\n")
-	if err := dest.PutManifest(manifest); err != nil {
-		return errors.Wrap(err, "Error writing manifest")
 	}
 
 	writeReport("Storing signatures\n")

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -1,6 +1,8 @@
 package copy
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
@@ -12,42 +14,89 @@ import (
 // Include v2s1 signed but not v2s1 unsigned, because docker/distribution requires a signature even if the unsigned MIME type is used.
 var preferredManifestMIMETypes = []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType}
 
+// orderedSet is a list of strings (MIME types in our case), with each string appearing at most once.
+type orderedSet struct {
+	list     []string
+	included map[string]struct{}
+}
+
+// newOrderedSet creates a correctly initialized orderedSet.
+// [Sometimes it would be really nice if Golang had constructors…]
+func newOrderedSet() *orderedSet {
+	return &orderedSet{
+		list:     []string{},
+		included: map[string]struct{}{},
+	}
+}
+
+// append adds s to the end of os, only if it is not included already.
+func (os *orderedSet) append(s string) {
+	if _, ok := os.included[s]; !ok {
+		os.list = append(os.list, s)
+		os.included[s] = struct{}{}
+	}
+}
+
 // determineManifestConversion updates manifestUpdates to convert manifest to a supported MIME type, if necessary and canModifyManifest.
 // Note that the conversion will only happen later, through src.UpdatedImage
-// Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified).
-func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) (string, error) {
+// Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
+// and a list of other possible alternatives, in order.
+func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) (string, []string, error) {
 	_, srcType, err := src.Manifest()
 	if err != nil { // This should have been cached?!
-		return "", errors.Wrap(err, "Error reading manifest")
+		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
 
 	if len(destSupportedManifestMIMETypes) == 0 {
-		return srcType, nil // Anything goes
+		return srcType, []string{}, nil // Anything goes; just use the original as is, do not try any conversions.
 	}
 	supportedByDest := map[string]struct{}{}
 	for _, t := range destSupportedManifestMIMETypes {
 		supportedByDest[t] = struct{}{}
 	}
 
+	// destSupportedManifestMIMETypes is a static guess; a particular registry may still only support a subset of the types.
+	// So, build a list of types to try in order of decreasing preference.
+	// FIXME? This treats manifest.DockerV2Schema1SignedMediaType and manifest.DockerV2Schema1MediaType as distinct,
+	// although we are not really making any conversion, and it is very unlikely that a destination would support one but not the other.
+	// In practice, schema1 is probably the lowest common denominator, so we would expect to try the first one of the MIME types
+	// and never attempt the other one.
+	prioritizedTypes := newOrderedSet()
+
+	// First of all, prefer to keep the original manifest unmodified.
 	if _, ok := supportedByDest[srcType]; ok {
-		logrus.Debugf("Manifest MIME type %s is declared supported by the destination", srcType)
-		return srcType, nil
+		prioritizedTypes.append(srcType)
 	}
-
-	// OK, we should convert the manifest.
 	if !canModifyManifest {
-		logrus.Debugf("Manifest MIME type %s is not supported by the destination, but we can't modify the manifest, hoping for the best...")
-		return srcType, nil // Take our chances - FIXME? Or should we fail without trying?
+		// We could also drop the !canModifyManifest parameter and have the caller
+		// make the choice; it is already doing that to an extent, to improve error
+		// messages.  But it is nice to hide the “if !canModifyManifest, do no conversion”
+		// special case in here; the caller can then worry (or not) only about a good UI.
+		logrus.Debugf("We can't modify the manifest, hoping for the best...")
+		return srcType, []string{}, nil // Take our chances - FIXME? Or should we fail without trying?
 	}
 
-	var chosenType = destSupportedManifestMIMETypes[0] // This one is known to be supported.
+	// Then use our list of preferred types.
 	for _, t := range preferredManifestMIMETypes {
 		if _, ok := supportedByDest[t]; ok {
-			chosenType = t
-			break
+			prioritizedTypes.append(t)
 		}
 	}
-	logrus.Debugf("Will convert manifest from MIME type %s to %s", srcType, chosenType)
-	manifestUpdates.ManifestMIMEType = chosenType
-	return chosenType, nil
+
+	// Finally, try anything else the destination supports.
+	for _, t := range destSupportedManifestMIMETypes {
+		prioritizedTypes.append(t)
+	}
+
+	logrus.Debugf("Manifest has MIME type %s, ordered candidate list [%s]", srcType, strings.Join(prioritizedTypes.list, ", "))
+	if len(prioritizedTypes.list) == 0 { // Coverage: destSupportedManifestMIMETypes is not empty (or we would have exited in the “Anything goes” case above), so this should never happen.
+		return "", nil, errors.New("Internal error: no candidate MIME types")
+	}
+	preferredType := prioritizedTypes.list[0]
+	if preferredType != srcType {
+		manifestUpdates.ManifestMIMEType = preferredType
+	} else {
+		logrus.Debugf("... will first try using the original manifest unmodified")
+	}
+	return preferredType, prioritizedTypes.list[1:], nil
 }

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -1,0 +1,51 @@
+package copy
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+)
+
+// preferredManifestMIMETypes lists manifest MIME types in order of our preference, if we can't use the original manifest and need to convert.
+// Prefer v2s2 to v2s1 because v2s2 does not need to be changed when uploading to a different location.
+// Include v2s1 signed but not v2s1 unsigned, because docker/distribution requires a signature even if the unsigned MIME type is used.
+var preferredManifestMIMETypes = []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType}
+
+// determineManifestConversion updates manifestUpdates to convert manifest to a supported MIME type, if necessary and canModifyManifest.
+// Note that the conversion will only happen later, through src.UpdatedImage
+func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) error {
+	if len(destSupportedManifestMIMETypes) == 0 {
+		return nil // Anything goes
+	}
+	supportedByDest := map[string]struct{}{}
+	for _, t := range destSupportedManifestMIMETypes {
+		supportedByDest[t] = struct{}{}
+	}
+
+	_, srcType, err := src.Manifest()
+	if err != nil { // This should have been cached?!
+		return errors.Wrap(err, "Error reading manifest")
+	}
+	if _, ok := supportedByDest[srcType]; ok {
+		logrus.Debugf("Manifest MIME type %s is declared supported by the destination", srcType)
+		return nil
+	}
+
+	// OK, we should convert the manifest.
+	if !canModifyManifest {
+		logrus.Debugf("Manifest MIME type %s is not supported by the destination, but we can't modify the manifest, hoping for the best...")
+		return nil // Take our chances - FIXME? Or should we fail without trying?
+	}
+
+	var chosenType = destSupportedManifestMIMETypes[0] // This one is known to be supported.
+	for _, t := range preferredManifestMIMETypes {
+		if _, ok := supportedByDest[t]; ok {
+			chosenType = t
+			break
+		}
+	}
+	logrus.Debugf("Will convert manifest from MIME type %s to %s", srcType, chosenType)
+	manifestUpdates.ManifestMIMEType = chosenType
+	return nil
+}

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -1,0 +1,129 @@
+package copy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeImageSource is an implementation of types.Image which only returns itself as a MIME type in Manifest
+// except that "" means “reading the manifest should fail”
+type fakeImageSource string
+
+func (f fakeImageSource) Reference() types.ImageReference {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) Close() error {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) Manifest() ([]byte, string, error) {
+	if string(f) == "" {
+		return nil, "", errors.New("Manifest() directed to fail")
+	}
+	return nil, string(f), nil
+}
+func (f fakeImageSource) Signatures() ([][]byte, error) {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) ConfigInfo() types.BlobInfo {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) ConfigBlob() ([]byte, error) {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) OCIConfig() (*v1.Image, error) {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) LayerInfos() []types.BlobInfo {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) Inspect() (*types.ImageInspectInfo, error) {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) IsMultiImage() bool {
+	panic("Unexpected call to a mock function")
+}
+func (f fakeImageSource) Size() (int64, error) {
+	panic("Unexpected call to a mock function")
+}
+
+func TestDetermineManifestConversion(t *testing.T) {
+	supportS1S2OCI := []string{
+		v1.MediaTypeImageManifest,
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+	supportS1OCI := []string{
+		v1.MediaTypeImageManifest,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+	supportS1S2 := []string{
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+	supportOnlyS1 := []string{
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+
+	cases := []struct {
+		description    string
+		sourceType     string
+		destTypes      []string
+		expectedUpdate string
+	}{
+		// Destination accepts anything — no conversion necessary
+		{"s1→anything", manifest.DockerV2Schema1SignedMediaType, nil, ""},
+		{"s2→anything", manifest.DockerV2Schema2MediaType, nil, ""},
+		// Destination accepts the unmodified original
+		{"s1→s1s2", manifest.DockerV2Schema1SignedMediaType, supportS1S2, ""},
+		{"s2→s1s2", manifest.DockerV2Schema2MediaType, supportS1S2, ""},
+		{"s1→s1", manifest.DockerV2Schema1SignedMediaType, supportOnlyS1, ""},
+		// Conversion necessary, a preferred format is acceptable
+		{"s2→s1", manifest.DockerV2Schema2MediaType, supportOnlyS1, manifest.DockerV2Schema1SignedMediaType},
+		// Conversion necessary, a preferred format is not acceptable
+		{"s2→OCI", manifest.DockerV2Schema2MediaType, []string{v1.MediaTypeImageManifest}, v1.MediaTypeImageManifest},
+		// Conversion necessary, try the preferred formats in order.
+		{"special→s2", "this needs conversion", supportS1S2OCI, manifest.DockerV2Schema2MediaType},
+		{"special→s1", "this needs conversion", supportS1OCI, manifest.DockerV2Schema1SignedMediaType},
+		{"special→OCI", "this needs conversion", []string{v1.MediaTypeImageManifest, "other options", "with lower priority"}, v1.MediaTypeImageManifest},
+	}
+
+	for _, c := range cases {
+		src := fakeImageSource(c.sourceType)
+		mu := types.ManifestUpdateOptions{}
+		err := determineManifestConversion(&mu, src, c.destTypes, true)
+		require.NoError(t, err, c.description)
+		assert.Equal(t, c.expectedUpdate, mu.ManifestMIMEType, c.description)
+	}
+
+	// Whatever the input is, with !canModifyManifest we return "keep the original as is"
+	for _, c := range cases {
+		src := fakeImageSource(c.sourceType)
+		mu := types.ManifestUpdateOptions{}
+		err := determineManifestConversion(&mu, src, c.destTypes, false)
+		require.NoError(t, err, c.description)
+		assert.Equal(t, "", mu.ManifestMIMEType, c.description)
+	}
+
+	// Error reading the manifest — smoke test only.
+	// (This error is not currently encountered if the destination accepts anything;
+	// that is not an API promise, though.)
+	mu := types.ManifestUpdateOptions{}
+	err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true)
+	assert.Error(t, err)
+}

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -106,24 +106,28 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		mu := types.ManifestUpdateOptions{}
-		err := determineManifestConversion(&mu, src, c.destTypes, true)
+		preferredMIMEType, err := determineManifestConversion(&mu, src, c.destTypes, true)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, c.expectedUpdate, mu.ManifestMIMEType, c.description)
+		if c.expectedUpdate == "" {
+			assert.Equal(t, c.sourceType, preferredMIMEType, c.description)
+		} else {
+			assert.Equal(t, c.expectedUpdate, preferredMIMEType, c.description)
+		}
 	}
 
 	// Whatever the input is, with !canModifyManifest we return "keep the original as is"
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		mu := types.ManifestUpdateOptions{}
-		err := determineManifestConversion(&mu, src, c.destTypes, false)
+		preferredMIMEType, err := determineManifestConversion(&mu, src, c.destTypes, false)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, "", mu.ManifestMIMEType, c.description)
+		assert.Equal(t, c.sourceType, preferredMIMEType, c.description)
 	}
 
 	// Error reading the manifest — smoke test only.
-	// (This error is not currently encountered if the destination accepts anything;
-	// that is not an API promise, though.)
 	mu := types.ManifestUpdateOptions{}
-	err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true)
+	_, err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true)
 	assert.Error(t, err)
 }

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -1,0 +1,35 @@
+package copy
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/containers/image/signature"
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+	"github.com/pkg/errors"
+)
+
+// createSignature creates a new signature of manifest at (identified by) dest using keyIdentity.
+func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity string, reportWriter io.Writer) ([]byte, error) {
+	mech, err := signature.NewGPGSigningMechanism()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error initializing GPG")
+	}
+	defer mech.Close()
+	if err := mech.SupportsSigning(); err != nil {
+		return nil, errors.Wrap(err, "Signing not supported")
+	}
+
+	dockerReference := dest.Reference().DockerReference()
+	if dockerReference == nil {
+		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(dest.Reference()))
+	}
+
+	fmt.Fprintf(reportWriter, "Signing manifest\n")
+	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating signature")
+	}
+	return newSig, nil
+}

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -1,0 +1,72 @@
+package copy
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/image/directory"
+	"github.com/containers/image/docker"
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/signature"
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testGPGHomeDirectory = "../signature/fixtures"
+	// TestKeyFingerprint is the fingerprint of the private key in testGPGHomeDirectory.
+	// Keep this in sync with signature/fixtures_info_test.go
+	testKeyFingerprint = "1D8230F6CDB6A06716E414C1DB72F2188BB46CC8"
+)
+
+func TestCreateSignature(t *testing.T) {
+	manifestBlob := []byte("Something")
+	manifestDigest, err := manifest.Digest(manifestBlob)
+	require.NoError(t, err)
+
+	mech, _, err := signature.NewEphemeralGPGSigningMechanism([]byte{})
+	require.NoError(t, err)
+	defer mech.Close()
+	if err := mech.SupportsSigning(); err != nil {
+		t.Skipf("Signing not supported: %v", err)
+	}
+
+	os.Setenv("GNUPGHOME", testGPGHomeDirectory)
+	defer os.Unsetenv("GNUPGHOME")
+
+	// Signing a directory: reference, which does not have a DockerRefrence(), fails.
+	tempDir, err := ioutil.TempDir("", "signature-dir-dest")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	dirRef, err := directory.NewReference(tempDir)
+	require.NoError(t, err)
+	dirDest, err := dirRef.NewImageDestination(nil)
+	require.NoError(t, err)
+	defer dirDest.Close()
+	_, err = createSignature(dirDest, manifestBlob, testKeyFingerprint, ioutil.Discard)
+	assert.Error(t, err)
+
+	// Set up a docker: reference
+	dockerRef, err := docker.ParseReference("//busybox")
+	require.NoError(t, err)
+	dockerDest, err := dockerRef.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
+	assert.NoError(t, err)
+	defer dockerDest.Close()
+
+	// Signing with an unknown key fails
+	_, err = createSignature(dockerDest, manifestBlob, "this key does not exist", ioutil.Discard)
+	assert.Error(t, err)
+
+	// Success
+	mech, err = signature.NewGPGSigningMechanism()
+	require.NoError(t, err)
+	defer mech.Close()
+	sig, err := createSignature(dockerDest, manifestBlob, testKeyFingerprint, ioutil.Discard)
+	require.NoError(t, err)
+	verified, err := signature.VerifyDockerManifestSignature(sig, manifestBlob, "docker.io/library/busybox:latest", mech, testKeyFingerprint)
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/busybox:latest", verified.DockerReference)
+	assert.Equal(t, manifestDigest, verified.DockerManifestDigest)
+}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -118,6 +118,10 @@ func (d *dirImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, 
 	return info, nil
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dirImageDestination) PutManifest(manifest []byte) error {
 	return ioutil.WriteFile(d.ref.manifestPath(), manifest, 0644)
 }

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -209,6 +209,10 @@ func (d *dockerImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInf
 	return info, nil
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dockerImageDestination) PutManifest(m []byte) error {
 	digest, err := manifest.Digest(m)
 	if err != nil {

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -156,10 +156,13 @@ func (d *Destination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
-// PutManifest sends the given manifest blob to the destination.
-// FIXME? This should also receive a MIME type if known, to differentiate
-//        between schema versions.
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *Destination) PutManifest(m []byte) error {
+	// We do not bother with types.ManifestTypeRejectedError; our .SupportedManifestMIMETypes() above is already providing only one alternative,
+	// so the caller trying a different manifest kind would be pointless.
 	var man schema2Manifest
 	if err := json.Unmarshal(m, &man); err != nil {
 		return errors.Wrap(err, "Error parsing manifest")

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -138,6 +138,10 @@ func (d *ociImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, 
 	return info, nil
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *ociImageDestination) PutManifest(m []byte) error {
 	digest, err := manifest.Digest(m)
 	if err != nil {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -383,6 +383,10 @@ func (d *openshiftImageDestination) ReapplyBlob(info types.BlobInfo) (types.Blob
 	return d.docker.ReapplyBlob(info)
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *openshiftImageDestination) PutManifest(m []byte) error {
 	manifestDigest, err := manifest.Digest(m)
 	if err != nil {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -218,6 +218,10 @@ func (d *ostreeImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInf
 	return info, nil
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *ostreeImageDestination) PutManifest(manifest []byte) error {
 	d.manifest = string(manifest)
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -420,6 +420,10 @@ func (s *storageImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }
 
+// PutManifest writes manifest to the destination.
+// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
+// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
+// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (s *storageImageDestination) PutManifest(manifest []byte) error {
 	s.Manifest = make([]byte, len(manifest))
 	copy(s.Manifest, manifest)


### PR DESCRIPTION
This modifies `copy.Image` to try a sequence of possibly supported manifest MIME types instead of only a single preferred one; notably this allows using the `docker:` transport with schema1-only registries, although the mechanism is ultimately fully general (i.e. it can deal with OCI-only registries just as well if `SupportsManifestMIMEType` includes OCI).

See the individual commit messages for detailed description;

**NOTE** The final commits, starting with “Define a ManifestTypeRejectedError for ImageDestination.PutManifest”, implement the behavior of only trying a sequence of MIME types if the initial manifest is rejected with a recognized "this is an invalid manifest” error (as opposed to anything else, e.g. insufficient permissions or out of space). This is IMHO more sensible, but it _does_ differ from docker/docker does, which AFAICT falls back from schema2 to schema1 on _any_ error.

(WIP because I don’t have the entire set of integration tests written, in particular using non-OpenShift registries; but the primary motivation, support for the OpenShift `acceptschema2` configuration option, does work correctly. **EDIT** Also the error messages might need tweaking.)
**EDIT** Integration tests exist, error messages are acceptable.