### PR TITLE
Support gzip for docker-archive files

### DIFF
--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -13,26 +13,24 @@ type archiveImageSource struct {
 
 // newImageSource returns a types.ImageSource for the specified image reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref archiveReference) types.ImageSource {
+func newImageSource(ctx *types.SystemContext, ref archiveReference) (types.ImageSource, error) {
 	if ref.destinationRef != nil {
 		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
 	}
-	src := tarfile.NewSource(ref.path)
+	src, err := tarfile.NewSourceFromFile(ref.path)
+	if err != nil {
+		return nil, err
+	}
 	return &archiveImageSource{
 		Source: src,
 		ref:    ref,
-	}
+	}, nil
 }
 
 // Reference returns the reference used to set up this source, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *archiveImageSource) Reference() types.ImageReference {
 	return s.ref
-}
-
-// Close removes resources associated with an initialized ImageSource, if any.
-func (s *archiveImageSource) Close() error {
-	return nil
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -131,14 +131,17 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src := newImageSource(ctx, ref)
+	src, err := newImageSource(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	return ctrImage.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref archiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref), nil
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -1,12 +1,7 @@
 package daemon
 
 import (
-	"io"
-	"io/ioutil"
-	"os"
-
 	"github.com/containers/image/docker/tarfile"
-	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -15,7 +10,6 @@ import (
 type daemonImageSource struct {
 	ref             daemonReference
 	*tarfile.Source // Implements most of types.ImageSource
-	tarCopyPath     string
 }
 
 type layerInfo struct {
@@ -45,29 +39,13 @@ func newImageSource(ctx *types.SystemContext, ref daemonReference) (types.ImageS
 	}
 	defer inputStream.Close()
 
-	// FIXME: use SystemContext here.
-	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-daemon-tar")
+	src, err := tarfile.NewSourceFromStream(inputStream)
 	if err != nil {
 		return nil, err
 	}
-	defer tarCopyFile.Close()
-
-	succeeded := false
-	defer func() {
-		if !succeeded {
-			os.Remove(tarCopyFile.Name())
-		}
-	}()
-
-	if _, err := io.Copy(tarCopyFile, inputStream); err != nil {
-		return nil, err
-	}
-
-	succeeded = true
 	return &daemonImageSource{
-		ref:         ref,
-		Source:      tarfile.NewSource(tarCopyFile.Name()),
-		tarCopyPath: tarCopyFile.Name(),
+		ref:    ref,
+		Source: src,
 	}, nil
 }
 
@@ -75,11 +53,6 @@ func newImageSource(ctx *types.SystemContext, ref daemonReference) (types.ImageS
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *daemonImageSource) Reference() types.ImageReference {
 	return s.ref
-}
-
-// Close removes resources associated with an initialized ImageSource, if any.
-func (s *daemonImageSource) Close() error {
-	return os.Remove(s.tarCopyPath)
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -3,6 +3,7 @@ package tarfile
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/types"
@@ -19,7 +21,8 @@ import (
 
 // Source is a partial implementation of types.ImageSource for reading from tarPath.
 type Source struct {
-	tarPath string
+	tarPath              string
+	removeTarPathOnClose bool // Remove temp file on close if true
 	// The following data is only available after ensureCachedDataIsPresent() succeeds
 	tarManifest       *ManifestItem // nil if not available yet.
 	configBytes       []byte
@@ -35,14 +38,58 @@ type layerInfo struct {
 	size int64
 }
 
-// NewSource returns a tarfile.Source for the specified path.
-func NewSource(path string) *Source {
-	// TODO: We could add support for multiple images in a single archive, so
-	//       that people could use docker-archive:opensuse.tar:opensuse:leap as
-	//       the source of an image.
-	return &Source{
-		tarPath: path,
+// TODO: We could add support for multiple images in a single archive, so
+//       that people could use docker-archive:opensuse.tar:opensuse:leap as
+//       the source of an image.
+// 	To do for both the NewSourceFromFile and NewSourceFromStream functions
+
+// NewSourceFromFile returns a tarfile.Source for the specified path
+// NewSourceFromFile supports both conpressed and uncompressed input
+func NewSourceFromFile(path string) (*Source, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error opening file %q", path)
 	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return &Source{
+			tarPath: path,
+		}, nil
+	}
+	defer reader.Close()
+
+	return NewSourceFromStream(reader)
+}
+
+// NewSourceFromStream returns a tarfile.Source for the specified inputStream, which must be uncompressed.
+// The caller can close the inputStream immediately after NewSourceFromFile returns.
+func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
+	// FIXME: use SystemContext here.
+	// Save inputStream to a temporary file
+	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-tar")
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating temporary file")
+	}
+	defer tarCopyFile.Close()
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			os.Remove(tarCopyFile.Name())
+		}
+	}()
+
+	if _, err := io.Copy(tarCopyFile, inputStream); err != nil {
+		return nil, errors.Wrapf(err, "error copying contents to temporary file %q", tarCopyFile.Name())
+	}
+	succeeded = true
+
+	return &Source{
+		tarPath:              tarCopyFile.Name(),
+		removeTarPathOnClose: true,
+	}, nil
 }
 
 // tarReadCloser is a way to close the backing file of a tar.Reader when the user no longer needs the tar component.
@@ -187,6 +234,14 @@ func (s *Source) loadTarManifest() ([]ManifestItem, error) {
 		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
 	}
 	return items, nil
+}
+
+// Close removes resources associated with an initialized Source, if any.
+func (s *Source) Close() error {
+	if s.removeTarPathOnClose {
+		return os.Remove(s.tarPath)
+	}
+	return nil
 }
 
 // LoadTarManifest loads and decodes the manifest.json


### PR DESCRIPTION
The docker-archive transport pulls in images from tar file
but would fail if the tar file was compressed using gzip.
This adds the functionality of detecting whether the file is
compressed, and if it is the contents are copied to a temp
uncompressed file.
This was supported for the docker-daemon transport, so moving
that functionality to tarfile/src.go for both docker-archive
and docker-daemon.

Signed-off-by: umohnani8 <umohnani@redhat.com>