### PR TITLE
pkg/sysregistries/system_registries.go: Override system registries path

### DIFF
--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -1,6 +1,7 @@
 package sysregistries
 
 import (
+	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -8,14 +9,14 @@ import (
 var testConfig = []byte("")
 
 func init() {
-	readConf = func() ([]byte, error) {
+	readConf = func(_ *types.SystemContext) ([]byte, error) {
 		return testConfig, nil
 	}
 }
 
 func TestGetRegistriesWithBlankData(t *testing.T) {
 	testConfig = []byte("")
-	registriesConfig, _ := GetRegistries()
+	registriesConfig, _ := GetRegistries(nil)
 	assert.Nil(t, registriesConfig)
 }
 
@@ -24,7 +25,7 @@ func TestGetRegistriesWithData(t *testing.T) {
 	testConfig = []byte(`[registries.search]
 registries= ['one.com']
 `)
-	registriesConfig, err := GetRegistries()
+	registriesConfig, err := GetRegistries(nil)
 	assert.Nil(t, err)
 	assert.Equal(t, registriesConfig, answer)
 }
@@ -33,14 +34,14 @@ func TestGetRegistriesWithBadData(t *testing.T) {
 	testConfig = []byte(`registries:
     - one.com
     ,`)
-	_, err := GetRegistries()
+	_, err := GetRegistries(nil)
 	assert.Error(t, err)
 }
 
 func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
 	answer := []string(nil)
 	testConfig = []byte("")
-	insecureRegistriesConfig, err := GetInsecureRegistries()
+	insecureRegistriesConfig, err := GetInsecureRegistries(nil)
 	assert.Nil(t, err)
 	assert.Equal(t, insecureRegistriesConfig, answer)
 }
@@ -52,7 +53,7 @@ registries = ['one.com']
 [registries.insecure]
 registries = ['two.com', 'three.com']
 `)
-	insecureRegistriesConfig, err := GetInsecureRegistries()
+	insecureRegistriesConfig, err := GetInsecureRegistries(nil)
 	if err != nil {
 		t.Fail()
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -302,6 +302,8 @@ type SystemContext struct {
 	SignaturePolicyPath string
 	// If not "", overrides the system's default path for registries.d (Docker signature storage configuration)
 	RegistriesDirPath string
+	// Path to the system-wide registries configuration file
+	SystemRegistriesConfPath string
 
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
pkg/sysregistries/system_registries.go: Override system registries path

For the purposes of testing, it is handy to override the default configuration
file location of the system registries configuration file.  This is particularilyi
true in the case of crio-o which consumes this library.

Signed-off-by: baude <bbaude@redhat.com>