### PR TITLE
Bump dependencies that reference Sirupsen

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,9 +1,9 @@
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/storage 5d8c2f87387fa5be9fa526ae39fbd79b8bdf27be
+github.com/containers/storage 47536c89fcc545a87745e1a1573addc439409165
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
-github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
-github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e
-github.com/docker/go-connections 7da10c8c50cad14494ec818dcdfb6506265c0086
+github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
+github.com/docker/docker 30eb4d8cdc422b023d5f11f29a82ecb73554183b
+github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/go-units 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
 github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
@@ -24,7 +24,7 @@ github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/vbatts/tar-split bd4c5d64c3e9297f410025a3b1bd0c58f659e721
 golang.org/x/crypto 453249f01cfeb54c3d549ddb75ff152ca243f9d8
 golang.org/x/net 6b27048ae5e6ad1ef927e72e437531493de612fe
-golang.org/x/sys 075e574b89e4c2d22f2286a7e2b919519c6f3547
+golang.org/x/sys 43e60d72a8e2bd92ee98319ba9a384a0e9837c08
 gopkg.in/cheggaaa/pb.v1 d7e6ca3010b6f084d8056847f55d7f572f180678
 gopkg.in/yaml.v2 a3f3340b5840cee44f372bddb5880fcbc419b46a
 k8s.io/client-go bcde30fb7eaed76fd98a36b4120321b94995ffb6
@@ -35,3 +35,4 @@ github.com/tchap/go-patricia v2.2.6
 github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d
 github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0
 github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
+github.com/gogo/protobuf/proto fcdc5011193ff531a548e9b0301828d5a5b97fd8


### PR DESCRIPTION
Although containers/image uses lowercase sirupsen as a dependency, some
of the referenced vendor shas still use uppercase Sirupsen which causes
build problems on OSX

Signed-off-by: Tiago Scolari <tscolari@pivotal.io>