### PR TITLE
Expand store locations to include runRoot and opts

### DIFF
--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -70,7 +70,9 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 // to build this reference object.
 func (s storageReference) Transport() types.ImageTransport {
 	return &storageTransport{
-		store: s.transport.store,
+		store:         s.transport.store,
+		defaultUIDMap: s.transport.defaultUIDMap,
+		defaultGIDMap: s.transport.defaultGIDMap,
 	}
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -83,7 +83,12 @@ func (s storageReference) DockerReference() reference.Named {
 // disambiguate between images which may be present in multiple stores and
 // share only their names.
 func (s storageReference) StringWithinTransport() string {
-	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
+	optionsList := ""
+	options := s.transport.store.GraphOptions()
+	if len(options) > 0 {
+		optionsList = ":" + strings.Join(options, ",")
+	}
+	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
 	if s.name == nil {
 		return storeSpec + "@" + s.id
 	}
@@ -94,7 +99,14 @@ func (s storageReference) StringWithinTransport() string {
 }
 
 func (s storageReference) PolicyConfigurationIdentity() string {
-	return s.StringWithinTransport()
+	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
+	if s.name == nil {
+		return storeSpec + "@" + s.id
+	}
+	if s.id == "" {
+		return storeSpec + s.reference
+	}
+	return storeSpec + s.reference + "@" + s.id
 }
 
 // Also accept policy that's tied to the combination of the graph root and

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,7 +58,12 @@ var validReferenceTestCases = []struct {
 
 func TestStorageReferenceStringWithinTransport(t *testing.T) {
 	store := newStore(t)
-	storeSpec := fmt.Sprintf("[%s@%s]", store.GraphDriverName(), store.GraphRoot())
+	optionsList := ""
+	options := store.GraphOptions()
+	if len(options) > 0 {
+		optionsList = ":" + strings.Join(options, ",")
+	}
+	storeSpec := fmt.Sprintf("[%s@%s+%s%s]", store.GraphDriverName(), store.GraphRoot(), store.RunRoot(), optionsList)
 
 	for _, c := range validReferenceTestCases {
 		ref, err := Transport.ParseReference(c.input)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func newStore(t *testing.T) storage.Store {
+func newStoreWithGraphDriverOptions(t *testing.T, options []string) storage.Store {
 	wd, err := ioutil.TempDir(topwd, "test.")
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func newStore(t *testing.T) storage.Store {
 		RunRoot:            run,
 		GraphRoot:          root,
 		GraphDriverName:    "vfs",
-		GraphDriverOptions: []string{},
+		GraphDriverOptions: options,
 		UIDMap:             uidmap,
 		GIDMap:             gidmap,
 	})
@@ -92,6 +92,10 @@ func newStore(t *testing.T) storage.Store {
 	}
 	Transport.SetStore(store)
 	return store
+}
+
+func newStore(t *testing.T) storage.Store {
+	return newStoreWithGraphDriverOptions(t, []string{})
 }
 
 func TestParse(t *testing.T) {
@@ -158,6 +162,46 @@ func TestParse(t *testing.T) {
 		}
 		if ref.reference != reference.reference {
 			t.Fatalf("ParseReference(%q) failed to extract reference (%q!=%q)", s, ref.reference, reference.reference)
+		}
+	}
+}
+
+func TestParseWithGraphDriverOptions(t *testing.T) {
+	optionLists := [][]string{
+		{},
+		{"unused1"},
+		{"unused1", "unused2"},
+		{"unused1", "unused2", "unused3"},
+	}
+	for _, optionList := range optionLists {
+		store := newStoreWithGraphDriverOptions(t, optionList)
+		ref, err := Transport.ParseStoreReference(store, "test")
+		if err != nil {
+			t.Fatalf("ParseStoreReference(%q, graph driver options %v) returned error %v", "test", optionList, err)
+		}
+		if ref == nil {
+			t.Fatalf("ParseStoreReference returned nil reference")
+		}
+		spec := ref.StringWithinTransport()
+		ref2, err := Transport.ParseReference(spec)
+		if err != nil {
+			t.Fatalf("ParseReference(%q) returned error %v", "test", err)
+		}
+		if ref == nil {
+			t.Fatalf("ParseReference returned nil reference")
+		}
+		sref, ok := ref2.(*storageReference)
+		if !ok {
+			t.Fatalf("ParseReference returned a reference from transport %s, not one of ours", ref2.Transport().Name())
+		}
+		parsedOptions := sref.transport.store.GraphOptions()
+		if len(parsedOptions) != len(optionList) {
+			t.Fatalf("Lost options between %v and %v", optionList, parsedOptions)
+		}
+		for i := range optionList {
+			if parsedOptions[i] != optionList[i] {
+				t.Fatalf("Mismatched option %d: %v and %v", i, optionList[i], parsedOptions[i])
+			}
 		}
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -69,23 +69,23 @@ func newStoreWithGraphDriverOptions(t *testing.T, options []string) storage.Stor
 	}
 	run := filepath.Join(wd, "run")
 	root := filepath.Join(wd, "root")
-	uidmap := []idtools.IDMap{{
+	Transport.SetDefaultUIDMap([]idtools.IDMap{{
 		ContainerID: 0,
 		HostID:      os.Getuid(),
 		Size:        1,
-	}}
-	gidmap := []idtools.IDMap{{
+	}})
+	Transport.SetDefaultGIDMap([]idtools.IDMap{{
 		ContainerID: 0,
 		HostID:      os.Getgid(),
 		Size:        1,
-	}}
+	}})
 	store, err := storage.GetStore(storage.StoreOptions{
 		RunRoot:            run,
 		GraphRoot:          root,
 		GraphDriverName:    "vfs",
 		GraphDriverOptions: options,
-		UIDMap:             uidmap,
-		GIDMap:             gidmap,
+		UIDMap:             Transport.DefaultUIDMap(),
+		GIDMap:             Transport.DefaultGIDMap(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +127,9 @@ func TestParse(t *testing.T) {
 	}
 
 	transport := storageTransport{
-		store: store,
+		store:         store,
+		defaultUIDMap: Transport.(*storageTransport).defaultUIDMap,
+		defaultGIDMap: Transport.(*storageTransport).defaultGIDMap,
 	}
 	_references := []storageReference{
 		{


### PR DESCRIPTION
Expand the syntax of the store's location to allow it to also contain the runRoot location (optional, after the root, separated by '+') and a list of driver options (optional, after the runRoot, separated by ":",
and itself broken up using ",").