### PR TITLE
Add registries.conf file and build library to parse it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ EPOCH_TEST_COMMIT ?= e68e0e1110e64f906f9b482e548f17d73e02e6b1
 .gitvalidation:
 	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make clean && make tools'" && false)
 ifeq ($(TRAVIS),true)
-	@git-validation -q -run DCO,short-subject,dangling-whitespace
+	git-validation -q -run DCO,short-subject,dangling-whitespace
 else
-	@git-validation -q -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
+	git-validation -q -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
 endif

--- a/docs/registries.conf.5.md
+++ b/docs/registries.conf.5.md
@@ -1,0 +1,41 @@
+% registries.conf(5) System-wide registry configuration file
+% Brent Baude
+% Aug 2017
+
+# NAME
+registries.conf - Syntax of System Registry Configuration File
+
+# DESCRIPTION
+The REGISTRIES configuration file is a system-wide configuration file for container image
+registries. The file format is TOML.
+
+# FORMAT
+The TOML_format is used to build simple list format for registries under two
+categories: `search` and `insecure`. You can list multiple registries using
+as a comma separated list.
+
+Search registries are used when the caller of a container runtime does not fully specify the
+container image that they want to execute.  These registries are prepended onto the front
+ of the specified container image until the named image is found at a registry.
+
+Insecure Registries.  By default container runtimes use TLS when retrieving images
+from a registry.  If the registry is not setup with TLS, then the container runtime
+will fail to pull images from the registry. If you add the registry to the list of
+insecure registries then the container runtime will attempt use standard web protocols to
+pull the image.  It also allows you to pull from a registry with self-signed certificates.
+Note insecure registries can be used for any registry, not just the
+registries listed under search.
+
+The following example configuration defines two searchable registries and one
+insecure registry.
+
+```
+[registries.search]
+registries = ["registry1.com", "registry2.com"]
+
+[registries.insecure]
+registries = ["registry3.com"]
+```
+
+# HISTORY
+Aug 2017, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -1,0 +1,76 @@
+package sysregistries
+
+import (
+	"github.com/BurntSushi/toml"
+	"io/ioutil"
+)
+
+// systemRegistriesConfPath is the path to the system-wide registry configuration file
+// and is used to add/subtract potential registries for obtaining images.
+// You can override this at build time with
+// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfPath=$your_path'
+var systemRegistriesConfPath = builtinRegistriesConfPath
+
+// builtinRegistriesConfPath is the path to registry configuration file
+// DO NOT change this, instead see systemRegistriesConfPath above.
+const builtinRegistriesConfPath = "/etc/containers/registries.conf"
+
+type registries struct {
+	Registries []string `toml:"registries"`
+}
+
+type tomlConfig struct {
+	Registries struct {
+		Search   registries `toml:"search"`
+		Insecure registries `toml:"insecure"`
+		Block    registries `toml:"block"`
+	} `toml:"registries"`
+}
+
+// Reads the global registry file from the filesystem. Returns
+// a byte array
+func readRegistryConf() ([]byte, error) {
+	configBytes, err := ioutil.ReadFile(systemRegistriesConfPath)
+	return configBytes, err
+}
+
+// For mocking in unittests
+var readConf = readRegistryConf
+
+// Loads the registry configuration file from the filesystem and
+// then unmarshals it.  Returns the unmarshalled object.
+func loadRegistryConf() (*tomlConfig, error) {
+	config := &tomlConfig{}
+
+	configBytes, err := readConf()
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(configBytes, &config)
+	return config, err
+}
+
+// Returns an array of strings that contain the names
+// of the registries as defined in the system-wide
+// registries file.  it returns an empty array if none are
+// defined
+func GetRegistries() ([]string, error) {
+	config, err := loadRegistryConf()
+	if err != nil {
+		return nil, err
+	}
+	return config.Registries.Search.Registries, nil
+}
+
+// Returns an array of strings that contain the names
+// of the insecure registries as defined in the system-wide
+// registries file.  it returns an empty array if none are
+// defined
+func GetInsecureRegistries() ([]string, error) {
+	config, err := loadRegistryConf()
+	if err != nil {
+		return nil, err
+	}
+	return config.Registries.Insecure.Registries, nil
+}

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -1,0 +1,60 @@
+package sysregistries
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var testConfig = []byte("")
+
+func init() {
+	readConf = func() ([]byte, error) {
+		return testConfig, nil
+	}
+}
+
+func TestGetRegistriesWithBlankData(t *testing.T) {
+	testConfig = []byte("")
+	registriesConfig, _ := GetRegistries()
+	assert.Nil(t, registriesConfig)
+}
+
+func TestGetRegistriesWithData(t *testing.T) {
+	answer := []string{"one.com"}
+	testConfig = []byte(`[registries.search]
+registries= ['one.com']
+`)
+	registriesConfig, err := GetRegistries()
+	assert.Nil(t, err)
+	assert.Equal(t, registriesConfig, answer)
+}
+
+func TestGetRegistriesWithBadData(t *testing.T) {
+	testConfig = []byte(`registries:
+    - one.com
+    ,`)
+	_, err := GetRegistries()
+	assert.Error(t, err)
+}
+
+func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
+	answer := []string(nil)
+	testConfig = []byte("")
+	insecureRegistriesConfig, err := GetInsecureRegistries()
+	assert.Nil(t, err)
+	assert.Equal(t, insecureRegistriesConfig, answer)
+}
+
+func TestGetInsecureRegistriesWithData(t *testing.T) {
+	answer := []string{"two.com", "three.com"}
+	testConfig = []byte(`[registries.search]
+registries = ['one.com']
+[registries.insecure]
+registries = ['two.com', 'three.com']
+`)
+	insecureRegistriesConfig, err := GetInsecureRegistries()
+	if err != nil {
+		t.Fail()
+	}
+	assert.Equal(t, insecureRegistriesConfig, answer)
+}

--- a/registries.conf
+++ b/registries.conf
@@ -1,0 +1,21 @@
+# For more information on this configuration file, see registries.conf(5).
+#
+# Registries to search for images that are not fully-qualified.
+# i.e. foobar.com/my_image:latest vs my_image:latest
+[registries.search]
+registries = []
+
+# Registries that do not use TLS when pulling images or uses self-signed
+# certificates.
+[registries.insecure]
+registries = []
+
+# Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
+# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
+# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
+# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
+# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
+# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
+# The atomic CLI `atomic trust` can be used to easily configure the policy.json file.
+[registries.block]
+registries = []


### PR DESCRIPTION
registries.conf is a system-wide configuration file initially
developed in https://github.com/projectatomic/registries.  We
eventually want to ship the configuration file with this project;
hence the addition.  However, we also needed a library like
approach that gave this and other projects the ability to
parse the file in the same manner.

Signed-off-by: baude <bbaude@redhat.com>