### PR TITLE
Fix bug in getting external docker blob

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -140,6 +140,7 @@ func (s *dockerImageSource) getExternalBlob(urls []string) (io.ReadCloser, int64
 				logrus.Debug(err)
 				continue
 			}
+			break
 		}
 	}
 	if resp.Body != nil && err == nil {


### PR DESCRIPTION
This has two impacts:
1. In the case where a request succeeds, break out of the loop so as not to
continue fetching unnecessary blobs.
2. Previously it was possible for a request to fail after succeeding in a
previous iteration, which would error the function, despite a successful
fetch.

Signed-off-by: Tiago Scolari <tscolari@pivotal.io>