### PR TITLE
Drop missing images logrus Errors to Warning

### DIFF
--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -71,7 +71,7 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		}
 	}
 	if s.id == "" {
-		logrus.Errorf("reference %q does not resolve to an image ID", s.StringWithinTransport())
+		logrus.Warnf("reference %q does not resolve to an image ID", s.StringWithinTransport())
 		return nil, ErrNoSuchImage
 	}
 	img, err := s.transport.store.Image(s.id)
@@ -90,7 +90,7 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 			}
 		}
 		if !nameMatch {
-			logrus.Errorf("no image matching reference %q found", s.StringWithinTransport())
+			logrus.Warnf("no image matching reference %q found", s.StringWithinTransport())
 			return nil, ErrNoSuchImage
 		}
 	}


### PR DESCRIPTION
These messages get blasted to the screen in kpod run and
probably on buildah, even though they are expected.  If the
image is not local then I will pull it, but don't blast an
error message at the screen.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>