### PR TITLE
Change errors structure to handle them gracefully

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -131,7 +131,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusAccepted {
 		logrus.Debugf("Error initiating layer upload, response %#v", *res)
-		return types.BlobInfo{}, errors.Errorf("Error initiating layer upload to %s, status %d", uploadPath, res.StatusCode)
+		return types.BlobInfo{}, errors.Wrapf(client.HandleErrorResponse(res), "Error initiating layer upload to %s", uploadPath)
 	}
 	uploadLocation, err := res.Location()
 	if err != nil {
@@ -167,7 +167,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
 		logrus.Debugf("Error uploading layer, response %#v", *res)
-		return types.BlobInfo{}, errors.Errorf("Error uploading layer to %s, status %d", uploadLocation, res.StatusCode)
+		return types.BlobInfo{}, errors.Wrapf(client.HandleErrorResponse(res), "Error uploading layer to %s", uploadLocation)
 	}
 
 	logrus.Debugf("Upload of layer %s complete", computedDigest)
@@ -447,7 +447,7 @@ sigExists:
 				logrus.Debugf("Error body %s", string(body))
 			}
 			logrus.Debugf("Error uploading signature, status %d, %#v", res.StatusCode, res)
-			return errors.Errorf("Error uploading signature to %s, status %d", path, res.StatusCode)
+			return errors.Wrapf(client.HandleErrorResponse(res), "Error uploading signature to %s", path)
 		}
 	}
 


### PR DESCRIPTION
Using `errors.Cause` one can understand what was the cause of the failure. Unfortunately, when the error is returned due to status code different than 203, 200 or 201 `errors.Cause` is a verbose string.

This patch suggests to set the cause of the error to be the staus text.

For example, if failed to upload a layer, instead of having the following:
`Error initiating layer upload to /path/to/upload, status 401`
This error message will be returned:
`Error initiating layer upload to /path/to/upload": Unauthorized`

It's then easier to handle this error by reading `errors.Cause`:
```Go
if errors.Cause(err) == http.StatusText(http.StatusUnauthorized) {
    return errors.New("You are not authorized. Missing credentials?")
}
```

This can help me to fix https://github.com/projectatomic/buildah/issues/254.