### PR TITLE
copy: avoid write() when no progress bar needed

### DIFF
--- a/copy/sign.go
+++ b/copy/sign.go
@@ -1,9 +1,6 @@
 package copy
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
@@ -11,7 +8,7 @@ import (
 )
 
 // createSignature creates a new signature of manifest at (identified by) dest using keyIdentity.
-func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity string, reportWriter io.Writer) ([]byte, error) {
+func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity string, reportWriter func(s string, a ...interface{})) ([]byte, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error initializing GPG")
@@ -26,7 +23,7 @@ func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity s
 		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(dest.Reference()))
 	}
 
-	fmt.Fprintf(reportWriter, "Signing manifest\n")
+	reportWriter("Signing manifest\n")
 	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating signature")

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -21,6 +21,10 @@ const (
 	testKeyFingerprint = "1D8230F6CDB6A06716E414C1DB72F2188BB46CC8"
 )
 
+func writerMock(s string, a ...interface{}) {
+	return
+}
+
 func TestCreateSignature(t *testing.T) {
 	manifestBlob := []byte("Something")
 	manifestDigest, err := manifest.Digest(manifestBlob)
@@ -45,7 +49,7 @@ func TestCreateSignature(t *testing.T) {
 	dirDest, err := dirRef.NewImageDestination(nil)
 	require.NoError(t, err)
 	defer dirDest.Close()
-	_, err = createSignature(dirDest, manifestBlob, testKeyFingerprint, ioutil.Discard)
+	_, err = createSignature(dirDest, manifestBlob, testKeyFingerprint, writerMock)
 	assert.Error(t, err)
 
 	// Set up a docker: reference
@@ -56,14 +60,14 @@ func TestCreateSignature(t *testing.T) {
 	defer dockerDest.Close()
 
 	// Signing with an unknown key fails
-	_, err = createSignature(dockerDest, manifestBlob, "this key does not exist", ioutil.Discard)
+	_, err = createSignature(dockerDest, manifestBlob, "this key does not exist", writerMock)
 	assert.Error(t, err)
 
 	// Success
 	mech, err = signature.NewGPGSigningMechanism()
 	require.NoError(t, err)
 	defer mech.Close()
-	sig, err := createSignature(dockerDest, manifestBlob, testKeyFingerprint, ioutil.Discard)
+	sig, err := createSignature(dockerDest, manifestBlob, testKeyFingerprint, writerMock)
 	require.NoError(t, err)
 	verified, err := signature.VerifyDockerManifestSignature(sig, manifestBlob, "docker.io/library/busybox:latest", mech, testKeyFingerprint)
 	require.NoError(t, err)


### PR DESCRIPTION
Observed some spikes of the progress bar while writing to `/dev/null` in CRI-O (since it has no progress bar).
This PR is a micro-optimization and will avoid a `write()` syscall when no progress bar is needed (and to keep the profiler to not show me that writing to /dev/null wastes some micro seconds).

@mrunalp @rhatdan @sameo PTAL this is needed by CRI-O post V1

Signed-off-by: Antonio Murdaca <runcom@redhat.com>