### PR TITLE
Interface to return list of transports names

### DIFF
--- a/transports/transports.go
+++ b/transports/transports.go
@@ -2,6 +2,7 @@ package transports
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/containers/image/types"
@@ -68,4 +69,14 @@ func Register(t types.ImageTransport) {
 // e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
 func ImageName(ref types.ImageReference) string {
 	return ref.Transport().Name() + ":" + ref.StringWithinTransport()
+}
+
+// List returns a comma separate list of transports
+func ListNames() []string {
+	var names []string
+	for _, transport := range kt.transports {
+	       names = append(names, transport.Name())
+	}
+	sort.Strings(names)
+	return names
 }


### PR DESCRIPTION
This interface can be used by callers in their Usage statements, to
guide users to all potential transports.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>