### PR TITLE
Preserve layer media types when updating images

### DIFF
--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -183,6 +183,7 @@ func (m *manifestSchema2) UpdatedImage(options types.ManifestUpdateOptions) (typ
 		}
 		copy.LayersDescriptors = make([]descriptor, len(options.LayerInfos))
 		for i, info := range options.LayerInfos {
+			copy.LayersDescriptors[i].MediaType = m.LayersDescriptors[i].MediaType
 			copy.LayersDescriptors[i].Digest = info.Digest
 			copy.LayersDescriptors[i].Size = info.Size
 			copy.LayersDescriptors[i].URLs = info.URLs

--- a/image/oci.go
+++ b/image/oci.go
@@ -156,6 +156,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 		}
 		copy.LayersDescriptors = make([]descriptorOCI1, len(options.LayerInfos))
 		for i, info := range options.LayerInfos {
+			copy.LayersDescriptors[i].MediaType = m.LayersDescriptors[i].MediaType
 			copy.LayersDescriptors[i].Digest = info.Digest
 			copy.LayersDescriptors[i].Size = info.Size
 		}


### PR DESCRIPTION
UpdatedImage() has been dropping the MediaType from layer descriptors when updating OCI v1 and Docker schema 2 images.  When updating them now, give the updated layer descriptors the media types of the original layers.