### PR TITLE
Make docker/tarfile.manifestItem public

### DIFF
--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -181,7 +181,7 @@ func (d *Destination) PutManifest(m []byte) error {
 		layerPaths = append(layerPaths, l.Digest.String())
 	}
 
-	items := []manifestItem{{
+	items := []ManifestItem{{
 		Config:       man.Config.Digest.String(),
 		RepoTags:     []string{d.repoTag},
 		Layers:       layerPaths,

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -20,7 +20,7 @@ import (
 type Source struct {
 	tarPath string
 	// The following data is only available after ensureCachedDataIsPresent() succeeds
-	tarManifest       *manifestItem // nil if not available yet.
+	tarManifest       *ManifestItem // nil if not available yet.
 	configBytes       []byte
 	configDigest      digest.Digest
 	orderedDiffIDList []diffID
@@ -175,13 +175,13 @@ func (s *Source) ensureCachedDataIsPresent() error {
 }
 
 // loadTarManifest loads and decodes the manifest.json.
-func (s *Source) loadTarManifest() ([]manifestItem, error) {
+func (s *Source) loadTarManifest() ([]ManifestItem, error) {
 	// FIXME? Do we need to deal with the legacy format?
 	bytes, err := s.readTarComponent(manifestFileName)
 	if err != nil {
 		return nil, err
 	}
-	var items []manifestItem
+	var items []ManifestItem
 	if err := json.Unmarshal(bytes, &items); err != nil {
 		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
 	}
@@ -189,11 +189,11 @@ func (s *Source) loadTarManifest() ([]manifestItem, error) {
 }
 
 // LoadTarManifest loads and decodes the manifest.json
-func (s *Source) LoadTarManifest() ([]manifestItem, error) {
+func (s *Source) LoadTarManifest() ([]ManifestItem, error) {
 	return s.loadTarManifest()
 }
 
-func (s *Source) prepareLayerData(tarManifest *manifestItem, parsedConfig *image) (map[diffID]*layerInfo, error) {
+func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *image) (map[diffID]*layerInfo, error) {
 	// Collect layer data available in manifest and config.
 	if len(tarManifest.Layers) != len(parsedConfig.RootFS.DiffIDs) {
 		return nil, errors.Errorf("Inconsistent layer count: %d in manifest, %d in config", len(tarManifest.Layers), len(parsedConfig.RootFS.DiffIDs))

--- a/docker/tarfile/types.go
+++ b/docker/tarfile/types.go
@@ -13,7 +13,8 @@ const (
 	// legacyRepositoriesFileName = "repositories"
 )
 
-type manifestItem struct {
+// ManifestItem is an element of the array stored in the top-level manifest.json file.
+type ManifestItem struct {
 	Config       string
 	RepoTags     []string
 	Layers       []string


### PR DESCRIPTION
Otherwise lint fails on Fedora 24:
> …/docker/tarfile/src.go:192:37: exported method LoadTarManifest returns unexported type []tarfile.manifestItem, which can be annoying to use

(Yes, #309 did pass tests. I don’t know what makes the difference. Anyway, I need the warning to go away to keep my workflow clean.)

This should not affect users of #309 because they were not able to name the type before anyway.