### PR TITLE
image: implement Docker v1 -> OCI conversion

### DIFF
--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -290,7 +290,7 @@ func validateV1ID(id string) error {
 }
 
 // Based on github.com/docker/docker/distribution/pull_v2.go
-func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.BlobInfo, layerDiffIDs []digest.Digest) (*manifestSchema2, error) {
+func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.BlobInfo, layerDiffIDs []digest.Digest) (genericManifest, error) {
 	if len(m.History) == 0 {
 		// What would this even mean?! Anyhow, the rest of the code depends on fsLayers[0] and history[0] existing.
 		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
@@ -354,8 +354,7 @@ func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.Bl
 		Digest:    digest.FromBytes(configJSON),
 	}
 
-	m2 := manifestSchema2FromComponents(configDescriptor, nil, configJSON, layers).(*manifestSchema2)
-	return m2, nil
+	return manifestSchema2FromComponents(configDescriptor, nil, configJSON, layers), nil
 }
 
 func configJSONFromV1Config(v1ConfigJSON []byte, rootFS rootFS, history []imageHistory) ([]byte, error) {

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -223,7 +223,10 @@ func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (typ
 		if err != nil {
 			return nil, err
 		}
-		return m2.UpdatedImage(options)
+		return m2.UpdatedImage(types.ManifestUpdateOptions{
+			ManifestMIMEType: imgspecv1.MediaTypeImageManifest,
+			InformationOnly:  options.InformationOnly,
+		})
 	default:
 		return nil, errors.Errorf("Conversion of image manifest from %s to %s is not implemented", manifest.DockerV2Schema1SignedMediaType, options.ManifestMIMEType)
 	}

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -212,7 +212,18 @@ func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (typ
 	// We have 2 MIME types for schema 1, which are basically equivalent (even the un-"Signed" MIME type will be rejected if there isn’t a signature; so,
 	// handle conversions between them by doing nothing.
 	case manifest.DockerV2Schema2MediaType:
-		return copy.convertToManifestSchema2(options.InformationOnly.LayerInfos, options.InformationOnly.LayerDiffIDs)
+		m2, err := copy.convertToManifestSchema2(options.InformationOnly.LayerInfos, options.InformationOnly.LayerDiffIDs)
+		if err != nil {
+			return nil, err
+		}
+		return memoryImageFromManifest(m2), nil
+	case imgspecv1.MediaTypeImageManifest:
+		// We can't directly convert to OCI, but we can transitively convert via a Docker V2.2 Distribution manifest
+		m2, err := copy.convertToManifestSchema2(options.InformationOnly.LayerInfos, options.InformationOnly.LayerDiffIDs)
+		if err != nil {
+			return nil, err
+		}
+		return m2.UpdatedImage(options)
 	default:
 		return nil, errors.Errorf("Conversion of image manifest from %s to %s is not implemented", manifest.DockerV2Schema1SignedMediaType, options.ManifestMIMEType)
 	}
@@ -279,7 +290,7 @@ func validateV1ID(id string) error {
 }
 
 // Based on github.com/docker/docker/distribution/pull_v2.go
-func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.BlobInfo, layerDiffIDs []digest.Digest) (types.Image, error) {
+func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.BlobInfo, layerDiffIDs []digest.Digest) (*manifestSchema2, error) {
 	if len(m.History) == 0 {
 		// What would this even mean?! Anyhow, the rest of the code depends on fsLayers[0] and history[0] existing.
 		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
@@ -343,8 +354,8 @@ func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.Bl
 		Digest:    digest.FromBytes(configJSON),
 	}
 
-	m2 := manifestSchema2FromComponents(configDescriptor, nil, configJSON, layers)
-	return memoryImageFromManifest(m2), nil
+	m2 := manifestSchema2FromComponents(configDescriptor, nil, configJSON, layers).(*manifestSchema2)
+	return m2, nil
 }
 
 func configJSONFromV1Config(v1ConfigJSON []byte, rootFS rootFS, history []imageHistory) ([]byte, error) {


### PR DESCRIPTION
Since we already know how to convert from Docker V1 to V2 and from
Docker V2 to OCI, we simply do a transitive manifest conversion.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>