### PR TITLE
Support copying a single image from manifest lists

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -162,7 +162,11 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		return err
 	}
 
-	if src.IsMultiImage() {
+	multiImage, err := isMultiImage(src)
+	if err != nil {
+		return errors.Wrapf(err, "Error determining manifest MIME type for %s", transports.ImageName(srcRef))
+	}
+	if multiImage {
 		return errors.Errorf("can not copy %s: manifest contains multiple images", transports.ImageName(srcRef))
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -69,20 +69,24 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 }
 
 // copier allows us to keep track of diffID values for blobs, and other
-// data, that we're copying between images, and cache other information that
-// might allow us to take some shortcuts
+// data shared across one or more images in a possible manifest list.
 type copier struct {
-	copiedBlobs       map[digest.Digest]digest.Digest
-	cachedDiffIDs     map[digest.Digest]digest.Digest
+	copiedBlobs      map[digest.Digest]digest.Digest
+	cachedDiffIDs    map[digest.Digest]digest.Digest
+	dest             types.ImageDestination
+	rawSource        types.ImageSource
+	reportWriter     io.Writer
+	progressInterval time.Duration
+	progress         chan types.ProgressProperties
+}
+
+// imageCopier tracks state specific to a single image (possibly an item of a manifest list)
+type imageCopier struct {
+	c                 *copier
 	manifestUpdates   *types.ManifestUpdateOptions
-	dest              types.ImageDestination
 	src               types.Image
-	rawSource         types.ImageSource
 	diffIDsAreNeeded  bool
 	canModifyManifest bool
-	reportWriter      io.Writer
-	progressInterval  time.Duration
-	progress          chan types.ProgressProperties
 }
 
 // Options allows supplying non-default configuration modifying the behavior of CopyImage.
@@ -204,22 +208,25 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		return err
 	}
 
+	c := &copier{
+		copiedBlobs:      make(map[digest.Digest]digest.Digest),
+		cachedDiffIDs:    make(map[digest.Digest]digest.Digest),
+		dest:             dest,
+		rawSource:        rawSource,
+		reportWriter:     reportWriter,
+		progressInterval: options.ProgressInterval,
+		progress:         options.Progress,
+	}
 	// If src.UpdatedImageNeedsLayerDiffIDs(manifestUpdates) will be true, it needs to be true by the time we get here.
-	c := copier{
-		copiedBlobs:       make(map[digest.Digest]digest.Digest),
-		cachedDiffIDs:     make(map[digest.Digest]digest.Digest),
+	ic := imageCopier{
+		c:                 c,
 		manifestUpdates:   &manifestUpdates,
-		dest:              dest,
 		src:               src,
-		rawSource:         rawSource,
 		diffIDsAreNeeded:  src.UpdatedImageNeedsLayerDiffIDs(manifestUpdates),
 		canModifyManifest: canModifyManifest,
-		reportWriter:      reportWriter,
-		progressInterval:  options.ProgressInterval,
-		progress:          options.Progress,
 	}
 
-	if err := c.copyLayers(); err != nil {
+	if err := ic.copyLayers(); err != nil {
 		return err
 	}
 
@@ -227,7 +234,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	// and at least with the OpenShift registry "acceptschema2" option, there is no way to detect the support
 	// without actually trying to upload something and getting a types.ManifestTypeRejectedError.
 	// So, try the preferred manifest MIME type. If the process succeeds, fine…
-	manifest, err := c.copyUpdatedConfigAndManifest()
+	manifest, err := ic.copyUpdatedConfigAndManifest()
 	if err != nil {
 		logrus.Debugf("Writing manifest using preferred type %s failed: %v", preferredManifestMIMEType, err)
 		// … if it fails, _and_ the failure is because the manifest is rejected, we may have other options.
@@ -250,7 +257,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		for _, manifestMIMEType := range otherManifestMIMETypeCandidates {
 			logrus.Debugf("Trying to use manifest type %s…", manifestMIMEType)
 			manifestUpdates.ManifestMIMEType = manifestMIMEType
-			attemptedManifest, err := c.copyUpdatedConfigAndManifest()
+			attemptedManifest, err := ic.copyUpdatedConfigAndManifest()
 			if err != nil {
 				logrus.Debugf("Upload of manifest type %s failed: %v", manifestMIMEType, err)
 				errs = append(errs, fmt.Sprintf("%s(%v)", manifestMIMEType, err))
@@ -321,9 +328,9 @@ func updateEmbeddedDockerReference(manifestUpdates *types.ManifestUpdateOptions,
 	return nil
 }
 
-// copyLayers copies layers from src/rawSource to dest, using and updating c.manifestUpdates if necessary and c.canModifyManifest.
-func (c *copier) copyLayers() error {
-	srcInfos := c.src.LayerInfos()
+// copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.canModifyManifest.
+func (ic *imageCopier) copyLayers() error {
+	srcInfos := ic.src.LayerInfos()
 	destInfos := []types.BlobInfo{}
 	diffIDs := []digest.Digest{}
 	for _, srcLayer := range srcInfos {
@@ -332,17 +339,17 @@ func (c *copier) copyLayers() error {
 			diffID   digest.Digest
 			err      error
 		)
-		if c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.
-			if c.diffIDsAreNeeded {
+			if ic.diffIDsAreNeeded {
 				return errors.New("getting DiffID for foreign layers is unimplemented")
 			}
 			destInfo = srcLayer
-			fmt.Fprintf(c.reportWriter, "Skipping foreign layer %q copy to %s\n", destInfo.Digest, c.dest.Reference().Transport().Name())
+			fmt.Fprintf(ic.c.reportWriter, "Skipping foreign layer %q copy to %s\n", destInfo.Digest, ic.c.dest.Reference().Transport().Name())
 		} else {
-			destInfo, diffID, err = c.copyLayer(srcLayer)
+			destInfo, diffID, err = ic.copyLayer(srcLayer)
 			if err != nil {
 				return err
 			}
@@ -350,12 +357,12 @@ func (c *copier) copyLayers() error {
 		destInfos = append(destInfos, destInfo)
 		diffIDs = append(diffIDs, diffID)
 	}
-	c.manifestUpdates.InformationOnly.LayerInfos = destInfos
-	if c.diffIDsAreNeeded {
-		c.manifestUpdates.InformationOnly.LayerDiffIDs = diffIDs
+	ic.manifestUpdates.InformationOnly.LayerInfos = destInfos
+	if ic.diffIDsAreNeeded {
+		ic.manifestUpdates.InformationOnly.LayerDiffIDs = diffIDs
 	}
 	if layerDigestsDiffer(srcInfos, destInfos) {
-		c.manifestUpdates.LayerInfos = destInfos
+		ic.manifestUpdates.LayerInfos = destInfos
 	}
 	return nil
 }
@@ -373,24 +380,24 @@ func layerDigestsDiffer(a, b []types.BlobInfo) bool {
 	return false
 }
 
-// copyUpdatedConfigAndManifest updates the image per c.manifestUpdates, if necessary,
+// copyUpdatedConfigAndManifest updates the image per ic.manifestUpdates, if necessary,
 // stores the resulting config and manifest to the destination, and returns the stored manifest.
-func (c *copier) copyUpdatedConfigAndManifest() ([]byte, error) {
-	pendingImage := c.src
-	if !reflect.DeepEqual(*c.manifestUpdates, types.ManifestUpdateOptions{InformationOnly: c.manifestUpdates.InformationOnly}) {
-		if !c.canModifyManifest {
+func (ic *imageCopier) copyUpdatedConfigAndManifest() ([]byte, error) {
+	pendingImage := ic.src
+	if !reflect.DeepEqual(*ic.manifestUpdates, types.ManifestUpdateOptions{InformationOnly: ic.manifestUpdates.InformationOnly}) {
+		if !ic.canModifyManifest {
 			return nil, errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden")
 		}
-		if !c.diffIDsAreNeeded && c.src.UpdatedImageNeedsLayerDiffIDs(*c.manifestUpdates) {
-			// We have set c.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
+		if !ic.diffIDsAreNeeded && ic.src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates) {
+			// We have set ic.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
 			// So, this can only happen if we are trying to upload using one of the other MIME type candidates.
 			// Because UpdatedImageNeedsLayerDiffIDs is true only when converting from s1 to s2, this case should only arise
-			// when c.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
+			// when ic.c.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
 			// Supposedly s2-only registries do not exist or are extremely rare, so failing with this error message is good enough for now.
-			// If handling such registries turns out to be necessary, we could compute c.diffIDsAreNeeded based on the full list of manifest MIME type candidates.
-			return nil, errors.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", c.manifestUpdates.ManifestMIMEType)
+			// If handling such registries turns out to be necessary, we could compute ic.diffIDsAreNeeded based on the full list of manifest MIME type candidates.
+			return nil, errors.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
 		}
-		pi, err := c.src.UpdatedImage(*c.manifestUpdates)
+		pi, err := ic.src.UpdatedImage(*ic.manifestUpdates)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating an updated image manifest")
 		}
@@ -401,12 +408,12 @@ func (c *copier) copyUpdatedConfigAndManifest() ([]byte, error) {
 		return nil, errors.Wrap(err, "Error reading manifest")
 	}
 
-	if err := c.copyConfig(pendingImage); err != nil {
+	if err := ic.c.copyConfig(pendingImage); err != nil {
 		return nil, err
 	}
 
-	fmt.Fprintf(c.reportWriter, "Writing manifest to image destination\n")
-	if err := c.dest.PutManifest(manifest); err != nil {
+	fmt.Fprintf(ic.c.reportWriter, "Writing manifest to image destination\n")
+	if err := ic.c.dest.PutManifest(manifest); err != nil {
 		return nil, errors.Wrap(err, "Error writing manifest")
 	}
 	return manifest, nil
@@ -441,14 +448,14 @@ type diffIDResult struct {
 
 // copyLayer copies a layer with srcInfo (with known Digest and possibly known Size) in src to dest, perhaps compressing it if canCompress,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
-func (c *copier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Digest, error) {
+func (ic *imageCopier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Digest, error) {
 	// Check if we already have a blob with this digest
-	haveBlob, extantBlobSize, err := c.dest.HasBlob(srcInfo)
+	haveBlob, extantBlobSize, err := ic.c.dest.HasBlob(srcInfo)
 	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error checking for blob %s at destination", srcInfo.Digest)
 	}
 	// If we already have a cached diffID for this blob, we don't need to compute it
-	diffIDIsNeeded := c.diffIDsAreNeeded && (c.cachedDiffIDs[srcInfo.Digest] == "")
+	diffIDIsNeeded := ic.diffIDsAreNeeded && (ic.c.cachedDiffIDs[srcInfo.Digest] == "")
 	// If we already have the blob, and we don't need to recompute the diffID, then we might be able to avoid reading it again
 	if haveBlob && !diffIDIsNeeded {
 		// Check the blob sizes match, if we were given a size this time
@@ -457,23 +464,23 @@ func (c *copier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Diges
 		}
 		srcInfo.Size = extantBlobSize
 		// Tell the image destination that this blob's delta is being applied again.  For some image destinations, this can be faster than using GetBlob/PutBlob
-		blobinfo, err := c.dest.ReapplyBlob(srcInfo)
+		blobinfo, err := ic.c.dest.ReapplyBlob(srcInfo)
 		if err != nil {
 			return types.BlobInfo{}, "", errors.Wrapf(err, "Error reapplying blob %s at destination", srcInfo.Digest)
 		}
-		fmt.Fprintf(c.reportWriter, "Skipping fetch of repeat blob %s\n", srcInfo.Digest)
-		return blobinfo, c.cachedDiffIDs[srcInfo.Digest], err
+		fmt.Fprintf(ic.c.reportWriter, "Skipping fetch of repeat blob %s\n", srcInfo.Digest)
+		return blobinfo, ic.c.cachedDiffIDs[srcInfo.Digest], err
 	}
 
 	// Fallback: copy the layer, computing the diffID if we need to do so
-	fmt.Fprintf(c.reportWriter, "Copying blob %s\n", srcInfo.Digest)
-	srcStream, srcBlobSize, err := c.rawSource.GetBlob(srcInfo)
+	fmt.Fprintf(ic.c.reportWriter, "Copying blob %s\n", srcInfo.Digest)
+	srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(srcInfo)
 	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error reading blob %s", srcInfo.Digest)
 	}
 	defer srcStream.Close()
 
-	blobInfo, diffIDChan, err := c.copyLayerFromStream(srcStream, types.BlobInfo{Digest: srcInfo.Digest, Size: srcBlobSize},
+	blobInfo, diffIDChan, err := ic.copyLayerFromStream(srcStream, types.BlobInfo{Digest: srcInfo.Digest, Size: srcBlobSize},
 		diffIDIsNeeded)
 	if err != nil {
 		return types.BlobInfo{}, "", err
@@ -485,7 +492,7 @@ func (c *copier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Diges
 			return types.BlobInfo{}, "", errors.Wrap(diffIDResult.err, "Error computing layer DiffID")
 		}
 		logrus.Debugf("Computed DiffID %s for layer %s", diffIDResult.digest, srcInfo.Digest)
-		c.cachedDiffIDs[srcInfo.Digest] = diffIDResult.digest
+		ic.c.cachedDiffIDs[srcInfo.Digest] = diffIDResult.digest
 	}
 	return blobInfo, diffIDResult.digest, nil
 }
@@ -494,7 +501,7 @@ func (c *copier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Diges
 // it copies a blob with srcInfo (with known Digest and possibly known Size) from srcStream to dest,
 // perhaps compressing the stream if canCompress,
 // and returns a complete blobInfo of the copied blob and perhaps a <-chan diffIDResult if diffIDIsNeeded, to be read by the caller.
-func (c *copier) copyLayerFromStream(srcStream io.Reader, srcInfo types.BlobInfo,
+func (ic *imageCopier) copyLayerFromStream(srcStream io.Reader, srcInfo types.BlobInfo,
 	diffIDIsNeeded bool) (types.BlobInfo, <-chan diffIDResult, error) {
 	var getDiffIDRecorder func(compression.DecompressorFunc) io.Writer // = nil
 	var diffIDChan chan diffIDResult
@@ -519,7 +526,7 @@ func (c *copier) copyLayerFromStream(srcStream io.Reader, srcInfo types.BlobInfo
 			return pipeWriter
 		}
 	}
-	blobInfo, err := c.copyBlobFromStream(srcStream, srcInfo, getDiffIDRecorder, c.canModifyManifest) // Sets err to nil on success
+	blobInfo, err := ic.c.copyBlobFromStream(srcStream, srcInfo, getDiffIDRecorder, ic.canModifyManifest) // Sets err to nil on success
 	return blobInfo, diffIDChan, err
 	// We need the defer … pipeWriter.CloseWithError() to happen HERE so that the caller can block on reading from diffIDChan
 }

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -145,7 +145,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		progress:         options.Progress,
 	}
 
-	unparsedImage := image.UnparsedFromSource(rawSource)
+	unparsedImage := image.UnparsedInstance(rawSource, nil)
 	defer func() {
 		if unparsedImage != nil {
 			if err := unparsedImage.Close(); err != nil {

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -104,3 +104,12 @@ func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, s
 	}
 	return preferredType, prioritizedTypes.list[1:], nil
 }
+
+// isMultiImage returns true if img is a list of images
+func isMultiImage(img types.UnparsedImage) (bool, error) {
+	_, mt, err := img.Manifest()
+	if err != nil {
+		return false, err
+	}
+	return manifest.MIMETypeIsMultiImage(mt), nil
+}

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -37,12 +37,12 @@ func (os *orderedSet) append(s string) {
 	}
 }
 
-// determineManifestConversion updates manifestUpdates to convert manifest to a supported MIME type, if necessary and canModifyManifest.
-// Note that the conversion will only happen later, through src.UpdatedImage
+// determineManifestConversion updates ic.manifestUpdates to convert manifest to a supported MIME type, if necessary and ic.canModifyManifest.
+// Note that the conversion will only happen later, through ic.src.UpdatedImage
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
-func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool, forceManifestMIMEType string) (string, []string, error) {
-	_, srcType, err := src.Manifest()
+func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMETypes []string, forceManifestMIMEType string) (string, []string, error) {
+	_, srcType, err := ic.src.Manifest()
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
@@ -71,10 +71,10 @@ func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, s
 	if _, ok := supportedByDest[srcType]; ok {
 		prioritizedTypes.append(srcType)
 	}
-	if !canModifyManifest {
-		// We could also drop the !canModifyManifest parameter and have the caller
+	if !ic.canModifyManifest {
+		// We could also drop the !ic.canModifyManifest check and have the caller
 		// make the choice; it is already doing that to an extent, to improve error
-		// messages.  But it is nice to hide the “if !canModifyManifest, do no conversion”
+		// messages.  But it is nice to hide the “if !ic.canModifyManifest, do no conversion”
 		// special case in here; the caller can then worry (or not) only about a good UI.
 		logrus.Debugf("We can't modify the manifest, hoping for the best...")
 		return srcType, []string{}, nil // Take our chances - FIXME? Or should we fail without trying?
@@ -98,7 +98,7 @@ func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, s
 	}
 	preferredType := prioritizedTypes.list[0]
 	if preferredType != srcType {
-		manifestUpdates.ManifestMIMEType = preferredType
+		ic.manifestUpdates.ManifestMIMEType = preferredType
 	} else {
 		logrus.Debugf("... will first try using the original manifest unmodified")
 	}

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -35,9 +35,6 @@ type fakeImageSource string
 func (f fakeImageSource) Reference() types.ImageReference {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) Close() error {
-	panic("Unexpected call to a mock function")
-}
 func (f fakeImageSource) Manifest() ([]byte, string, error) {
 	if string(f) == "" {
 		return nil, "", errors.New("Manifest() directed to fail")

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -71,9 +71,6 @@ func (f fakeImageSource) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpd
 func (f fakeImageSource) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) IsMultiImage() bool {
-	panic("Unexpected call to a mock function")
-}
 func (f fakeImageSource) Size() (int64, error) {
 	panic("Unexpected call to a mock function")
 }
@@ -172,5 +169,26 @@ func TestDetermineManifestConversion(t *testing.T) {
 	// Error reading the manifest — smoke test only.
 	mu := types.ManifestUpdateOptions{}
 	_, _, err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true, "")
+	assert.Error(t, err)
+}
+
+func TestIsMultiImage(t *testing.T) {
+	// MIME type is available; more or less a smoke test, other cases are handled in manifest.MIMETypeIsMultiImage
+	for _, c := range []struct {
+		mt       string
+		expected bool
+	}{
+		{manifest.DockerV2ListMediaType, true},
+		{manifest.DockerV2Schema2MediaType, false},
+	} {
+		src := fakeImageSource(c.mt)
+		res, err := isMultiImage(src)
+		require.NoError(t, err)
+		assert.Equal(t, c.expected, res, c.mt)
+	}
+
+	// Error getting manifest MIME type
+	src := fakeImageSource("")
+	_, err := isMultiImage(src)
 	assert.Error(t, err)
 }

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -1,8 +1,6 @@
 package copy
 
 import (
-	"fmt"
-
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
 	"github.com/pkg/errors"
@@ -24,7 +22,7 @@ func (c *copier) createSignature(manifest []byte, keyIdentity string) ([]byte, e
 		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(c.dest.Reference()))
 	}
 
-	fmt.Fprintf(c.reportWriter, "Signing manifest\n")
+	c.Printf("Signing manifest\n")
 	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating signature")

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -2,16 +2,14 @@ package copy
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
-	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 )
 
-// createSignature creates a new signature of manifest at (identified by) dest using keyIdentity.
-func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity string, reportWriter io.Writer) ([]byte, error) {
+// createSignature creates a new signature of manifest using keyIdentity.
+func (c *copier) createSignature(manifest []byte, keyIdentity string) ([]byte, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error initializing GPG")
@@ -21,12 +19,12 @@ func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity s
 		return nil, errors.Wrap(err, "Signing not supported")
 	}
 
-	dockerReference := dest.Reference().DockerReference()
+	dockerReference := c.dest.Reference().DockerReference()
 	if dockerReference == nil {
-		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(dest.Reference()))
+		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(c.dest.Reference()))
 	}
 
-	fmt.Fprintf(reportWriter, "Signing manifest\n")
+	fmt.Fprintf(c.reportWriter, "Signing manifest\n")
 	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating signature")

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -35,16 +35,17 @@ func (s *dirImageSource) Close() error {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return nil, "", errors.Errorf(`Getting target manifest not supported by "dir:"`)
+	}
 	m, err := ioutil.ReadFile(s.ref.manifestPath())
 	if err != nil {
 		return nil, "", err
 	}
 	return m, manifest.GuessMIMEType(m), err
-}
-
-func (s *dirImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return nil, "", errors.Errorf(`Getting target manifest not supported by "dir:"`)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -61,7 +61,14 @@ func (s *dirImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, err
 	return r, fi.Size(), nil
 }
 
-func (s *dirImageSource) GetSignatures(ctx context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, errors.Errorf(`Manifests lists are not supported by "dir:"`)
+	}
 	signatures := [][]byte{}
 	for i := 0; ; i++ {
 		signature, err := ioutil.ReadFile(s.ref.signaturePath(i))

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -41,10 +42,16 @@ func TestGetPutManifest(t *testing.T) {
 	src, err := ref.NewImageSource(nil)
 	require.NoError(t, err)
 	defer src.Close()
-	m, mt, err := src.GetManifest()
+	m, mt, err := src.GetManifest(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, man, m)
 	assert.Equal(t, "", mt)
+
+	// Non-default instances are not supported
+	md, err := manifest.Digest(man)
+	require.NoError(t, err)
+	_, _, err = src.GetManifest(&md)
+	assert.Error(t, err)
 }
 
 func TestGetPutBlob(t *testing.T) {

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -141,7 +141,7 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (ref dirReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ref)
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -134,11 +134,12 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref dirReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ref)
 	return image.FromSource(src)
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -125,11 +125,12 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 	return []string{}
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ctx, ref)
 	return ctrImage.FromSource(src)
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -132,7 +132,7 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ctx, ref)
-	return ctrImage.FromSource(src)
+	return ctrImage.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -161,7 +161,7 @@ func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.ImageCloser
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -151,9 +151,12 @@ func (ref daemonReference) PolicyConfigurationNamespaces() []string {
 	return []string{}
 }
 
-// NewImage returns a types.Image for this reference.
-// The caller must call .Close() on the returned Image.
-func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -12,17 +12,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Image is a Docker-specific implementation of types.Image with a few extra methods
+// Image is a Docker-specific implementation of types.ImageCloser with a few extra methods
 // which are specific to Docker.
 type Image struct {
-	types.Image
+	types.ImageCloser
 	src *dockerImageSource
 }
 
 // newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
-func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error) {
+func newImage(ctx *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
 	s, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error
 	if err != nil {
 		return nil, err
 	}
-	return &Image{Image: img, src: s}, nil
+	return &Image{ImageCloser: img, src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -27,7 +27,7 @@ func newImage(ctx *types.SystemContext, ref dockerReference) (types.ImageCloser,
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(s)
+	img, err := image.FromSource(ctx, s)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -122,11 +122,12 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	return newImage(ctx, ref)
 }
 

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -152,7 +152,12 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	img, err := ref.NewImage(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
+	img, err := ref.NewImage(&types.SystemContext{
+		RegistriesDirPath:        "/this/doesnt/exist",
+		DockerPerHostCertDirPath: "/this/doesnt/exist",
+		ArchitectureChoice:       "amd64",
+		OSChoice:                 "linux",
+	})
 	require.NoError(t, err)
 	defer img.Close()
 }

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -249,7 +249,13 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *image
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *Source) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *Source) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, "", errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
+	}
 	if s.generatedManifest == nil {
 		if err := s.ensureCachedDataIsPresent(); err != nil {
 			return nil, "", err
@@ -282,13 +288,6 @@ func (s *Source) GetManifest() ([]byte, string, error) {
 		s.generatedManifest = manifestBytes
 	}
 	return s.generatedManifest, manifest.DockerV2Schema2MediaType, nil
-}
-
-// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest
-// out of a manifest list.
-func (s *Source) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	// How did we even get here? GetManifest() above has returned a manifest.DockerV2Schema2MediaType.
-	return nil, "", errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
 }
 
 type readCloseWrapper struct {

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -354,6 +354,13 @@ func (s *Source) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
-func (s *Source) GetSignatures(ctx context.Context) ([][]byte, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
+	}
 	return [][]byte{}, nil
 }

--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -46,7 +46,7 @@ func manifestSchema2FromManifestList(src types.ImageSource, manblob []byte) (gen
 	if targetManifestDigest == "" {
 		return nil, errors.New("no supported platform found in manifest list")
 	}
-	manblob, mt, err := src.GetTargetManifest(targetManifestDigest)
+	manblob, mt, err := src.GetManifest(&targetManifestDigest)
 	if err != nil {
 		return nil, err
 	}

--- a/image/docker_list_test.go
+++ b/image/docker_list_test.go
@@ -1,0 +1,44 @@
+package image
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChooseDigestFromManifestList(t *testing.T) {
+	manifest, err := ioutil.ReadFile(filepath.Join("fixtures", "schema2list.json"))
+	require.NoError(t, err)
+
+	// Match found
+	for arch, expected := range map[string]digest.Digest{
+		"amd64": "sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af",
+		"s390x": "sha256:e5aa1b0a24620228b75382997a0977f609b3ca3a95533dafdef84c74cc8df642",
+		// There are several "arm" images with different variants;
+		// the current code returns the first match. NOTE: This is NOT an API promise.
+		"arm": "sha256:9142d97ef280a7953cf1a85716de49a24cc1dd62776352afad67e635331ff77a",
+	} {
+		digest, err := chooseDigestFromManifestList(&types.SystemContext{
+			ArchitectureChoice: arch,
+			OSChoice:           "linux",
+		}, manifest)
+		require.NoError(t, err, arch)
+		assert.Equal(t, expected, digest)
+	}
+
+	// Invalid manifest list
+	_, err = chooseDigestFromManifestList(&types.SystemContext{
+		ArchitectureChoice: "amd64", OSChoice: "linux",
+	}, bytes.Join([][]byte{manifest, []byte("!INVALID")}, nil))
+	assert.Error(t, err)
+
+	// Not found
+	_, err = chooseDigestFromManifestList(&types.SystemContext{OSChoice: "Unmatched"}, manifest)
+	assert.Error(t, err)
+}

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -35,7 +35,7 @@ func (f unusedImageSource) GetManifest(*digest.Digest) ([]byte, string, error) {
 func (f unusedImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f unusedImageSource) GetSignatures(context.Context) ([][]byte, error) {
+func (f unusedImageSource) GetSignatures(context.Context, *digest.Digest) ([][]byte, error) {
 	panic("Unexpected call to a mock function")
 }
 

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -320,7 +320,7 @@ func (ref refImageReferenceMock) PolicyConfigurationIdentity() string {
 func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
+func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -29,10 +29,7 @@ func (f unusedImageSource) Reference() types.ImageReference {
 func (f unusedImageSource) Close() error {
 	panic("Unexpected call to a mock function")
 }
-func (f unusedImageSource) GetManifest() ([]byte, string, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f unusedImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
+func (f unusedImageSource) GetManifest(*digest.Digest) ([]byte, string, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f unusedImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {

--- a/image/fixtures/schema2list.json
+++ b/image/fixtures/schema2list.json
@@ -1,0 +1,82 @@
+{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:9142d97ef280a7953cf1a85716de49a24cc1dd62776352afad67e635331ff77a",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux",
+            "variant": "v5"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:b5dbad4bdb4444d919294afe49a095c23e86782f98cdf0aa286198ddb814b50b",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux",
+            "variant": "v6"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:a8fe0549cac196f439de3bf2b57af14f7cd4e59915ccd524428f588628a4ef31",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux",
+            "variant": "v7"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:dc472a59fb006797aa2a6bfb54cc9c57959bb0a6d11fadaa608df8c16dea39cf",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux",
+            "variant": "v8"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:9a33b9909e56b0a2092a65fb1b79ef6717fa160b1f084476b860418780e8d53b",
+         "platform": {
+            "architecture": "386",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:59117d7c016fba6ede7f87991204bd672a1dca444102de66db632383507ed90b",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:e5aa1b0a24620228b75382997a0977f609b3ca3a95533dafdef84c74cc8df642",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         }
+      }
+   ]
+}

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -87,6 +87,8 @@ type genericManifest interface {
 	UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error)
 }
 
+// manifestInstanceFromBlob returns a genericManifest implementation for (manblob, mt) in src.
+// If manblob is a manifest list, it implicitly chooses an appropriate image from the list.
 func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
 	switch mt {
 	// "application/json" is a valid v2s1 value per https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md .

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -89,7 +89,7 @@ type genericManifest interface {
 
 // manifestInstanceFromBlob returns a genericManifest implementation for (manblob, mt) in src.
 // If manblob is a manifest list, it implicitly chooses an appropriate image from the list.
-func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
+func manifestInstanceFromBlob(ctx *types.SystemContext, src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
 	switch mt {
 	// "application/json" is a valid v2s1 value per https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md .
 	// This works for now, when nothing else seems to return "application/json"; if that were not true, the mapping/detection might
@@ -101,7 +101,7 @@ func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) 
 	case manifest.DockerV2Schema2MediaType:
 		return manifestSchema2FromManifest(src, manblob)
 	case manifest.DockerV2ListMediaType:
-		return manifestSchema2FromManifestList(src, manblob)
+		return manifestSchema2FromManifestList(ctx, src, manblob)
 	default:
 		// If it's not a recognized manifest media type, or we have failed determining the type, we'll try one last time
 		// to deserialize using v2s1 as per https://github.com/docker/distribution/blob/master/manifests.go#L108

--- a/image/memory.go
+++ b/image/memory.go
@@ -33,11 +33,6 @@ func (i *memoryImage) Reference() types.ImageReference {
 	return nil
 }
 
-// Close removes resources associated with an initialized UnparsedImage, if any.
-func (i *memoryImage) Close() error {
-	return nil
-}
-
 // Size returns the size of the image as stored, if known, or -1 if not.
 func (i *memoryImage) Size() (int64, error) {
 	return -1, nil

--- a/image/memory.go
+++ b/image/memory.go
@@ -66,8 +66,3 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
 	return inspectManifest(i.genericManifest)
 }
-
-// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
-func (i *memoryImage) IsMultiImage() bool {
-	return false
-}

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -7,7 +7,10 @@ import (
 	"github.com/containers/image/types"
 )
 
-// FromSource returns a types.Image implementation for source.
+// FromSource returns a types.Image implementation for the default instance of source.
+// If source is a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate image instance.
+//
 // The caller must call .Close() on the returned Image.
 //
 // FromSource “takes ownership” of the input ImageSource and will call src.Close()
@@ -18,7 +21,7 @@ import (
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
 func FromSource(src types.ImageSource) (types.Image, error) {
-	return FromUnparsedImage(UnparsedFromSource(src))
+	return FromUnparsedImage(UnparsedInstance(src, nil))
 }
 
 // sourcedImage is a general set of utilities for working with container images,

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -7,11 +7,19 @@ import (
 	"github.com/containers/image/types"
 )
 
-// FromSource returns a types.Image implementation for the default instance of source.
+// imageCloser implements types.ImageCloser, perhaps allowing simple users
+// to use a single object without having keep a reference to a types.ImageSource
+// only to call types.ImageSource.Close().
+type imageCloser struct {
+	types.Image
+	src types.ImageSource
+}
+
+// FromSource returns a types.ImageCloser implementation for the default instance of source.
 // If source is a manifest list, .Manifest() still returns the manifest list,
 // but other methods transparently return data from an appropriate image instance.
 //
-// The caller must call .Close() on the returned Image.
+// The caller must call .Close() on the returned ImageCloser.
 //
 // FromSource “takes ownership” of the input ImageSource and will call src.Close()
 // when the image is closed.  (This does not prevent callers from using both the
@@ -20,8 +28,19 @@ import (
 //
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
-func FromSource(src types.ImageSource) (types.Image, error) {
-	return FromUnparsedImage(UnparsedInstance(src, nil))
+func FromSource(src types.ImageSource) (types.ImageCloser, error) {
+	img, err := FromUnparsedImage(UnparsedInstance(src, nil))
+	if err != nil {
+		return nil, err
+	}
+	return &imageCloser{
+		Image: img,
+		src:   src,
+	}, nil
+}
+
+func (ic *imageCloser) Close() error {
+	return ic.src.Close()
 }
 
 // sourcedImage is a general set of utilities for working with container images,
@@ -40,19 +59,14 @@ type sourcedImage struct {
 }
 
 // FromUnparsedImage returns a types.Image implementation for unparsed.
-// The caller must call .Close() on the returned Image.
+// If unparsed represents a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate single image.
 //
-// FromSource “takes ownership” of the input UnparsedImage and will call uparsed.Close()
-// when the image is closed.  (This does not prevent callers from using both the
-// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
-// keep a reference to the Image.)
+// The Image must not be used after the underlying ImageSource is Close()d.
 func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
 	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
 	// this is the only UnparsedImage implementation around, anyway.
-
-	// Also, we do not explicitly implement types.Image.Close; we let the implementation fall through to
-	// unparsed.Close.
 
 	// NOTE: It is essential for signature verification that all parsing done in this object happens on the same manifest which is returned by unparsed.Manifest().
 	manifestBlob, manifestMIMEType, err := unparsed.Manifest()

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -4,7 +4,6 @@
 package image
 
 import (
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -83,8 +82,4 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 
 func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
 	return inspectManifest(i.genericManifest)
-}
-
-func (i *sourcedImage) IsMultiImage() bool {
-	return manifest.MIMETypeIsMultiImage(i.manifestMIMEType)
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -86,5 +86,5 @@ func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
 }
 
 func (i *sourcedImage) IsMultiImage() bool {
-	return i.manifestMIMEType == manifest.DockerV2ListMediaType
+	return manifest.MIMETypeIsMultiImage(i.manifestMIMEType)
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -28,8 +28,8 @@ type imageCloser struct {
 //
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
-func FromSource(src types.ImageSource) (types.ImageCloser, error) {
-	img, err := FromUnparsedImage(UnparsedInstance(src, nil))
+func FromSource(ctx *types.SystemContext, src types.ImageSource) (types.ImageCloser, error) {
+	img, err := FromUnparsedImage(ctx, UnparsedInstance(src, nil))
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ type sourcedImage struct {
 // but other methods transparently return data from an appropriate single image.
 //
 // The Image must not be used after the underlying ImageSource is Close()d.
-func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
+func FromUnparsedImage(ctx *types.SystemContext, unparsed *UnparsedImage) (types.Image, error) {
 	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
 	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
 	// this is the only UnparsedImage implementation around, anyway.
@@ -74,7 +74,7 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 		return nil, err
 	}
 
-	parsedManifest, err := manifestInstanceFromBlob(unparsed.src, manifestBlob, manifestMIMEType)
+	parsedManifest, err := manifestInstanceFromBlob(ctx, unparsed.src, manifestBlob, manifestMIMEType)
 	if err != nil {
 		return nil, err
 	}

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -45,7 +45,7 @@ func (i *UnparsedImage) Close() error {
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest()
+		m, mt, err := i.src.GetManifest(nil)
 		if err != nil {
 			return nil, "", err
 		}

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -11,8 +11,10 @@ import (
 )
 
 // UnparsedImage implements types.UnparsedImage .
+// An UnparsedImage is a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
 type UnparsedImage struct {
 	src            types.ImageSource
+	instanceDigest *digest.Digest
 	cachedManifest []byte // A private cache for Manifest(); nil if not yet known.
 	// A private cache for Manifest(), may be the empty string if guessing failed.
 	// Valid iff cachedManifest is not nil.
@@ -20,20 +22,25 @@ type UnparsedImage struct {
 	cachedSignatures       [][]byte // A private cache for Signatures(); nil if not yet known.
 }
 
-// UnparsedFromSource returns a types.UnparsedImage implementation for source.
+// UnparsedInstance returns a types.UnparsedImage implementation for (source, instanceDigest).
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // The caller must call .Close() on the returned UnparsedImage.
 //
-// UnparsedFromSource “takes ownership” of the input ImageSource and will call src.Close()
+// UnparsedInstance “takes ownership” of the input ImageSource and will call src.Close()
 // when the image is closed.  (This does not prevent callers from using both the
 // UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
 // keep a reference to the UnparsedImage.)
-func UnparsedFromSource(src types.ImageSource) *UnparsedImage {
-	return &UnparsedImage{src: src}
+func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *UnparsedImage {
+	return &UnparsedImage{
+		src:            src,
+		instanceDigest: instanceDigest,
+	}
 }
 
 // Reference returns the reference used to set up this source, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (i *UnparsedImage) Reference() types.ImageReference {
+	// Note that this does not depend on instanceDigest; e.g. all instances within a manifest list need to be signed with the manifest list identity.
 	return i.src.Reference()
 }
 
@@ -45,24 +52,20 @@ func (i *UnparsedImage) Close() error {
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest(nil)
+		m, mt, err := i.src.GetManifest(i.instanceDigest)
 		if err != nil {
 			return nil, "", err
 		}
 
 		// ImageSource.GetManifest does not do digest verification, but we do;
 		// this immediately protects also any user of types.Image.
-		ref := i.Reference().DockerReference()
-		if ref != nil {
-			if canonical, ok := ref.(reference.Canonical); ok {
-				digest := digest.Digest(canonical.Digest())
-				matches, err := manifest.MatchesDigest(m, digest)
-				if err != nil {
-					return nil, "", errors.Wrap(err, "Error computing manifest digest")
-				}
-				if !matches {
-					return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
-				}
+		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
+			matches, err := manifest.MatchesDigest(m, digest)
+			if err != nil {
+				return nil, "", errors.Wrap(err, "Error computing manifest digest")
+			}
+			if !matches {
+				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
 			}
 		}
 
@@ -72,10 +75,26 @@ func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 	return i.cachedManifest, i.cachedManifestMIMEType, nil
 }
 
+// expectedManifestDigest returns a the expected value of the manifest digest, and an indicator whether it is known.
+// The bool return value seems redundant with digest != ""; it is used explicitly
+// to refuse (unexpected) situations when the digest exists but is "".
+func (i *UnparsedImage) expectedManifestDigest() (digest.Digest, bool) {
+	if i.instanceDigest != nil {
+		return *i.instanceDigest, true
+	}
+	ref := i.Reference().DockerReference()
+	if ref != nil {
+		if canonical, ok := ref.(reference.Canonical); ok {
+			return canonical.Digest(), true
+		}
+	}
+	return "", false
+}
+
 // Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 	if i.cachedSignatures == nil {
-		sigs, err := i.src.GetSignatures(ctx, nil)
+		sigs, err := i.src.GetSignatures(ctx, i.instanceDigest)
 		if err != nil {
 			return nil, err
 		}

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -23,13 +23,9 @@ type UnparsedImage struct {
 }
 
 // UnparsedInstance returns a types.UnparsedImage implementation for (source, instanceDigest).
-// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
-// The caller must call .Close() on the returned UnparsedImage.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list).
 //
-// UnparsedInstance “takes ownership” of the input ImageSource and will call src.Close()
-// when the image is closed.  (This does not prevent callers from using both the
-// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
-// keep a reference to the UnparsedImage.)
+// The UnparsedImage must not be used after the underlying ImageSource is Close()d.
 func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *UnparsedImage {
 	return &UnparsedImage{
 		src:            src,
@@ -42,11 +38,6 @@ func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *Unp
 func (i *UnparsedImage) Reference() types.ImageReference {
 	// Note that this does not depend on instanceDigest; e.g. all instances within a manifest list need to be signed with the manifest list identity.
 	return i.src.Reference()
-}
-
-// Close removes resources associated with an initialized UnparsedImage, if any.
-func (i *UnparsedImage) Close() error {
-	return i.src.Close()
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -75,7 +75,7 @@ func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 // Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 	if i.cachedSignatures == nil {
-		sigs, err := i.src.GetSignatures(ctx)
+		sigs, err := i.src.GetSignatures(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -142,3 +142,8 @@ func AddDummyV2S1Signature(manifest []byte) ([]byte, error) {
 	}
 	return js.PrettySignature("signatures")
 }
+
+// MIMETypeIsMultiImage returns true if mimeType is a list of images
+func MIMETypeIsMultiImage(mimeType string) bool {
+	return mimeType == DockerV2ListMediaType
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -35,7 +35,7 @@ var DefaultRequestedManifestMIMETypes = []string{
 	DockerV2Schema2MediaType,
 	DockerV2Schema1SignedMediaType,
 	DockerV2Schema1MediaType,
-	// DockerV2ListMediaType, // FIXME: Restore this ASAP
+	DockerV2ListMediaType,
 }
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -123,3 +123,18 @@ func TestAddDummyV2S1Signature(t *testing.T) {
 	_, err = AddDummyV2S1Signature([]byte("}this is invalid JSON"))
 	assert.Error(t, err)
 }
+
+func TestMIMETypeIsMultiImage(t *testing.T) {
+	for _, c := range []struct {
+		mt       string
+		expected bool
+	}{
+		{DockerV2ListMediaType, true},
+		{DockerV2Schema1MediaType, false},
+		{DockerV2Schema1SignedMediaType, false},
+		{DockerV2Schema2MediaType, false},
+	} {
+		res := MIMETypeIsMultiImage(c.mt)
+		assert.Equal(t, c.expected, res, c.mt)
+	}
+}

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -81,6 +81,10 @@ func (s *ociArchiveImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int
 	return s.unpackedSrc.GetBlob(info)
 }
 
-func (s *ociArchiveImageSource) GetSignatures(c context.Context) ([][]byte, error) {
-	return s.unpackedSrc.GetSignatures(c)
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	return s.unpackedSrc.GetSignatures(ctx, instanceDigest)
 }

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -68,14 +68,12 @@ func (s *ociArchiveImageSource) Close() error {
 	return s.unpackedSrc.Close()
 }
 
-// GetManifest returns the image's manifest along with its MIME type
-// (which may be empty when it can't be determined but the manifest is available).
-func (s *ociArchiveImageSource) GetManifest() ([]byte, string, error) {
-	return s.unpackedSrc.GetManifest()
-}
-
-func (s *ociArchiveImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return s.unpackedSrc.GetTargetManifest(digest)
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *ociArchiveImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	return s.unpackedSrc.GetManifest(instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -164,7 +164,7 @@ func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.ImageCl
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -154,9 +154,12 @@ func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
-func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -61,8 +61,26 @@ func (s *ociImageSource) Close() error {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *ociImageSource) GetManifest() ([]byte, string, error) {
-	manifestPath, err := s.ref.blobPath(digest.Digest(s.descriptor.Digest), s.sharedBlobDir)
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	var dig digest.Digest
+	var mimeType string
+	if instanceDigest == nil {
+		dig = digest.Digest(s.descriptor.Digest)
+		mimeType = s.descriptor.MediaType
+	} else {
+		dig = *instanceDigest
+		// XXX: instanceDigest means that we don't immediately have the context of what
+		//      mediaType the manifest has. In OCI this means that we don't know
+		//      what reference it came from, so we just *assume* that its
+		//      MediaTypeImageManifest.
+		// FIXME: We should actually be able to look up the manifest in the index,
+		// and see the MIME type there.
+		mimeType = imgspecv1.MediaTypeImageManifest
+	}
+
+	manifestPath, err := s.ref.blobPath(dig, s.sharedBlobDir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -71,25 +89,7 @@ func (s *ociImageSource) GetManifest() ([]byte, string, error) {
 		return nil, "", err
 	}
 
-	return m, s.descriptor.MediaType, nil
-}
-
-func (s *ociImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	manifestPath, err := s.ref.blobPath(digest, s.sharedBlobDir)
-	if err != nil {
-		return nil, "", err
-	}
-
-	m, err := ioutil.ReadFile(manifestPath)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// XXX: GetTargetManifest means that we don't have the context of what
-	//      mediaType the manifest has. In OCI this means that we don't know
-	//      what reference it came from, so we just *assume* that its
-	//      MediaTypeImageManifest.
-	return m, imgspecv1.MediaTypeImageManifest, nil
+	return m, mimeType, nil
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -114,7 +114,11 @@ func (s *ociImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, err
 	return r, fi.Size(), nil
 }
 
-func (s *ociImageSource) GetSignatures(context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	return [][]byte{}, nil
 }
 

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -177,11 +177,12 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref ociReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -187,7 +187,7 @@ func (ref ociReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, e
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
 }
 
 // getIndex returns a pointer to the index references by this ociReference. If an error occurs opening an index nil is returned together

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -200,20 +200,15 @@ func (s *openshiftImageSource) Close() error {
 	return nil
 }
 
-func (s *openshiftImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
-		return nil, "", err
-	}
-	return s.docker.GetTargetManifest(digest)
-}
-
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *openshiftImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
 		return nil, "", err
 	}
-	return s.docker.GetManifest()
+	return s.docker.GetManifest(instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -219,12 +219,21 @@ func (s *openshiftImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int6
 	return s.docker.GetBlob(info)
 }
 
-func (s *openshiftImageSource) GetSignatures(ctx context.Context) ([][]byte, error) {
-	if err := s.ensureImageIsResolved(ctx); err != nil {
-		return nil, err
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *openshiftImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	var imageName string
+	if instanceDigest == nil {
+		if err := s.ensureImageIsResolved(ctx); err != nil {
+			return nil, err
+		}
+		imageName = s.imageStreamImageName
+	} else {
+		imageName = instanceDigest.String()
 	}
-
-	image, err := s.client.getImage(ctx, s.imageStreamImageName)
+	image, err := s.client.getImage(ctx, imageName)
 	if err != nil {
 		return nil, err
 	}

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -125,11 +125,12 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.dockerReference)
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -135,7 +135,7 @@ func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.ImageClo
 	if err != nil {
 		return nil, err
 	}
-	return genericImage.FromSource(src)
+	return genericImage.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -168,11 +168,12 @@ func (ref ostreeReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref ostreeReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref ostreeReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	return nil, errors.New("Reading ostree: images is currently not supported")
 }
 

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -29,10 +29,10 @@ func dirImageMockWithRef(t *testing.T, dir string, ref types.ImageReference) typ
 	require.NoError(t, err)
 	src, err := srcRef.NewImageSource(nil)
 	require.NoError(t, err)
-	return image.UnparsedFromSource(&dirImageSourceMock{
+	return image.UnparsedInstance(&dirImageSourceMock{
 		ImageSource: src,
 		ref:         ref,
-	})
+	}, nil)
 }
 
 // dirImageSourceMock inherits dirImageSource, but overrides its Reference method.

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -34,7 +34,7 @@ func (ref nameOnlyImageReferenceMock) PolicyConfigurationIdentity() string {
 func (ref nameOnlyImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
+func (ref nameOnlyImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref nameOnlyImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -92,7 +92,7 @@ func (ref pcImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	}
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
-func (ref pcImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
+func (ref pcImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref pcImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
@@ -205,8 +205,8 @@ func TestPolicyContextRequirementsForImageRef(t *testing.T) {
 }
 
 // pcImageMock returns a types.UnparsedImage for a directory, claiming a specified dockerReference and implementing PolicyConfigurationIdentity/PolicyConfigurationNamespaces.
-// The caller must call .Close() on the returned Image.
-func pcImageMock(t *testing.T, dir, dockerReference string) types.UnparsedImage {
+// The caller must call the returned close callback when done.
+func pcImageMock(t *testing.T, dir, dockerReference string) (types.UnparsedImage, func() error) {
 	ref, err := reference.ParseNormalizedNamed(dockerReference)
 	require.NoError(t, err)
 	return dirImageMockWithRef(t, dir, pcImageReferenceMock{"docker", ref})
@@ -255,85 +255,85 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
-	defer img.Close()
+	img, closer := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer closer()
 	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
-	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
-	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
@@ -345,8 +345,8 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer closer()
 	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -357,8 +357,8 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// Error reading signatures.
 	invalidSigDir := createInvalidSigDir(t)
 	defer os.RemoveAll(invalidSigDir)
-	img = pcImageMock(t, invalidSigDir, "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, invalidSigDir, "testing/manifest:latest")
+	defer closer()
 	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
@@ -394,63 +394,63 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	defer pc.Destroy()
 
 	// Success
-	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
-	defer img.Close()
+	img, closer := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer closer()
 	res, err := pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
-	img = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
-	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
-	img = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
-	img = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
+	defer closer()
 	res, err = pc.IsRunningImageAllowed(img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
@@ -459,8 +459,8 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	require.NoError(t, err)
 	err = destroyedPC.Destroy()
 	require.NoError(t, err)
-	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
-	defer img.Close()
+	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
+	defer closer()
 	res, err = destroyedPC.IsRunningImageAllowed(img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -94,7 +94,7 @@ func (ref refImageReferenceMock) PolicyConfigurationIdentity() string {
 func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.Image, error) {
+func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -543,7 +543,14 @@ func (s *storageImageSource) GetManifest(instanceDigest *ddigest.Digest) (manife
 	return manifestBlob, manifest.GuessMIMEType(manifestBlob), err
 }
 
-func (s *storageImageSource) GetSignatures(ctx context.Context) (signatures [][]byte, err error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *ddigest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, ErrNoManifestLists
+	}
 	var offset int
 	signature, err := s.imageRef.transport.store.ImageBigData(s.ID, "signatures")
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -611,12 +611,12 @@ func (s *storageImageCloser) Size() (int64, error) {
 }
 
 // newImage creates an ImageCloser that also knows its size
-func newImage(s storageReference) (types.ImageCloser, error) {
+func newImage(ctx *types.SystemContext, s storageReference) (types.ImageCloser, error) {
 	src, err := newImageSource(s)
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(src)
+	img, err := image.FromSource(ctx, src)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -67,8 +67,8 @@ type storageLayerMetadata struct {
 	CompressedSize int64  `json:"compressed-size,omitempty"`
 }
 
-type storageImage struct {
-	types.Image
+type storageImageCloser struct {
+	types.ImageCloser
 	size int64
 }
 
@@ -606,12 +606,12 @@ func (s *storageImageSource) getSize() (int64, error) {
 	return sum, nil
 }
 
-func (s *storageImage) Size() (int64, error) {
+func (s *storageImageCloser) Size() (int64, error) {
 	return s.size, nil
 }
 
-// newImage creates an image that also knows its size
-func newImage(s storageReference) (types.Image, error) {
+// newImage creates an ImageCloser that also knows its size
+func newImage(s storageReference) (types.ImageCloser, error) {
 	src, err := newImageSource(s)
 	if err != nil {
 		return nil, err
@@ -624,5 +624,5 @@ func newImage(s storageReference) (types.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &storageImage{Image: img, size: size}, nil
+	return &storageImageCloser{ImageCloser: img, size: size}, nil
 }

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -552,7 +552,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context) (signatures [][]
 		offset += length
 	}
 	if offset != len(signature) {
-		return nil, errors.Errorf("signatures data contained %d extra bytes", len(signatures)-offset)
+		return nil, errors.Errorf("signatures data contained %d extra bytes", len(signature)-offset)
 	}
 	return sigslice, nil
 }

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -137,7 +137,12 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 	return namespaces
 }
 
-func (s storageReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (s storageReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	return newImage(s)
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -143,7 +143,7 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (s storageReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	return newImage(s)
+	return newImage(ctx, s)
 }
 
 func (s storageReference) DeleteImage(ctx *types.SystemContext) error {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -457,7 +457,7 @@ func TestWriteRead(t *testing.T) {
 		if err == nil {
 			t.Fatalf("GetManifest(%q) with an instanceDigest is supposed to fail", ref.StringWithinTransport())
 		}
-		sigs, err := src.GetSignatures(context.Background())
+		sigs, err := src.GetSignatures(context.Background(), nil)
 		if err != nil {
 			t.Fatalf("GetSignatures(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -471,6 +471,10 @@ func TestWriteRead(t *testing.T) {
 			if bytes.Compare(sigs[i], signatures[i]) != 0 {
 				t.Fatalf("Signature %d was corrupted", i)
 			}
+		}
+		_, err = src.GetSignatures(context.Background(), &sum)
+		if err == nil {
+			t.Fatalf("GetSignatures(%q) with instanceDigest is supposed to fail", ref.StringWithinTransport())
 		}
 		for _, layerInfo := range layerInfos {
 			buf := bytes.Buffer{}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -444,7 +444,7 @@ func TestWriteRead(t *testing.T) {
 				t.Fatalf("NewImageSource(%q) changed the reference to %q", ref.StringWithinTransport(), src.Reference().StringWithinTransport())
 			}
 		}
-		retrievedManifest, manifestType, err := src.GetManifest()
+		retrievedManifest, manifestType, err := src.GetManifest(nil)
 		if err != nil {
 			t.Fatalf("GetManifest(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -453,9 +453,9 @@ func TestWriteRead(t *testing.T) {
 			t.Fatalf("NewImageSource(%q) changed the manifest: %q was %q", ref.StringWithinTransport(), string(retrievedManifest), manifest)
 		}
 		sum = ddigest.SHA256.FromBytes([]byte(manifest))
-		_, _, err = src.GetTargetManifest(sum)
+		_, _, err = src.GetManifest(&sum)
 		if err == nil {
-			t.Fatalf("GetTargetManifest(%q) is supposed to fail", ref.StringWithinTransport())
+			t.Fatalf("GetManifest(%q) with an instanceDigest is supposed to fail", ref.StringWithinTransport())
 		}
 		sigs, err := src.GetSignatures(context.Background())
 		if err != nil {

--- a/tarball/tarball_reference.go
+++ b/tarball/tarball_reference.go
@@ -71,7 +71,7 @@ func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.ImageCloser
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(src)
+	img, err := image.FromSource(ctx, src)
 	if err != nil {
 		src.Close()
 		return nil, err

--- a/tarball/tarball_reference.go
+++ b/tarball/tarball_reference.go
@@ -61,7 +61,12 @@ func (r *tarballReference) PolicyConfigurationNamespaces() []string {
 	return nil
 }
 
-func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := r.NewImageSource(ctx)
 	if err != nil {
 		return nil, err

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -239,7 +239,14 @@ func (is *tarballImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte
 	return is.manifest, imgspecv1.MediaTypeImageManifest, nil
 }
 
-func (*tarballImageSource) GetSignatures(context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (*tarballImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
+	}
 	return nil, nil
 }
 

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -228,16 +228,19 @@ func (is *tarballImageSource) GetBlob(blobinfo types.BlobInfo) (io.ReadCloser, i
 	return nil, -1, fmt.Errorf("no blob with digest %q found", blobinfo.Digest.String())
 }
 
-func (is *tarballImageSource) GetManifest() ([]byte, string, error) {
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (is *tarballImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return nil, "", fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
+	}
 	return is.manifest, imgspecv1.MediaTypeImageManifest, nil
 }
 
 func (*tarballImageSource) GetSignatures(context.Context) ([][]byte, error) {
 	return nil, nil
-}
-
-func (*tarballImageSource) GetTargetManifest(digest.Digest) ([]byte, string, error) {
-	return nil, "", fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
 }
 
 func (is *tarballImageSource) Reference() types.ImageReference {

--- a/types/types.go
+++ b/types/types.go
@@ -242,8 +242,6 @@ type Image interface {
 	// Everything in options.InformationOnly should be provided, other fields should be set only if a modification is desired.
 	// This does not change the state of the original Image object.
 	UpdatedImage(options ManifestUpdateOptions) (Image, error)
-	// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
-	IsMultiImage() bool
 	// Size returns an approximation of the amount of disk space which is consumed by the image in its current
 	// location.  If the size is not known, -1 will be returned.
 	Size() (int64, error)

--- a/types/types.go
+++ b/types/types.go
@@ -99,7 +99,7 @@ type BlobInfo struct {
 	MediaType   string
 }
 
-// ImageSource is a service, possibly remote (= slow), to download components of a single image.
+// ImageSource is a service, possibly remote (= slow), to download components of a single image or a named image set (manifest list).
 // This is primarily useful for copying images around; for examining their properties, Image (below)
 // is usually more useful.
 // Each ImageSource should eventually be closed by calling Close().
@@ -121,7 +121,10 @@ type ImageSource interface {
 	// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	GetBlob(BlobInfo) (io.ReadCloser, int64, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
-	GetSignatures(context.Context) ([][]byte, error)
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+	// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+	// (e.g. if the source never returns manifest lists).
+	GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error)
 }
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.

--- a/types/types.go
+++ b/types/types.go
@@ -198,6 +198,9 @@ func (e ManifestTypeRejectedError) Error() string {
 // Thus, an UnparsedImage can be created from an ImageSource simply by fetching blobs without interpreting them,
 // allowing cryptographic signature verification to happen first, before even fetching the manifest, or parsing anything else.
 // This also makes the UnparsedImage→Image conversion an explicitly visible step.
+//
+// An UnparsedImage is a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
+//
 // Each UnparsedImage should eventually be closed by calling Close().
 type UnparsedImage interface {
 	// Reference returns the reference used to set up this source, _as specified by the user_
@@ -212,6 +215,7 @@ type UnparsedImage interface {
 }
 
 // Image is the primary API for inspecting properties of images.
+// An Image is based on a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
 // Each Image should eventually be closed by calling Close().
 type Image interface {
 	// Note that Reference may return nil in the return value of UpdatedImage!

--- a/types/types.go
+++ b/types/types.go
@@ -321,6 +321,10 @@ type SystemContext struct {
 	SystemRegistriesConfPath string
 	// If not "", overrides the default path for the authentication file
 	AuthFilePath string
+	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
+	ArchitectureChoice string
+	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
+	OSChoice string
 
 	// === OCI.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),

--- a/types/types.go
+++ b/types/types.go
@@ -114,10 +114,9 @@ type ImageSource interface {
 	Close() error
 	// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 	// It may use a remote (= slow) service.
-	GetManifest() ([]byte, string, error)
-	// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest
-	// out of a manifest list.
-	GetTargetManifest(digest digest.Digest) ([]byte, string, error)
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+	// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+	GetManifest(instanceDigest *digest.Digest) ([]byte, string, error)
 	// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 	// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	GetBlob(BlobInfo) (io.ReadCloser, int64, error)


### PR DESCRIPTION
This teaches `copy.Image` to handle manifest lists, instead of failing, by choosing an image appropriate for the current system, and copying only that one.

Ultimately we want to copy the whole manifest list; this does not yet do that.

**NOTE:** This is an alternative to #344, and should have a similar effect for Linux users. macOS users trying to access Linux images will instead start seeing errors like
```
Error choosing an image from manifest list docker://busybox:latest: no image found in manifest list for architecture amd64, OS darwin 
```
unless they explicitly make a `types.SystemContext{OSChoice:"linux"}` override. This may be fine for some uses, but the advertised use of `skopeo copy` for copying between docker/distribution registries suffers (until we implement a copy of the whole manifest list).

`types.ImageSource` is modified to understand a set of images distinguished by an optional `instanceDigest`; (as opposed to creating new `types.ImageSource` instances for each image instance, this allows sharing state, e.g. `docker load`, or an unpacked archive, for all of the instances). Then `copy.Image` is split into a per-manifest-list initialization, and a per-image-instance copy operation, so the per-manifest-list part can choose a single instance if necessary.

**NOTE:** One of the implications of this is that signature verification now happens _only_ for the individual instances; manifest list signatures are not required and not processed at all.

The overall diff is probably difficult to review, please see the individual commits, and read the individual commit messages messages for more detailed discussion:

 - Fix an incorrect variable reference in storageImageSource.GetSignatures
 - Move the core logic of types.Image.IsMultiImage to c/i/manifest
 - Remove types.Image.IsMultiImage
 - Do the isMultiImage decision already on an UnparsedImage, not an Image
 - Rename copy.imageCopier to copier
 - Split copy.imageCopier from copy.copier
 - Use copier and imageCopier instead of parameters and variables
 - Add copier.Printf
 - FIXME Replace GetTargetManifest by GetManifest(instanceDigest)
 - FIXME: Add a instanceDigest parameter to GetSignatures
 - Support instanceDigest in types.UnparsedImage and types.Image
 - Do not Close the ImageSource in UnparsedImage/Image
 - Split copier.copyOneImage from copy.Image
 - Finally, if the copy.Image source is a manifest list, copy a single instance
 - Add architecture/OS overrides to types.SystemContext
 - Revert "Hotfix: Do not fetch manifest lists from Docker registries"