### PR TITLE
Resolve linting errors and fix make lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,13 @@ validate: lint
 	@test -z "$$(gofmt -s -l . | grep -ve '^vendor' | tee /dev/stderr)"
 
 lint:
-	@out="$$(golint $(PACKAGES))"; \
-	if [ -n "$$out" ]; then \
-		echo "$$out"; \
-		exit 1; \
-	fi
+	@for package in $(PACKAGES); do \
+		out="$$(golint $$package)"; \
+		if [ -n "$$out" ]; then \
+			echo "$$out"; \
+			exit 1; \
+		fi \
+	done
 
 .PHONY: .gitvalidation
 

--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -51,7 +51,7 @@ func loadRegistryConf() (*tomlConfig, error) {
 	return config, err
 }
 
-// Returns an array of strings that contain the names
+// GetRegistries returns an array of strings that contain the names
 // of the registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined
@@ -63,7 +63,7 @@ func GetRegistries() ([]string, error) {
 	return config.Registries.Search.Registries, nil
 }
 
-// Returns an array of strings that contain the names
+// GetInsecureRegistries returns an array of strings that contain the names
 // of the insecure registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined


### PR DESCRIPTION
The version of golint in Travis is quietly failing because it doesn't
support multiple packages as [variadic args]. This fixes the makefile
by running golint against each package individually. It also resolves
the linting error surfaced from fixing the makefile.

[variadic args]: https://github.com/golang/lint/pull/271

Signed-off-by: Gareth Clay <gclay@pivotal.io>

You can see the failure I'm talking about in this build for example https://travis-ci.org/containers/image/jobs/269932656. Between .gitvalidation and the vendor target, golint errors with:

```
open github.com/containers/image: no such file or directory
open github.com/containers/image/copy: no such file or directory
open github.com/containers/image/directory: no such file or directory
open github.com/containers/image/directory/explicitfilepath: no such file or directory
open github.com/containers/image/docker: no such file or directory
open github.com/containers/image/docker/archive: no such file or directory
open github.com/containers/image/docker/daemon: no such file or directory
open github.com/containers/image/docker/policyconfiguration: no such file or directory
open github.com/containers/image/docker/reference: no such file or directory
open github.com/containers/image/docker/tarfile: no such file or directory
open github.com/containers/image/image: no such file or directory
open github.com/containers/image/manifest: no such file or directory
open github.com/containers/image/oci: no such file or directory
open github.com/containers/image/oci/layout: no such file or directory
open github.com/containers/image/openshift: no such file or directory
open github.com/containers/image/ostree: no such file or directory
open github.com/containers/image/pkg/compression: no such file or directory
open github.com/containers/image/pkg/strslice: no such file or directory
open github.com/containers/image/pkg/sysregistries: no such file or directory
open github.com/containers/image/signature: no such file or directory
open github.com/containers/image/storage: no such file or directory
open github.com/containers/image/transports: no such file or directory
open github.com/containers/image/transports/alltransports: no such file or directory
open github.com/containers/image/types: no such file or directory
open github.com/containers/image/version: no such file or directory
```

which is comparable to the issue opened here:

https://github.com/golang/lint/issues/270

I guess the version of golint in the zesty apt repository doesn't have this variadic package args functionality yet.