### PR TITLE
storage: log image-not-resolving at debug level, not error

### DIFF
--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -71,8 +71,8 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		}
 	}
 	if s.id == "" {
-		logrus.Errorf("reference %q does not resolve to an image ID", s.StringWithinTransport())
-		return nil, ErrNoSuchImage
+		logrus.Debugf("reference %q does not resolve to an image ID", s.StringWithinTransport())
+		return nil, errors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
 	}
 	img, err := s.transport.store.Image(s.id)
 	if err != nil {


### PR DESCRIPTION
Log the message about a given reference not being resolvable to an image ID at the debug level rather than as an error, and wrap the error that we return in case the caller wants to relay the reference's value back as part of the error.