### PR TITLE
copy: fail early when image os doesn't match host os

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -51,6 +51,11 @@ func (d *dirImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *dirImageDestination) MustMatchRuntimeOS() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -78,6 +78,11 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 	defer resp.Body.Close()
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *daemonImageDestination) MustMatchRuntimeOS() bool {
+	return true
+}
+
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *daemonImageDestination) Close() error {
 	if !d.committed {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -99,6 +99,11 @@ func (d *dockerImageDestination) AcceptsForeignLayerURLs() bool {
 	return true
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *dockerImageDestination) MustMatchRuntimeOS() bool {
+	return false
+}
+
 // sizeCounter is an io.Writer which only counts the total size of its input.
 type sizeCounter struct{ size int64 }
 

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -81,6 +81,11 @@ func (d *Destination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *Destination) MustMatchRuntimeOS() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -375,6 +375,9 @@ func (d *memoryImageDest) ShouldCompressLayers() bool {
 func (d *memoryImageDest) AcceptsForeignLayerURLs() bool {
 	panic("Unexpected call to a mock function")
 }
+func (d *memoryImageDest) MustMatchRuntimeOS() bool {
+	panic("Unexpected call to a mock function")
+}
 func (d *memoryImageDest) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
 	if d.storedBlobs == nil {
 		d.storedBlobs = make(map[digest.Digest][]byte)

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -66,6 +66,11 @@ func (d *ociImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *ociImageDestination) MustMatchRuntimeOS() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -358,6 +358,11 @@ func (d *openshiftImageDestination) AcceptsForeignLayerURLs() bool {
 	return true
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -86,6 +86,11 @@ func (d *ostreeImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
+	return true
+}
+
 func (d *ostreeImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -449,6 +449,11 @@ func (s *storageImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+func (s *storageImageDestination) MustMatchRuntimeOS() bool {
+	return true
+}
+
 func (s *storageImageDestination) PutSignatures(signatures [][]byte) error {
 	sizes := []int{}
 	sigblob := []byte{}

--- a/types/types.go
+++ b/types/types.go
@@ -148,11 +148,11 @@ type ImageDestination interface {
 	SupportsSignatures() error
 	// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
 	ShouldCompressLayers() bool
-
 	// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 	// uploaded to the image destination, true otherwise.
 	AcceptsForeignLayerURLs() bool
-
+	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+	MustMatchRuntimeOS() bool
 	// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 	// inputInfo.Size is the expected length of stream, if known.


### PR DESCRIPTION
We don't want to pull all layers for an image before realizing it's incompatible with the host OS. An example would be when you try to copy a windows image with skopeo:

```
$ ./skopeo copy docker://microsoft/windowsservercore docker-daemon:testwin:latest
```
The above will pull all layers (more than 3GB) before realizing it's incompatible.

We want to fail early as docker itself does today, so this patch modifies the flow to check for OS compatibility asap (relying on the OCI config):
```
$ sudo ./skopeo copy docker://microsoft/windowsservercore docker-daemon:testwin:latest
FATA[0003] image operating system "windows" cannot be used on "linux"
```

@mtrmac PTAL

needed for BZ https://bugzilla.redhat.com/show_bug.cgi?id=1418173

Signed-off-by: Antonio Murdaca <runcom@redhat.com>