### PR TITLE
Normalize source manifest MIME type before determining possible conversions

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -46,6 +46,11 @@ func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMEType
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
+	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
+	if srcType != normalizedSrcType {
+		logrus.Debugf("Source manifest MIME type %s, treating it as %s", srcType, normalizedSrcType)
+		srcType = normalizedSrcType
+	}
 
 	if forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -138,3 +138,25 @@ func TestMIMETypeIsMultiImage(t *testing.T) {
 		assert.Equal(t, c.expected, res, c.mt)
 	}
 }
+
+func TestNormalizedMIMEType(t *testing.T) {
+	for _, c := range []string{ // Valid MIME types, normalized to themselves
+		DockerV2Schema1MediaType,
+		DockerV2Schema1SignedMediaType,
+		DockerV2Schema2MediaType,
+		DockerV2ListMediaType,
+		imgspecv1.MediaTypeImageManifest,
+	} {
+		res := NormalizedMIMEType(c)
+		assert.Equal(t, c, res, c)
+	}
+	for _, c := range []string{
+		"application/json",
+		"text/plain",
+		"not at all a valid MIME type",
+		"",
+	} {
+		res := NormalizedMIMEType(c)
+		assert.Equal(t, DockerV2Schema1SignedMediaType, res, c)
+	}
+}


### PR DESCRIPTION
Without this, images from misguided registries which return `text/plain` for s1 were treated as needing conversion to any MIME-type-restricted destination (and choosing to convert to the destination's preferred type, usually s2).

Now, if the destination accepts s1, we treat `text/plain` equivalently to specifying s1, and do no conversion.
