### PR TITLE
Stub out the right transport name for storage

### DIFF
--- a/transports/alltransports/storage_stub.go
+++ b/transports/alltransports/storage_stub.go
@@ -5,5 +5,5 @@ package alltransports
 import "github.com/containers/image/transports"
 
 func init() {
-	transports.Register(transports.NewStubTransport("storage"))
+	transports.Register(transports.NewStubTransport("containers-storage"))
 }


### PR DESCRIPTION
We never did rename the `containers-storage:` transport (per https://github.com/containers/image/blob/master/storage/storage_transport.go#L70, give or take), but the stub thought that we had.