### PR TITLE
Revert to containers/storage master

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/storage manifest-digest https://github.com/nalind/storage
+github.com/containers/storage master
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716


### PR DESCRIPTION
We no longer need a private branch of containers/storage, so update vendor.conf to use master.