### PR TITLE
Make the libostree dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,20 @@ Ensure that the dependencies documented [in vendor.conf](https://github.com/cont
 are also available
 (using those exact versions or different versions of your choosing).
 
-This library, by default, also depends on the GpgME C library. Either install it:
+This library, by default, also depends on the GpgME and libostree C libraries. Either install them:
 ```sh
-Fedora$ dnf install gpgme-devel libassuan-devel
+Fedora$ dnf install gpgme-devel libassuan-devel libostree-devel
 macOS$ brew install gpgme
 ```
-or use the `containers_image_openpgp` build tag (e.g. using `go build -tags …`)
-This will use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
+or use the build tags described below to avoid the dependencies (e.g. using `go build -tags …`)
+
+### Supported build tags
+
+- `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
 the primary downside is that creating new signatures with the Golang-only implementation is not supported.
+- `containers_image_ostree_stub`: Instead of importing `ostree:` transport in `github.com/containers/image/transports/alltransports`, use a stub which reports that the transport is not supported. This allows building the library without requiring the `libostree` development libraries.
+
+  (Note that explicitly importing `github.com/containers/image/ostree` will still depend on the `libostree` library, this build tag only affects generic users of …`/alltransports`.)
 
 ## Contributing
 

--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/containers/image/docker/daemon"
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"
-	_ "github.com/containers/image/ostree"
+	// The ostree transport is registered by ostree*.go
 	_ "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -24,6 +24,7 @@ func TestParseImageName(t *testing.T) {
 
 // A table-driven test summarizing the various transports' behavior.
 func TestImageNameHandling(t *testing.T) {
+	// Always registered transports
 	for _, c := range []struct{ transport, input, roundtrip string }{
 		{"dir", "/etc", "/etc"},
 		{"docker", "//busybox", "//busybox:latest"},
@@ -41,5 +42,11 @@ func TestImageNameHandling(t *testing.T) {
 		require.NoError(t, err, fullInput)
 		s := transports.ImageName(ref)
 		assert.Equal(t, c.transport+":"+c.roundtrip, s, fullInput)
+	}
+
+	// Possibly stubbed-out transports: Only verify that something is registered.
+	for _, c := range []string{"ostree"} {
+		transport := transports.Get(c)
+		assert.NotNil(t, transport, c)
 	}
 }

--- a/transports/alltransports/ostree.go
+++ b/transports/alltransports/ostree.go
@@ -1,0 +1,8 @@
+// +build !containers_image_ostree_stub
+
+package alltransports
+
+import (
+	// Register the ostree transport
+	_ "github.com/containers/image/ostree"
+)

--- a/transports/alltransports/ostree_stub.go
+++ b/transports/alltransports/ostree_stub.go
@@ -1,0 +1,9 @@
+// +build containers_image_ostree_stub
+
+package alltransports
+
+import "github.com/containers/image/transports"
+
+func init() {
+	transports.Register(transports.NewStubTransport("ostree"))
+}

--- a/transports/stub.go
+++ b/transports/stub.go
@@ -1,0 +1,36 @@
+package transports
+
+import (
+	"fmt"
+
+	"github.com/containers/image/types"
+)
+
+// stubTransport is an implementation of types.ImageTransport which has a name, but rejects any references with “the transport $name: is not supported in this build”.
+type stubTransport string
+
+// NewStubTransport returns an implementation of types.ImageTransport which has a name, but rejects any references with “the transport $name: is not supported in this build”.
+func NewStubTransport(name string) types.ImageTransport {
+	return stubTransport(name)
+}
+
+// Name returns the name of the transport, which must be unique among other transports.
+func (s stubTransport) Name() string {
+	return string(s)
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (s stubTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return nil, fmt.Errorf(`The transport "%s:" is not supported in this build`, string(s))
+}
+
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+// scope passed to this function will not be "", that value is always allowed.
+func (s stubTransport) ValidatePolicyConfigurationScope(scope string) error {
+	// Allowing any reference in here allows tools with some transports stubbed-out to still
+	// use signature verification policies which refer to these stubbed-out transports.
+	// See also the treatment of unknown transports in policyTransportScopesWithTransport.UnmarshalJSON .
+	return nil
+}

--- a/transports/stub_test.go
+++ b/transports/stub_test.go
@@ -1,0 +1,18 @@
+package transports
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStubTransport(t *testing.T) {
+	const name = "whatever"
+
+	s := NewStubTransport(name)
+	assert.Equal(t, name, s.Name())
+	_, err := s.ParseReference("this is rejected regardless of content")
+	assert.Error(t, err)
+	err = s.ValidatePolicyConfigurationScope("this is accepted regardless of content")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This adds a `containers_image_ostree_stub` build tag to allow making the libostree dependency optional. See the individual commit messages for more details.

@williamh , could you please try applying this PR to the vendored copy of containers/image in skopeo, and then building skopeo with `make binary-local BUILDTAGS=containers_image_ostree_stub` ?

@giuseppe FYI