### PR TITLE
Add support for credential helpers.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,7 @@
 github.com/sirupsen/logrus v1.0.0
 github.com/containers/storage 47536c89fcc545a87745e1a1573addc439409165
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
+github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
 github.com/docker/docker 30eb4d8cdc422b023d5f11f29a82ecb73554183b
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d


### PR DESCRIPTION
Does this look reasonable? It adds a new dependency on docker/container-registry-helpers. I'm happy to rewrite this without that dependency if it seems preferable.

Also happy to add some tests for this if the approach looks correct.

Ref #334 