### PR TITLE
Support /etc/docker/certs.d

### DIFF
--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -51,7 +51,7 @@ func TestCreateSignature(t *testing.T) {
 	// Set up a docker: reference
 	dockerRef, err := docker.ParseReference("//busybox")
 	require.NoError(t, err)
-	dockerDest, err := dockerRef.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
+	dockerDest, err := dockerRef.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	require.NoError(t, err)
 	defer dockerDest.Close()
 

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -52,7 +52,7 @@ func TestCreateSignature(t *testing.T) {
 	dockerRef, err := docker.ParseReference("//busybox")
 	require.NoError(t, err)
 	dockerDest, err := dockerRef.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer dockerDest.Close()
 
 	// Signing with an unknown key fails

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -148,6 +148,7 @@ func dockerCertDir(ctx *types.SystemContext, hostPort string) string {
 }
 
 func setupCertificates(dir string, tlsc *tls.Config) error {
+	logrus.Debugf("Looking for TLS certificates and private keys in %s", dir)
 	fs, err := ioutil.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -164,7 +165,7 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
 				return errors.Wrap(err, "unable to get system cert pool")
 			}
 			tlsc.RootCAs = systemPool
-			logrus.Debugf("crt: %s", fullPath)
+			logrus.Debugf(" crt: %s", fullPath)
 			data, err := ioutil.ReadFile(fullPath)
 			if err != nil {
 				return err
@@ -174,7 +175,7 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
 		if strings.HasSuffix(f.Name(), ".cert") {
 			certName := f.Name()
 			keyName := certName[:len(certName)-5] + ".key"
-			logrus.Debugf("cert: %s", fullPath)
+			logrus.Debugf(" cert: %s", fullPath)
 			if !hasFile(fs, keyName) {
 				return errors.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
 			}
@@ -187,7 +188,7 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
 		if strings.HasSuffix(f.Name(), ".key") {
 			keyName := f.Name()
 			certName := keyName[:len(keyName)-4] + ".cert"
-			logrus.Debugf("key: %s", fullPath)
+			logrus.Debugf(" key: %s", fullPath)
 			if !hasFile(fs, certName) {
 				return errors.Errorf("missing client certificate %s for key %s", certName, keyName)
 			}

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -202,18 +202,13 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool, 
 		return nil, err
 	}
 	tr := newTransport()
+	tr.TLSClientConfig = serverDefault()
 	if ctx != nil && (ctx.DockerCertPath != "" || ctx.DockerInsecureSkipTLSVerify) {
-		tlsc := &tls.Config{}
-
-		if err := setupCertificates(ctx.DockerCertPath, tlsc); err != nil {
+		if err := setupCertificates(ctx.DockerCertPath, tr.TLSClientConfig); err != nil {
 			return nil, err
 		}
 
-		tlsc.InsecureSkipVerify = ctx.DockerInsecureSkipTLSVerify
-		tr.TLSClientConfig = tlsc
-	}
-	if tr.TLSClientConfig == nil {
-		tr.TLSClientConfig = serverDefault()
+		tr.TLSClientConfig.InsecureSkipVerify = ctx.DockerInsecureSkipTLSVerify
 	}
 	client := &http.Client{Transport: tr}
 

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -134,7 +134,10 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
 		return nil
 	}
 	fs, err := ioutil.ReadDir(dir)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -153,7 +153,7 @@ func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
 	img, err := ref.NewImage(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer img.Close()
 }
 
@@ -169,7 +169,7 @@ func TestReferenceNewImageDestination(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
 	dest, err := ref.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer dest.Close()
 }
 

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -152,7 +152,7 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	img, err := ref.NewImage(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
+	img, err := ref.NewImage(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	require.NoError(t, err)
 	defer img.Close()
 }
@@ -160,7 +160,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	src, err := ref.NewImageSource(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"}, nil)
+	src, err := ref.NewImageSource(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"}, nil)
 	assert.NoError(t, err)
 	defer src.Close()
 }
@@ -168,7 +168,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	dest, err := ref.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist"})
+	dest, err := ref.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	require.NoError(t, err)
 	defer dest.Close()
 }

--- a/types/types.go
+++ b/types/types.go
@@ -307,7 +307,10 @@ type SystemContext struct {
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
 	// a client certificate (ending with ".cert") and a client ceritificate key
 	// (ending with ".key") used when talking to a Docker Registry.
-	DockerCertPath              string
+	DockerCertPath string
+	// If not "", overrides the system’s default path for a directory containing host[:port] subdirectories with the same structure as DockerCertPath above.
+	// Ignored if DockerCertPath is non-empty.
+	DockerPerHostCertDirPath    string
 	DockerInsecureSkipTLSVerify bool // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig


### PR DESCRIPTION
This adds `types.SystemContext.DockerPerHostCertDirPath`, defaulting to `/etc/docker/certs.d`, and making it work by default.

Note that this also applies the general TLS defaults to cases when they were previously ignored, notably even when TLS verification is disabled we now restrict the TLS version. That may not be the right thing to do, but if so, we should make an explicit decision about that.

See the individual commit messages for details.