### PR TITLE
Helper interface to generate a comma separate list of transports.

### DIFF
--- a/transports/transports.go
+++ b/transports/transports.go
@@ -69,3 +69,16 @@ func Register(t types.ImageTransport) {
 func ImageName(ref types.ImageReference) string {
 	return ref.Transport().Name() + ":" + ref.StringWithinTransport()
 }
+
+// List returns a comma separate list of transports
+func ListNames() string {
+	list := ""
+	for _, transport := range kt.transports {
+		if list == "" {
+			list = transport.Name()
+		} else {
+			list = list + ", " + transport.Name()
+		}
+	}
+	return list
+}


### PR DESCRIPTION
This interface can be used by callers in their Usage statements, to
guide users to all potential transports.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>