### PR TITLE
Support pulling/pushing OCI manifests from a docker registry

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -129,9 +129,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		}
 	}()
 
-	destSupportedManifestMIMETypes := dest.SupportedManifestMIMETypes()
-
-	rawSource, err := srcRef.NewImageSource(options.SourceCtx, destSupportedManifestMIMETypes)
+	rawSource, err := srcRef.NewImageSource(options.SourceCtx)
 	if err != nil {
 		return errors.Wrapf(err, "Error initializing source %s", transports.ImageName(srcRef))
 	}
@@ -195,7 +193,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 
 	// We compute preferredManifestMIMEType only to show it in error messages.
 	// Without having to add this context in an error message, we would be happy enough to know only that no conversion is needed.
-	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest)
+	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest)
 	if err != nil {
 		return err
 	}

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -38,7 +38,7 @@ func TestGetPutManifest(t *testing.T) {
 	err = dest.Commit()
 	assert.NoError(t, err)
 
-	src, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil)
 	require.NoError(t, err)
 	defer src.Close()
 	m, mt, err := src.GetManifest()
@@ -64,7 +64,7 @@ func TestGetPutBlob(t *testing.T) {
 	assert.Equal(t, int64(9), info.Size)
 	assert.Equal(t, digest.FromBytes(blob), info.Digest)
 
-	src, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil)
 	require.NoError(t, err)
 	defer src.Close()
 	rc, size, err := src.GetBlob(info)
@@ -143,7 +143,7 @@ func TestGetPutSignatures(t *testing.T) {
 	err = dest.Commit()
 	assert.NoError(t, err)
 
-	src, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil)
 	require.NoError(t, err)
 	defer src.Close()
 	sigs, err := src.GetSignatures(context.Background())
@@ -155,7 +155,7 @@ func TestSourceReference(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	src, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil)
 	require.NoError(t, err)
 	defer src.Close()
 	ref2 := src.Reference()

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -143,11 +143,9 @@ func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) 
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dirReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref dirReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ref), nil
 }
 

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -185,7 +185,7 @@ func TestReferenceNewImageNoValidManifest(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	src, err := ref.NewImageSource(nil, nil)
+	src, err := ref.NewImageSource(nil)
 	assert.NoError(t, err)
 	defer src.Close()
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -134,11 +134,9 @@ func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.Image, err
 	return ctrImage.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref archiveReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref archiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ctx, ref), nil
 }
 

--- a/docker/archive/transport_test.go
+++ b/docker/archive/transport_test.go
@@ -154,7 +154,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 	for _, suffix := range []string{"", ":thisisignoredbutaccepted"} {
 		ref, err := ParseReference(tarFixture + suffix)
 		require.NoError(t, err, suffix)
-		src, err := ref.NewImageSource(nil, nil)
+		src, err := ref.NewImageSource(nil)
 		assert.NoError(t, err, suffix)
 		defer src.Close()
 	}

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -161,11 +161,9 @@ func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref daemonReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref daemonReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ctx, ref)
 }
 

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -23,7 +23,7 @@ type Image struct {
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
 func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error) {
-	s, err := newImageSource(ctx, ref, nil)
+	s, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -56,7 +57,7 @@ func (d *dockerImageDestination) Close() error {
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
-		// TODO(runcom): we'll add OCI as part of another PR here
+		imgspecv1.MediaTypeImageManifest,
 		manifest.DockerV2Schema2MediaType,
 		manifest.DockerV2Schema1SignedMediaType,
 		manifest.DockerV2Schema1MediaType,

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -24,21 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var manifestMIMETypes = []string{
-	// TODO(runcom): we'll add OCI as part of another PR here
-	manifest.DockerV2Schema2MediaType,
-	manifest.DockerV2Schema1SignedMediaType,
-	manifest.DockerV2Schema1MediaType,
-}
-
-func supportedManifestMIMETypesMap() map[string]bool {
-	m := make(map[string]bool, len(manifestMIMETypes))
-	for _, mt := range manifestMIMETypes {
-		m[mt] = true
-	}
-	return m
-}
-
 type dockerImageDestination struct {
 	ref dockerReference
 	c   *dockerClient
@@ -70,7 +55,12 @@ func (d *dockerImageDestination) Close() error {
 }
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
-	return manifestMIMETypes
+	return []string{
+		// TODO(runcom): we'll add OCI as part of another PR here
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -130,12 +130,10 @@ func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return newImage(ctx, ref)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dockerReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref dockerReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -160,7 +160,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	src, err := ref.NewImageSource(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"}, nil)
+	src, err := ref.NewImageSource(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	assert.NoError(t, err)
 	defer src.Close()
 }

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -326,7 +326,7 @@ func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
 func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -19,13 +19,13 @@ type ociArchiveImageSource struct {
 
 // newImageSource returns an ImageSource for reading from an existing directory.
 // newImageSource untars the file and saves it in a temp directory
-func newImageSource(ctx *types.SystemContext, ref ociArchiveReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func newImageSource(ctx *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp directory")
 	}
 
-	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, requestedManifestMIMETypes)
+	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
 			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -157,18 +157,17 @@ func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
 // NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
 func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	src, err := newImageSource(ctx, ref, nil)
+	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/oci/archive/oci_transport_test.go
+++ b/oci/archive/oci_transport_test.go
@@ -273,7 +273,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpTarFile := refToTempOCIArchive(t)
 	defer os.RemoveAll(tmpTarFile)
-	_, err := ref.NewImageSource(nil, nil)
+	_, err := ref.NewImageSource(nil)
 	assert.NoError(t, err)
 }
 

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -241,11 +241,9 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 	return ociRef.getManifestDescriptor()
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ref)
 }
 

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -241,7 +241,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImageSource(nil, nil)
+	_, err := ref.NewImageSource(nil)
 	assert.NoError(t, err)
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -162,18 +162,15 @@ func (c *openshiftClient) convertDockerImageReference(ref string) (string, error
 type openshiftImageSource struct {
 	client *openshiftClient
 	// Values specific to this image
-	ctx                        *types.SystemContext
-	requestedManifestMIMETypes []string
+	ctx *types.SystemContext
 	// State
 	docker               types.ImageSource // The Docker Registry endpoint, or nil if not resolved yet
 	imageStreamImageName string            // Resolved image identifier, or "" if not known yet
 }
 
-// newImageSource creates a new ImageSource for the specified reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// newImageSource creates a new ImageSource for the specified reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func newImageSource(ctx *types.SystemContext, ref openshiftReference) (types.ImageSource, error) {
 	client, err := newOpenshiftClient(ref)
 	if err != nil {
 		return nil, err
@@ -182,7 +179,6 @@ func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedM
 	return &openshiftImageSource{
 		client: client,
 		ctx:    ctx,
-		requestedManifestMIMETypes: requestedManifestMIMETypes,
 	}, nil
 }
 
@@ -286,7 +282,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
-	d, err := dockerRef.NewImageSource(s.ctx, s.requestedManifestMIMETypes)
+	d, err := dockerRef.NewImageSource(s.ctx)
 	if err != nil {
 		return err
 	}

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -130,19 +130,17 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	src, err := newImageSource(ctx, ref, nil)
+	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return genericImage.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref openshiftReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref openshiftReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -185,11 +185,9 @@ func (ref ostreeReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return nil, errors.New("Reading ostree: images is currently not supported")
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ostreeReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref ostreeReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return nil, errors.New("Reading ostree: images is currently not supported")
 }
 

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -249,7 +249,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := Transport.ParseReference("busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImageSource(nil, nil)
+	_, err = ref.NewImageSource(nil)
 	assert.Error(t, err)
 }
 

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -27,7 +27,7 @@ func dirImageMock(t *testing.T, dir, dockerReference string) types.UnparsedImage
 func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) types.UnparsedImage {
 	srcRef, err := directory.NewReference(dir)
 	require.NoError(t, err)
-	src, err := srcRef.NewImageSource(nil, nil)
+	src, err := srcRef.NewImageSource(nil)
 	require.NoError(t, err)
 	return image.UnparsedFromSource(&dirImageSourceMock{
 		ImageSource: src,

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -37,7 +37,7 @@ func (ref nameOnlyImageReferenceMock) PolicyConfigurationNamespaces() []string {
 func (ref nameOnlyImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref nameOnlyImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref nameOnlyImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -95,7 +95,7 @@ func (ref pcImageReferenceMock) PolicyConfigurationNamespaces() []string {
 func (ref pcImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref pcImageReferenceMock) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref pcImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref pcImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -97,7 +97,7 @@ func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
 func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -154,7 +154,7 @@ func (s storageReference) DeleteImage(ctx *types.SystemContext) error {
 	return err
 }
 
-func (s storageReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (s storageReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(s)
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -429,7 +429,7 @@ func TestWriteRead(t *testing.T) {
 			t.Fatalf("Image %q claims to have been created at time 0", ref.StringWithinTransport())
 		}
 
-		src, err := ref.NewImageSource(systemContext(), []string{})
+		src, err := ref.NewImageSource(systemContext())
 		if err != nil {
 			t.Fatalf("NewImageSource(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -900,7 +900,7 @@ func TestDuplicateBlob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewImage(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
-	src, err := ref.NewImageSource(systemContext(), nil)
+	src, err := ref.NewImageSource(systemContext())
 	if err != nil {
 		t.Fatalf("NewImageSource(%q) returned error %v", ref.StringWithinTransport(), err)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -78,11 +78,9 @@ type ImageReference interface {
 	// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 	// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 	NewImage(ctx *SystemContext) (Image, error)
-	// NewImageSource returns a types.ImageSource for this reference,
-	// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-	// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+	// NewImageSource returns a types.ImageSource for this reference.
 	// The caller must call .Close() on the returned ImageSource.
-	NewImageSource(ctx *SystemContext, requestedManifestMIMETypes []string) (ImageSource, error)
+	NewImageSource(ctx *SystemContext) (ImageSource, error)
 	// NewImageDestination returns a types.ImageDestination for this reference.
 	// The caller must call .Close() on the returned ImageDestination.
 	NewImageDestination(ctx *SystemContext) (ImageDestination, error)


### PR DESCRIPTION
This pull request has a tiny one-line patch to add imgspecv1.MediaTypeImageManifest to the list of MIME types that a docker registry might support (as always, the exact list depends on the version of the registry we are talking to), and a bigger, though still trivial patch that prevents some breakage from the change - as discussed in #331.

(With the obvious compilation fix to skopeo, the skopeo tests all pass with these changes.)

The breakage that is avoided is that for copying from docker to oci, we don't want to pass only the imgspecv1.MediaTypeImageManifest in the Accept header - a) the particular docker registry might not in fact support imgspecv1.MediaTypeImageManifest b) and if it did, the particular manifest being requested might not be a imgspecv1.MediaTypeImageManifest, instead we want to pass in our normal list, get the manifest in it's original form and convert if necessary.