### PR TITLE
Resolve linting errors and use recent golint

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:zesty
 
 RUN apt-get -qq update && \
-    apt-get install -y sudo docker.io git make golang golint btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev
+    apt-get install -y sudo docker.io git make golang btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev

--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -51,7 +51,7 @@ func loadRegistryConf() (*tomlConfig, error) {
 	return config, err
 }
 
-// Returns an array of strings that contain the names
+// GetRegistries returns an array of strings that contain the names
 // of the registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined
@@ -63,7 +63,7 @@ func GetRegistries() ([]string, error) {
 	return config.Registries.Search.Registries, nil
 }
 
-// Returns an array of strings that contain the names
+// GetInsecureRegistries returns an array of strings that contain the names
 // of the insecure registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined


### PR DESCRIPTION
The version of golint in Travis is quietly failing because it doesn't
support multiple packages as variadic args. This removes the version of
golint being fetched from apt in favour of that built by the tools make
target. It also resolves the linting error surfaced from fixing the makefile.

Signed-off-by: Gareth Clay <gclay@pivotal.io>

This is a replacement for the PR #335 which resolved this issue in a different way. 