### PR TITLE
Vendor in latest changes for containers/storage

### DIFF
--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
-	"github.com/containers/storage/storage"
+	"github.com/containers/storage"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +37,7 @@ func newReference(transport storageTransport, reference, id string, name referen
 // one present with the same name or ID, and return the image.
 func (s *storageReference) resolveImage() (*storage.Image, error) {
 	if s.id == "" {
-		image, err := s.transport.store.GetImage(s.reference)
+		image, err := s.transport.store.Image(s.reference)
 		if image != nil && err == nil {
 			s.id = image.ID
 		}
@@ -46,7 +46,7 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		logrus.Errorf("reference %q does not resolve to an image ID", s.StringWithinTransport())
 		return nil, ErrNoSuchImage
 	}
-	img, err := s.transport.store.GetImage(s.id)
+	img, err := s.transport.store.Image(s.id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading image %q", s.id)
 	}
@@ -83,7 +83,7 @@ func (s storageReference) DockerReference() reference.Named {
 // disambiguate between images which may be present in multiple stores and
 // share only their names.
 func (s storageReference) StringWithinTransport() string {
-	storeSpec := "[" + s.transport.store.GetGraphDriverName() + "@" + s.transport.store.GetGraphRoot() + "]"
+	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
 	if s.name == nil {
 		return storeSpec + "@" + s.id
 	}
@@ -102,8 +102,8 @@ func (s storageReference) PolicyConfigurationIdentity() string {
 // graph root, in case we're using multiple drivers in the same directory for
 // some reason.
 func (s storageReference) PolicyConfigurationNamespaces() []string {
-	storeSpec := "[" + s.transport.store.GetGraphDriverName() + "@" + s.transport.store.GetGraphRoot() + "]"
-	driverlessStoreSpec := "[" + s.transport.store.GetGraphRoot() + "]"
+	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
+	driverlessStoreSpec := "[" + s.transport.store.GraphRoot() + "]"
 	namespaces := []string{}
 	if s.name != nil {
 		if s.id != "" {

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -57,7 +57,7 @@ var validReferenceTestCases = []struct {
 
 func TestStorageReferenceStringWithinTransport(t *testing.T) {
 	store := newStore(t)
-	storeSpec := fmt.Sprintf("[%s@%s]", store.GetGraphDriverName(), store.GetGraphRoot())
+	storeSpec := fmt.Sprintf("[%s@%s]", store.GraphDriverName(), store.GraphRoot())
 
 	for _, c := range validReferenceTestCases {
 		ref, err := Transport.ParseReference(c.input)
@@ -68,7 +68,7 @@ func TestStorageReferenceStringWithinTransport(t *testing.T) {
 
 func TestStorageReferencePolicyConfigurationIdentity(t *testing.T) {
 	store := newStore(t)
-	storeSpec := fmt.Sprintf("[%s@%s]", store.GetGraphDriverName(), store.GetGraphRoot())
+	storeSpec := fmt.Sprintf("[%s@%s]", store.GraphDriverName(), store.GraphRoot())
 
 	for _, c := range validReferenceTestCases {
 		ref, err := Transport.ParseReference(c.input)
@@ -79,7 +79,7 @@ func TestStorageReferencePolicyConfigurationIdentity(t *testing.T) {
 
 func TestStorageReferencePolicyConfigurationNamespaces(t *testing.T) {
 	store := newStore(t)
-	storeSpec := fmt.Sprintf("[%s@%s]", store.GetGraphDriverName(), store.GetGraphRoot())
+	storeSpec := fmt.Sprintf("[%s@%s]", store.GraphDriverName(), store.GraphRoot())
 
 	for _, c := range validReferenceTestCases {
 		ref, err := Transport.ParseReference(c.input)
@@ -89,7 +89,7 @@ func TestStorageReferencePolicyConfigurationNamespaces(t *testing.T) {
 			expectedNS = append(expectedNS, storeSpec+ns)
 		}
 		expectedNS = append(expectedNS, storeSpec)
-		expectedNS = append(expectedNS, fmt.Sprintf("[%s]", store.GetGraphRoot()))
+		expectedNS = append(expectedNS, fmt.Sprintf("[%s]", store.GraphRoot()))
 		assert.Equal(t, expectedNS, ref.PolicyConfigurationNamespaces())
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/types"
+	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/containers/storage/storage"
 	ddigest "github.com/opencontainers/go-digest"
 )
 

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
-	"github.com/containers/storage/storage"
+	"github.com/containers/storage"
 	"github.com/opencontainers/go-digest"
 	ddigest "github.com/opencontainers/go-digest"
 )
@@ -110,7 +110,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		// recognize.
 		return nil, ErrInvalidReference
 	}
-	storeSpec := "[" + store.GetGraphDriverName() + "@" + store.GetGraphRoot() + "]"
+	storeSpec := "[" + store.GraphDriverName() + "@" + store.GraphRoot() + "]"
 	id := ""
 	if sum.Validate() == nil {
 		id = sum.Hex()
@@ -205,14 +205,14 @@ func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageRefe
 	if dref == nil {
 		if sref, ok := ref.(*storageReference); ok {
 			if sref.id != "" {
-				if img, err := store.GetImage(sref.id); err == nil {
+				if img, err := store.Image(sref.id); err == nil {
 					return img, nil
 				}
 			}
 		}
 		return nil, ErrInvalidReference
 	}
-	return store.GetImage(verboseName(dref))
+	return store.Image(verboseName(dref))
 }
 
 func (s *storageTransport) GetImage(ref types.ImageReference) (*storage.Image, error) {

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -65,8 +65,8 @@ func TestTransportParseStoreReference(t *testing.T) {
 
 func TestTransportParseReference(t *testing.T) {
 	store := newStore(t)
-	driver := store.GetGraphDriverName()
-	root := store.GetGraphRoot()
+	driver := store.GraphDriverName()
+	root := store.GraphRoot()
 
 	for _, c := range []struct{ prefix, expectedDriver, expectedRoot string }{
 		{"", driver, root},                              // Implicit store location prefix
@@ -93,16 +93,16 @@ func TestTransportParseReference(t *testing.T) {
 			require.NoError(t, err, c.prefix)
 			storageRef, ok := ref.(*storageReference)
 			require.True(t, ok, c.prefix)
-			assert.Equal(t, c.expectedDriver, storageRef.transport.store.GetGraphDriverName(), c.prefix)
-			assert.Equal(t, c.expectedRoot, storageRef.transport.store.GetGraphRoot(), c.prefix)
+			assert.Equal(t, c.expectedDriver, storageRef.transport.store.GraphDriverName(), c.prefix)
+			assert.Equal(t, c.expectedRoot, storageRef.transport.store.GraphRoot(), c.prefix)
 		}
 	}
 }
 
 func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 	store := newStore(t)
-	driver := store.GetGraphDriverName()
-	root := store.GetGraphRoot()
+	driver := store.GraphDriverName()
+	root := store.GraphRoot()
 	storeSpec := fmt.Sprintf("[%s@%s]", driver, root) // As computed in PolicyConfigurationNamespaces
 
 	// Valid inputs

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Sirupsen/logrus 7f4b1adc791766938c29457bed0703fb9134421a
-github.com/containers/storage d10d8680af74070b362637408a7fe28c4b1f1eff
+github.com/containers/storage master
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
 github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e
@@ -31,5 +31,5 @@ k8s.io/client-go bcde30fb7eaed76fd98a36b4120321b94995ffb6
 github.com/xeipuuv/gojsonschema master
 github.com/xeipuuv/gojsonreference master
 github.com/xeipuuv/gojsonpointer master
-github.com/tchap/go-patricia/patricia v2.2.6
+github.com/tchap/go-patricia v2.2.6
 github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d


### PR DESCRIPTION
This involves some API Changes.

Mainly containers/storage/storage files moved to containers/storage

store.Get* functions dropped the Get to get in compliance with Golang standards.

