### PR TITLE
Fix checks for storage.Errors and tests for them

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -174,11 +174,11 @@ func (s *storageImageDestination) putBlob(stream io.Reader, blobinfo types.BlobI
 		}
 		// Attempt to create the identified layer and import its contents.
 		layer, uncompressedSize, err := s.imageRef.transport.store.PutLayer(id, parentLayer, nil, "", true, multi)
-		if err != nil && err != storage.ErrDuplicateID {
+		if err != nil && errors.Cause(err) != storage.ErrDuplicateID {
 			logrus.Debugf("error importing layer blob %q as %q: %v", blobinfo.Digest, id, err)
 			return errorBlobInfo, err
 		}
-		if err == storage.ErrDuplicateID {
+		if errors.Cause(err) == storage.ErrDuplicateID {
 			// We specified an ID, and there's already a layer with
 			// the same ID.  Drain the input so that we can look at
 			// its length and digest.
@@ -291,7 +291,7 @@ func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobI
 // it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) HasBlob(blobinfo types.BlobInfo) (bool, int64, error) {
 	if blobinfo.Digest == "" {
-		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, -1, errors.Errorf(`Can not check for a blob with unknown digest`)
 	}
 	for _, blob := range s.BlobList {
 		if blob.Digest == blobinfo.Digest {
@@ -331,7 +331,7 @@ func (s *storageImageDestination) Commit() error {
 	}
 	img, err := s.imageRef.transport.store.CreateImage(s.ID, nil, lastLayer, "", nil)
 	if err != nil {
-		if err != storage.ErrDuplicateID {
+		if errors.Cause(err) != storage.ErrDuplicateID {
 			logrus.Debugf("error creating image: %q", err)
 			return errors.Wrapf(err, "error creating image %q", s.ID)
 		}
@@ -340,8 +340,8 @@ func (s *storageImageDestination) Commit() error {
 			return errors.Wrapf(err, "error reading image %q", s.ID)
 		}
 		if img.TopLayer != lastLayer {
-			logrus.Debugf("error creating image: image with ID %q exists, but uses different layers", err)
-			return errors.Wrapf(err, "image with ID %q already exists, but uses a different top layer", s.ID)
+			logrus.Debugf("error creating image: image with ID %q exists, but uses different layers", s.ID)
+			return errors.Wrapf(storage.ErrDuplicateID, "image with ID %q already exists, but uses a different top layer", s.ID)
 		}
 		logrus.Debugf("reusing image ID %q", img.ID)
 	} else {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	ddigest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -498,6 +499,7 @@ func TestDuplicateName(t *testing.T) {
 	if dest == nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
+	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
@@ -551,17 +553,18 @@ func TestDuplicateID(t *testing.T) {
 	if dest == nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
+	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
 	}); err != nil {
 		t.Fatalf("Error saving randomly-generated layer to destination, second pass: %v", err)
 	}
-	if err := dest.Commit(); err != storage.ErrDuplicateID {
+	if err := dest.Commit(); errors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
-		t.Fatalf("Incorrectly succeeded committing changes to destination, second pass: %v", err)
+		t.Fatal("Incorrectly succeeded committing changes to destination, second pass: no error")
 	}
 	dest.Close()
 }
@@ -607,17 +610,18 @@ func TestDuplicateNameID(t *testing.T) {
 	if dest == nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
+	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
 	}); err != nil {
 		t.Fatalf("Error saving randomly-generated layer to destination, second pass: %v", err)
 	}
-	if err := dest.Commit(); err != storage.ErrDuplicateID {
+	if err := dest.Commit(); errors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
-		t.Fatalf("Incorrectly succeeded committing changes to destination, second pass: %v", err)
+		t.Fatal("Incorrectly succeeded committing changes to destination, second pass: no error")
 	}
 	dest.Close()
 }


### PR DESCRIPTION
The storage library, and parts of our storage-related logic, can return errors wrapped by `github.com/pkg/errors.Wrap()` and friends, so when checking for equality to specific errors, use `errors.Cause()` to dig into them.

Tests for duplicate ID detection were broken starting in d41025d60560cf463a215fc951a6ed949523a4bf, which made it acceptable to reuse an image ID if the new image and the old image had the same top layer, so adjust the tests for that error to use different layer contents when creating the second image with the same ID as one that it had just created.