### PR TITLE
Make token parsing compatible with Docker's Token Authentication Spec

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -66,9 +66,10 @@ type extensionSignatureList struct {
 }
 
 type bearerToken struct {
-	Token     string    `json:"token"`
-	ExpiresIn int       `json:"expires_in"`
-	IssuedAt  time.Time `json:"issued_at"`
+	Token       string    `json:"token"`
+	AccessToken string    `json:"access_token"`
+	ExpiresIn   int       `json:"expires_in"`
+	IssuedAt    time.Time `json:"issued_at"`
 }
 
 // dockerClient is configuration for dealing with a single Docker registry.
@@ -94,6 +95,24 @@ type dockerClient struct {
 type authScope struct {
 	remoteName string
 	actions    string
+}
+
+func newBearerTokenFromJsonBlob(blob []byte) (*bearerToken, error) {
+	token := new(bearerToken)
+	if err := json.Unmarshal(blob, &token); err != nil {
+		return nil, err
+	}
+	if token.Token == "" {
+		token.Token = token.AccessToken
+	}
+	if token.ExpiresIn < minimumTokenLifetimeSeconds {
+		token.ExpiresIn = minimumTokenLifetimeSeconds
+		logrus.Debugf("Increasing token expiration to: %d seconds", token.ExpiresIn)
+	}
+	if token.IssuedAt.IsZero() {
+		token.IssuedAt = time.Now().UTC()
+	}
+	return token, nil
 }
 
 // this is cloned from docker/go-connections because upstream docker has changed
@@ -332,18 +351,8 @@ func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope
 	if err != nil {
 		return nil, err
 	}
-	var token bearerToken
-	if err := json.Unmarshal(tokenBlob, &token); err != nil {
-		return nil, err
-	}
-	if token.ExpiresIn < minimumTokenLifetimeSeconds {
-		token.ExpiresIn = minimumTokenLifetimeSeconds
-		logrus.Debugf("Increasing token expiration to: %d seconds", token.ExpiresIn)
-	}
-	if token.IssuedAt.IsZero() {
-		token.IssuedAt = time.Now().UTC()
-	}
-	return &token, nil
+
+	return newBearerTokenFromJsonBlob(tokenBlob)
 }
 
 // detectProperties detects various properties of the registry.

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -3,11 +3,13 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/image/types"
@@ -507,6 +509,62 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 	}
 }
 
+func TestNewBearerTokenFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJsonBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerAccessTokenFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"access_token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJsonBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerTokenFromInvalidJsonBlob(t *testing.T) {
+	tokenBlob := []byte("IAmNotJson")
+	_, err := newBearerTokenFromJsonBlob(tokenBlob)
+	if err == nil {
+		t.Fatalf("unexpected an error unmarshalling JSON")
+	}
+}
+
+func TestNewBearerTokenSmallExpiryFromJsonBlob(t *testing.T) {
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 60, IssuedAt: time.Unix(1514800802, 0)}
+	tokenBlob := []byte(`{"token":"IAmAToken","expires_in":1,"issued_at":"2018-01-01T10:00:02+00:00"}`)
+	token, err := newBearerTokenFromJsonBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertBearerTokensEqual(t, expected, token)
+}
+
+func TestNewBearerTokenIssuedAtZeroFromJsonBlob(t *testing.T) {
+	zeroTime := time.Time{}.Format(time.RFC3339)
+	expected := &bearerToken{Token: "IAmAToken", ExpiresIn: 100}
+	tokenBlob := []byte(fmt.Sprintf(`{"token":"IAmAToken","expires_in":100,"issued_at":"%s"}`, zeroTime))
+	token, err := newBearerTokenFromJsonBlob(tokenBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if token.IssuedAt.Before(time.Now()) {
+		t.Fatalf("expected [%s] not to be before [%s]", expected.IssuedAt, token.IssuedAt)
+	}
+
+}
+
 type testAuthConfigData struct {
 	username string
 	password string
@@ -542,4 +600,16 @@ func makeTestAuthConfig(authConfigData map[string]testAuthConfigData) testAuthCo
 		}
 	}
 	return ac
+}
+
+func assertBearerTokensEqual(t *testing.T, expected, subject *bearerToken) {
+	if expected.Token != subject.Token {
+		t.Fatalf("expected [%s] to equal [%s], it did not", subject.Token, expected.Token)
+	}
+	if expected.ExpiresIn != subject.ExpiresIn {
+		t.Fatalf("expected [%d] to equal [%d], it did not", subject.ExpiresIn, expected.ExpiresIn)
+	}
+	if !expected.IssuedAt.Equal(subject.IssuedAt) {
+		t.Fatalf("expected [%s] to equal [%s], it did not", subject.IssuedAt, expected.IssuedAt)
+	}
 }


### PR DESCRIPTION
According to the docker registry spec when you request a bearer token from a registry, the response JSON could contain an access_token or token key. Currently containers/image only supports the second option and is therefore incompatible with Azure container registries.

Signed-off-by: Tom Godkin tgodkin@pivotal.io
Signed-off-by: Ed King eking@pivotal.io
Signed-off-by: Will Martin wmartin@pivotal.io