### PR TITLE
Improve docker/* error messages

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -495,7 +495,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		defer resp.Body.Close()
 		logrus.Debugf("Ping %s status %d", url, resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-			return errors.Errorf("error pinging repository, response code %d", resp.StatusCode)
+			return errors.Errorf("error pinging registry %s, response code %d", c.registry, resp.StatusCode)
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme
@@ -547,7 +547,7 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, client.HandleErrorResponse(res)
+		return nil, errors.Wrapf(client.HandleErrorResponse(res), "Error downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
 	}
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -95,7 +95,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, "", client.HandleErrorResponse(res)
+		return nil, "", errors.Wrapf(client.HandleErrorResponse(res), "Error reading manifest %s in %s", tagOrDigest, s.ref.ref.Name())
 	}
 	manblob, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
especially focus on those from `client.HandleErrorResponse`, which may be very unhelpful, e.g. `"unknown: Not Found"`.

In general, make sure the error includes an expanded Docker reference, or a full URL, or a hostname + path.


Examples:
```console
$ ./skopeo-old inspect docker://www.example.com/busybox
FATA[0001] pinging docker registry returned: error pinging repository, response code 404 
$ ./skopeo inspect docker://www.example.com/busybox
FATA[0001] pinging docker registry returned: error pinging registry www.example.com, response code 404
```
```console
$ ./skopeo-old --override-os linux --policy default-policy.json copy docker://busybox:latest docker://busybox:thisisnotpermitted
…
FATA[0005] Error writing manifest: Error uploading manifest to /v2/library/busybox/manifests/thisisnotpermitted: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
$ ./skopeo --override-os linux --policy default-policy.json copy docker://busybox:latest docker://busybox:thisisnotpermitted
…
FATA[0005] Error writing manifest: Error uploading manifest thisisnotpermitted to docker.io/library/busybox: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```
```console
$ ./skopeo-old --override-os linux --policy default-policy.json copy docker://alpine:latest docker://busybox:thisisnotpermitted
…
FATA[0005] Error writing blob: Error initiating layer upload to /v2/library/busybox/blobs/uploads/: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
$ ./skopeo --override-os linux --policy default-policy.json copy docker://alpine:latest docker://busybox:thisisnotpermitted
…
FATA[0005] Error writing blob: Error initiating layer upload to /v2/library/busybox/blobs/uploads/ in registry-1.docker.io: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```
```console
$ ./skopeo-old inspect docker://busybox:thisdoesnotexist
FATA[0001] manifest unknown: manifest unknown           
$ ./skopeo inspect docker://busybox:thisdoesnotexist
FATA[0001] Error reading manifest thisdoesnotexist in docker.io/library/busybox: manifest unknown: manifest unknown 
```
