### PR TITLE
README.md: Update fedora package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ are also available
 
 This library, by default, also depends on the GpgME and libostree C libraries. Either install them:
 ```sh
-Fedora$ dnf install gpgme-devel libassuan-devel libostree-devel
+Fedora$ dnf install gpgme-devel libassuan-devel ostree-devel
 macOS$ brew install gpgme
 ```
 or use the build tags described below to avoid the dependencies (e.g. using `go build -tags …`)


### PR DESCRIPTION
- libostree-devel is now ostree-devel
- make test-skopeo requires device-mapper-devel and btrfs-progs-devel