### PR TITLE
Update test image to always use go version 1.8

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,4 +1,10 @@
 FROM ubuntu:zesty
 
 RUN apt-get -qq update && \
-    apt-get install -y sudo docker.io git make golang btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev
+    apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev
+
+ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp
+
+RUN tar -C /usr/local -xzf /tmp/go1.8.3.linux-amd64.tar.gz && \
+    rm /tmp/go1.8.3.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/* /usr/local/bin/


### PR DESCRIPTION
We noticed that the travis output can be a bit misleading because it
says that it's running the tests against go 1.9 but the actual version
inside the docker image is 1.7.

Signed-off-by: Danail Branekov <danail.branekov@sap.com>