### PR TITLE
Rebase containers/storage to fix build on macOS

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Sirupsen/logrus 7f4b1adc791766938c29457bed0703fb9134421a
-github.com/containers/storage 5cbbc6bafb45bd7ef10486b673deb3b81bb3b787
+github.com/containers/storage d10d8680af74070b362637408a7fe28c4b1f1eff
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
 github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e
@@ -31,3 +31,5 @@ k8s.io/client-go bcde30fb7eaed76fd98a36b4120321b94995ffb6
 github.com/xeipuuv/gojsonschema master
 github.com/xeipuuv/gojsonreference master
 github.com/xeipuuv/gojsonpointer master
+github.com/tchap/go-patricia/patricia v2.2.6
+github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d


### PR DESCRIPTION
The version we use expects Linux-specific `struct stat`; per https://github.com/containers/image/issues/268#issuecomment-301072144 the update fixes this.
