### PR TITLE
storage: add support for manifest list

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -416,8 +416,15 @@ func (s *storageImageDestination) Commit() error {
 	return nil
 }
 
+var manifestMIMETypes = []string{
+	// TODO(runcom): we'll add OCI as part of another PR here
+	manifest.DockerV2Schema2MediaType,
+	manifest.DockerV2Schema1SignedMediaType,
+	manifest.DockerV2Schema1MediaType,
+}
+
 func (s *storageImageDestination) SupportedManifestMIMETypes() []string {
-	return nil
+	return manifestMIMETypes
 }
 
 // PutManifest writes manifest to the destination.


### PR DESCRIPTION
`storage` should support manifest list like `docker-daemon` - this is needed in CRI-O

Signed-off-by: Antonio Murdaca <runcom@redhat.com>