### PR TITLE
Add oci-archive transport that creates a tar archive of an image

### DIFF
--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -1,0 +1,135 @@
+package archive
+
+import (
+	"io"
+	"os"
+
+	"github.com/containers/image/types"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
+)
+
+type ociArchiveImageDestination struct {
+	ref          ociArchiveReference
+	unpackedDest types.ImageDestination
+	tempDirRef   tempDirOCIRef
+}
+
+// newImageDestination returns an ImageDestination for writing to an existing directory.
+func newImageDestination(ctx *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
+	tempDirRef, err := createOCIRef(ref.image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating oci reference")
+	}
+	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx)
+	if err != nil {
+		if err := tempDirRef.deleteTempDir(); err != nil {
+			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)
+		}
+		return nil, err
+	}
+	return &ociArchiveImageDestination{ref: ref,
+		unpackedDest: unpackedDest,
+		tempDirRef:   tempDirRef}, nil
+}
+
+// Reference returns the reference used to set up this destination.
+func (d *ociArchiveImageDestination) Reference() types.ImageReference {
+	return d.ref
+}
+
+// Close removes resources associated with an initialized ImageDestination, if any
+// Close deletes the temp directory of the oci-archive image
+func (d *ociArchiveImageDestination) Close() error {
+	defer d.tempDirRef.deleteTempDir()
+	return d.unpackedDest.Close()
+}
+
+func (d *ociArchiveImageDestination) SupportedManifestMIMETypes() []string {
+	return d.unpackedDest.SupportedManifestMIMETypes()
+}
+
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures
+func (d *ociArchiveImageDestination) SupportsSignatures() error {
+	return d.unpackedDest.SupportsSignatures()
+}
+
+// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination
+func (d *ociArchiveImageDestination) ShouldCompressLayers() bool {
+	return d.unpackedDest.ShouldCompressLayers()
+}
+
+// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
+// uploaded to the image destination, true otherwise.
+func (d *ociArchiveImageDestination) AcceptsForeignLayerURLs() bool {
+	return d.unpackedDest.AcceptsForeignLayerURLs()
+}
+
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise
+func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
+	return d.unpackedDest.MustMatchRuntimeOS()
+}
+
+// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
+// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Size is the expected length of stream, if known.
+func (d *ociArchiveImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlob(stream, inputInfo)
+}
+
+// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob
+func (d *ociArchiveImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+	return d.unpackedDest.HasBlob(info)
+}
+
+func (d *ociArchiveImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+	return d.unpackedDest.ReapplyBlob(info)
+}
+
+// PutManifest writes manifest to the destination
+func (d *ociArchiveImageDestination) PutManifest(m []byte) error {
+	return d.unpackedDest.PutManifest(m)
+}
+
+func (d *ociArchiveImageDestination) PutSignatures(signatures [][]byte) error {
+	return d.unpackedDest.PutSignatures(signatures)
+}
+
+// Commit marks the process of storing the image as successful and asks for the image to be persisted
+// after the directory is made, it is tarred up into a file and the directory is deleted
+func (d *ociArchiveImageDestination) Commit() error {
+	if err := d.unpackedDest.Commit(); err != nil {
+		return errors.Wrapf(err, "error storing image %q", d.ref.image)
+	}
+
+	// path of directory to tar up
+	src := d.tempDirRef.tempDirectory
+	// path to save tarred up file
+	dst := d.ref.resolvedFile
+	if err := tarDirectory(src, dst); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// tar converts the directory at src and saves it to dst
+func tarDirectory(src, dst string) error {
+	// input is a stream of bytes from the archive of the directory at path
+	input, err := archive.Tar(src, archive.Uncompressed)
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving stream of bytes from %q", src)
+	}
+
+	// creates the tar file
+	outFile, err := os.Create(dst)
+	if err != nil {
+		return errors.Wrapf(err, "error creating tar file %q", dst)
+	}
+	defer outFile.Close()
+
+	// copies the contents of the directory to the tar file
+	_, err = io.Copy(outFile, input)
+
+	return err
+}

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -1,0 +1,88 @@
+package archive
+
+import (
+	"context"
+	"io"
+
+	ocilayout "github.com/containers/image/oci/layout"
+	"github.com/containers/image/types"
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type ociArchiveImageSource struct {
+	ref         ociArchiveReference
+	unpackedSrc types.ImageSource
+	tempDirRef  tempDirOCIRef
+}
+
+// newImageSource returns an ImageSource for reading from an existing directory.
+// newImageSource untars the file and saves it in a temp directory
+func newImageSource(ctx *types.SystemContext, ref ociArchiveReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+	tempDirRef, err := createUntarTempDir(ref)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating temp directory")
+	}
+
+	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, requestedManifestMIMETypes)
+	if err != nil {
+		if err := tempDirRef.deleteTempDir(); err != nil {
+			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)
+		}
+		return nil, err
+	}
+	return &ociArchiveImageSource{ref: ref,
+		unpackedSrc: unpackedSrc,
+		tempDirRef:  tempDirRef}, nil
+}
+
+// LoadManifestDescriptor loads the manifest
+func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
+	ociArchRef, ok := imgRef.(ociArchiveReference)
+	if !ok {
+		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociArchiveReference")
+	}
+	tempDirRef, err := createUntarTempDir(ociArchRef)
+	if err != nil {
+		return imgspecv1.Descriptor{}, errors.Wrap(err, "error creating temp directory")
+	}
+	defer tempDirRef.deleteTempDir()
+
+	descriptor, err := ocilayout.LoadManifestDescriptor(tempDirRef.ociRefExtracted)
+	if err != nil {
+		return imgspecv1.Descriptor{}, errors.Wrap(err, "error loading index")
+	}
+	return descriptor, nil
+}
+
+// Reference returns the reference used to set up this source.
+func (s *ociArchiveImageSource) Reference() types.ImageReference {
+	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+// Close deletes the temporary directory at dst
+func (s *ociArchiveImageSource) Close() error {
+	defer s.tempDirRef.deleteTempDir()
+	return s.unpackedSrc.Close()
+}
+
+// GetManifest returns the image's manifest along with its MIME type
+// (which may be empty when it can't be determined but the manifest is available).
+func (s *ociArchiveImageSource) GetManifest() ([]byte, string, error) {
+	return s.unpackedSrc.GetManifest()
+}
+
+func (s *ociArchiveImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
+	return s.unpackedSrc.GetTargetManifest(digest)
+}
+
+// GetBlob returns a stream for the specified blob, and the blob's size.
+func (s *ociArchiveImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+	return s.unpackedSrc.GetBlob(info)
+}
+
+func (s *ociArchiveImageSource) GetSignatures(c context.Context) ([][]byte, error) {
+	return s.unpackedSrc.GetSignatures(c)
+}

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -1,0 +1,226 @@
+package archive
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/containers/image/directory/explicitfilepath"
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
+	ocilayout "github.com/containers/image/oci/layout"
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	transports.Register(Transport)
+}
+
+// Transport is an ImageTransport for OCI archive
+// it creates an oci-archive tar file by calling into the OCI transport
+// tarring the directory created by oci and deleting the directory
+var Transport = ociArchiveTransport{}
+
+type ociArchiveTransport struct{}
+
+// ociArchiveReference is an ImageReference for OCI Archive paths
+type ociArchiveReference struct {
+	file         string
+	resolvedFile string
+	image        string
+}
+
+func (t ociArchiveTransport) Name() string {
+	return "oci-archive"
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix
+// into an ImageReference.
+func (t ociArchiveTransport) ParseReference(reference string) (types.ImageReference, error) {
+	return ParseReference(reference)
+}
+
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+func (t ociArchiveTransport) ValidatePolicyConfigurationScope(scope string) error {
+	var file string
+	sep := strings.SplitN(scope, ":", 2)
+	file = sep[0]
+
+	if len(sep) == 2 {
+		image := sep[1]
+		if !refRegexp.MatchString(image) {
+			return errors.Errorf("Invalid image %s", image)
+		}
+	}
+
+	if !strings.HasPrefix(file, "/") {
+		return errors.Errorf("Invalid scope %s: must be an absolute path", scope)
+	}
+	// Refuse also "/", otherwise "/" and "" would have the same semantics,
+	// and "" could be unexpectedly shadowed by the "/" entry.
+	// (Note: we do allow "/:someimage", a bit ridiculous but why refuse it?)
+	if scope == "/" {
+		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
+	}
+	cleaned := filepath.Clean(file)
+	if cleaned != file {
+		return errors.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+	}
+	return nil
+}
+
+// annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+const (
+	separator = `(?:[-._:@+]|--)`
+	alphanum  = `(?:[A-Za-z0-9]+)`
+	component = `(?:` + alphanum + `(?:` + separator + alphanum + `)*)`
+)
+
+var refRegexp = regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
+func ParseReference(reference string) (types.ImageReference, error) {
+	var file, image string
+	sep := strings.SplitN(reference, ":", 2)
+	file = sep[0]
+
+	if len(sep) == 2 {
+		image = sep[1]
+	}
+	return NewReference(file, image)
+}
+
+// NewReference returns an OCI reference for a file and a image.
+func NewReference(file, image string) (types.ImageReference, error) {
+	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(file)
+	if err != nil {
+		return nil, err
+	}
+	// This is necessary to prevent directory paths returned by PolicyConfigurationNamespaces
+	// from being ambiguous with values of PolicyConfigurationIdentity.
+	if strings.Contains(resolved, ":") {
+		return nil, errors.Errorf("Invalid OCI reference %s:%s: path %s contains a colon", file, image, resolved)
+	}
+	if len(image) > 0 && !refRegexp.MatchString(image) {
+		return nil, errors.Errorf("Invalid image %s", image)
+	}
+	return ociArchiveReference{file: file, resolvedFile: resolved, image: image}, nil
+}
+
+func (ref ociArchiveReference) Transport() types.ImageTransport {
+	return Transport
+}
+
+// StringWithinTransport returns a string representation of the reference, which MUST be such that
+// reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
+func (ref ociArchiveReference) StringWithinTransport() string {
+	return fmt.Sprintf("%s:%s", ref.file, ref.image)
+}
+
+// DockerReference returns a Docker reference associated with this reference
+func (ref ociArchiveReference) DockerReference() reference.Named {
+	return nil
+}
+
+// PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
+func (ref ociArchiveReference) PolicyConfigurationIdentity() string {
+	// NOTE: ref.image is not a part of the image identity, because "$dir:$someimage" and "$dir:" may mean the
+	// same image and the two can’t be statically disambiguated.  Using at least the repository directory is
+	// less granular but hopefully still useful.
+	return fmt.Sprintf("%s", ref.resolvedFile)
+}
+
+// PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
+// for if explicit configuration for PolicyConfigurationIdentity() is not set
+func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
+	res := []string{}
+	path := ref.resolvedFile
+	for {
+		lastSlash := strings.LastIndex(path, "/")
+		// Note that we do not include "/"; it is redundant with the default "" global default,
+		// and rejected by ociTransport.ValidatePolicyConfigurationScope above.
+		if lastSlash == -1 || path == "/" {
+			break
+		}
+		res = append(res, path)
+		path = path[:lastSlash]
+	}
+	return res
+}
+
+// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned Image.
+func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+	src, err := newImageSource(ctx, ref, nil)
+	if err != nil {
+		return nil, err
+	}
+	return image.FromSource(src)
+}
+
+// NewImageSource returns a types.ImageSource for this reference,
+// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
+// The caller must call .Close() on the returned ImageSource.
+func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+}
+
+// NewImageDestination returns a types.ImageDestination for this reference.
+// The caller must call .Close() on the returned ImageDestination.
+func (ref ociArchiveReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, ref)
+}
+
+// DeleteImage deletes the named image from the registry, if supported.
+func (ref ociArchiveReference) DeleteImage(ctx *types.SystemContext) error {
+	return errors.Errorf("Deleting images not implemented for oci: images")
+}
+
+// struct to store the ociReference and temporary directory returned by createOCIRef
+type tempDirOCIRef struct {
+	tempDirectory   string
+	ociRefExtracted types.ImageReference
+}
+
+// deletes the temporary directory created
+func (t *tempDirOCIRef) deleteTempDir() error {
+	return os.RemoveAll(t.tempDirectory)
+}
+
+// createOCIRef creates the oci reference of the image
+func createOCIRef(image string) (tempDirOCIRef, error) {
+	dir, err := ioutil.TempDir("/var/tmp", "oci")
+	if err != nil {
+		return tempDirOCIRef{}, errors.Wrapf(err, "error creating temp directory")
+	}
+	ociRef, err := ocilayout.NewReference(dir, image)
+	if err != nil {
+		return tempDirOCIRef{}, err
+	}
+
+	tempDirRef := tempDirOCIRef{tempDirectory: dir, ociRefExtracted: ociRef}
+	return tempDirRef, nil
+}
+
+// creates the temporary directory and copies the tarred content to it
+func createUntarTempDir(ref ociArchiveReference) (tempDirOCIRef, error) {
+	tempDirRef, err := createOCIRef(ref.image)
+	if err != nil {
+		return tempDirOCIRef{}, errors.Wrap(err, "error creating oci reference")
+	}
+	src := ref.resolvedFile
+	dst := tempDirRef.tempDirectory
+	if err := archive.UntarPath(src, dst); err != nil {
+		if err := tempDirRef.deleteTempDir(); err != nil {
+			return tempDirOCIRef{}, errors.Wrapf(err, "error deleting temp directory %q", tempDirRef.tempDirectory)
+		}
+		return tempDirOCIRef{}, errors.Wrapf(err, "error untarring file %q", tempDirRef.tempDirectory)
+	}
+	return tempDirRef, nil
+}

--- a/oci/archive/oci_transport_test.go
+++ b/oci/archive/oci_transport_test.go
@@ -1,0 +1,292 @@
+package archive
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportName(t *testing.T) {
+	assert.Equal(t, "oci-archive", Transport.Name())
+}
+
+func TestTransportParseReference(t *testing.T) {
+	testParseReference(t, Transport.ParseReference)
+}
+
+func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
+	for _, scope := range []string{
+		"/etc",
+		"/etc:notlatest",
+		"/this/does/not/exist",
+		"/this/does/not/exist:notlatest",
+		"/:strangecornercase",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.NoError(t, err, scope)
+	}
+
+	for _, scope := range []string{
+		"relative/path",
+		"/",
+		"/double//slashes",
+		"/has/./dot",
+		"/has/dot/../dot",
+		"/trailing/slash/",
+		"/etc:invalid'image!value@",
+		"/etc_no_image:",
+		"/etc:multiple_:separators",
+	} {
+		err := Transport.ValidatePolicyConfigurationScope(scope)
+		assert.Error(t, err, scope)
+	}
+}
+
+func TestParseReference(t *testing.T) {
+	testParseReference(t, ParseReference)
+}
+
+// testParseReference is a test shared for Transport.ParseReference and ParseReference.
+func testParseReference(t *testing.T, fn func(string) (types.ImageReference, error)) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	for _, path := range []string{
+		"/",
+		"/etc",
+		tmpDir,
+		"relativepath",
+		tmpDir + "/thisdoesnotexist",
+	} {
+		for _, image := range []struct{ suffix, image string }{
+			{":notlatest:image", "notlatest:image"},
+			{":latestimage", "latestimage"},
+			{":", ""},
+			{"", ""},
+		} {
+			input := path + image.suffix
+			ref, err := fn(input)
+			require.NoError(t, err, input)
+			ociArchRef, ok := ref.(ociArchiveReference)
+			require.True(t, ok)
+			assert.Equal(t, path, ociArchRef.file, input)
+			assert.Equal(t, image.image, ociArchRef.image, input)
+		}
+	}
+
+	_, err = fn(tmpDir + ":invalid'image!value@")
+	assert.Error(t, err)
+}
+
+func TestNewReference(t *testing.T) {
+	const (
+		imageValue   = "imageValue"
+		noImageValue = ""
+	)
+
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ref, err := NewReference(tmpDir, imageValue)
+	require.NoError(t, err)
+	ociArchRef, ok := ref.(ociArchiveReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir, ociArchRef.file)
+	assert.Equal(t, imageValue, ociArchRef.image)
+
+	ref, err = NewReference(tmpDir, noImageValue)
+	require.NoError(t, err)
+	ociArchRef, ok = ref.(ociArchiveReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir, ociArchRef.file)
+	assert.Equal(t, noImageValue, ociArchRef.image)
+
+	_, err = NewReference(tmpDir+"/thisparentdoesnotexist/something", imageValue)
+	assert.Error(t, err)
+
+	_, err = NewReference(tmpDir, "invalid'image!value@")
+	assert.Error(t, err)
+
+	_, err = NewReference(tmpDir+"/has:colon", imageValue)
+	assert.Error(t, err)
+}
+
+// refToTempOCI creates a temporary directory and returns an reference to it.
+// The caller should
+//   defer os.RemoveAll(tmpDir)
+func refToTempOCI(t *testing.T) (ref types.ImageReference, tmpDir string) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	m := `{
+		"schemaVersion": 2,
+		"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 7143,
+			"digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "imageValue"
+			}
+		}
+		]
+	}
+`
+	ioutil.WriteFile(filepath.Join(tmpDir, "index.json"), []byte(m), 0644)
+	ref, err = NewReference(tmpDir, "imageValue")
+	require.NoError(t, err)
+	return ref, tmpDir
+}
+
+// refToTempOCIArchive creates a temporary directory, copies the contents of that directory
+// to a temporary tar file and returns a reference to the temporary tar file
+func refToTempOCIArchive(t *testing.T) (ref types.ImageReference, tmpTarFile string) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	defer os.RemoveAll(tmpDir)
+	require.NoError(t, err)
+	m := `{
+		"schemaVersion": 2,
+		"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 7143,
+			"digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "imageValue"
+			}
+		}
+		]
+	}
+`
+	ioutil.WriteFile(filepath.Join(tmpDir, "index.json"), []byte(m), 0644)
+	tarFile, err := ioutil.TempFile("", "oci-transport-test.tar")
+	err = tarDirectory(tmpDir, tarFile.Name())
+	ref, err = NewReference(tarFile.Name(), "")
+	require.NoError(t, err)
+	return ref, tarFile.Name()
+}
+
+func TestReferenceTransport(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Equal(t, Transport, ref.Transport())
+}
+
+func TestReferenceStringWithinTransport(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	for _, c := range []struct{ input, result string }{
+		{"/dir1:notlatest:notlatest", "/dir1:notlatest:notlatest"}, // Explicit image
+		{"/dir3:", "/dir3:"},                                       // No image
+	} {
+		ref, err := ParseReference(tmpDir + c.input)
+		require.NoError(t, err, c.input)
+		stringRef := ref.StringWithinTransport()
+		assert.Equal(t, tmpDir+c.result, stringRef, c.input)
+		// Do one more round to verify that the output can be parsed, to an equal value.
+		ref2, err := Transport.ParseReference(stringRef)
+		require.NoError(t, err, c.input)
+		stringRef2 := ref2.StringWithinTransport()
+		assert.Equal(t, stringRef, stringRef2, c.input)
+	}
+}
+
+func TestReferenceDockerReference(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	assert.Nil(t, ref.DockerReference())
+}
+
+func TestReferencePolicyConfigurationIdentity(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+
+	assert.Equal(t, tmpDir, ref.PolicyConfigurationIdentity())
+	// A non-canonical path.  Test just one, the various other cases are
+	// tested in explicitfilepath.ResolvePathToFullyExplicit.
+	ref, err := NewReference(tmpDir+"/.", "image2")
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir, ref.PolicyConfigurationIdentity())
+
+	// "/" as a corner case.
+	ref, err = NewReference("/", "image3")
+	require.NoError(t, err)
+	assert.Equal(t, "/", ref.PolicyConfigurationIdentity())
+}
+
+func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	// We don't really know enough to make a full equality test here.
+	ns := ref.PolicyConfigurationNamespaces()
+	require.NotNil(t, ns)
+	assert.True(t, len(ns) >= 2)
+	assert.Equal(t, tmpDir, ns[0])
+	assert.Equal(t, filepath.Dir(tmpDir), ns[1])
+
+	// Test with a known path which should exist. Test just one non-canonical
+	// path, the various other cases are tested in explicitfilepath.ResolvePathToFullyExplicit.
+	//
+	// It would be nice to test a deeper hierarchy, but it is not obvious what
+	// deeper path is always available in the various distros, AND is not likely
+	// to contains a symbolic link.
+	for _, path := range []string{"/etc/skel", "/etc/skel/./."} {
+		_, err := os.Lstat(path)
+		require.NoError(t, err)
+		ref, err := NewReference(path, "someimage")
+		require.NoError(t, err)
+		ns := ref.PolicyConfigurationNamespaces()
+		require.NotNil(t, ns)
+		assert.Equal(t, []string{"/etc/skel", "/etc"}, ns)
+	}
+
+	// "/" as a corner case.
+	ref, err := NewReference("/", "image3")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, ref.PolicyConfigurationNamespaces())
+}
+
+func TestReferenceNewImage(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	_, err := ref.NewImage(nil)
+	assert.Error(t, err)
+}
+
+func TestReferenceNewImageSource(t *testing.T) {
+	ref, tmpTarFile := refToTempOCIArchive(t)
+	defer os.RemoveAll(tmpTarFile)
+	_, err := ref.NewImageSource(nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestReferenceNewImageDestination(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	dest, err := ref.NewImageDestination(nil)
+	assert.NoError(t, err)
+	defer dest.Close()
+}
+
+func TestReferenceDeleteImage(t *testing.T) {
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	err := ref.DeleteImage(nil)
+	assert.Error(t, err)
+}

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -180,6 +180,10 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 
+	if d.ref.image == "" {
+		return errors.Errorf("cannot save image with empyt image.ref.name")
+	}
+
 	annotations := make(map[string]string)
 	annotations["org.opencontainers.image.ref.name"] = d.ref.image
 	desc.Annotations = annotations

--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/containers/image/docker"
 	_ "github.com/containers/image/docker/archive"
 	_ "github.com/containers/image/docker/daemon"
+	_ "github.com/containers/image/oci/archive"
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"
 	// The ostree transport is registered by ostree*.go

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -33,7 +33,10 @@ func TestImageNameHandling(t *testing.T) {
 		{"docker-daemon", "busybox:latest", "busybox:latest"},
 		{"docker-archive", "/var/lib/oci/busybox.tar:busybox:latest", "/var/lib/oci/busybox.tar:docker.io/library/busybox:latest"},
 		{"docker-archive", "busybox.tar:busybox:latest", "busybox.tar:docker.io/library/busybox:latest"},
-		{"oci", "/etc:someimage:latest", "/etc:someimage:latest"},
+		{"oci", "/etc:someimage", "/etc:someimage"},
+		{"oci", "/etc:someimage:mytag", "/etc:someimage:mytag"},
+		{"oci-archive", "/etc:someimage", "/etc:someimage"},
+		{"oci-archive", "/etc:someimage:mytag", "/etc:someimage:mytag"},
 		// "atomic" not tested here because it depends on per-user configuration for the default cluster.
 		// "containers-storage" not tested here because it needs to initialize various directories on the fs.
 	} {


### PR DESCRIPTION
The oci-archive transport uses oci to create a directory of the image, which is then tarred up into a file. oci-archive will be used in kpod save and kpod load for oci images.
Signed-off-by: umohnani8 <umohnani@redhat.com>