### PR TITLE
Update Ubuntu from Zesty to Atful

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM ubuntu:artful
 
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev


### PR DESCRIPTION
Primarily because Zesty is EOL and the repositories are no longer available.

The Ubuntu EOL manifests in failures like
```
W: The repository 'http://security.ubuntu.com/ubuntu zesty-security Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-updates Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-backports Release' does not have a Release file.
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/zesty-security/universe/source/Sources  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty/universe/source/Sources  404  Not Found [IP: 91.189.88.161 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-updates/universe/source/Sources  404  Not Found [IP: 91.189.88.161 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-backports/main/binary-amd64/Packages  404  Not Found [IP: 91.189.88.161 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get -qq update &&     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev' returned a non-zero code: 100
```

The Go update is, strictly speaking, unrelated, but we don’t have a process to keep it updated and this is as good an opportunity as any.