### PR TITLE
Make token parsing compatible with Docker's Token Authentication Spec

### DIFF
--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -3,11 +3,13 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/image/types"
@@ -507,6 +509,62 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 	}
 }
 
+func TestNewBearerTokenFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJSONBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerAccessTokenFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"access_token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJSONBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerTokenFromInvalidJsonBlob(t *testing.T) {
+	tokenBlob := []byte("IAmNotJson")
+	_, err := newBearerTokenFromJSONBlob(tokenBlob)
+	if err == nil {
+		t.Fatalf("unexpected an error unmarshalling JSON")
+	}
+}
+
+func TestNewBearerTokenSmallExpiryFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 60, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"token":"IAmAToken","expires_in":1,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJSONBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerTokenIssuedAtZeroFromJsonBlob(t *testing.T) {
+	zeroTime := time.Time{}.Format(time.RFC3339)
+	now := time.Now()
+	tokenBlob := []byte(fmt.Sprintf(`{"token":"IAmAToken","expires_in":100,"issued_at":"%s"}`, zeroTime))
+	token, err := newBearerTokenFromJSONBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token.IssuedAt.Before(now) {
+		t.Fatalf("expected [%s] not to be before [%s]", token.IssuedAt, now)
+	}
+
+}
+
 type testAuthConfigData struct {
 	username string
 	password string
@@ -542,4 +600,16 @@ func makeTestAuthConfig(authConfigData map[string]testAuthConfigData) testAuthCo
 		}
 	}
 	return ac
+}
+
+func assertBearerTokensEqual(t *testing.T, expected, subject *bearerToken) {
+	if expected.Token != subject.Token {
+		t.Fatalf("expected [%s] to equal [%s], it did not", subject.Token, expected.Token)
+	}
+	if expected.ExpiresIn != subject.ExpiresIn {
+		t.Fatalf("expected [%d] to equal [%d], it did not", subject.ExpiresIn, expected.ExpiresIn)
+	}
+	if !expected.IssuedAt.Equal(subject.IssuedAt) {
+		t.Fatalf("expected [%s] to equal [%s], it did not", subject.IssuedAt, expected.IssuedAt)
+	}
 }


### PR DESCRIPTION
According to the [docker registry spec](https://docs.docker.com/registry/spec/auth/token/#requesting-a-token) when you request a bearer token from a registry, the response JSON could contain an `access_token` or `token` key. Currently `containers/image` only supports the second option and is therefore incompatible with Azure container registries.

Signed-off-by: Tom Godkin <tgodkin@pivotal.io>
Signed-off-by: Ed King <eking@pivotal.io>
Signed-off-by: Will Martin <wmartin@pivotal.io>