### PR TITLE
Bump github.com/containers/storage

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -521,7 +521,7 @@ func diffLayer(store storage.Store, layerID string) (rc io.ReadCloser, n int64, 
 	} else {
 		n = layerMeta.CompressedSize
 	}
-	diff, err := store.Diff("", layer.ID)
+	diff, err := store.Diff("", layer.ID, nil)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Sirupsen/logrus 7f4b1adc791766938c29457bed0703fb9134421a
-github.com/containers/storage 989b1c1d85f5dfe2076c67b54289cc13dc836c8c
+github.com/containers/storage 105f7c77aef0c797429e41552743bf5b03b63263
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
 github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e


### PR DESCRIPTION
Update the vendored version of github.com/containers/storage to 105f7c77aef0c797429e41552743bf5b03b63263, and pass nil as the new options parameter to the storage/Store.Diff() method.