### PR TITLE
image: fix docker schema v1 -> OCI conversion

### DIFF
--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -95,7 +95,7 @@ func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
 // This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
 // (most importantly it forces us to download the full layers even if they are already present at the destination).
 func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
-	return options.ManifestMIMEType == manifest.DockerV2Schema2MediaType
+	return (options.ManifestMIMEType == manifest.DockerV2Schema2MediaType || options.ManifestMIMEType == imgspecv1.MediaTypeImageManifest)
 }
 
 // UpdatedImage returns a types.Image modified according to options.


### PR DESCRIPTION
Chasing #380; DiffIDs are required in the OCI format, but we were
skipping them because of this check. Without this, converting from a V1
image registry source to an OCI layout results in broken images.