### PR TITLE
Implement policy configuration scopes in docker-daemon:

### DIFF
--- a/docker/daemon/daemon_transport_test.go
+++ b/docker/daemon/daemon_transport_test.go
@@ -25,16 +25,22 @@ func TestTransportParseReference(t *testing.T) {
 }
 
 func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
-	for _, scope := range []string{ // A semi-representative assortment of values; everything is rejected.
-		sha256digestHex,
-		sha256digest,
-		"docker.io/library/busybox:latest",
-		"docker.io",
-		"",
+	// docker/policyconfiguation-accepted identities and scopes are accepted
+	for _, scope := range []string{
+		"registry.example.com/ns/stream" + sha256digest,
+		"registry.example.com/ns/stream:notlatest",
+		"registry.example.com/ns/stream",
+		"registry.example.com/ns",
+		"registry.example.com",
+		sha256digestHex, // Accept also unqualified hexdigest valies, they are in principle possible host names.
 	} {
 		err := Transport.ValidatePolicyConfigurationScope(scope)
-		assert.Error(t, err, scope)
+		assert.NoError(t, err, scope)
 	}
+
+	// Hexadecimal IDs are rejected. algo:hexdigest is clearly an invalid host:port value.
+	err := Transport.ValidatePolicyConfigurationScope(sha256digest)
+	assert.Error(t, err)
 }
 
 func TestParseReference(t *testing.T) {
@@ -188,27 +194,30 @@ func TestReferenceDockerReference(t *testing.T) {
 }
 
 func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	// id-only references have no identity.
 	ref, err := ParseReference(sha256digest)
 	require.NoError(t, err)
 	assert.Equal(t, "", ref.PolicyConfigurationIdentity())
 
-	for _, c := range validNamedReferenceTestCases {
-		ref, err := ParseReference(c.input)
-		require.NoError(t, err, c.input)
-		assert.Equal(t, "", ref.PolicyConfigurationIdentity(), c.input)
-	}
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err = ParseReference("busybox:notlatest")
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/busybox:notlatest", ref.PolicyConfigurationIdentity())
 }
 
 func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	// id-only references have no identity.
 	ref, err := ParseReference(sha256digest)
 	require.NoError(t, err)
 	assert.Empty(t, ref.PolicyConfigurationNamespaces())
 
-	for _, c := range validNamedReferenceTestCases {
-		ref, err := ParseReference(c.input)
-		require.NoError(t, err, c.input)
-		assert.Empty(t, ref.PolicyConfigurationNamespaces(), c.input)
-	}
+	// Just a smoke test, the substance is tested in policyconfiguration.TestDockerReference.
+	ref, err = ParseReference("busybox:notlatest")
+	assert.Equal(t, []string{
+		"docker.io/library/busybox",
+		"docker.io/library",
+		"docker.io",
+	}, ref.PolicyConfigurationNamespaces())
 }
 
 // daemonReference.NewImage, daemonReference.NewImageSource, openshiftReference.NewImageDestination


### PR DESCRIPTION
This is necessary for verification / policy enforcement of in-daemon images. (#288)

It is awkward in that an image may have no name and be usable only by an ID; such IDs could have a policy identity but they can’t really be namespaced.

For now, implement policy configuration scopes only for named image references; ID-only references use the root scope.  This allows users to make ID-only images untrusted or to reject them, forcing users to use image names if they want the policy to approve.  This gives a fairly natural semantics, equivalent to `docker:` policies.  ID-like policy configuration scopes are forbidden.  If truly necessary, we can add support for single-ID policy IDs into the policy in the future, but that’s unlikely to be too useful—IDs change over time, so such a policy would not be likely to be persistent; and a single-use policy built for a single image can just as well use the universal `""` scope.

(Note that `docker-daemon:` and `docker:` namespaces are still separate in the policy—images from any source can be loaded into the daemon via `(docker load)` / copy to `docker-daemon:`, so there is in general no expectation that the two namespaces are equal.  Though a special-purpose tool may well want to create an in-memory policy by loading the system-wide one and grafting the `docker:`
`PolicyTransportScopes` map to `docker-daemon:` as well.)

[In many cases an image will have an unique `RepoTags`/`RepoDigests` value which can be used to get _a_ name from the ID, probably the right guess. For now we keep the `ImageReference` implementation dumb, though inspecting the image by ID and giving the reference a tagged/digested
name is at least plausible in principle.  Special-purpose tools can script this without having to wait for `daemonReference` to add this.]