### PR TITLE
Golang update

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:artful
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev
 
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp
+ADD https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz /tmp
 
-RUN tar -C /usr/local -xzf /tmp/go1.8.3.linux-amd64.tar.gz && \
-    rm /tmp/go1.8.3.linux-amd64.tar.gz && \
+RUN tar -C /usr/local -xzf /tmp/go1.9.2.linux-amd64.tar.gz && \
+    rm /tmp/go1.9.2.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/* /usr/local/bin/


### PR DESCRIPTION
This
- Updates Golang to 1.9.2
- ~~Takes advantage of the 1.9 semantics of `./...` to simplify `Makefile` a bit.~~

Both are RFCs:
- We could instead update to 1.8.5 from the current 1.8.3.  Per #403, F26 has 1.8 (with about 7 months til EOL), F27 and EPEL have 1.9.
- ~~The latter commit will break, or at least make life difficult for, 1.8 users. Without it, we would be testing on 1.9 but still probably making it possible to use the repo with 1.8.  And honestly the benefit of that commit is extremely weak.~~

~~Do not merge as is, it includes https://github.com/containers/image/pull/403 and should be rebased on top of it.~~
