### PR TITLE
Add "Annotations" to OCI manifest and descriptors

### DIFF
--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -16,7 +16,7 @@ type platformSpec struct {
 	OSVersion    string   `json:"os.version,omitempty"`
 	OSFeatures   []string `json:"os.features,omitempty"`
 	Variant      string   `json:"variant,omitempty"`
-	Features     []string `json:"features,omitempty"`
+	Features     []string `json:"features,omitempty"` // removed in OCI
 }
 
 // A manifestDescriptor references a platform-specific manifest.

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -213,15 +213,17 @@ func (m *manifestSchema2) convertToManifestOCI1() (types.Image, error) {
 		return nil, err
 	}
 
-	config := descriptor{
-		MediaType: imgspecv1.MediaTypeImageConfig,
-		Size:      int64(len(configOCIBytes)),
-		Digest:    digest.FromBytes(configOCIBytes),
+	config := descriptorOCI1{
+		descriptor: descriptor{
+			MediaType: imgspecv1.MediaTypeImageConfig,
+			Size:      int64(len(configOCIBytes)),
+			Digest:    digest.FromBytes(configOCIBytes),
+		},
 	}
 
-	layers := make([]descriptor, len(m.LayersDescriptors))
+	layers := make([]descriptorOCI1, len(m.LayersDescriptors))
 	for idx := range layers {
-		layers[idx] = m.LayersDescriptors[idx]
+		layers[idx] = descriptorOCI1{descriptor: m.LayersDescriptors[idx]}
 		if m.LayersDescriptors[idx].MediaType == manifest.DockerV2Schema2ForeignLayerMediaType {
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributable
 		} else {

--- a/image/oci.go
+++ b/image/oci.go
@@ -12,12 +12,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+type descriptorOCI1 struct {
+	descriptor
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
 type manifestOCI1 struct {
 	src               types.ImageSource // May be nil if configBlob is not nil
 	configBlob        []byte            // If set, corresponds to contents of ConfigDescriptor.
 	SchemaVersion     int               `json:"schemaVersion"`
-	ConfigDescriptor  descriptor        `json:"config"`
-	LayersDescriptors []descriptor      `json:"layers"`
+	ConfigDescriptor  descriptorOCI1    `json:"config"`
+	LayersDescriptors []descriptorOCI1  `json:"layers"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
 }
 
 func manifestOCI1FromManifest(src types.ImageSource, manifest []byte) (genericManifest, error) {
@@ -29,7 +35,7 @@ func manifestOCI1FromManifest(src types.ImageSource, manifest []byte) (genericMa
 }
 
 // manifestOCI1FromComponents builds a new manifestOCI1 from the supplied data:
-func manifestOCI1FromComponents(config descriptor, src types.ImageSource, configBlob []byte, layers []descriptor) genericManifest {
+func manifestOCI1FromComponents(config descriptorOCI1, src types.ImageSource, configBlob []byte, layers []descriptorOCI1) genericManifest {
 	return &manifestOCI1{
 		src:               src,
 		configBlob:        configBlob,
@@ -148,7 +154,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 		if len(copy.LayersDescriptors) != len(options.LayerInfos) {
 			return nil, errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(copy.LayersDescriptors), len(options.LayerInfos))
 		}
-		copy.LayersDescriptors = make([]descriptor, len(options.LayerInfos))
+		copy.LayersDescriptors = make([]descriptorOCI1, len(options.LayerInfos))
 		for i, info := range options.LayerInfos {
 			copy.LayersDescriptors[i].Digest = info.Digest
 			copy.LayersDescriptors[i].Size = info.Size
@@ -169,7 +175,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 
 func (m *manifestOCI1) convertToManifestSchema2() (types.Image, error) {
 	// Create a copy of the descriptor.
-	config := m.ConfigDescriptor
+	config := m.ConfigDescriptor.descriptor
 
 	// The only difference between OCI and DockerSchema2 is the mediatypes. The
 	// media type of the manifest is handled by manifestSchema2FromComponents.
@@ -177,7 +183,7 @@ func (m *manifestOCI1) convertToManifestSchema2() (types.Image, error) {
 
 	layers := make([]descriptor, len(m.LayersDescriptors))
 	for idx := range layers {
-		layers[idx] = m.LayersDescriptors[idx]
+		layers[idx] = m.LayersDescriptors[idx].descriptor
 		layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaType
 	}
 

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -29,36 +29,36 @@ func manifestOCI1FromFixture(t *testing.T, src types.ImageSource, fixture string
 }
 
 func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
-	return manifestOCI1FromComponents(descriptor{
+	return manifestOCI1FromComponents(descriptorOCI1{descriptor: descriptor{
 		MediaType: imgspecv1.MediaTypeImageConfig,
 		Size:      5940,
 		Digest:    "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
-	}, nil, configBlob, []descriptor{
-		{
+	}}, nil, configBlob, []descriptorOCI1{
+		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
 			Size:      51354364,
-		},
-		{
+		}},
+		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
 			Size:      150,
-		},
-		{
+		}},
+		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
 			Size:      11739507,
-		},
-		{
+		}},
+		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
 			Size:      8841833,
-		},
-		{
+		}},
+		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
 			Size:      291,
-		},
+		}},
 	})
 }
 


### PR DESCRIPTION
Add the "Annotations" field to our definition for the OCI manifest type, and give OCI its own descriptor type, so that UpdatedImage() doesn't lose annotations unless it's converting between formats.  Handle
conversions between OCI descriptors and traditional ones.