### PR TITLE
Fix error handling in dirImageSource.GetBlob

### DIFF
--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -52,11 +52,11 @@ func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, str
 func (s *dirImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(info.Digest))
 	if err != nil {
-		return nil, 0, nil
+		return nil, -1, err
 	}
 	fi, err := r.Stat()
 	if err != nil {
-		return nil, 0, nil
+		return nil, -1, err
 	}
 	return r, fi.Size(), nil
 }


### PR DESCRIPTION
Return the error values instead of `nil`.

(Also modifies the returned size to be `-1` instead of `0` on the error paths, purely out of paranoia.)
