### PR TITLE
docker: loop auth handlers instead of using just one

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -308,31 +308,33 @@ func (c *dockerClient) setupRequestAuth(req *http.Request) error {
 	if len(c.challenges) == 0 {
 		return nil
 	}
-	// assume just one...
-	challenge := c.challenges[0]
-	switch challenge.Scheme {
-	case "basic":
-		req.SetBasicAuth(c.username, c.password)
-		return nil
-	case "bearer":
-		if c.token == nil || time.Now().After(c.tokenExpiration) {
-			realm, ok := challenge.Parameters["realm"]
-			if !ok {
-				return errors.Errorf("missing realm in bearer auth challenge")
+	for _, challenge := range c.challenges {
+		switch challenge.Scheme {
+		case "basic":
+			req.SetBasicAuth(c.username, c.password)
+			return nil
+		case "bearer":
+			if c.token == nil || time.Now().After(c.tokenExpiration) {
+				realm, ok := challenge.Parameters["realm"]
+				if !ok {
+					return errors.Errorf("missing realm in bearer auth challenge")
+				}
+				service, _ := challenge.Parameters["service"] // Will be "" if not present
+				scope := fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions)
+				token, err := c.getBearerToken(realm, service, scope)
+				if err != nil {
+					return err
+				}
+				c.token = token
+				c.tokenExpiration = token.IssuedAt.Add(time.Duration(token.ExpiresIn) * time.Second)
 			}
-			service, _ := challenge.Parameters["service"] // Will be "" if not present
-			scope := fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions)
-			token, err := c.getBearerToken(realm, service, scope)
-			if err != nil {
-				return err
-			}
-			c.token = token
-			c.tokenExpiration = token.IssuedAt.Add(time.Duration(token.ExpiresIn) * time.Second)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token.Token))
+			return nil
+		default:
+			logrus.Debugf("no handler for %s authentication", challenge.Scheme)
 		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token.Token))
-		return nil
 	}
-	return errors.Errorf("no handler for %s authentication", challenge.Scheme)
+	return nil
 }
 
 func (c *dockerClient) getBearerToken(realm, service, scope string) (*bearerToken, error) {


### PR DESCRIPTION
As already done docker-side at
https://github.com/moby/moby/blob/master/vendor/github.com/docker/distribution/registry/client/auth/session.go#L98

@mtrmac PTAL this fixes https://github.com/projectatomic/skopeo/issues/375

Signed-off-by: Antonio Murdaca <runcom@redhat.com>