### PR TITLE
ostree: fix a couple of issues

### DIFF
--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -153,7 +153,7 @@ func fixFiles(dir string, usermode bool) error {
 			if err != nil {
 				return err
 			}
-		} else if usermode && (info.Mode().IsRegular() || (info.Mode()&os.ModeSymlink) != 0) {
+		} else if usermode && (info.Mode().IsRegular()) {
 			if err := os.Chmod(fullpath, info.Mode()|0600); err != nil {
 				return err
 			}

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -84,24 +84,15 @@ func NewReference(image string, repo string) (types.ImageReference, error) {
 	// image is not _really_ in a containers/image/docker/reference format;
 	// as far as the libOSTree ociimage/* namespace is concerned, it is more or
 	// less an arbitrary string with an implied tag.
-	// We use the reference.* parsers basically for the default tag name in
-	// reference.TagNameOnly, and incidentally for some character set and length
-	// restrictions.
-	var ostreeImage reference.Named
-	s := strings.SplitN(image, ":", 2)
-
-	named, err := reference.WithName(s[0])
+	// Parse the image using reference.ParseNormalizedNamed so that we can
+	// check whether the images has a tag specified and we can add ":latest" if needed
+	ostreeImage, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(s) == 1 {
-		ostreeImage = reference.TagNameOnly(named)
-	} else {
-		ostreeImage, err = reference.WithTag(named, s[1])
-		if err != nil {
-			return nil, err
-		}
+	if reference.IsNameOnly(ostreeImage) {
+		image = image + ":latest"
 	}
 
 	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(repo)
@@ -123,8 +114,8 @@ func NewReference(image string, repo string) (types.ImageReference, error) {
 	}
 
 	return ostreeReference{
-		image:      ostreeImage.String(),
-		branchName: encodeOStreeRef(ostreeImage.String()),
+		image:      image,
+		branchName: encodeOStreeRef(image),
 		repo:       resolved,
 	}, nil
 }

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -44,6 +44,7 @@ var imageNameTestcases = []struct{ input, normalized, branchName string }{
 	{"busybox:notlatest", "busybox:notlatest", "busybox_3Anotlatest"},                                                  // Explicit tag
 	{"busybox", "busybox:latest", "busybox_3Alatest"},                                                                  // Default tag
 	{"docker.io/library/busybox:latest", "docker.io/library/busybox:latest", "docker.io_2Flibrary_2Fbusybox_3Alatest"}, // A hierarchical name
+	{"127.0.0.1:5000/busybox:latest", "127.0.0.1:5000/busybox:latest", "127.0.0.1_3A5000_2Fbusybox_3Alatest"},          // Port usage
 	{"UPPERCASEISINVALID", "", ""},                                                                                     // Invalid input
 	{"busybox" + sha256digest, "", ""},                                                                                 // Digested references are not supported (parsed as invalid repository name)
 	{"busybox:invalid+tag", "", ""},                                                                                    // Invalid tag value

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -45,11 +45,11 @@ var imageNameTestcases = []struct{ input, normalized, branchName string }{
 	{"busybox", "busybox:latest", "busybox_3Alatest"},                                                                  // Default tag
 	{"docker.io/library/busybox:latest", "docker.io/library/busybox:latest", "docker.io_2Flibrary_2Fbusybox_3Alatest"}, // A hierarchical name
 	{"127.0.0.1:5000/busybox:latest", "127.0.0.1:5000/busybox:latest", "127.0.0.1_3A5000_2Fbusybox_3Alatest"},          // Port usage
-	{"UPPERCASEISINVALID", "", ""},                                                                                     // Invalid input
-	{"busybox" + sha256digest, "", ""},                                                                                 // Digested references are not supported (parsed as invalid repository name)
-	{"busybox:invalid+tag", "", ""},                                                                                    // Invalid tag value
-	{"busybox:tag:with:colons", "", ""},                                                                                // Multiple colons - treated as a tag which contains a colon, which is invalid
-	{"", "", ""},                                                                                                       // Empty input is rejected (invalid repository.Named)
+	{"busybox" + sha256digest, "busybox" + sha256digest, "busybox_40sha256_3A0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+	{"UPPERCASEISINVALID", "", ""},      // Invalid input
+	{"busybox:invalid+tag", "", ""},     // Invalid tag value
+	{"busybox:tag:with:colons", "", ""}, // Multiple colons - treated as a tag which contains a colon, which is invalid
+	{"", "", ""},                        // Empty input is rejected (invalid repository.Named)
 }
 
 func TestTransportParseReference(t *testing.T) {


### PR DESCRIPTION
a couple of issues I've observed while using `atomic pull` (which now uses Skopeo copy for ostree as well)