### PR TITLE
docker: ignore EPERM when scanning for certificates

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -155,6 +155,10 @@ func setupCertificates(dir string, tlsc *tls.Config) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
+		if os.IsPermission(err) {
+			logrus.Debugf("Skipping scan of %s due to permission error: %v", dir, err)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Ignore (but log) all permission errors when trying to get the list of
additionally trusted Docker certificates and keys. This should not
result in any security issues, because additional trusted certificates
are additive (and thus the only issue that can occur is that a transport
is not trusted by skopeo when it should be).

Not ignoring permission errors would cause issues when trying to perform
a copy of a Docker image on a machine that has Docker installed (by
default Docker makes /etc/docker/certs.d not accessible). This would
manifest itself like so:

  % ./skopeo copy docker://busybox oci:busybox
  FATA[0000] Error initializing source docker://busybox:latest: open /etc/docker/certs.d/docker.io: permission denied

Fixes #297
Signed-off-by: Aleksa Sarai <asarai@suse.de>