### PR TITLE
ostree: provide DockerReference when the image is fully qualified

### DIFF
--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -142,6 +142,13 @@ func (ref ostreeReference) StringWithinTransport() string {
 // (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
 // not e.g. after redirect or alias processing), or nil if unknown/not applicable.
 func (ref ostreeReference) DockerReference() reference.Named {
+	img, err := reference.ParseNormalizedNamed(ref.image)
+	if err != nil {
+		return nil
+	}
+	if !reference.IsNameOnly(img) {
+		return img
+	}
 	return nil
 }
 

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/image/docker/reference"
 	_ "github.com/containers/image/internal/testing/explicitfilepath-tmpdir"
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
@@ -185,7 +186,9 @@ func TestReferenceDockerReference(t *testing.T) {
 		ref, err := Transport.ParseReference(withTmpDir(c.input, tmpDir))
 		require.NoError(t, err, c.input)
 		dockerRef := ref.DockerReference()
-		assert.Nil(t, dockerRef, c.input)
+		if dockerRef != nil {
+			assert.False(t, reference.IsNameOnly(dockerRef))
+		}
 	}
 }
 


### PR DESCRIPTION
skopeo copy "--sign-by=" will work after this change when ostree is used
as a destination.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>