### PR TITLE
ostree, src: support copy of compressed layers

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -368,7 +368,10 @@ func (ic *imageCopier) copyLayers() error {
 	srcInfos := ic.src.LayerInfos()
 	destInfos := []types.BlobInfo{}
 	diffIDs := []digest.Digest{}
-	updatedSrcInfos := ic.src.LayerInfosForCopy()
+	updatedSrcInfos, err := ic.src.LayerInfosForCopy()
+	if err != nil {
+		return err
+	}
 	srcInfosUpdated := false
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if !ic.canModifyManifest {

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -56,7 +56,7 @@ func (f fakeImageSource) OCIConfig() (*v1.Image, error) {
 func (f fakeImageSource) LayerInfos() []types.BlobInfo {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) LayerInfosForCopy() []types.BlobInfo {
+func (f fakeImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -84,6 +84,6 @@ func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when copying, in preference to values in the manifest, if specified.
-func (s *dirImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *dirImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -36,6 +36,6 @@ func (s *archiveImageSource) Close() error {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *archiveImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *archiveImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -83,6 +83,6 @@ func (s *daemonImageSource) Close() error {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *daemonImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *daemonImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -53,8 +53,8 @@ func (s *dockerImageSource) Close() error {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *dockerImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *dockerImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }
 
 // simplifyContentType drops parameters from a HTTP media type (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1)

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -38,7 +38,7 @@ func (f unusedImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, e
 func (f unusedImageSource) GetSignatures(context.Context, *digest.Digest) ([][]byte, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f unusedImageSource) LayerInfosForCopy() []types.BlobInfo {
+func (f unusedImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 

--- a/image/memory.go
+++ b/image/memory.go
@@ -65,6 +65,6 @@ func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *memoryImage) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (i *memoryImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -101,6 +101,6 @@ func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
 	return inspectManifest(i.genericManifest)
 }
 
-func (i *sourcedImage) LayerInfosForCopy() []types.BlobInfo {
+func (i *sourcedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	return i.UnparsedImage.LayerInfosForCopy()
 }

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -97,6 +97,6 @@ func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *UnparsedImage) LayerInfosForCopy() []types.BlobInfo {
+func (i *UnparsedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	return i.src.LayerInfosForCopy()
 }

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -90,6 +90,6 @@ func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDiges
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociArchiveImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *ociArchiveImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -144,8 +144,8 @@ func (s *ociImageSource) getExternalBlob(urls []string) (io.ReadCloser, int64, e
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *ociImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }
 
 func getBlobSize(resp *http.Response) int64 {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -247,8 +247,8 @@ func (s *openshiftImageSource) GetSignatures(ctx context.Context, instanceDigest
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *openshiftImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (s *openshiftImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }
 
 // ensureImageIsResolved sets up s.docker and s.imageStreamImageName

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -230,33 +230,36 @@ func (d *ostreeImageDestination) ostreeCommit(repo *otbuiltin.Repo, branch strin
 	return err
 }
 
-func generateTarSplitMetadata(output *bytes.Buffer, file string) error {
+func generateTarSplitMetadata(output *bytes.Buffer, file string) (digest.Digest, int64, error) {
 	mfz := gzip.NewWriter(output)
 	defer mfz.Close()
 	metaPacker := storage.NewJSONPacker(mfz)
 
 	stream, err := os.OpenFile(file, os.O_RDONLY, 0)
 	if err != nil {
-		return err
+		return "", -1, err
 	}
 	defer stream.Close()
 
 	gzReader, err := archive.DecompressStream(stream)
 	if err != nil {
-		return err
+		return "", -1, err
 	}
 	defer gzReader.Close()
 
 	its, err := asm.NewInputTarStream(gzReader, metaPacker, nil)
 	if err != nil {
-		return err
+		return "", -1, err
 	}
 
-	_, err = io.Copy(ioutil.Discard, its)
+	digester := digest.Canonical.Digester()
+
+	written, err := io.Copy(digester.Hash(), its)
 	if err != nil {
-		return err
+		return "", -1, err
 	}
-	return nil
+
+	return digester.Digest(), written, nil
 }
 
 func (d *ostreeImageDestination) importBlob(selinuxHnd *C.struct_selabel_handle, repo *otbuiltin.Repo, blob *blobToImport) error {
@@ -271,7 +274,8 @@ func (d *ostreeImageDestination) importBlob(selinuxHnd *C.struct_selabel_handle,
 	}()
 
 	var tarSplitOutput bytes.Buffer
-	if err := generateTarSplitMetadata(&tarSplitOutput, blob.BlobPath); err != nil {
+	uncompressedDigest, uncompressedSize, err := generateTarSplitMetadata(&tarSplitOutput, blob.BlobPath)
+	if err != nil {
 		return err
 	}
 
@@ -293,6 +297,8 @@ func (d *ostreeImageDestination) importBlob(selinuxHnd *C.struct_selabel_handle,
 		}
 	}
 	return d.ostreeCommit(repo, ostreeBranch, destinationPath, []string{fmt.Sprintf("docker.size=%d", blob.Size),
+		fmt.Sprintf("docker.uncompressed_size=%d", uncompressedSize),
+		fmt.Sprintf("docker.uncompressed_digest=%s", uncompressedDigest.String()),
 		fmt.Sprintf("tarsplit.output=%s", base64.StdEncoding.EncodeToString(tarSplitOutput.Bytes()))})
 
 }

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -321,7 +321,17 @@ func (d *ostreeImageDestination) HasBlob(info types.BlobInfo) (bool, int64, erro
 	}
 	branch := fmt.Sprintf("ociimage/%s", info.Digest.Hex())
 
-	found, data, err := readMetadata(d.repo, branch, "docker.size")
+	found, data, err := readMetadata(d.repo, branch, "docker.uncompressed_digest")
+	if err != nil || !found {
+		return found, -1, err
+	}
+
+	found, data, err = readMetadata(d.repo, branch, "docker.uncompressed_size")
+	if err != nil || !found {
+		return found, -1, err
+	}
+
+	found, data, err = readMetadata(d.repo, branch, "docker.size")
 	if err != nil || !found {
 		return found, -1, err
 	}

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -67,7 +67,7 @@ func (ref refImageMock) Manifest() ([]byte, string, error) {
 func (ref refImageMock) Signatures(context.Context) ([][]byte, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageMock) LayerInfosForCopy() []types.BlobInfo {
+func (ref refImageMock) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 
@@ -335,7 +335,7 @@ func (ref forbiddenImageMock) Manifest() ([]byte, string, error) {
 func (ref forbiddenImageMock) Signatures(context.Context) ([][]byte, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref forbiddenImageMock) LayerInfosForCopy() []types.BlobInfo {
+func (ref forbiddenImageMock) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -177,18 +177,18 @@ func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifes
 
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
-func (s *storageImageSource) LayerInfosForCopy() []types.BlobInfo {
+func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	simg, err := s.imageRef.transport.store.Image(s.ID)
 	if err != nil {
 		logrus.Errorf("error reading image %q: %v", s.ID, err)
-		return nil
+		return nil, nil
 	}
 	updatedBlobInfos := []types.BlobInfo{}
 	layerID := simg.TopLayer
 	_, manifestType, err := s.GetManifest(nil)
 	if err != nil {
 		logrus.Errorf("error reading image manifest for %q: %v", s.ID, err)
-		return nil
+		return nil, nil
 	}
 	uncompressedLayerType := ""
 	switch manifestType {
@@ -202,15 +202,15 @@ func (s *storageImageSource) LayerInfosForCopy() []types.BlobInfo {
 		layer, err := s.imageRef.transport.store.Layer(layerID)
 		if err != nil {
 			logrus.Errorf("error reading layer %q in image %q: %v", layerID, s.ID, err)
-			return nil
+			return nil, nil
 		}
 		if layer.UncompressedDigest == "" {
 			logrus.Errorf("uncompressed digest for layer %q is unknown", layerID)
-			return nil
+			return nil, nil
 		}
 		if layer.UncompressedSize < 0 {
 			logrus.Errorf("uncompressed size for layer %q is unknown", layerID)
-			return nil
+			return nil, nil
 		}
 		blobInfo := types.BlobInfo{
 			Digest:    layer.UncompressedDigest,
@@ -220,7 +220,7 @@ func (s *storageImageSource) LayerInfosForCopy() []types.BlobInfo {
 		updatedBlobInfos = append([]types.BlobInfo{blobInfo}, updatedBlobInfos...)
 		layerID = layer.Parent
 	}
-	return updatedBlobInfos
+	return updatedBlobInfos, nil
 }
 
 // GetSignatures() parses the image's signatures blob into a slice of byte slices.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -180,15 +180,13 @@ func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifes
 func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	simg, err := s.imageRef.transport.store.Image(s.ID)
 	if err != nil {
-		logrus.Errorf("error reading image %q: %v", s.ID, err)
-		return nil, nil
+		return nil, errors.Wrapf(err, "error reading image %q", s.ID)
 	}
 	updatedBlobInfos := []types.BlobInfo{}
 	layerID := simg.TopLayer
 	_, manifestType, err := s.GetManifest(nil)
 	if err != nil {
-		logrus.Errorf("error reading image manifest for %q: %v", s.ID, err)
-		return nil, nil
+		return nil, errors.Wrapf(err, "error reading image manifest for %q", s.ID)
 	}
 	uncompressedLayerType := ""
 	switch manifestType {
@@ -201,16 +199,13 @@ func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	for layerID != "" {
 		layer, err := s.imageRef.transport.store.Layer(layerID)
 		if err != nil {
-			logrus.Errorf("error reading layer %q in image %q: %v", layerID, s.ID, err)
-			return nil, nil
+			return nil, errors.Wrapf(err, "error reading layer %q in image %q", layerID, s.ID)
 		}
 		if layer.UncompressedDigest == "" {
-			logrus.Errorf("uncompressed digest for layer %q is unknown", layerID)
-			return nil, nil
+			return nil, errors.Errorf("uncompressed digest for layer %q is unknown", layerID)
 		}
 		if layer.UncompressedSize < 0 {
-			logrus.Errorf("uncompressed size for layer %q is unknown", layerID)
-			return nil, nil
+			return nil, errors.Errorf("uncompressed size for layer %q is unknown", layerID)
 		}
 		blobInfo := types.BlobInfo{
 			Digest:    layer.UncompressedDigest,

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1012,7 +1012,11 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("ImageSource is not a storage image")
 	}
 	layers := []string{}
-	for _, layerInfo := range img.LayerInfosForCopy() {
+	layersInfo, err := img.LayerInfosForCopy()
+	if err != nil {
+		t.Fatalf("LayerInfosForCopy() returned error %v", err)
+	}
+	for _, layerInfo := range layersInfo {
 		rc, _, layerID, err := source.getBlobAndLayerID(layerInfo)
 		if err != nil {
 			t.Fatalf("getBlobAndLayerID(%q) returned error %v", layerInfo.Digest, err)

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -255,6 +255,6 @@ func (is *tarballImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (*tarballImageSource) LayerInfosForCopy() []types.BlobInfo {
-	return nil
+func (*tarballImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+	return nil, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -129,7 +129,7 @@ type ImageSource interface {
 	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy() []BlobInfo
+	LayerInfosForCopy() ([]BlobInfo, error)
 }
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
@@ -218,7 +218,7 @@ type UnparsedImage interface {
 	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
 	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy() []BlobInfo
+	LayerInfosForCopy() ([]BlobInfo, error)
 }
 
 // Image is the primary API for inspecting properties of images.


### PR DESCRIPTION
add implementation for LayerInfosForCopy so we can provide a modified manifest to be used for `copy`