### PR TITLE
Print Skipping comment on new line in progress

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -581,7 +581,7 @@ func (ic *imageCopier) copyBlobFromStream(srcStream io.Reader, srcInfo types.Blo
 	bar.ShowPercent = false
 	bar.Start()
 	destStream = bar.NewProxyReader(destStream)
-	defer fmt.Fprint(ic.reportWriter, "\n")
+	defer bar.Finish()
 
 	// === Send a copy of the original, uncompressed, stream, to a separate path if necessary.
 	var originalLayerReader io.Reader // DO NOT USE this other than to drain the input if no other consumer in the pipeline has done so.


### PR DESCRIPTION
Were seeing progress that looks like this:

Copying blob sha256:e190868d63f8f8b85b026e53b5724c3c2a4548e1d642953442559cfa5f79b2c9
 62.72 MiB / 62.72 MiB [=======================================================]
Copying blob sha256:909cd34c6fd77d398af1d93e9d4f7f76104903f237be3d4db7b345a19631f291
 0 B / 69.81 KiB [-------------------------------------------------------------]
Copying blob sha256:0b9bfabab7c119abe303f22a146ff78be4ab0abdc798b0a0e97e94e80238a7e8
 0 B / 682 B [-----------------------------------------------------------------]
Copying blob sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
 0 B / 32 B [------------------------------------------------------------------]
Copying blob sha256:00bf65475aba8f1077fa9629f088a5f531d645faeccb6acd7a8626c7d896a4c4
 35.96 MiB / 35.96 MiB [=======================================================]
Copying blob sha256:c57b6bcc83e3e88fb3748ea3f0cb13d77c4e2ffa7b9a8ded3d636f17d2d83759
 0 B / 60.23 KiB [-------------------------------------------------------------]
 60.23 KiB / 60.23 KiB [=======================================================]Skipping fetch of repeat blob sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
Copying blob sha256:8978f6879e2f86eb7a063e70f7d89feecde9950c40fc68f1f53d00b3c8ce9b52
 0 B / 17.89 KiB [-------------------------------------------------------------]
Copying blob sha256:8eed3712d2cfd8c37b19d324452ba9cdb445933c04c9175c4e945b0d7241f1e3
 0 B / 11.34 KiB [-------------------------------------------------------------]
 11.34 KiB / 11.34 KiB [=======================================================]Skipping fetch of repeat blob sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
Copying blob sha256:d77be42f1619b53dbc92cfea3fd2281ac14e572eb5e62e6ed4542c9322499d77
 5.67 MiB / 5.80 MiB [=======================================================>-]
Copying config sha256:63406bcaf11e080af840ff0ef65049a6f028bd997be670a2bf12cb82ded83339
 0 B / 4.63 KiB [--------------------------------------------------------------]
Writing manifest to image destination
Storing signatures
testing-working-container

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>