### PR TITLE
Revert "image: make imageInspectInfo() use manifest.Inspect()"

### DIFF
--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -88,7 +88,21 @@ func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 }
 
 func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
-	return m.m.Inspect(nil)
+	v1 := &manifest.Schema2V1Image{}
+	if err := json.Unmarshal([]byte(m.m.History[0].V1Compatibility), v1); err != nil {
+		return nil, err
+	}
+	i := &types.ImageInspectInfo{
+		Tag:           m.m.Tag,
+		DockerVersion: v1.DockerVersion,
+		Created:       v1.Created,
+		Architecture:  v1.Architecture,
+		Os:            v1.OS,
+	}
+	if v1.Config != nil {
+		i.Labels = v1.Config.Labels
+	}
+	return i, nil
 }
 
 // UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -131,18 +131,24 @@ func (m *manifestSchema2) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 }
 
 func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
-	getter := func(info types.BlobInfo) ([]byte, error) {
-		if info.Digest != m.ConfigInfo().Digest {
-			// Shouldn't ever happen
-			return nil, errors.New("asked for a different config blob")
-		}
-		config, err := m.ConfigBlob()
-		if err != nil {
-			return nil, err
-		}
-		return config, nil
+	config, err := m.ConfigBlob()
+	if err != nil {
+		return nil, err
 	}
-	return m.m.Inspect(getter)
+	v1 := &manifest.Schema2V1Image{}
+	if err := json.Unmarshal(config, v1); err != nil {
+		return nil, err
+	}
+	i := &types.ImageInspectInfo{
+		DockerVersion: v1.DockerVersion,
+		Created:       v1.Created,
+		Architecture:  v1.Architecture,
+		Os:            v1.OS,
+	}
+	if v1.Config != nil {
+		i.Labels = v1.Config.Labels
+	}
+	return i, nil
 }
 
 // UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -271,13 +271,7 @@ func TestManifestSchema2ImageInspectInfo(t *testing.T) {
 		Labels:        map[string]string{},
 		Architecture:  "amd64",
 		Os:            "linux",
-		Layers: []string{
-			"sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
-			"sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
-			"sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
-			"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
-			"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
-		},
+		Layers:        nil,
 	}, *ii)
 
 	// nil configBlob will trigger an error in m.ConfigBlob()

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -63,5 +63,14 @@ func manifestInstanceFromBlob(ctx *types.SystemContext, src types.ImageSource, m
 
 // inspectManifest is an implementation of types.Image.Inspect
 func inspectManifest(m genericManifest) (*types.ImageInspectInfo, error) {
-	return m.imageInspectInfo()
+	info, err := m.imageInspectInfo()
+	if err != nil {
+		return nil, err
+	}
+	layers := m.LayerInfos()
+	info.Layers = make([]string, len(layers))
+	for i, layer := range layers {
+		info.Layers[i] = layer.Digest.String()
+	}
+	return info, nil
 }

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -258,13 +258,7 @@ func TestManifestOCI1ImageInspectInfo(t *testing.T) {
 		Labels:        map[string]string{},
 		Architecture:  "amd64",
 		Os:            "linux",
-		Layers: []string{
-			"sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
-			"sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
-			"sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
-			"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
-			"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
-		},
+		Layers:        nil,
 	}, *ii)
 
 	// nil configBlob will trigger an error in m.ConfigBlob()


### PR DESCRIPTION
This reverts commit 82b213b830bd67ee1a71a145aea7b171117aecd2.

This change caused a regression where the Labels dict is empty when
inspecting images in the registry registry.access.redhat.com. For
example:

  skopeo inspect docker://registry.access.redhat.com/rhosp12/openstack-nova-api:latest

Returns "Labels": {} instead of the expected 22 entries

Signed-off-by: Steve Baker <sbaker@redhat.com>
Closes #413