### PR TITLE
Hotfix: Do not fetch manifest lists from Docker registries

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -35,7 +35,7 @@ var DefaultRequestedManifestMIMETypes = []string{
 	DockerV2Schema2MediaType,
 	DockerV2Schema1SignedMediaType,
 	DockerV2Schema1MediaType,
-	DockerV2ListMediaType,
+	// DockerV2ListMediaType, // FIXME: Restore this ASAP
 }
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.


### PR DESCRIPTION
This allows `copy.Image` to work with Docker Hub registries, which now use manifest lists for many images; the downside is breaking non-`copy` uses for any non-default architecture.