### PR TITLE
Add /etc/containers/certs.d as default certs directory

### DIFF
--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/homedir"
@@ -23,9 +25,9 @@ func TestDockerCertDir(t *testing.T) {
 	const nondefaultPerHostDir = "/this/is/not/the/default/certs.d"
 	const variableReference = "$HOME"
 	const rootPrefix = "/root/prefix"
-	const registryHostPort = "localhost:5000"
+	const registryHostPort = "thishostdefinitelydoesnotexist:5000"
 
-	systemPerHostResult := filepath.Join(systemPerHostCertDirPath, registryHostPort)
+	systemPerHostResult := filepath.Join(systemPerHostCertDirPaths[len(systemPerHostCertDirPaths)-1], registryHostPort)
 	for _, c := range []struct {
 		ctx      *types.SystemContext
 		expected string
@@ -85,7 +87,8 @@ func TestDockerCertDir(t *testing.T) {
 			filepath.Join(variableReference, registryHostPort),
 		},
 	} {
-		path := dockerCertDir(c.ctx, registryHostPort)
+		path, err := dockerCertDir(c.ctx, registryHostPort)
+		require.Equal(t, nil, err)
 		assert.Equal(t, c.expected, path)
 	}
 }


### PR DESCRIPTION
Adding /etc/containers/certs.d as another default certs directory
The code will first check /etc/containers/certs.d for the certificates
and if not found at this path it will fall back to /etc/docker/certs.dir

Taking over https://github.com/containers/image/pull/388

Signed-off-by: umohnani8 <umohnani@redhat.com>