### PR TITLE
directory: make the "version" file non-executable

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -70,7 +70,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 		}
 	}
 	// create version file
-	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0755)
+	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0644)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating version file %q", d.ref.versionPath())
 	}


### PR DESCRIPTION
Take the execute bit off of the "version" file that we create when writing images to a "directory:" destination.