### PR TITLE
OCI: add a sharedBlobDir mode

### DIFF
--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"path/filepath"
+
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
 )
 
 // readerFromFunc allows implementing Reader by any function, e.g. a closure.
@@ -27,7 +28,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	dirRef, ok := ref.(ociReference)
 	require.True(t, ok)
-	blobPath, err := dirRef.blobPath(blobDigest)
+	blobPath, err := dirRef.blobPath(blobDigest, "")
 	assert.NoError(t, err)
 
 	firstRead := true
@@ -102,7 +103,7 @@ func TestPutManifestTwice(t *testing.T) {
 }
 
 func putTestManifest(t *testing.T, ociRef ociReference, tmpDir string) {
-	imageDest, err := newImageDestination(ociRef)
+	imageDest, err := newImageDestination(nil, ociRef)
 	assert.NoError(t, err)
 
 	data := []byte("abc")

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -261,7 +261,7 @@ func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSou
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref)
+	return newImageDestination(ctx, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -280,9 +280,13 @@ func (ref ociReference) indexPath() string {
 }
 
 // blobPath returns a path for a blob within a directory using OCI image-layout conventions.
-func (ref ociReference) blobPath(digest digest.Digest) (string, error) {
+func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
 	if err := digest.Validate(); err != nil {
 		return "", errors.Wrapf(err, "unexpected digest reference %s", digest)
 	}
-	return filepath.Join(ref.dir, "blobs", digest.Algorithm().String(), digest.Hex()), nil
+	blobDir := filepath.Join(ref.dir, "blobs")
+	if sharedBlobDir != "" {
+		blobDir = sharedBlobDir
+	}
+	return filepath.Join(blobDir, digest.Algorithm().String(), digest.Hex()), nil
 }

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -283,9 +283,21 @@ func TestReferenceBlobPath(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
-	bp, err := ociRef.blobPath("sha256:" + hex)
+	bp, err := ociRef.blobPath("sha256:"+hex, "")
 	assert.NoError(t, err)
 	assert.Equal(t, tmpDir+"/blobs/sha256/"+hex, bp)
+}
+
+func TestReferenceSharedBlobPathShared(t *testing.T) {
+	const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	ref, tmpDir := refToTempOCI(t)
+	defer os.RemoveAll(tmpDir)
+	ociRef, ok := ref.(ociReference)
+	require.True(t, ok)
+	bp, err := ociRef.blobPath("sha256:"+hex, "/external/path")
+	assert.NoError(t, err)
+	assert.Equal(t, "/external/path/sha256/"+hex, bp)
 }
 
 func TestReferenceBlobPathInvalid(t *testing.T) {
@@ -295,7 +307,7 @@ func TestReferenceBlobPathInvalid(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
-	_, err := ociRef.blobPath(hex)
+	_, err := ociRef.blobPath(hex, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected digest reference "+hex)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -316,6 +316,8 @@ type SystemContext struct {
 	OCICertPath string
 	// Allow downloading OCI image layers over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	OCIInsecureSkipTLSVerify bool
+	// If not "", use a shared directory for storing blobs rather than within OCI layouts
+	OCISharedBlobDirPath string
 
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
This is a POC/RFC for allowing users to specify an external blob directory for OCI image layout sources and destinations. The OCI image spec stipulates that image layouts [must have a `blobs` subdirectory](https://github.com/opencontainers/image-spec/blame/master/image-layout.md#L19), but that it [may be empty and implementations may fetch blobs from other sources](https://github.com/opencontainers/image-spec/blame/master/image-layout.md#L59))

For our use case, we're forced to use a Docker V2 registry as a canonical store but prefer to use OCI when building and manipulating images locally. So a typical workflow involves a `skopeo copy docker://image oci:image`; `umoci unpack`; `umoci repack`; `skopeo copy oci:image docker://` sequence. Since we have various shared layers we want to improve the performance of the copies as much as possible by sharing blobs, but this isn't possible with the current implementation because blobs are always stored within each independent layout.

Here's an example of this in action in conjunction with the corresponding umoci change (see https://github.com/openSUSE/umoci/pull/190) and a small skopeo patch (https://github.com/nstack/skopeo/commit/1854cbea233a234fe0dfb72bf97de25405dcb853):

```
# /home/jon/src/skopeo/skopeo copy docker://busybox:latest oci:busybox-1:latest --dest-shared-blob-dir=./blobs
Getting image source signatures
Copying blob sha256:03b1be98f3f9b05cb57782a3a71a44aaf6ec695de5f4f8e6c1058cd42f04953e
 698.42 KB / 698.42 KB [====================================================] 0s
Copying config sha256:cbd374fddd3ee5b8792fb6ae179676cfd3673e91c6afee89b7286ff0c2c0ce61
 575 B / 575 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
# /home/jon/src/skopeo/skopeo copy docker://busybox:latest oci:busybox-2:latest --dest-shared-blob-dir=./blobs
Getting image source signatures
Skipping fetch of repeat blob sha256:03b1be98f3f9b05cb57782a3a71a44aaf6ec695de5f4f8e6c1058cd42f04953e
Copying config sha256:cbd374fddd3ee5b8792fb6ae179676cfd3673e91c6afee89b7286ff0c2c0ce61
 575 B / 575 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
# find 
.
./busybox-2
./busybox-2/index.json
./busybox-2/oci-layout
./blobs
./blobs/sha256
./blobs/sha256/cbd374fddd3ee5b8792fb6ae179676cfd3673e91c6afee89b7286ff0c2c0ce61
./blobs/sha256/57b4b433672b7d0ee3c3ea274bda013bf090610cbf5c68455839f7c1a94673fa
./blobs/sha256/03b1be98f3f9b05cb57782a3a71a44aaf6ec695de5f4f8e6c1058cd42f04953e
./busybox-1
./busybox-1/index.json
./busybox-1/oci-layout
# /home/jon/src/umoci/umoci unpack --shared-cas $(pwd)/blobs/ --image busybox-1 busybox-unpacked 
# ls busybox-unpacked/
config.json  rootfs  sha256_57b4b433672b7d0ee3c3ea274bda013bf090610cbf5c68455839f7c1a94673fa.mtree  umoci.json
```

@runcom @mtrmac would love to have some feedback on whether you would take something like this upstream. It's pretty critical for our performance requirements so we might end up maintaining a branch if not, but it would be great if there's some path we can agree on.

Also cc @cyphar 