### PR TITLE
Bump the recommended containers/storage version

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Sirupsen/logrus 7f4b1adc791766938c29457bed0703fb9134421a
-github.com/containers/storage 105f7c77aef0c797429e41552743bf5b03b63263
+github.com/containers/storage 5d8c2f87387fa5be9fa526ae39fbd79b8bdf27be
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
 github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e


### PR DESCRIPTION
This updates the version of `containers/storage` that we recommend to the current master revision.