### PR TITLE
Add manifest type conversion support for "dir" transport

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	pb "gopkg.in/cheggaaa/pb.v1"
-
 	"github.com/containers/image/image"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/signature"
@@ -22,6 +20,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 type digestingReader struct {
@@ -95,6 +94,8 @@ type Options struct {
 	DestinationCtx   *types.SystemContext
 	ProgressInterval time.Duration                 // time to wait between reports to signal the progress channel
 	Progress         chan types.ProgressProperties // Reported to when ProgressInterval has arrived for a single artifact+offset.
+	// manifest MIME type of image set by user. "" is default and means use the autodetection to the the manifest MIME type
+	ForceManifestMIMEType string
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
@@ -193,7 +194,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 
 	// We compute preferredManifestMIMEType only to show it in error messages.
 	// Without having to add this context in an error message, we would be happy enough to know only that no conversion is needed.
-	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest)
+	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest, options.ForceManifestMIMEType)
 	if err != nil {
 		return err
 	}

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -41,10 +41,14 @@ func (os *orderedSet) append(s string) {
 // Note that the conversion will only happen later, through src.UpdatedImage
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
-func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) (string, []string, error) {
+func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool, forceManifestMIMEType string) (string, []string, error) {
 	_, srcType, err := src.Manifest()
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
+	}
+
+	if forceManifestMIMEType != "" {
+		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}
 	}
 
 	if len(destSupportedManifestMIMETypes) == 0 {

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -136,7 +136,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		mu := types.ManifestUpdateOptions{}
-		preferredMIMEType, otherCandidates, err := determineManifestConversion(&mu, src, c.destTypes, true)
+		preferredMIMEType, otherCandidates, err := determineManifestConversion(&mu, src, c.destTypes, true, "")
 		require.NoError(t, err, c.description)
 		assert.Equal(t, c.expectedUpdate, mu.ManifestMIMEType, c.description)
 		if c.expectedUpdate == "" {
@@ -151,15 +151,26 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		mu := types.ManifestUpdateOptions{}
-		preferredMIMEType, otherCandidates, err := determineManifestConversion(&mu, src, c.destTypes, false)
+		preferredMIMEType, otherCandidates, err := determineManifestConversion(&mu, src, c.destTypes, false, "")
 		require.NoError(t, err, c.description)
 		assert.Equal(t, "", mu.ManifestMIMEType, c.description)
 		assert.Equal(t, c.sourceType, preferredMIMEType, c.description)
 		assert.Equal(t, []string{}, otherCandidates, c.description)
 	}
 
+	// With forceManifestMIMEType, the output is always the forced manifest type (in this case oci manifest)
+	for _, c := range cases {
+		src := fakeImageSource(c.sourceType)
+		mu := types.ManifestUpdateOptions{}
+		preferredMIMEType, otherCandidates, err := determineManifestConversion(&mu, src, c.destTypes, true, v1.MediaTypeImageManifest)
+		require.NoError(t, err, c.description)
+		assert.Equal(t, v1.MediaTypeImageManifest, mu.ManifestMIMEType, c.description)
+		assert.Equal(t, v1.MediaTypeImageManifest, preferredMIMEType, c.description)
+		assert.Equal(t, []string{}, otherCandidates, c.description)
+	}
+
 	// Error reading the manifest — smoke test only.
 	mu := types.ManifestUpdateOptions{}
-	_, _, err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true)
+	_, _, err := determineManifestConversion(&mu, fakeImageSource(""), supportS1S2, true, "")
 	assert.Error(t, err)
 }

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -152,7 +152,11 @@ func (ref dirReference) NewImageSource(ctx *types.SystemContext) (types.ImageSou
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref dirReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref), nil
+	compress := false
+	if ctx != nil {
+		compress = ctx.DirForceCompress
+	}
+	return newImageDestination(ref, compress)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -174,4 +178,9 @@ func (ref dirReference) layerPath(digest digest.Digest) string {
 // signaturePath returns a path for a signature within a directory using our conventions.
 func (ref dirReference) signaturePath(index int) string {
 	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
+}
+
+// versionPath returns a path for the version file within a directory using our conventions.
+func (ref dirReference) versionPath() string {
+	return filepath.Join(ref.path, "version")
 }

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -231,3 +231,11 @@ func TestReferenceSignaturePath(t *testing.T) {
 	assert.Equal(t, tmpDir+"/signature-1", dirRef.signaturePath(0))
 	assert.Equal(t, tmpDir+"/signature-10", dirRef.signaturePath(9))
 }
+
+func TestReferenceVersionPath(t *testing.T) {
+	ref, tmpDir := refToTempDir(t)
+	defer os.RemoveAll(tmpDir)
+	dirRef, ok := ref.(dirReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir+"/version", dirRef.versionPath())
+}

--- a/types/types.go
+++ b/types/types.go
@@ -349,6 +349,10 @@ type SystemContext struct {
 	DockerDaemonHost string
 	// Used to skip TLS verification, off by default. To take effect DockerDaemonCertPath needs to be specified as well.
 	DockerDaemonInsecureSkipTLSVerify bool
+
+	// === dir.Transport overrides ===
+	// DirForceCompress compresses the image layers if set to true
+	DirForceCompress bool
 }
 
 // ProgressProperties is used to pass information from the copy code to a monitor which


### PR DESCRIPTION
Gives the user the option to switch between the oci, v2s1, and v2s2 manifests
Add directory creation if the directory doesn't exist
Add overwrite functionality only if the directory was a container image directory
Feature added for the pulp team

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>