### PR TITLE
Allow using schema2 when pushing to OpenShift

### DIFF
--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -338,10 +338,7 @@ func (d *openshiftImageDestination) Close() error {
 }
 
 func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
-		manifest.DockerV2Schema1SignedMediaType,
-		manifest.DockerV2Schema1MediaType,
-	}
+	return d.docker.SupportedManifestMIMETypes()
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.


### PR DESCRIPTION
With #264 we can dynamically try pushing using schema2, and fall back to schema1, without relying on a static `SupportedManifestMIMETypes` list. Therefore, modify the `atomic:` transport to use the same set of of statically declared MIME types candidates as the `docker:` transport.

In practical terms, OpenShift registries configured with `acceptschema2: true` will now get schema2 images if the input is schema2 (schema1 images would be copied unmodified as schema1), while `accpetschema2:false` registries will continue to always get schema1.

One notable difference is that `SupportedManifestMIMETypes` affects what we configure the _source_ to accept: e.g. when streaming from `docker:` to s1-only `atomic:`, previously the conversion was done by the `docker:` registry server, but now the source registry gives us schema2 and we do the conversion, changing the manifest digest.  Right now that is a difference, but soon(will add link here) we will update the manifest to use the destination’s name/tag, and then the manifest digest will change in any case.

This PR depends on, and includes, #264, only the last commit is actually new. I will rebase as necessary.

@aweiteka @baude FYI