### PR TITLE
copy: handle text/plain from manifest source

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -46,6 +46,7 @@ func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMEType
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
+	srcType = manifest.NormalizedMIMEType(srcType)
 
 	if forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}


### PR DESCRIPTION
This will make sure to default to v2s1 if we receive text/plain from misbehaving registries

@nalind @mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>