### PR TITLE
Add LoadTarManifest to get the manifest from docker-archive

### DIFF
--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -145,23 +145,28 @@ func (s *Source) ensureCachedDataIsPresent() error {
 		return err
 	}
 
+	// Check to make sure length is 1
+	if len(tarManifest) != 1 {
+		return errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(tarManifest))
+	}
+
 	// Read and parse config.
-	configBytes, err := s.readTarComponent(tarManifest.Config)
+	configBytes, err := s.readTarComponent(tarManifest[0].Config)
 	if err != nil {
 		return err
 	}
 	var parsedConfig image // Most fields ommitted, we only care about layer DiffIDs.
 	if err := json.Unmarshal(configBytes, &parsedConfig); err != nil {
-		return errors.Wrapf(err, "Error decoding tar config %s", tarManifest.Config)
+		return errors.Wrapf(err, "Error decoding tar config %s", tarManifest[0].Config)
 	}
 
-	knownLayers, err := s.prepareLayerData(tarManifest, &parsedConfig)
+	knownLayers, err := s.prepareLayerData(&tarManifest[0], &parsedConfig)
 	if err != nil {
 		return err
 	}
 
 	// Success; commit.
-	s.tarManifest = tarManifest
+	s.tarManifest = &tarManifest[0]
 	s.configBytes = configBytes
 	s.configDigest = digest.FromBytes(configBytes)
 	s.orderedDiffIDList = parsedConfig.RootFS.DiffIDs
@@ -170,7 +175,7 @@ func (s *Source) ensureCachedDataIsPresent() error {
 }
 
 // loadTarManifest loads and decodes the manifest.json.
-func (s *Source) loadTarManifest() (*manifestItem, error) {
+func (s *Source) loadTarManifest() ([]manifestItem, error) {
 	// FIXME? Do we need to deal with the legacy format?
 	bytes, err := s.readTarComponent(manifestFileName)
 	if err != nil {
@@ -180,10 +185,12 @@ func (s *Source) loadTarManifest() (*manifestItem, error) {
 	if err := json.Unmarshal(bytes, &items); err != nil {
 		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
 	}
-	if len(items) != 1 {
-		return nil, errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(items))
-	}
-	return &items[0], nil
+	return items, nil
+}
+
+// LoadTarManifest loads and decodes the manifest.json
+func (s *Source) LoadTarManifest() ([]manifestItem, error) {
+	return s.loadTarManifest()
 }
 
 func (s *Source) prepareLayerData(tarManifest *manifestItem, parsedConfig *image) (map[diffID]*layerInfo, error) {


### PR DESCRIPTION
Need it in kpod pull and kpod load. These commands need all the manifests, so took out the length checking block from loadTarManifest.

Signed-off-by: umohnani8 <umohnani@redhat.com>