### PR TITLE
transports: make containers/storage stubbable

### DIFF
--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -14,7 +14,7 @@ import (
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"
 	// The ostree transport is registered by ostree*.go
-	_ "github.com/containers/image/storage"
+	// The storage transport is registered by storage*.go
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"

--- a/transports/alltransports/storage.go
+++ b/transports/alltransports/storage.go
@@ -1,0 +1,8 @@
+// +build !containers_image_storage_stub
+
+package alltransports
+
+import (
+	// Register the storage transport
+	_ "github.com/containers/image/storage"
+)

--- a/transports/alltransports/storage_stub.go
+++ b/transports/alltransports/storage_stub.go
@@ -1,0 +1,9 @@
+// +build containers_image_storage_stub
+
+package alltransports
+
+import "github.com/containers/image/transports"
+
+func init() {
+	transports.Register(transports.NewStubTransport("containers-storage"))
+}


### PR DESCRIPTION
Currently containers/storage is only used in very specialised use-cases,
outside of the more generic usecase of converting to and from OCI
images. As a result, the fairly involved build dependencies are not
necessary for a large portion of users (for example, users that only use
skopeo as a tool for fetching OCI images and then use umoci or other
such tools to manipulate said images).

This copies the existing stubbing conventions for ostree.

Signed-off-by: Aleksa Sarai <asarai@suse.de>