### PR TITLE
Support URLs on oci layers

### DIFF
--- a/image/fixtures/oci1-to-schema2.json
+++ b/image/fixtures/oci1-to-schema2.json
@@ -20,7 +20,8 @@
       {
          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
          "size": 11739507,
-         "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
+         "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
+         "urls": ["https://layer.url"]
       },
       {
          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",

--- a/image/fixtures/oci1.json
+++ b/image/fixtures/oci1.json
@@ -22,7 +22,8 @@
       {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
          "size": 11739507,
-         "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
+         "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
+         "urls": ["https://layer.url"]
       },
       {
          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",

--- a/image/oci.go
+++ b/image/oci.go
@@ -109,7 +109,7 @@ func (m *manifestOCI1) OCIConfig() (*imgspecv1.Image, error) {
 func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
 	blobs := []types.BlobInfo{}
 	for _, layer := range m.LayersDescriptors {
-		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size, Annotations: layer.Annotations})
+		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size, Annotations: layer.Annotations, URLs: layer.URLs})
 	}
 	return blobs
 }
@@ -160,6 +160,7 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 			copy.LayersDescriptors[i].Digest = info.Digest
 			copy.LayersDescriptors[i].Size = info.Size
 			copy.LayersDescriptors[i].Annotations = info.Annotations
+			copy.LayersDescriptors[i].URLs = info.URLs
 		}
 	}
 	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1, but we really don't care.

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -53,6 +53,9 @@ func manifestOCI1FromComponentsLikeFixture(configBlob []byte) genericManifest {
 			MediaType: imgspecv1.MediaTypeImageLayerGzip,
 			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
 			Size:      11739507,
+			URLs: []string{
+				"https://layer.url",
+			},
 		}},
 		{
 			descriptor: descriptor{
@@ -207,6 +210,9 @@ func TestManifestOCI1LayerInfo(t *testing.T) {
 			{
 				Digest: "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
 				Size:   11739507,
+				URLs: []string{
+					"https://layer.url",
+				},
 			},
 			{
 				Digest: "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -106,11 +106,8 @@ func (d *ociArchiveImageDestination) Commit() error {
 	src := d.tempDirRef.tempDirectory
 	// path to save tarred up file
 	dst := d.ref.resolvedFile
-	if err := tarDirectory(src, dst); err != nil {
-		return err
-	}
 
-	return nil
+	return tarDirectory(src, dst)
 }
 
 // tar converts the directory at src and saves it to dst

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -180,13 +180,9 @@ func (s *untrustedSignature) strictUnmarshalJSON(data []byte) error {
 	}
 	s.UntrustedDockerManifestDigest = digest.Digest(digestString)
 
-	if err := paranoidUnmarshalJSONObjectExactFields(identity, map[string]interface{}{
+	return paranoidUnmarshalJSONObjectExactFields(identity, map[string]interface{}{
 		"docker-reference": &s.UntrustedDockerReference,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 // Sign formats the signature and returns a blob signed using mech and keyIdentity


### PR DESCRIPTION
According to the image spec [1], descriptors should be able to contain
URLs. Support them on the returned BlobInfo for layers.

[1] https://github.com/opencontainers/image-spec/blob/master/descriptor.md

Signed-off-by: Danail Branekov <danail.branekov@sap.com>