### PR TITLE
Support annotations on BlobInfos

### DIFF
--- a/image/fixtures/oci1.json
+++ b/image/fixtures/oci1.json
@@ -3,7 +3,10 @@
    "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "size": 5940,
-      "digest": "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f"
+      "digest": "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
+      "annotations": {
+         "test-annotation-1": "one"
+      }
    },
    "layers": [
       {
@@ -24,7 +27,10 @@
       {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
          "size": 8841833,
-         "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
+         "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+         "annotations": {
+            "test-annotation-2": "two"
+         }
       },
       {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",

--- a/image/oci.go
+++ b/image/oci.go
@@ -56,7 +56,7 @@ func (m *manifestOCI1) manifestMIMEType() string {
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 // Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
 func (m *manifestOCI1) ConfigInfo() types.BlobInfo {
-	return types.BlobInfo{Digest: m.ConfigDescriptor.Digest, Size: m.ConfigDescriptor.Size}
+	return types.BlobInfo{Digest: m.ConfigDescriptor.Digest, Size: m.ConfigDescriptor.Size, Annotations: m.ConfigDescriptor.Annotations}
 }
 
 // ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
@@ -109,7 +109,7 @@ func (m *manifestOCI1) OCIConfig() (*imgspecv1.Image, error) {
 func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
 	blobs := []types.BlobInfo{}
 	for _, layer := range m.LayersDescriptors {
-		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size})
+		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size, Annotations: layer.Annotations})
 	}
 	return blobs
 }
@@ -159,6 +159,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 			copy.LayersDescriptors[i].MediaType = m.LayersDescriptors[i].MediaType
 			copy.LayersDescriptors[i].Digest = info.Digest
 			copy.LayersDescriptors[i].Size = info.Size
+			copy.LayersDescriptors[i].Annotations = info.Annotations
 		}
 	}
 	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1, but we really don't care.

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -29,11 +29,16 @@ func manifestOCI1FromFixture(t *testing.T, src types.ImageSource, fixture string
 }
 
 func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
-	return manifestOCI1FromComponents(descriptorOCI1{descriptor: descriptor{
-		MediaType: imgspecv1.MediaTypeImageConfig,
-		Size:      5940,
-		Digest:    "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
-	}}, nil, configBlob, []descriptorOCI1{
+	return manifestOCI1FromComponents(descriptorOCI1{
+		descriptor: descriptor{
+			MediaType: imgspecv1.MediaTypeImageConfig,
+			Size:      5940,
+			Digest:    "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
+		},
+		Annotations: map[string]string{
+			"test-annotation-1": "one",
+		},
+	}, nil, configBlob, []descriptorOCI1{
 		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
@@ -49,11 +54,16 @@ func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
 			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
 			Size:      11739507,
 		}},
-		{descriptor: descriptor{
-			MediaType: imgspecv1.MediaTypeImageLayerGzip,
-			Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
-			Size:      8841833,
-		}},
+		{
+			descriptor: descriptor{
+				MediaType: imgspecv1.MediaTypeImageLayerGzip,
+				Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+				Size:      8841833,
+			},
+			Annotations: map[string]string{
+				"test-annotation-2": "two",
+			},
+		},
 		{descriptor: descriptor{
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
@@ -118,6 +128,9 @@ func TestManifestOCI1ConfigInfo(t *testing.T) {
 		assert.Equal(t, types.BlobInfo{
 			Size:   5940,
 			Digest: "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f",
+			Annotations: map[string]string{
+				"test-annotation-1": "one",
+			},
 		}, m.ConfigInfo())
 	}
 }
@@ -198,6 +211,9 @@ func TestManifestOCI1LayerInfo(t *testing.T) {
 			{
 				Digest: "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
 				Size:   8841833,
+				Annotations: map[string]string{
+					"test-annotation-2": "two",
+				},
 			},
 			{
 				Digest: "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",

--- a/types/types.go
+++ b/types/types.go
@@ -94,9 +94,10 @@ type ImageReference interface {
 // BlobInfo collects known information about a blob (layer/config).
 // In some situations, some fields may be unknown, in others they may be mandatory; documenting an “unknown” value here does not override that.
 type BlobInfo struct {
-	Digest digest.Digest // "" if unknown.
-	Size   int64         // -1 if unknown
-	URLs   []string
+	Digest      digest.Digest // "" if unknown.
+	Size        int64         // -1 if unknown
+	URLs        []string
+	Annotations map[string]string
 }
 
 // ImageSource is a service, possibly remote (= slow), to download components of a single image.


### PR DESCRIPTION
According to the image spec [1], descriptors should be able to contain
annotations. Support them on the returned BlobInfo.

[1] https://github.com/opencontainers/image-spec/blob/fc936c78346d017dcdbc6dd220a8ff60675ce3b5/descriptor.md

Signed-off-by: Will Martin <wmartin@pivotal.io>