### PR TITLE
#305 cleanup

### DIFF
--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -188,7 +188,7 @@ func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.Bl
 			diffIDs = append(diffIDs, d)
 		}
 	}
-	configJSON, err := m.m.ToSchema2(diffIDs)
+	configJSON, err := m.m.ToSchema2Config(diffIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -87,7 +87,8 @@ func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 	return m.m.Name != name || m.m.Tag != tag
 }
 
-func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema1) Inspect() (*types.ImageInspectInfo, error) {
 	return m.m.Inspect(nil)
 }
 

--- a/image/docker_schema1_test.go
+++ b/image/docker_schema1_test.go
@@ -1,13 +1,62 @@
 package image
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var schema1FixtureLayerInfos = []types.BlobInfo{
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      74876245,
+		Digest:    "sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4",
+	},
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      1239,
+		Digest:    "sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a",
+	},
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      78339724,
+		Digest:    "sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e",
+	},
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      76857203,
+		Digest:    "sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6",
+	},
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      25923380,
+		Digest:    "sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788",
+	},
+	{
+		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		Size:      23511300,
+		Digest:    "sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d",
+	},
+}
+
+var schema1FixtureLayerDiffIDs = []digest.Digest{
+	"sha256:e1d829eddb62dc49f1c56dbf8acd0c71299b3996115399de853a9d66d81b822f",
+	"sha256:02404b4d7e5d89b1383ca346b4462b199128aa4b238c5a2b2c186004ac148ba8",
+	"sha256:45fad80a4b1cec165c421eb570dec312d825bd8fac362e255028fa3f2169148d",
+	"sha256:7ddef8efd44586e54880ec4797458eac87b368544c438d7e7c63fbc0d9a7ae97",
+	"sha256:b56b16b6407ba1b86252e7e50f98f142cf6844fab42e4495d56ebb7ce559e2af",
+	"sha256:9bd63850e406167b4751f5050f6dc0ebd789bb5ef5e5c6c31ed062bda8c063e8",
+}
 
 func manifestSchema1FromFixture(t *testing.T, fixture string) genericManifest {
 	manifest, err := ioutil.ReadFile(filepath.Join("fixtures", fixture))
@@ -18,9 +67,341 @@ func manifestSchema1FromFixture(t *testing.T, fixture string) genericManifest {
 	return m
 }
 
-func TestManifestSchema1ToOCIConfig(t *testing.T) {
+func manifestSchema1FromComponentsLikeFixture(t *testing.T) genericManifest {
+	ref, err := reference.ParseNormalizedNamed("rhosp12/openstack-nova-api:latest")
+	require.NoError(t, err)
+	return manifestSchema1FromComponents(ref, []manifest.Schema1FSLayers{
+		{BlobSum: "sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d"},
+		{BlobSum: "sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788"},
+		{BlobSum: "sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6"},
+		{BlobSum: "sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e"},
+		{BlobSum: "sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a"},
+		{BlobSum: "sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4"},
+	}, []manifest.Schema1History{
+		{V1Compatibility: "{\"architecture\":\"amd64\",\"config\":{\"Hostname\":\"9428cdea83ba\",\"Domainname\":\"\",\"User\":\"nova\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\",\"container=oci\",\"KOLLA_BASE_DISTRO=rhel\",\"KOLLA_INSTALL_TYPE=binary\",\"KOLLA_INSTALL_METATYPE=rhos\",\"PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ \"],\"Cmd\":[\"kolla_start\"],\"Healthcheck\":{\"Test\":[\"CMD-SHELL\",\"/openstack/healthcheck\"]},\"ArgsEscaped\":true,\"Image\":\"3bf9afe371220b1eb1c57bec39b5a99ba976c36c92d964a1c014584f95f51e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"Kolla-SHA\":\"5.0.0-39-g6f1b947b\",\"architecture\":\"x86_64\",\"authoritative-source-url\":\"registry.access.redhat.com\",\"build-date\":\"2018-01-25T00:32:27.807261\",\"com.redhat.build-host\":\"ip-10-29-120-186.ec2.internal\",\"com.redhat.component\":\"openstack-nova-api-docker\",\"description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"distribution-scope\":\"public\",\"io.k8s.description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.k8s.display-name\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.openshift.tags\":\"rhosp osp openstack osp-12.0\",\"kolla_version\":\"stable/pike\",\"name\":\"rhosp12/openstack-nova-api\",\"release\":\"20180124.1\",\"summary\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"tripleo-common_version\":\"7.6.3-23-g4891cfe\",\"url\":\"https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1\",\"vcs-ref\":\"9b31243b7b448eb2fc3b6e2c96935b948f806e98\",\"vcs-type\":\"git\",\"vendor\":\"Red Hat, Inc.\",\"version\":\"12.0\",\"version-release\":\"12.0-20180124.1\"}},\"container_config\":{\"Hostname\":\"9428cdea83ba\",\"Domainname\":\"\",\"User\":\"nova\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\",\"container=oci\",\"KOLLA_BASE_DISTRO=rhel\",\"KOLLA_INSTALL_TYPE=binary\",\"KOLLA_INSTALL_METATYPE=rhos\",\"PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ \"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) \",\"USER [nova]\"],\"Healthcheck\":{\"Test\":[\"CMD-SHELL\",\"/openstack/healthcheck\"]},\"ArgsEscaped\":true,\"Image\":\"sha256:274ce4dcbeb09fa173a5d50203ae5cec28f456d1b8b59477b47a42bd74d068bf\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"Kolla-SHA\":\"5.0.0-39-g6f1b947b\",\"architecture\":\"x86_64\",\"authoritative-source-url\":\"registry.access.redhat.com\",\"build-date\":\"2018-01-25T00:32:27.807261\",\"com.redhat.build-host\":\"ip-10-29-120-186.ec2.internal\",\"com.redhat.component\":\"openstack-nova-api-docker\",\"description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"distribution-scope\":\"public\",\"io.k8s.description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.k8s.display-name\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.openshift.tags\":\"rhosp osp openstack osp-12.0\",\"kolla_version\":\"stable/pike\",\"name\":\"rhosp12/openstack-nova-api\",\"release\":\"20180124.1\",\"summary\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"tripleo-common_version\":\"7.6.3-23-g4891cfe\",\"url\":\"https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1\",\"vcs-ref\":\"9b31243b7b448eb2fc3b6e2c96935b948f806e98\",\"vcs-type\":\"git\",\"vendor\":\"Red Hat, Inc.\",\"version\":\"12.0\",\"version-release\":\"12.0-20180124.1\"}},\"created\":\"2018-01-25T00:37:48.268558Z\",\"docker_version\":\"1.12.6\",\"id\":\"486cbbaf6c6f7d890f9368c86eda3f4ebe3ae982b75098037eb3c3cc6f0e0cdf\",\"os\":\"linux\",\"parent\":\"20d0c9c79f9fee83c4094993335b9b321112f13eef60ed9ec1599c7593dccf20\"}"},
+		{V1Compatibility: "{\"id\":\"20d0c9c79f9fee83c4094993335b9b321112f13eef60ed9ec1599c7593dccf20\",\"parent\":\"47a1014db2116c312736e11adcc236fb77d0ad32457f959cbaec0c3fc9ab1caa\",\"created\":\"2018-01-24T23:08:25.300741Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"},
+		{V1Compatibility: "{\"id\":\"47a1014db2116c312736e11adcc236fb77d0ad32457f959cbaec0c3fc9ab1caa\",\"parent\":\"cec66cab6c92a5f7b50ef407b80b83840a0d089b9896257609fd01de3a595824\",\"created\":\"2018-01-24T22:00:57.807862Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"},
+		{V1Compatibility: "{\"id\":\"cec66cab6c92a5f7b50ef407b80b83840a0d089b9896257609fd01de3a595824\",\"parent\":\"0e7730eccb3d014b33147b745d771bc0e38a967fd932133a6f5325a3c84282e2\",\"created\":\"2018-01-24T21:40:32.494686Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"},
+		{V1Compatibility: "{\"id\":\"0e7730eccb3d014b33147b745d771bc0e38a967fd932133a6f5325a3c84282e2\",\"parent\":\"3e49094c0233214ab73f8e5c204af8a14cfc6f0403384553c17fbac2e9d38345\",\"created\":\"2017-11-21T16:49:37.292899Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/compose-rpms-1.repo'\"]},\"author\":\"Red Hat, Inc.\"}"},
+		{V1Compatibility: "{\"id\":\"3e49094c0233214ab73f8e5c204af8a14cfc6f0403384553c17fbac2e9d38345\",\"comment\":\"Imported from -\",\"created\":\"2017-11-21T16:47:27.755341705Z\",\"container_config\":{\"Cmd\":[\"\"]}}"},
+	}, "amd64")
+}
+
+func TestManifestSchema1FromManifest(t *testing.T) {
+	// This just tests that the JSON can be loaded; we test that the parsed
+	// values are correctly returned in tests for the individual getter methods.
+	_ = manifestSchema1FromFixture(t, "schema1.json")
+
+	// FIXME: Detailed coverage of manifest.Schema1FromManifest failures
+	_, err := manifestSchema1FromManifest([]byte{})
+	assert.Error(t, err)
+}
+
+func TestManifestSchema1FromComponents(t *testing.T) {
+	// This just smoke-tests that the manifest can be created; we test that the parsed
+	// values are correctly returned in tests for the individual getter methods.
+	_ = manifestSchema1FromComponentsLikeFixture(t)
+}
+
+func TestManifestSchema1Serialize(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		serialized, err := m.serialize()
+		require.NoError(t, err)
+		var contents map[string]interface{}
+		err = json.Unmarshal(serialized, &contents)
+		require.NoError(t, err)
+
+		original, err := ioutil.ReadFile("fixtures/schema1.json")
+		require.NoError(t, err)
+		var originalContents map[string]interface{}
+		err = json.Unmarshal(original, &originalContents)
+		require.NoError(t, err)
+
+		// Drop the signature which is generated by AddDummyV2S1Signature
+		delete(contents, "signatures")
+		delete(originalContents, "signatures")
+		// We would ideally like to compare “serialized” with some transformation of
+		// “original”, but the ordering of fields in JSON maps is undefined, so this is
+		// easier.
+		assert.Equal(t, originalContents, contents)
+	}
+}
+
+func TestManifestSchema1ManifestMIMEType(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		assert.Equal(t, manifest.DockerV2Schema1SignedMediaType, m.manifestMIMEType())
+	}
+}
+
+func TestManifestSchema1ConfigInfo(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		assert.Equal(t, types.BlobInfo{Digest: ""}, m.ConfigInfo())
+	}
+}
+
+func TestManifestSchema1ConfigBlob(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		blob, err := m.ConfigBlob()
+		require.NoError(t, err)
+		assert.Nil(t, blob)
+	}
+}
+
+func TestManifestSchema1OCIConfig(t *testing.T) {
 	m := manifestSchema1FromFixture(t, "schema1-to-oci-config.json")
 	configOCI, err := m.OCIConfig()
 	require.NoError(t, err)
+	// FIXME: A more comprehensive test?
 	assert.Equal(t, "/pause", configOCI.Config.Entrypoint[0])
 }
+
+func TestManifestSchema1LayerInfo(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		assert.Equal(t, []types.BlobInfo{
+			{
+				Digest: "sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4",
+				Size:   -1,
+			},
+			{
+				Digest: "sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a",
+				Size:   -1,
+			},
+			{
+				Digest: "sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e",
+				Size:   -1,
+			},
+			{
+				Digest: "sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6",
+				Size:   -1,
+			},
+			{
+				Digest: "sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788",
+				Size:   -1,
+			},
+			{
+				Digest: "sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d",
+				Size:   -1,
+			},
+		}, m.LayerInfos())
+	}
+}
+
+func TestManifestSchema1EmbeddedDockerReferenceConflicts(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		for name, expected := range map[string]bool{
+			"rhosp12/openstack-nova-api:latest":                false, // Exactly the embedded reference
+			"example.com/rhosp12/openstack-nova-api:latest":    false, // A different host name, but path and tag match
+			"docker.io:3333/rhosp12/openstack-nova-api:latest": false, // A different port, but path and tag match
+			"busybox":                              true, // Entirely different, minimal
+			"example.com:5555/ns/repo:tag":         true, // Entirely different, maximal
+			"rhosp12/openstack-nova-api":           true, // Missing tag
+			"rhosp12/openstack-nova-api:notlatest": true, // Different tag
+			"notrhosp12/openstack-nova-api:latest": true, // Different namespace
+			"rhosp12/notopenstack-nova-api:latest": true, // Different repo
+		} {
+			ref, err := reference.ParseNormalizedNamed(name)
+			require.NoError(t, err, name)
+			conflicts := m.EmbeddedDockerReferenceConflicts(ref)
+			assert.Equal(t, expected, conflicts, name)
+		}
+	}
+}
+
+func TestManifestSchema1Inspect(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		ii, err := m.Inspect()
+		require.NoError(t, err)
+		created := time.Date(2018, 1, 25, 0, 37, 48, 268558000, time.UTC)
+		assert.Equal(t, types.ImageInspectInfo{
+			Tag:           "latest",
+			Created:       &created,
+			DockerVersion: "1.12.6",
+			Labels: map[string]string{
+				"Kolla-SHA":                "5.0.0-39-g6f1b947b",
+				"architecture":             "x86_64",
+				"authoritative-source-url": "registry.access.redhat.com",
+				"build-date":               "2018-01-25T00:32:27.807261",
+				"com.redhat.build-host":    "ip-10-29-120-186.ec2.internal",
+				"com.redhat.component":     "openstack-nova-api-docker",
+				"description":              "Red Hat OpenStack Platform 12.0 nova-api",
+				"distribution-scope":       "public",
+				"io.k8s.description":       "Red Hat OpenStack Platform 12.0 nova-api",
+				"io.k8s.display-name":      "Red Hat OpenStack Platform 12.0 nova-api",
+				"io.openshift.tags":        "rhosp osp openstack osp-12.0",
+				"kolla_version":            "stable/pike",
+				"name":                     "rhosp12/openstack-nova-api",
+				"release":                  "20180124.1",
+				"summary":                  "Red Hat OpenStack Platform 12.0 nova-api",
+				"tripleo-common_version":   "7.6.3-23-g4891cfe",
+				"url":             "https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1",
+				"vcs-ref":         "9b31243b7b448eb2fc3b6e2c96935b948f806e98",
+				"vcs-type":        "git",
+				"vendor":          "Red Hat, Inc.",
+				"version":         "12.0",
+				"version-release": "12.0-20180124.1",
+			},
+			Architecture: "amd64",
+			Os:           "linux",
+			Layers: []string{
+				"sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4",
+				"sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a",
+				"sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e",
+				"sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6",
+				"sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788",
+				"sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d",
+			},
+		}, *ii)
+	}
+}
+
+func TestManifestSchema1UpdatedImageNeedsLayerDiffIDs(t *testing.T) {
+	for _, m := range []genericManifest{
+		manifestSchema1FromFixture(t, "schema1.json"),
+		manifestSchema1FromComponentsLikeFixture(t),
+	} {
+		for mt, expected := range map[string]bool{
+			"": false,
+			manifest.DockerV2Schema1MediaType:       false,
+			manifest.DockerV2Schema1SignedMediaType: false,
+			manifest.DockerV2Schema2MediaType:       true,
+			imgspecv1.MediaTypeImageManifest:        true,
+		} {
+			needsDiffIDs := m.UpdatedImageNeedsLayerDiffIDs(types.ManifestUpdateOptions{
+				ManifestMIMEType: mt,
+			})
+			assert.Equal(t, expected, needsDiffIDs, mt)
+		}
+	}
+}
+
+func TestManifestSchema1UpdatedImage(t *testing.T) {
+	original := manifestSchema1FromFixture(t, "schema1.json")
+
+	// LayerInfos:
+	layerInfos := append(original.LayerInfos()[1:], original.LayerInfos()[0])
+	res, err := original.UpdatedImage(types.ManifestUpdateOptions{
+		LayerInfos: layerInfos,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, layerInfos, res.LayerInfos())
+	_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+		LayerInfos: append(layerInfos, layerInfos[0]),
+	})
+	assert.Error(t, err)
+
+	// EmbeddedDockerReference:
+	for _, refName := range []string{
+		"busybox",
+		"busybox:notlatest",
+		"rhosp12/openstack-nova-api:latest",
+	} {
+		embeddedRef, err := reference.ParseNormalizedNamed(refName)
+		require.NoError(t, err)
+		res, err = original.UpdatedImage(types.ManifestUpdateOptions{
+			EmbeddedDockerReference: embeddedRef,
+		})
+		require.NoError(t, err)
+		// The previous embedded docker reference now does not match.
+		nonEmbeddedRef, err := reference.ParseNormalizedNamed("rhosp12/openstack-nova-api:latest")
+		require.NoError(t, err)
+		conflicts := res.EmbeddedDockerReferenceConflicts(nonEmbeddedRef)
+		assert.Equal(t, refName != "rhosp12/openstack-nova-api:latest", conflicts)
+	}
+
+	// ManifestMIMEType:
+	// Only smoke-test the valid conversions, detailed tests are below. (This also verifies that “original” is not affected.)
+	for _, mime := range []string{
+		manifest.DockerV2Schema2MediaType,
+		imgspecv1.MediaTypeImageManifest,
+	} {
+		_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+			ManifestMIMEType: mime,
+			InformationOnly: types.ManifestUpdateInformation{
+				LayerInfos:   schema1FixtureLayerInfos,
+				LayerDiffIDs: schema1FixtureLayerDiffIDs,
+			},
+		})
+		assert.NoError(t, err, mime)
+	}
+	for _, mime := range []string{
+		"this is invalid",
+	} {
+		_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+			ManifestMIMEType: mime,
+		})
+		assert.Error(t, err, mime)
+	}
+
+	// m hasn’t been changed:
+	m2 := manifestSchema1FromFixture(t, "schema1.json")
+	typedOriginal, ok := original.(*manifestSchema1)
+	require.True(t, ok)
+	typedM2, ok := m2.(*manifestSchema1)
+	require.True(t, ok)
+	assert.Equal(t, *typedM2, *typedOriginal)
+}
+
+func TestManifestSchema1ConvertToSchema2(t *testing.T) {
+	original := manifestSchema1FromFixture(t, "schema1.json")
+	res, err := original.UpdatedImage(types.ManifestUpdateOptions{
+		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
+		InformationOnly: types.ManifestUpdateInformation{
+			LayerInfos:   schema1FixtureLayerInfos,
+			LayerDiffIDs: schema1FixtureLayerDiffIDs,
+		},
+	})
+	require.NoError(t, err)
+
+	convertedJSON, mt, err := res.Manifest()
+	require.NoError(t, err)
+	assert.Equal(t, manifest.DockerV2Schema2MediaType, mt)
+
+	byHandJSON, err := ioutil.ReadFile("fixtures/schema1-to-schema2.json")
+	require.NoError(t, err)
+	var converted, byHand map[string]interface{}
+	err = json.Unmarshal(byHandJSON, &byHand)
+	require.NoError(t, err)
+	err = json.Unmarshal(convertedJSON, &converted)
+	delete(converted, "config")
+	delete(byHand, "config")
+	require.NoError(t, err)
+	assert.Equal(t, byHand, converted)
+
+	convertedConfig, err := res.ConfigBlob()
+	require.NoError(t, err)
+
+	byHandConfig, err := ioutil.ReadFile("fixtures/schema1-to-schema2-config.json")
+	require.NoError(t, err)
+	converted = map[string]interface{}{}
+	byHand = map[string]interface{}{}
+	err = json.Unmarshal(byHandConfig, &byHand)
+	require.NoError(t, err)
+	err = json.Unmarshal(convertedConfig, &converted)
+	require.NoError(t, err)
+	assert.Equal(t, byHand, converted)
+
+	// FIXME? Test also the various failure cases, if only to see that we don't crash?
+}
+
+// FIXME: Schema1→OCI conversion untested

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -130,7 +130,8 @@ func (m *manifestSchema2) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 	return false
 }
 
-func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema2) Inspect() (*types.ImageInspectInfo, error) {
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -264,9 +264,10 @@ func TestManifestSchema2Inspect(t *testing.T) {
 	m := manifestSchema2FromComponentsLikeFixture(configJSON)
 	ii, err := m.Inspect()
 	require.NoError(t, err)
+	created := time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)
 	assert.Equal(t, types.ImageInspectInfo{
 		Tag:           "",
-		Created:       time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC),
+		Created:       &created,
 		DockerVersion: "1.12.1",
 		Labels:        map[string]string{},
 		Architecture:  "amd64",

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -257,12 +257,12 @@ func TestManifestSchema2EmbeddedDockerReferenceConflicts(t *testing.T) {
 	}
 }
 
-func TestManifestSchema2ImageInspectInfo(t *testing.T) {
+func TestManifestSchema2Inspect(t *testing.T) {
 	configJSON, err := ioutil.ReadFile("fixtures/schema2-config.json")
 	require.NoError(t, err)
 
 	m := manifestSchema2FromComponentsLikeFixture(configJSON)
-	ii, err := m.imageInspectInfo()
+	ii, err := m.Inspect()
 	require.NoError(t, err)
 	assert.Equal(t, types.ImageInspectInfo{
 		Tag:           "",
@@ -282,11 +282,11 @@ func TestManifestSchema2ImageInspectInfo(t *testing.T) {
 
 	// nil configBlob will trigger an error in m.ConfigBlob()
 	m = manifestSchema2FromComponentsLikeFixture(nil)
-	_, err = m.imageInspectInfo()
+	_, err = m.Inspect()
 	assert.Error(t, err)
 
 	m = manifestSchema2FromComponentsLikeFixture([]byte("invalid JSON"))
-	_, err = m.imageInspectInfo()
+	_, err = m.Inspect()
 	assert.Error(t, err)
 }
 

--- a/image/fixtures/schema1-to-schema2-config.json
+++ b/image/fixtures/schema1-to-schema2-config.json
@@ -1,0 +1,163 @@
+{
+    "architecture": "amd64",
+    "config": {
+        "Hostname": "9428cdea83ba",
+        "Domainname": "",
+        "User": "nova",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "container=oci",
+            "KOLLA_BASE_DISTRO=rhel",
+            "KOLLA_INSTALL_TYPE=binary",
+            "KOLLA_INSTALL_METATYPE=rhos",
+            "PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ "
+        ],
+        "Cmd": [
+            "kolla_start"
+        ],
+        "Healthcheck": {
+            "Test": [
+                "CMD-SHELL",
+                "/openstack/healthcheck"
+            ]
+        },
+        "ArgsEscaped": true,
+        "Image": "3bf9afe371220b1eb1c57bec39b5a99ba976c36c92d964a1c014584f95f51e33",
+        "Volumes": null,
+        "WorkingDir": "",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {
+            "Kolla-SHA": "5.0.0-39-g6f1b947b",
+            "architecture": "x86_64",
+            "authoritative-source-url": "registry.access.redhat.com",
+            "build-date": "2018-01-25T00:32:27.807261",
+            "com.redhat.build-host": "ip-10-29-120-186.ec2.internal",
+            "com.redhat.component": "openstack-nova-api-docker",
+            "description": "Red Hat OpenStack Platform 12.0 nova-api",
+            "distribution-scope": "public",
+            "io.k8s.description": "Red Hat OpenStack Platform 12.0 nova-api",
+            "io.k8s.display-name": "Red Hat OpenStack Platform 12.0 nova-api",
+            "io.openshift.tags": "rhosp osp openstack osp-12.0",
+            "kolla_version": "stable/pike",
+            "name": "rhosp12/openstack-nova-api",
+            "release": "20180124.1",
+            "summary": "Red Hat OpenStack Platform 12.0 nova-api",
+            "tripleo-common_version": "7.6.3-23-g4891cfe",
+            "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1",
+            "vcs-ref": "9b31243b7b448eb2fc3b6e2c96935b948f806e98",
+            "vcs-type": "git",
+            "vendor": "Red Hat, Inc.",
+            "version": "12.0",
+            "version-release": "12.0-20180124.1"
+        }
+    },
+    "container_config": {
+        "Hostname": "9428cdea83ba",
+        "Domainname": "",
+        "User": "nova",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "container=oci",
+            "KOLLA_BASE_DISTRO=rhel",
+            "KOLLA_INSTALL_TYPE=binary",
+            "KOLLA_INSTALL_METATYPE=rhos",
+            "PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ "
+        ],
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) ",
+            "USER [nova]"
+        ],
+        "Healthcheck": {
+            "Test": [
+                "CMD-SHELL",
+                "/openstack/healthcheck"
+            ]
+        },
+        "ArgsEscaped": true,
+        "Image": "sha256:274ce4dcbeb09fa173a5d50203ae5cec28f456d1b8b59477b47a42bd74d068bf",
+        "Volumes": null,
+        "WorkingDir": "",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {
+            "Kolla-SHA": "5.0.0-39-g6f1b947b",
+            "architecture": "x86_64",
+            "authoritative-source-url": "registry.access.redhat.com",
+            "build-date": "2018-01-25T00:32:27.807261",
+            "com.redhat.build-host": "ip-10-29-120-186.ec2.internal",
+            "com.redhat.component": "openstack-nova-api-docker",
+            "description": "Red Hat OpenStack Platform 12.0 nova-api",
+            "distribution-scope": "public",
+            "io.k8s.description": "Red Hat OpenStack Platform 12.0 nova-api",
+            "io.k8s.display-name": "Red Hat OpenStack Platform 12.0 nova-api",
+            "io.openshift.tags": "rhosp osp openstack osp-12.0",
+            "kolla_version": "stable/pike",
+            "name": "rhosp12/openstack-nova-api",
+            "release": "20180124.1",
+            "summary": "Red Hat OpenStack Platform 12.0 nova-api",
+            "tripleo-common_version": "7.6.3-23-g4891cfe",
+            "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1",
+            "vcs-ref": "9b31243b7b448eb2fc3b6e2c96935b948f806e98",
+            "vcs-type": "git",
+            "vendor": "Red Hat, Inc.",
+            "version": "12.0",
+            "version-release": "12.0-20180124.1"
+        }
+    },
+    "created": "2018-01-25T00:37:48.268558Z",
+    "docker_version": "1.12.6",
+    "os": "linux",
+    "history": [
+        {
+            "comment": "Imported from -",
+            "created": "2017-11-21T16:47:27.755341705Z"
+        },
+        {
+            "author": "Red Hat, Inc.",
+            "created": "2017-11-21T16:49:37.292899Z",
+            "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/compose-rpms-1.repo'"
+        },
+        {
+            "created": "2018-01-24T21:40:32.494686Z",
+            "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'"
+        },
+        {
+            "created": "2018-01-24T22:00:57.807862Z",
+            "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'"
+        },
+        {
+            "created": "2018-01-24T23:08:25.300741Z",
+            "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'"
+        },
+        {
+            "created": "2018-01-25T00:37:48.268558Z",
+            "created_by": "/bin/sh -c #(nop)  USER [nova]"
+        }
+    ],
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:e1d829eddb62dc49f1c56dbf8acd0c71299b3996115399de853a9d66d81b822f",
+            "sha256:02404b4d7e5d89b1383ca346b4462b199128aa4b238c5a2b2c186004ac148ba8",
+            "sha256:45fad80a4b1cec165c421eb570dec312d825bd8fac362e255028fa3f2169148d",
+            "sha256:7ddef8efd44586e54880ec4797458eac87b368544c438d7e7c63fbc0d9a7ae97",
+            "sha256:b56b16b6407ba1b86252e7e50f98f142cf6844fab42e4495d56ebb7ce559e2af",
+            "sha256:9bd63850e406167b4751f5050f6dc0ebd789bb5ef5e5c6c31ed062bda8c063e8"
+        ]
+    }
+}

--- a/image/fixtures/schema1-to-schema2.json
+++ b/image/fixtures/schema1-to-schema2.json
@@ -1,0 +1,41 @@
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "config": {
+        "mediaType": "application/octet-stream",
+        "size": -1,
+        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "layers": [
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 74876245,
+            "digest": "sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 1239,
+            "digest": "sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 78339724,
+            "digest": "sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 76857203,
+            "digest": "sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 25923380,
+            "digest": "sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 23511300,
+            "digest": "sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d"
+        }
+    ]
+}

--- a/image/fixtures/schema1.json
+++ b/image/fixtures/schema1.json
@@ -1,0 +1,62 @@
+{
+   "schemaVersion": 1,
+   "name": "rhosp12/openstack-nova-api",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d"
+      },
+      {
+         "blobSum": "sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788"
+      },
+      {
+         "blobSum": "sha256:9e92df2aea7dc0baf5f1f8d509678d6a6306de27ad06513f8e218371938c07a6"
+      },
+      {
+         "blobSum": "sha256:f576d102e09b9eef0e305aaef705d2d43a11bebc3fd5810a761624bd5e11997e"
+      },
+      {
+         "blobSum": "sha256:4aa565ad8b7a87248163ce7dba1dd3894821aac97e846b932ff6b8ef9a8a508a"
+      },
+      {
+         "blobSum": "sha256:9cadd93b16ff2a0c51ac967ea2abfadfac50cfa3af8b5bf983d89b8f8647f3e4"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"architecture\":\"amd64\",\"config\":{\"Hostname\":\"9428cdea83ba\",\"Domainname\":\"\",\"User\":\"nova\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\",\"container=oci\",\"KOLLA_BASE_DISTRO=rhel\",\"KOLLA_INSTALL_TYPE=binary\",\"KOLLA_INSTALL_METATYPE=rhos\",\"PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ \"],\"Cmd\":[\"kolla_start\"],\"Healthcheck\":{\"Test\":[\"CMD-SHELL\",\"/openstack/healthcheck\"]},\"ArgsEscaped\":true,\"Image\":\"3bf9afe371220b1eb1c57bec39b5a99ba976c36c92d964a1c014584f95f51e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"Kolla-SHA\":\"5.0.0-39-g6f1b947b\",\"architecture\":\"x86_64\",\"authoritative-source-url\":\"registry.access.redhat.com\",\"build-date\":\"2018-01-25T00:32:27.807261\",\"com.redhat.build-host\":\"ip-10-29-120-186.ec2.internal\",\"com.redhat.component\":\"openstack-nova-api-docker\",\"description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"distribution-scope\":\"public\",\"io.k8s.description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.k8s.display-name\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.openshift.tags\":\"rhosp osp openstack osp-12.0\",\"kolla_version\":\"stable/pike\",\"name\":\"rhosp12/openstack-nova-api\",\"release\":\"20180124.1\",\"summary\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"tripleo-common_version\":\"7.6.3-23-g4891cfe\",\"url\":\"https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1\",\"vcs-ref\":\"9b31243b7b448eb2fc3b6e2c96935b948f806e98\",\"vcs-type\":\"git\",\"vendor\":\"Red Hat, Inc.\",\"version\":\"12.0\",\"version-release\":\"12.0-20180124.1\"}},\"container_config\":{\"Hostname\":\"9428cdea83ba\",\"Domainname\":\"\",\"User\":\"nova\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\",\"container=oci\",\"KOLLA_BASE_DISTRO=rhel\",\"KOLLA_INSTALL_TYPE=binary\",\"KOLLA_INSTALL_METATYPE=rhos\",\"PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ \"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) \",\"USER [nova]\"],\"Healthcheck\":{\"Test\":[\"CMD-SHELL\",\"/openstack/healthcheck\"]},\"ArgsEscaped\":true,\"Image\":\"sha256:274ce4dcbeb09fa173a5d50203ae5cec28f456d1b8b59477b47a42bd74d068bf\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{\"Kolla-SHA\":\"5.0.0-39-g6f1b947b\",\"architecture\":\"x86_64\",\"authoritative-source-url\":\"registry.access.redhat.com\",\"build-date\":\"2018-01-25T00:32:27.807261\",\"com.redhat.build-host\":\"ip-10-29-120-186.ec2.internal\",\"com.redhat.component\":\"openstack-nova-api-docker\",\"description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"distribution-scope\":\"public\",\"io.k8s.description\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.k8s.display-name\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"io.openshift.tags\":\"rhosp osp openstack osp-12.0\",\"kolla_version\":\"stable/pike\",\"name\":\"rhosp12/openstack-nova-api\",\"release\":\"20180124.1\",\"summary\":\"Red Hat OpenStack Platform 12.0 nova-api\",\"tripleo-common_version\":\"7.6.3-23-g4891cfe\",\"url\":\"https://access.redhat.com/containers/#/registry.access.redhat.com/rhosp12/openstack-nova-api/images/12.0-20180124.1\",\"vcs-ref\":\"9b31243b7b448eb2fc3b6e2c96935b948f806e98\",\"vcs-type\":\"git\",\"vendor\":\"Red Hat, Inc.\",\"version\":\"12.0\",\"version-release\":\"12.0-20180124.1\"}},\"created\":\"2018-01-25T00:37:48.268558Z\",\"docker_version\":\"1.12.6\",\"id\":\"486cbbaf6c6f7d890f9368c86eda3f4ebe3ae982b75098037eb3c3cc6f0e0cdf\",\"os\":\"linux\",\"parent\":\"20d0c9c79f9fee83c4094993335b9b321112f13eef60ed9ec1599c7593dccf20\"}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"20d0c9c79f9fee83c4094993335b9b321112f13eef60ed9ec1599c7593dccf20\",\"parent\":\"47a1014db2116c312736e11adcc236fb77d0ad32457f959cbaec0c3fc9ab1caa\",\"created\":\"2018-01-24T23:08:25.300741Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"47a1014db2116c312736e11adcc236fb77d0ad32457f959cbaec0c3fc9ab1caa\",\"parent\":\"cec66cab6c92a5f7b50ef407b80b83840a0d089b9896257609fd01de3a595824\",\"created\":\"2018-01-24T22:00:57.807862Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"cec66cab6c92a5f7b50ef407b80b83840a0d089b9896257609fd01de3a595824\",\"parent\":\"0e7730eccb3d014b33147b745d771bc0e38a967fd932133a6f5325a3c84282e2\",\"created\":\"2018-01-24T21:40:32.494686Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/rhel-7.4.repo' '/etc/yum.repos.d/rhos-optools-12.0.repo' '/etc/yum.repos.d/rhos-12.0-container-yum-need_images.repo'\"]}}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"0e7730eccb3d014b33147b745d771bc0e38a967fd932133a6f5325a3c84282e2\",\"parent\":\"3e49094c0233214ab73f8e5c204af8a14cfc6f0403384553c17fbac2e9d38345\",\"created\":\"2017-11-21T16:49:37.292899Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c rm -f '/etc/yum.repos.d/compose-rpms-1.repo'\"]},\"author\":\"Red Hat, Inc.\"}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3e49094c0233214ab73f8e5c204af8a14cfc6f0403384553c17fbac2e9d38345\",\"comment\":\"Imported from -\",\"created\":\"2017-11-21T16:47:27.755341705Z\",\"container_config\":{\"Cmd\":[\"\"]}}"
+      }
+   ],
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "DB2X:GSG2:72H3:AE3R:KCMI:Y77E:W7TF:ERHK:V5HR:JJ2Y:YMS6:HFGJ",
+               "kty": "EC",
+               "x": "jyr9-xZBorSC9fhqNsmfU_Ud31wbaZ-bVGz0HmySvbQ",
+               "y": "vkE6qZCCvYRWjSUwgAOvibQx_s8FipYkAiHS0VnAFNs"
+            },
+            "alg": "ES256"
+         },
+         "signature": "jBBsnocfxw77LzmM_VeN6Nb031BtqPgx-DbppYOEnhZfGLRcyYwGUPW--3JrkeEX6AlEGzPI57R0tlu5bZvrnQ",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjY4MTMsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxOC0wMS0zMFQxOToyNToxMloifQ"
+      }
+   ]
+}

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -34,7 +34,8 @@ type genericManifest interface {
 	// It returns false if the manifest does not embed a Docker reference.
 	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
 	EmbeddedDockerReferenceConflicts(ref reference.Named) bool
-	imageInspectInfo() (*types.ImageInspectInfo, error) // To be called by inspectManifest
+	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+	Inspect() (*types.ImageInspectInfo, error)
 	// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
 	// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
 	// (most importantly it forces us to download the full layers even if they are already present at the destination).
@@ -59,9 +60,4 @@ func manifestInstanceFromBlob(ctx *types.SystemContext, src types.ImageSource, m
 	default: // Note that this may not be reachable, manifest.NormalizedMIMEType has a default for unknown values.
 		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", mt)
 	}
-}
-
-// inspectManifest is an implementation of types.Image.Inspect
-func inspectManifest(m genericManifest) (*types.ImageInspectInfo, error) {
-	return m.imageInspectInfo()
 }

--- a/image/memory.go
+++ b/image/memory.go
@@ -57,11 +57,6 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 	return nil, errors.New("Internal error: Image.Signatures() is not supported for images modified in memory")
 }
 
-// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
-func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
-	return inspectManifest(i.genericManifest)
-}
-
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.

--- a/image/oci.go
+++ b/image/oci.go
@@ -110,7 +110,8 @@ func (m *manifestOCI1) EmbeddedDockerReferenceConflicts(ref reference.Named) boo
 	return false
 }
 
-func (m *manifestOCI1) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestOCI1) Inspect() (*types.ImageInspectInfo, error) {
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -251,9 +251,10 @@ func TestManifestOCI1Inspect(t *testing.T) {
 	m := manifestOCI1FromComponentsLikeFixture(configJSON)
 	ii, err := m.Inspect()
 	require.NoError(t, err)
+	created := time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)
 	assert.Equal(t, types.ImageInspectInfo{
 		Tag:           "",
-		Created:       time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC),
+		Created:       &created,
 		DockerVersion: "1.12.1",
 		Labels:        map[string]string{},
 		Architecture:  "amd64",

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -244,12 +244,12 @@ func TestManifestOCI1EmbeddedDockerReferenceConflicts(t *testing.T) {
 	}
 }
 
-func TestManifestOCI1ImageInspectInfo(t *testing.T) {
+func TestManifestOCI1Inspect(t *testing.T) {
 	configJSON, err := ioutil.ReadFile("fixtures/oci1-config.json")
 	require.NoError(t, err)
 
 	m := manifestOCI1FromComponentsLikeFixture(configJSON)
-	ii, err := m.imageInspectInfo()
+	ii, err := m.Inspect()
 	require.NoError(t, err)
 	assert.Equal(t, types.ImageInspectInfo{
 		Tag:           "",
@@ -269,11 +269,11 @@ func TestManifestOCI1ImageInspectInfo(t *testing.T) {
 
 	// nil configBlob will trigger an error in m.ConfigBlob()
 	m = manifestOCI1FromComponentsLikeFixture(nil)
-	_, err = m.imageInspectInfo()
+	_, err = m.Inspect()
 	assert.Error(t, err)
 
 	m = manifestOCI1FromComponentsLikeFixture([]byte("invalid JSON"))
-	_, err = m.imageInspectInfo()
+	_, err = m.Inspect()
 	assert.Error(t, err)
 }
 

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -97,10 +97,6 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }
 
-func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
-	return inspectManifest(i.genericManifest)
-}
-
 func (i *sourcedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
 	return i.UnparsedImage.LayerInfosForCopy()
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -98,5 +98,5 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 }
 
 func (i *sourcedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
-	return i.UnparsedImage.LayerInfosForCopy()
+	return i.UnparsedImage.src.LayerInfosForCopy()
 }

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -93,10 +93,3 @@ func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 	}
 	return i.cachedSignatures, nil
 }
-
-// LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
-// The Digest field is guaranteed to be provided; Size may be -1.
-// WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *UnparsedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
-	return i.src.LayerInfosForCopy()
-}

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -223,26 +223,18 @@ func (m *Schema1) ToSchema2(diffIDs []digest.Digest) ([]byte, error) {
 	if len(m.History) == 0 {
 		return nil, errors.New("image has no layers")
 	}
-	s2 := struct {
-		Schema2Image
-		ID        string `json:"id,omitempty"`
-		Parent    string `json:"parent,omitempty"`
-		ParentID  string `json:"parent_id,omitempty"`
-		LayerID   string `json:"layer_id,omitempty"`
-		ThrowAway bool   `json:"throwaway,omitempty"`
-		Size      int64  `json:",omitempty"`
-	}{}
+	s1 := Schema2V1Image{}
 	config := []byte(m.History[0].V1Compatibility)
-	err := json.Unmarshal(config, &s2)
+	err := json.Unmarshal(config, &s1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error decoding configuration")
 	}
 	// Images created with versions prior to 1.8.3 require us to re-encode the encoded object,
 	// adding some fields that aren't "omitempty".
-	if s2.DockerVersion != "" && versions.LessThan(s2.DockerVersion, "1.8.3") {
-		config, err = json.Marshal(&s2)
+	if s1.DockerVersion != "" && versions.LessThan(s1.DockerVersion, "1.8.3") {
+		config, err = json.Marshal(&s1)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error re-encoding compat image config %#v", s2)
+			return nil, errors.Wrapf(err, "error re-encoding compat image config %#v", s1)
 		}
 	}
 	// Build the history.
@@ -273,7 +265,7 @@ func (m *Schema1) ToSchema2(diffIDs []digest.Digest) ([]byte, error) {
 	raw := make(map[string]*json.RawMessage)
 	err = json.Unmarshal(config, &raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error re-decoding compat image config %#v: %v", s2)
+		return nil, errors.Wrapf(err, "error re-decoding compat image config %#v: %v", s1)
 	}
 	// Drop some fields.
 	delete(raw, "id")
@@ -298,7 +290,7 @@ func (m *Schema1) ToSchema2(diffIDs []digest.Digest) ([]byte, error) {
 	// Encode the result.
 	config, err = json.Marshal(raw)
 	if err != nil {
-		return nil, errors.Errorf("error re-encoding compat image config %#v: %v", s2, err)
+		return nil, errors.Errorf("error re-encoding compat image config %#v: %v", s1, err)
 	}
 	return config, nil
 }

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -116,6 +116,7 @@ func (m *Schema1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.FSLayers) != len(layerInfos) {
 		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.FSLayers), len(layerInfos))
 	}
+	m.FSLayers = make([]Schema1FSLayers, len(layerInfos))
 	for i, info := range layerInfos {
 		// (docker push) sets up m.History.V1Compatibility->{Id,Parent} based on values of info.Digest,
 		// but (docker pull) ignores them in favor of computing DiffIDs from uncompressed data, except verifying the child->parent links and uniqueness.

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -216,8 +216,8 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 	return i, nil
 }
 
-// ToSchema2 builds a schema2-style configuration blob using the supplied diffIDs.
-func (m *Schema1) ToSchema2(diffIDs []digest.Digest) ([]byte, error) {
+// ToSchema2Config builds a schema2-style configuration blob using the supplied diffIDs.
+func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	// Convert the schema 1 compat info into a schema 2 config, constructing some of the fields
 	// that aren't directly comparable using info from the manifest.
 	if len(m.History) == 0 {
@@ -297,7 +297,7 @@ func (m *Schema1) ToSchema2(diffIDs []digest.Digest) ([]byte, error) {
 
 // ImageID computes an ID which can uniquely identify this image by its contents.
 func (m *Schema1) ImageID(diffIDs []digest.Digest) (string, error) {
-	image, err := m.ToSchema2(diffIDs)
+	image, err := m.ToSchema2Config(diffIDs)
 	if err != nil {
 		return "", err
 	}

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -204,7 +204,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 	}
 	return &types.ImageInspectInfo{
 		Tag:           m.Tag,
-		Created:       s1.Created,
+		Created:       &s1.Created,
 		DockerVersion: s1.DockerVersion,
 		Labels:        make(map[string]string),
 		Architecture:  s1.Architecture,

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -202,15 +202,18 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 	if err := json.Unmarshal([]byte(m.History[0].V1Compatibility), s1); err != nil {
 		return nil, err
 	}
-	return &types.ImageInspectInfo{
+	i := &types.ImageInspectInfo{
 		Tag:           m.Tag,
 		Created:       &s1.Created,
 		DockerVersion: s1.DockerVersion,
-		Labels:        make(map[string]string),
 		Architecture:  s1.Architecture,
 		Os:            s1.OS,
 		Layers:        LayerInfosToStrings(m.LayerInfos()),
-	}, nil
+	}
+	if s1.Config != nil {
+		i.Labels = s1.Config.Labels
+	}
+	return i, nil
 }
 
 // ToSchema2 builds a schema2-style configuration blob using the supplied diffIDs.

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -142,13 +142,6 @@ type Schema2Image struct {
 	History    []Schema2History `json:"history,omitempty"`
 	OSVersion  string           `json:"os.version,omitempty"`
 	OSFeatures []string         `json:"os.features,omitempty"`
-
-	// rawJSON caches the immutable JSON associated with this image.
-	rawJSON []byte
-
-	// computedID is the ID computed from the hash of the image config.
-	// Not to be confused with the legacy V1 ID in V1Image.
-	computedID digest.Digest
 }
 
 // Schema2FromManifest creates a Schema2 manifest instance from a manifest blob.

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -230,7 +230,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 	}
 	i := &types.ImageInspectInfo{
 		Tag:           "",
-		Created:       s2.Created,
+		Created:       &s2.Created,
 		DockerVersion: s2.DockerVersion,
 		Architecture:  s2.Architecture,
 		Os:            s2.OS,

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -95,13 +94,9 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 	}
 	d1 := &Schema2V1Image{}
 	json.Unmarshal(config, d1)
-	created := time.Time{}
-	if v1.Created != nil {
-		created = *v1.Created
-	}
 	i := &types.ImageInspectInfo{
 		Tag:           "",
-		Created:       created,
+		Created:       v1.Created,
 		DockerVersion: d1.DockerVersion,
 		Labels:        v1.Config.Labels,
 		Architecture:  v1.Architecture,

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -442,6 +442,8 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 	case *manifest.Schema2, *manifest.OCI1:
 		// We know the ID calculation for these formats doesn't actually use the diffIDs,
 		// so we don't need to populate the diffID list.
+	default:
+		return ""
 	}
 	id, err := m.ImageID(diffIDs)
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -566,9 +566,9 @@ func (s *storageImageDestination) Commit() error {
 	// If one of those blobs was a configuration blob, then we can try to dig out the date when the image
 	// was originally created, in case we're just copying it.  If not, no harm done.
 	options := &storage.ImageOptions{}
-	if inspect, err := man.Inspect(s.getConfigBlob); err == nil {
+	if inspect, err := man.Inspect(s.getConfigBlob); err == nil && inspect.Created != nil {
 		logrus.Debugf("setting image creation date to %s", inspect.Created)
-		options.CreationDate = inspect.Created
+		options.CreationDate = *inspect.Created
 	}
 	if manifestDigest, err := manifest.Digest(s.manifest); err == nil {
 		options.Digest = manifestDigest

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -412,17 +412,11 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 	// fill in the DiffIDs.  It's expected (but not enforced by us) that the number of
 	// diffIDs corresponds to the number of non-EmptyLayer entries in the history.
 	var diffIDs []digest.Digest
-	switch m.(type) {
+	switch m := m.(type) {
 	case *manifest.Schema1:
 		// Build a list of the diffIDs we've generated for the non-throwaway FS layers,
 		// in reverse of the order in which they were originally listed.
-		s1, ok := m.(*manifest.Schema1)
-		if !ok {
-			// Shouldn't happen
-			logrus.Debugf("internal error reading schema 1 manifest")
-			return ""
-		}
-		for i, history := range s1.History {
+		for i, history := range m.History {
 			compat := manifest.Schema1V1Compatibility{}
 			if err := json.Unmarshal([]byte(history.V1Compatibility), &compat); err != nil {
 				logrus.Debugf("internal error reading schema 1 history: %v", err)
@@ -431,7 +425,7 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 			if compat.ThrowAway {
 				continue
 			}
-			blobSum := s1.FSLayers[i].BlobSum
+			blobSum := m.FSLayers[i].BlobSum
 			diffID, ok := s.blobDiffIDs[blobSum]
 			if !ok {
 				logrus.Infof("error looking up diffID for layer %q", blobSum.String())

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -51,8 +51,6 @@ type storageImageSource struct {
 }
 
 type storageImageDestination struct {
-	image          types.ImageCloser
-	systemContext  *types.SystemContext
 	imageRef       storageReference                // The reference we'll use to name the image
 	publicRef      storageReference                // The reference we return when asked about the name we'll give to the image
 	directory      string                          // Temporary directory where we store blobs until Commit() time
@@ -253,7 +251,6 @@ func newImageDestination(ctx *types.SystemContext, imageRef storageReference) (*
 	publicRef := imageRef
 	publicRef.name = nil
 	image := &storageImageDestination{
-		systemContext:  ctx,
 		imageRef:       imageRef,
 		publicRef:      publicRef,
 		directory:      directory,

--- a/types/types.go
+++ b/types/types.go
@@ -292,7 +292,7 @@ type ManifestUpdateInformation struct {
 // for other manifest types.
 type ImageInspectInfo struct {
 	Tag           string
-	Created       time.Time
+	Created       *time.Time
 	DockerVersion string
 	Labels        map[string]string
 	Architecture  string

--- a/types/types.go
+++ b/types/types.go
@@ -215,10 +215,6 @@ type UnparsedImage interface {
 	Manifest() ([]byte, string, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures(ctx context.Context) ([][]byte, error)
-	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
-	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
-	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy() ([]BlobInfo, error)
 }
 
 // Image is the primary API for inspecting properties of images.
@@ -242,6 +238,10 @@ type Image interface {
 	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []BlobInfo
+	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
+	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+	// WARNING: The list may contain duplicates, and they are semantically relevant.
+	LayerInfosForCopy() ([]BlobInfo, error)
 	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
 	// It returns false if the manifest does not embed a Docker reference.
 	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)


### PR DESCRIPTION
This is a set of quite independent cleanups and minor bug fixes on top of #305 .  Notably resolves #413, and adds tests for the schema1 code to decrease risk of similar breakage in the future.

See individual commit messages for more details. I’ll be happy to break this up into several PRs if any part needs more discussion than others.

Cc: @nalind 

- Simplify `types.Image.Inspect` call chain
- Make `ImageInspectInfo.Created` optional
- Move `LayerInfosForCopy` from `UnparsedImage` to `Image`/`sourcedImage`
- Populate labels in `manifest.Schema1.Inspect`
- Clean up manifest types
- Return `""` in `computeID` for unknown manifest types
- Instead of a type switch + cast + error, let the type switch do the conversion
- Rename `manifest.Schema1.ToSchema2` to `ToSchema2Config`
- Load a `*storage.Image` only once in `storageImageSource`
- Drop unused `storageImageDestination.{image,systemContext}`
- Create a new slice in `Schema1.UpdateLayerInfos`
- Add tests for `image.manifestSchema1`
