### PR TITLE
Remove .tar extension from blob and config file names

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const version = "Directory Transport Version: 1.0\n"
+const version = "Directory Transport Version: 1.1\n"
 
 // ErrNotContainerImageDir indicates that the directory doesn't match the expected contents of a directory created
 // using the 'dir' transport

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -52,11 +52,11 @@ func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, str
 func (s *dirImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(info.Digest))
 	if err != nil {
-		return nil, 0, nil
+		return nil, -1, err
 	}
 	fi, err := r.Stat()
 	if err != nil {
-		return nil, 0, nil
+		return nil, -1, err
 	}
 	return r, fi.Size(), nil
 }

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -5,14 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -173,7 +172,7 @@ func (ref dirReference) manifestPath() string {
 // layerPath returns a path for a layer tarball within a directory using our conventions.
 func (ref dirReference) layerPath(digest digest.Digest) string {
 	// FIXME: Should we keep the digest identification?
-	return filepath.Join(ref.path, digest.Hex()+".tar")
+	return filepath.Join(ref.path, digest.Hex())
 }
 
 // signaturePath returns a path for a signature within a directory using our conventions.

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -220,7 +220,7 @@ func TestReferenceLayerPath(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	dirRef, ok := ref.(dirReference)
 	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/"+hex+".tar", dirRef.layerPath("sha256:"+hex))
+	assert.Equal(t, tmpDir+"/"+hex, dirRef.layerPath("sha256:"+hex))
 }
 
 func TestReferenceSignaturePath(t *testing.T) {


### PR DESCRIPTION
The config file was being saved as digest.tar for the directory transport.
This is misleading as the config file is not a tar archive.
Dropped the .tar extension from all files now, including blobs.
The user can use a tool like file to determine the format of the files in the directory.

Fixes issue https://github.com/projectatomic/buildah/issues/481

Signed-off-by: umohnani8 <umohnani@redhat.com>