### PR TITLE
#305 cleanup 2: Reference handling

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -347,6 +347,9 @@ func checkImageDestinationForCurrentRuntimeOS(ctx context.Context, sys *types.Sy
 
 // updateEmbeddedDockerReference handles the Docker reference embedded in Docker schema1 manifests.
 func (ic *imageCopier) updateEmbeddedDockerReference() error {
+	if ic.c.dest.IgnoresEmbeddedDockerReference() {
+		return nil // Destination would prefer us not to update the embedded reference.
+	}
 	destRef := ic.c.dest.Reference().DockerReference()
 	if destRef == nil {
 		return nil // Destination does not care about Docker references

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -117,6 +117,13 @@ func (d *dirImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *dirImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -95,6 +95,13 @@ func (d *dockerImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *dockerImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // We do want the manifest updated; older registry versions refuse manifests if the embedded reference does not match.
+}
+
 // sizeCounter is an io.Writer which only counts the total size of its input.
 type sizeCounter struct{ size int64 }
 

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -75,6 +75,13 @@ func (d *Destination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *Destination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -386,6 +386,9 @@ func (d *memoryImageDest) AcceptsForeignLayerURLs() bool {
 func (d *memoryImageDest) MustMatchRuntimeOS() bool {
 	panic("Unexpected call to a mock function")
 }
+func (d *memoryImageDest) IgnoresEmbeddedDockerReference() bool {
+	panic("Unexpected call to a mock function")
+}
 func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	if d.storedBlobs == nil {
 		d.storedBlobs = make(map[digest.Digest][]byte)

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -70,6 +70,13 @@ func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
 	return d.unpackedDest.MustMatchRuntimeOS()
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ociArchiveImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.unpackedDest.IgnoresEmbeddedDockerReference()
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -95,6 +95,13 @@ func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -369,6 +369,13 @@ func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *openshiftImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.docker.IgnoresEmbeddedDockerReference()
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -125,6 +125,13 @@ func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (d *ostreeImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return false // N/A, DockerReference() returns nil.
+}
+
 func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -703,6 +703,13 @@ func (s *storageImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }
 
+// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (s *storageImageDestination) IgnoresEmbeddedDockerReference() bool {
+	return true // Yes, we want the unmodified manifest
+}
+
 // PutSignatures records the image's signatures for committing as a single data blob.
 func (s *storageImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	sizes := []int{}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -248,6 +248,7 @@ func newImageDestination(imageRef storageReference) (*storageImageDestination, e
 	// digest, and that makes the image unusable if we subsequently try to access it using a
 	// reference that mentions the no-longer-correct digest.
 	publicRef := imageRef
+	publicRef.breakDockerReference = true // FIXME: this does not change .StringWithinTransport(), but modifies DockerReference()
 	publicRef.name = nil
 	image := &storageImageDestination{
 		imageRef:       imageRef,

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -613,7 +613,7 @@ func (s *storageImageDestination) Commit(ctx context.Context) error {
 	if name := s.imageRef.DockerReference(); len(oldNames) > 0 || name != nil {
 		names := []string{}
 		if name != nil {
-			names = append(names, verboseName(name))
+			names = append(names, name.String())
 		}
 		if len(oldNames) > 0 {
 			names = append(names, oldNames...)

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -249,7 +249,6 @@ func newImageDestination(imageRef storageReference) (*storageImageDestination, e
 	// reference that mentions the no-longer-correct digest.
 	publicRef := imageRef
 	publicRef.breakDockerReference = true // FIXME: this does not change .StringWithinTransport(), but modifies DockerReference()
-	publicRef.name = nil
 	image := &storageImageDestination{
 		imageRef:       imageRef,
 		publicRef:      publicRef,

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -50,8 +50,7 @@ type storageImageSource struct {
 }
 
 type storageImageDestination struct {
-	imageRef       storageReference                // The reference we'll use to name the image
-	publicRef      storageReference                // The reference we return when asked about the name we'll give to the image
+	imageRef       storageReference
 	directory      string                          // Temporary directory where we store blobs until Commit() time
 	nextTempFileID int32                           // A counter that we use for computing filenames to assign to blobs
 	manifest       []byte                          // Manifest contents, temporary
@@ -243,15 +242,8 @@ func newImageDestination(imageRef storageReference) (*storageImageDestination, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
 	}
-	// Break reading of the reference we're writing, so that copy.Image() won't try to rewrite
-	// schema1 image manifests to remove embedded references, since that changes the manifest's
-	// digest, and that makes the image unusable if we subsequently try to access it using a
-	// reference that mentions the no-longer-correct digest.
-	publicRef := imageRef
-	publicRef.breakDockerReference = true // FIXME: this does not change .StringWithinTransport(), but modifies DockerReference()
 	image := &storageImageDestination{
 		imageRef:       imageRef,
-		publicRef:      publicRef,
 		directory:      directory,
 		blobDiffIDs:    make(map[digest.Digest]digest.Digest),
 		fileSizes:      make(map[digest.Digest]int64),
@@ -261,11 +253,10 @@ func newImageDestination(imageRef storageReference) (*storageImageDestination, e
 	return image, nil
 }
 
-// Reference returns a mostly-usable image reference that can't return a DockerReference, to
-// avoid triggering logic in copy.Image() that rewrites schema 1 image manifests in order to
-// remove image names that they contain which don't match the value we're using.
+// Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
+// e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
 func (s storageImageDestination) Reference() types.ImageReference {
-	return s.publicRef
+	return s.imageRef
 }
 
 // Close cleans up the temporary directory.

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -16,6 +16,7 @@ import (
 // A storageReference holds an arbitrary name and/or an ID, which is a 32-byte
 // value hex-encoded into a 64-character string, and a reference to a Store
 // where an image is, or would be, kept.
+// Either "named" or "id" must be set.
 type storageReference struct {
 	transport            storageTransport
 	named                reference.Named // may include a tag and/or a digest
@@ -23,7 +24,10 @@ type storageReference struct {
 	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
 }
 
-func newReference(transport storageTransport, named reference.Named, id string) *storageReference {
+func newReference(transport storageTransport, named reference.Named, id string) (*storageReference, error) {
+	if named == nil && id == "" {
+		return nil, ErrInvalidReference
+	}
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
@@ -32,7 +36,7 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 		transport: transport,
 		named:     named,
 		id:        id,
-	}
+	}, nil
 }
 
 // imageMatchesRepo returns true iff image.Names contains an element with the same repo as ref

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -23,12 +23,11 @@ type storageReference struct {
 	reference            string
 	id                   string
 	name                 reference.Named
-	tag                  string
 	digest               digest.Digest
 	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
 }
 
-func newReference(transport storageTransport, completeReference reference.Named, reference, id string, name reference.Named, tag string, digest digest.Digest) *storageReference {
+func newReference(transport storageTransport, completeReference reference.Named, reference, id string, name reference.Named, digest digest.Digest) *storageReference {
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
@@ -39,7 +38,6 @@ func newReference(transport storageTransport, completeReference reference.Named,
 		reference:         reference,
 		id:                id,
 		name:              name,
-		tag:               tag,
 		digest:            digest,
 	}
 }

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -23,11 +22,10 @@ type storageReference struct {
 	reference            string
 	id                   string
 	name                 reference.Named
-	digest               digest.Digest
 	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
 }
 
-func newReference(transport storageTransport, completeReference reference.Named, reference, id string, name reference.Named, digest digest.Digest) *storageReference {
+func newReference(transport storageTransport, completeReference reference.Named, reference, id string, name reference.Named) *storageReference {
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
@@ -38,7 +36,6 @@ func newReference(transport storageTransport, completeReference reference.Named,
 		reference:         reference,
 		id:                id,
 		name:              name,
-		digest:            digest,
 	}
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -156,6 +156,11 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 			// The reference without the ID is also a valid namespace.
 			namespaces = append(namespaces, storeSpec+s.named.String())
 		}
+		tagged, isTagged := s.named.(reference.Tagged)
+		_, isDigested := s.named.(reference.Digested)
+		if isTagged && isDigested { // s.named is "name:tag@digest"; add a "name:tag" parent namespace.
+			namespaces = append(namespaces, storeSpec+s.named.Name()+":"+tagged.Tag())
+		}
 		components := strings.Split(s.named.Name(), "/")
 		for len(components) > 0 {
 			namespaces = append(namespaces, storeSpec+strings.Join(components, "/"))

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -18,10 +18,9 @@ import (
 // where an image is, or would be, kept.
 // Either "named" or "id" must be set.
 type storageReference struct {
-	transport            storageTransport
-	named                reference.Named // may include a tag and/or a digest
-	id                   string
-	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
+	transport storageTransport
+	named     reference.Named // may include a tag and/or a digest
+	id        string
 }
 
 func newReference(transport storageTransport, named reference.Named, id string) (*storageReference, error) {
@@ -113,9 +112,6 @@ func (s storageReference) Transport() types.ImageTransport {
 
 // Return a name with a tag or digest, if we have either, else return it bare.
 func (s storageReference) DockerReference() reference.Named {
-	if s.breakDockerReference {
-		return nil
-	}
 	return s.named
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -117,8 +117,8 @@ func (s storageReference) DockerReference() reference.Named {
 		return nil
 	}
 	name := s.name
-	if s.tag != "" {
-		if namedTagged, err := reference.WithTag(name, s.tag); err == nil {
+	if tagged, ok := s.completeReference.(reference.Tagged); ok {
+		if namedTagged, err := reference.WithTag(name, tagged.Tag()); err == nil {
 			name = namedTagged
 		}
 	}

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -167,6 +167,10 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 	driverlessStoreSpec := "[" + s.transport.store.GraphRoot() + "]"
 	namespaces := []string{}
 	if s.name != nil {
+		if s.id != "" {
+			// The reference without the ID is also a valid namespace.
+			namespaces = append(namespaces, storeSpec+s.reference)
+		}
 		name := reference.TrimNamed(s.name)
 		components := strings.Split(name.String(), "/")
 		for len(components) > 0 {

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -21,11 +21,10 @@ type storageReference struct {
 	completeReference    reference.Named // may include a tag and/or a digest
 	reference            string
 	id                   string
-	name                 reference.Named // May include a tag, not a digest
-	breakDockerReference bool            // Possibly set by newImageDestination.  FIXME: Figure out another way.
+	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
 }
 
-func newReference(transport storageTransport, completeReference reference.Named, reference, id string, name reference.Named) *storageReference {
+func newReference(transport storageTransport, completeReference reference.Named, reference, id string) *storageReference {
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
@@ -35,7 +34,6 @@ func newReference(transport storageTransport, completeReference reference.Named,
 		completeReference: completeReference,
 		reference:         reference,
 		id:                id,
-		name:              name,
 	}
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -55,7 +55,7 @@ func imageMatchesRepo(image *storage.Image, ref reference.Named) bool {
 func (s *storageReference) resolveImage() (*storage.Image, error) {
 	if s.id == "" {
 		// Look for an image that has the expanded reference name as an explicit Name value.
-		image, err := s.transport.store.Image(s.reference)
+		image, err := s.transport.store.Image(s.completeReference.String())
 		if image != nil && err == nil {
 			s.id = image.ID
 		}
@@ -121,13 +121,13 @@ func (s storageReference) StringWithinTransport() string {
 		optionsList = ":" + strings.Join(options, ",")
 	}
 	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
-	if s.reference == "" {
+	if s.completeReference == nil {
 		return storeSpec + "@" + s.id
 	}
 	if s.id == "" {
-		return storeSpec + s.reference
+		return storeSpec + s.completeReference.String()
 	}
-	return storeSpec + s.reference + "@" + s.id
+	return storeSpec + s.completeReference.String() + "@" + s.id
 }
 
 func (s storageReference) PolicyConfigurationIdentity() string {
@@ -136,9 +136,9 @@ func (s storageReference) PolicyConfigurationIdentity() string {
 		return storeSpec + "@" + s.id
 	}
 	if s.id == "" {
-		return storeSpec + s.reference
+		return storeSpec + s.completeReference.String()
 	}
-	return storeSpec + s.reference + "@" + s.id
+	return storeSpec + s.completeReference.String() + "@" + s.id
 }
 
 // Also accept policy that's tied to the combination of the graph root and
@@ -152,7 +152,7 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 	if s.completeReference != nil {
 		if s.id != "" {
 			// The reference without the ID is also a valid namespace.
-			namespaces = append(namespaces, storeSpec+s.reference)
+			namespaces = append(namespaces, storeSpec+s.completeReference.String())
 		}
 		components := strings.Split(s.completeReference.Name(), "/")
 		for len(components) > 0 {

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -122,25 +122,25 @@ func (s storageReference) StringWithinTransport() string {
 	if len(options) > 0 {
 		optionsList = ":" + strings.Join(options, ",")
 	}
-	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
-	if s.named == nil {
-		return storeSpec + "@" + s.id
+	res := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "+" + s.transport.store.RunRoot() + optionsList + "]"
+	if s.named != nil {
+		res = res + s.named.String()
 	}
-	if s.id == "" {
-		return storeSpec + s.named.String()
+	if s.id != "" {
+		res = res + "@" + s.id
 	}
-	return storeSpec + s.named.String() + "@" + s.id
+	return res
 }
 
 func (s storageReference) PolicyConfigurationIdentity() string {
-	storeSpec := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
-	if s.named == nil {
-		return storeSpec + "@" + s.id
+	res := "[" + s.transport.store.GraphDriverName() + "@" + s.transport.store.GraphRoot() + "]"
+	if s.named != nil {
+		res = res + s.named.String()
 	}
-	if s.id == "" {
-		return storeSpec + s.named.String()
+	if s.id != "" {
+		res = res + "@" + s.id
 	}
-	return storeSpec + s.named.String() + "@" + s.id
+	return res
 }
 
 // Also accept policy that's tied to the combination of the graph root and

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -116,19 +116,18 @@ func (s storageReference) DockerReference() reference.Named {
 	if s.name == nil {
 		return nil
 	}
+	name := s.name
 	if s.tag != "" {
-		if namedTagged, err := reference.WithTag(s.name, s.tag); err == nil {
-			return namedTagged
+		if namedTagged, err := reference.WithTag(name, s.tag); err == nil {
+			name = namedTagged
 		}
 	}
 	if s.digest != "" {
-		if canonical, err := reference.WithDigest(s.name, s.digest); err == nil {
-			return canonical
+		if canonical, err := reference.WithDigest(name, s.digest); err == nil {
+			name = canonical
 		}
 	}
-	// FIXME: This should never happen, ParseStoreReference sets name = reference.TagNameOnly(name) if s.digest == ""
-	// FIXME: This also violates the DockerReference contract.
-	return s.name
+	return name
 }
 
 // Return a name with a tag, prefixed with the graph root and driver name, to

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -110,21 +110,7 @@ func (s storageReference) DockerReference() reference.Named {
 	if s.breakDockerReference {
 		return nil
 	}
-	if s.completeReference == nil {
-		return nil
-	}
-	name := s.completeReference
-	if tagged, ok := s.completeReference.(reference.Tagged); ok {
-		if namedTagged, err := reference.WithTag(name, tagged.Tag()); err == nil {
-			name = namedTagged
-		}
-	}
-	if digested, ok := s.completeReference.(reference.Digested); ok {
-		if canonical, err := reference.WithDigest(name, digested.Digest()); err == nil {
-			name = canonical
-		}
-	}
-	return name
+	return s.completeReference
 }
 
 // Return a name with a tag, prefixed with the graph root and driver name, to

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -123,6 +123,8 @@ func (s storageReference) DockerReference() reference.Named {
 			return canonical
 		}
 	}
+	// FIXME: This should never happen, ParseStoreReference sets name = reference.TagNameOnly(name) if s.digest == ""
+	// FIXME: This also violates the DockerReference contract.
 	return s.name
 }
 

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -19,12 +19,11 @@ import (
 type storageReference struct {
 	transport            storageTransport
 	completeReference    reference.Named // may include a tag and/or a digest
-	reference            string
 	id                   string
 	breakDockerReference bool // Possibly set by newImageDestination.  FIXME: Figure out another way.
 }
 
-func newReference(transport storageTransport, completeReference reference.Named, reference, id string) *storageReference {
+func newReference(transport storageTransport, completeReference reference.Named, id string) *storageReference {
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by
@@ -32,7 +31,6 @@ func newReference(transport storageTransport, completeReference reference.Named,
 	return &storageReference{
 		transport:         transport,
 		completeReference: completeReference,
-		reference:         reference,
 		id:                id,
 	}
 }

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -57,12 +57,12 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		// that the canonical reference can be implicitly resolved to the image.
 		images, err := s.transport.store.ImagesByDigest(s.digest)
 		if images != nil && err == nil {
-			repo := reference.FamiliarName(reference.TrimNamed(s.name))
+			repo := reference.FamiliarName(s.name)
 		search:
 			for _, image := range images {
 				for _, name := range image.Names {
 					if named, err := reference.ParseNormalizedNamed(name); err == nil {
-						if reference.FamiliarName(reference.TrimNamed(named)) == repo {
+						if reference.FamiliarName(named) == repo {
 							s.id = image.ID
 							break search
 						}
@@ -80,11 +80,11 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		return nil, errors.Wrapf(err, "error reading image %q", s.id)
 	}
 	if s.name != nil {
-		repo := reference.FamiliarName(reference.TrimNamed(s.name))
+		repo := reference.FamiliarName(s.name)
 		nameMatch := false
 		for _, name := range img.Names {
 			if named, err := reference.ParseNormalizedNamed(name); err == nil {
-				if reference.FamiliarName(reference.TrimNamed(named)) == repo {
+				if reference.FamiliarName(named) == repo {
 					nameMatch = true
 					break
 				}
@@ -171,8 +171,7 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 			// The reference without the ID is also a valid namespace.
 			namespaces = append(namespaces, storeSpec+s.reference)
 		}
-		name := reference.TrimNamed(s.name)
-		components := strings.Split(name.String(), "/")
+		components := strings.Split(s.name.Name(), "/")
 		for len(components) > 0 {
 			namespaces = append(namespaces, storeSpec+strings.Join(components, "/"))
 			components = components[:len(components)-1]

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -57,12 +57,12 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		// that the canonical reference can be implicitly resolved to the image.
 		images, err := s.transport.store.ImagesByDigest(s.digest)
 		if images != nil && err == nil {
-			repo := reference.FamiliarName(s.name)
+			repo := s.name.Name()
 		search:
 			for _, image := range images {
 				for _, name := range image.Names {
 					if named, err := reference.ParseNormalizedNamed(name); err == nil {
-						if reference.FamiliarName(named) == repo {
+						if named.Name() == repo {
 							s.id = image.ID
 							break search
 						}
@@ -80,11 +80,11 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		return nil, errors.Wrapf(err, "error reading image %q", s.id)
 	}
 	if s.name != nil {
-		repo := reference.FamiliarName(s.name)
+		repo := s.name.Name()
 		nameMatch := false
 		for _, name := range img.Names {
 			if named, err := reference.ParseNormalizedNamed(name); err == nil {
-				if reference.FamiliarName(named) == repo {
+				if named.Name() == repo {
 					nameMatch = true
 					break
 				}

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -61,7 +61,7 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex,
-		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+		[]string{"docker.io/library/busybox:notlatest", "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 	{
 		"busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, "docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex,
@@ -69,8 +69,7 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex,
-		// FIXME: After …/busybox:tag@digest, there should be a …/busybox:tag, only then a plain …/busybox
-		[]string{"docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox", "docker.io/library", "docker.io"},
+		[]string{"docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox:notlatest", "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 }
 

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -40,8 +40,7 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox@" + sha256digestHex, "docker.io/library/busybox:latest", "docker.io/library/busybox:latest@" + sha256digestHex,
-		// FIXME: This should start with …/busybox:latest
-		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+		[]string{"docker.io/library/busybox:latest", "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 	{
 		"busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex,
@@ -49,8 +48,7 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox:notlatest@" + sha256digestHex, "docker.io/library/busybox:notlatest", "docker.io/library/busybox:notlatest@" + sha256digestHex,
-		// FIXME: This should start with …/busybox:notlatest
-		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+		[]string{"docker.io/library/busybox:notlatest", "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 	{
 		"busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex,
@@ -58,13 +56,12 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, "docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex,
-		// FIXME: This should start with …/busybox@digest
-		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+		[]string{"docker.io/library/busybox@" + sha256Digest2, "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 	{
 		"busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex,
-		// FIXME: This should start with …/busybox:tag@digest, then :tag, only then plain repo name …/busybox
-		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+		// FIXME: After …/busybox:tag@digest, there should be a …/busybox:tag, only then a plain …/busybox
+		[]string{"docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 }
 

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -40,10 +40,30 @@ var validReferenceTestCases = []struct {
 	},
 	{
 		"busybox@" + sha256digestHex, "docker.io/library/busybox:latest", "docker.io/library/busybox:latest@" + sha256digestHex,
+		// FIXME: This should start with …/busybox:latest
 		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 	{
 		"busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex,
+		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+	},
+	{
+		"busybox:notlatest@" + sha256digestHex, "docker.io/library/busybox:notlatest", "docker.io/library/busybox:notlatest@" + sha256digestHex,
+		// FIXME: This should start with …/busybox:notlatest
+		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+	},
+	{
+		"busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex,
+		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+	},
+	{
+		"busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, "docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex,
+		// FIXME: This should start with …/busybox@digest
+		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
+	},
+	{
+		"busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@" + sha256Digest2, "docker.io/library/busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex,
+		// FIXME: This should start with …/busybox:tag@digest, then :tag, only then plain repo name …/busybox
 		[]string{"docker.io/library/busybox", "docker.io/library", "docker.io"},
 	},
 }
@@ -104,7 +124,7 @@ func TestStorageReferencePolicyConfigurationNamespaces(t *testing.T) {
 		}
 		expectedNS = append(expectedNS, storeSpec)
 		expectedNS = append(expectedNS, fmt.Sprintf("[%s]", store.GraphRoot()))
-		assert.Equal(t, expectedNS, ref.PolicyConfigurationNamespaces())
+		assert.Equal(t, expectedNS, ref.PolicyConfigurationNamespaces(), c.input)
 	}
 }
 

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewReference(t *testing.T) {
+	newStore(t)
+	st, ok := Transport.(*storageTransport)
+	require.True(t, ok)
+	// Success is tested throughout; test only the failure
+	_, err := newReference(*st, nil, "")
+	assert.Error(t, err)
+}
+
 func TestStorageReferenceTransport(t *testing.T) {
 	newStore(t)
 	ref, err := Transport.ParseReference("busybox")

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -137,13 +137,13 @@ func TestParse(t *testing.T) {
 	_references := []storageReference{
 		{
 			name:      ref.(*storageReference).name,
-			reference: verboseName(ref.(*storageReference).name),
+			reference: ref.(*storageReference).name.String(),
 			id:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			transport: transport,
 		},
 		{
 			name:      ref.(*storageReference).name,
-			reference: verboseName(ref.(*storageReference).name),
+			reference: ref.(*storageReference).name.String(),
 			transport: transport,
 		},
 		{
@@ -152,7 +152,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:      ref.DockerReference(),
-			reference: verboseName(ref.DockerReference()),
+			reference: ref.DockerReference().String(),
 			transport: transport,
 		},
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -137,13 +137,11 @@ func TestParse(t *testing.T) {
 	_references := []storageReference{
 		{
 			completeReference: ref.(*storageReference).completeReference,
-			reference:         ref.(*storageReference).completeReference.String(),
 			id:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			transport:         transport,
 		},
 		{
 			completeReference: ref.(*storageReference).completeReference,
-			reference:         ref.(*storageReference).completeReference.String(),
 			transport:         transport,
 		},
 		{
@@ -152,7 +150,6 @@ func TestParse(t *testing.T) {
 		},
 		{
 			completeReference: ref.DockerReference(),
-			reference:         ref.DockerReference().String(),
 			transport:         transport,
 		},
 	}
@@ -165,8 +162,14 @@ func TestParse(t *testing.T) {
 		if ref.id != reference.id {
 			t.Fatalf("ParseReference(%q) failed to extract ID", s)
 		}
-		if ref.reference != reference.reference {
-			t.Fatalf("ParseReference(%q) failed to extract reference (%q!=%q)", s, ref.reference, reference.reference)
+		if reference.completeReference == nil {
+			if ref.completeReference != nil {
+				t.Fatalf("ParseReference(%q) set non-nil completeReference", s)
+			}
+		} else {
+			if ref.completeReference.String() != reference.completeReference.String() {
+				t.Fatalf("ParseReference(%q) failed to extract reference (%q!=%q)", s, ref.completeReference.String(), reference.completeReference.String())
+			}
 		}
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -136,24 +136,24 @@ func TestParse(t *testing.T) {
 	}
 	_references := []storageReference{
 		{
-			name:      ref.(*storageReference).name,
-			reference: ref.(*storageReference).name.String(),
+			completeReference: ref.(*storageReference).completeReference,
+			reference:         ref.(*storageReference).completeReference.String(),
+			id:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			transport:         transport,
+		},
+		{
+			completeReference: ref.(*storageReference).completeReference,
+			reference:         ref.(*storageReference).completeReference.String(),
+			transport:         transport,
+		},
+		{
 			id:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			transport: transport,
 		},
 		{
-			name:      ref.(*storageReference).name,
-			reference: ref.(*storageReference).name.String(),
-			transport: transport,
-		},
-		{
-			id:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			transport: transport,
-		},
-		{
-			name:      ref.DockerReference(),
-			reference: ref.DockerReference().String(),
-			transport: transport,
+			completeReference: ref.DockerReference(),
+			reference:         ref.DockerReference().String(),
+			transport:         transport,
 		},
 	}
 	for _, reference := range _references {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -136,21 +136,21 @@ func TestParse(t *testing.T) {
 	}
 	_references := []storageReference{
 		{
-			completeReference: ref.(*storageReference).completeReference,
-			id:                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			transport:         transport,
+			named:     ref.(*storageReference).named,
+			id:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			transport: transport,
 		},
 		{
-			completeReference: ref.(*storageReference).completeReference,
-			transport:         transport,
+			named:     ref.(*storageReference).named,
+			transport: transport,
 		},
 		{
 			id:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			transport: transport,
 		},
 		{
-			completeReference: ref.DockerReference(),
-			transport:         transport,
+			named:     ref.DockerReference(),
+			transport: transport,
 		},
 	}
 	for _, reference := range _references {
@@ -162,13 +162,13 @@ func TestParse(t *testing.T) {
 		if ref.id != reference.id {
 			t.Fatalf("ParseReference(%q) failed to extract ID", s)
 		}
-		if reference.completeReference == nil {
-			if ref.completeReference != nil {
-				t.Fatalf("ParseReference(%q) set non-nil completeReference", s)
+		if reference.named == nil {
+			if ref.named != nil {
+				t.Fatalf("ParseReference(%q) set non-nil named", s)
 			}
 		} else {
-			if ref.completeReference.String() != reference.completeReference.String() {
-				t.Fatalf("ParseReference(%q) failed to extract reference (%q!=%q)", s, ref.completeReference.String(), reference.completeReference.String())
+			if ref.named.String() != reference.named.String() {
+				t.Fatalf("ParseReference(%q) failed to extract reference (%q!=%q)", s, ref.named.String(), reference.named.String())
 			}
 		}
 	}

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -209,15 +209,6 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		// so refuse it.
 		return nil, errors.Errorf("invalid reference with digest @%s without a repository name", sum)
 	}
-
-	// Construct a copy of the store spec.
-	optionsList := ""
-	options := store.GraphOptions()
-	if len(options) > 0 {
-		optionsList = ":" + strings.Join(options, ",")
-	}
-	storeSpec := "[" + store.GraphDriverName() + "@" + store.GraphRoot() + "+" + store.RunRoot() + optionsList + "]"
-
 	if completeReference != nil {
 		if sum.Validate() == nil {
 			cr2, err := reference.WithDigest(completeReference, sum)
@@ -229,14 +220,10 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			completeReference = reference.TagNameOnly(completeReference)
 		}
 	}
-	if completeReference == nil {
-		logrus.Debugf("parsed reference to id into %q", storeSpec+"@"+id)
-	} else if id == "" {
-		logrus.Debugf("parsed reference to refname into %q", storeSpec+completeReference.String())
-	} else {
-		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+completeReference.String()+"@"+id)
-	}
-	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, id), nil
+
+	result := newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, id)
+	logrus.Debugf("parsed reference into %q", result.StringWithinTransport())
+	return result, nil
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -428,20 +428,5 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 }
 
 func verboseName(r reference.Named) string {
-	digested, isDigested := r.(reference.Digested)
-	tagged, isTagged := r.(reference.Tagged)
-	tag := ""
-	sum := ""
-	name := r.Name()
-	if isTagged {
-		if tagged.Tag() != "" {
-			tag = ":" + tagged.Tag()
-		}
-	}
-	if isDigested {
-		if digested.Digest().Validate() == nil {
-			sum = "@" + digested.Digest().String()
-		}
-	}
-	return name + tag + sum
+	return r.String()
 }

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -193,6 +193,12 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		if name, err = reference.ParseNormalizedNamed(ref); err != nil {
 			return nil, errors.Wrapf(err, "error parsing named reference %q", ref)
 		}
+		if _, hasDigest := name.(reference.Digested); hasDigest {
+			// We have already checked for up to two @… suffixes, so ID and digest, if any, must already have been parsed separately.
+			// This means that we got a name@digest@digest@ID, ambiguous and invalid.
+			// FIXME? Reorganize the code to always parse the digest in ParseNormalizedNamed, then this condition disappears.
+			return nil, errors.Errorf("invalid reference %q, with digest %q and ID %q", ref, sum, id)
+		}
 	}
 	if name == nil && sum == "" && id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
 		return nil, errors.Errorf("error parsing reference")

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -227,11 +227,10 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 				return nil, errors.Wrapf(err, "error mixing name %q with digest %q", completeReference, sum)
 			}
 			completeReference = cr2
-			refname = completeReference.String()
 		} else {
 			completeReference = reference.TagNameOnly(completeReference)
-			refname = completeReference.String()
 		}
+		refname = completeReference.String()
 	}
 	if refname == "" {
 		logrus.Debugf("parsed reference to id into %q", storeSpec+"@"+id)

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -200,16 +200,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			// FIXME? Reorganize the code to always parse the digest in ParseNormalizedNamed, then this condition disappears.
 			return nil, errors.Errorf("invalid reference %q, with digest %q and ID %q", ref, sum, id)
 		}
-	}
-	if completeReference == nil && sum == "" && id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
-		return nil, errors.Errorf("error parsing reference")
-	}
-	if completeReference == nil && sum != "" {
-		// "@digest" with no name: this package can't read nor write images with such names (the digest value is used only if name != nil),
-		// so refuse it.
-		return nil, errors.Errorf("invalid reference with digest @%s without a repository name", sum)
-	}
-	if completeReference != nil {
+
 		if sum.Validate() == nil {
 			cr2, err := reference.WithDigest(completeReference, sum)
 			if err != nil {
@@ -218,6 +209,15 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			completeReference = cr2
 		} else {
 			completeReference = reference.TagNameOnly(completeReference)
+		}
+	} else { // ref == "", completeReference == nil {
+		if sum != "" {
+			// "@digest" with no name: this package can't read nor write images with such names (the digest value is used only if name != nil),
+			// so refuse it.
+			return nil, errors.Errorf("invalid reference with digest @%s without a repository name", sum)
+		}
+		if id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
+			return nil, errors.Errorf("error parsing reference")
 		}
 	}
 

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -428,15 +428,11 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 }
 
 func verboseName(r reference.Named) string {
-	named, isNamed := r.(reference.Named)
 	digested, isDigested := r.(reference.Digested)
 	tagged, isTagged := r.(reference.Tagged)
-	name := ""
 	tag := ""
 	sum := ""
-	if isNamed {
-		name = (reference.TrimNamed(named)).String()
-	}
+	name := (reference.TrimNamed(r)).String()
 	if isTagged {
 		if tagged.Tag() != "" {
 			tag = ":" + tagged.Tag()

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -146,17 +146,17 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	// if we have one, as an ID.
 	id := ""
 	if sum != "" {
-		if idSum, err := digest.Parse("sha256:" + idOrDigest); err != nil || idSum.Validate() != nil {
-			return nil, errors.Wrapf(ErrInvalidReference, "%q does not look like an image ID", idOrDigest)
-		}
 		if err := sum.Validate(); err != nil {
 			return nil, errors.Wrapf(ErrInvalidReference, "%q does not look like an image digest", sum)
 		}
-		id = idOrDigest
-		if img, err := store.Image(idOrDigest); err == nil && img != nil && len(idOrDigest) >= minimumTruncatedIDLength && strings.HasPrefix(img.ID, idOrDigest) {
+		if idSum, err := digest.Parse("sha256:" + idOrDigest); err == nil && idSum.Validate() == nil {
+			id = idOrDigest
+		} else if img, err := store.Image(idOrDigest); err == nil && img != nil && len(idOrDigest) >= minimumTruncatedIDLength && strings.HasPrefix(img.ID, idOrDigest) {
 			// The ID is a truncated version of the ID of an image that's present in local storage,
 			// so we might as well use the expanded value.
 			id = img.ID
+		} else {
+			return nil, errors.Wrapf(ErrInvalidReference, "%q does not look like an image ID", idOrDigest)
 		}
 	} else if idOrDigest != "" {
 		// There was no middle portion, so the final portion could be either a digest or an ID.

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -193,7 +193,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			return nil, errors.Wrapf(err, "error parsing named reference %q", ref)
 		}
 	}
-	if name == nil && sum == "" && id == "" {
+	if name == nil && sum == "" && id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
 		return nil, errors.Errorf("error parsing reference")
 	}
 

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -218,7 +218,6 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	}
 	storeSpec := "[" + store.GraphDriverName() + "@" + store.GraphRoot() + "+" + store.RunRoot() + optionsList + "]"
 
-	refname := ""
 	if completeReference != nil {
 		if sum.Validate() == nil {
 			cr2, err := reference.WithDigest(completeReference, sum)
@@ -229,7 +228,6 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		} else {
 			completeReference = reference.TagNameOnly(completeReference)
 		}
-		refname = completeReference.String()
 	}
 	if completeReference == nil {
 		logrus.Debugf("parsed reference to id into %q", storeSpec+"@"+id)
@@ -238,7 +236,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	} else {
 		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+completeReference.String()+"@"+id)
 	}
-	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id), nil
+	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, id), nil
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -197,6 +197,11 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	if name == nil && sum == "" && id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
 		return nil, errors.Errorf("error parsing reference")
 	}
+	if name == nil && sum != "" {
+		// "@digest" with no name: this package can't read nor write images with such names (the digest value is used only if name != nil),
+		// so refuse it.
+		return nil, errors.Errorf("invalid reference with digest @%s without a repository name", sum)
+	}
 
 	// Construct a copy of the store spec.
 	optionsList := ""

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -245,7 +245,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	} else {
 		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+refname+"@"+id)
 	}
-	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id, name, sum), nil
+	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id, name), nil
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -432,7 +432,7 @@ func verboseName(r reference.Named) string {
 	tagged, isTagged := r.(reference.Tagged)
 	tag := ""
 	sum := ""
-	name := (reference.TrimNamed(r)).String()
+	name := r.Name()
 	if isTagged {
 		if tagged.Tag() != "" {
 			tag = ":" + tagged.Tag()

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -245,7 +245,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	} else {
 		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+refname+"@"+id)
 	}
-	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id, name), nil
+	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id), nil
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -215,14 +215,14 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			if err != nil {
 				return nil, errors.Wrapf(err, "error mixing name %q with digest %q", name, sum)
 			}
-			refname = verboseName(canonical)
+			refname = canonical.String()
 		} else {
 			name = reference.TagNameOnly(name)
 			tagged, ok := name.(reference.Tagged)
 			if !ok {
 				return nil, errors.Errorf("error parsing possibly-tagless name %q", ref)
 			}
-			refname = verboseName(name)
+			refname = name.String()
 			tag = tagged.Tag()
 		}
 	}
@@ -339,7 +339,7 @@ func (s *storageTransport) ParseReference(reference string) (types.ImageReferenc
 func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageReference) (*storage.Image, error) {
 	dref := ref.DockerReference()
 	if dref != nil {
-		if img, err := store.Image(verboseName(dref)); err == nil {
+		if img, err := store.Image(dref.String()); err == nil {
 			return img, nil
 		}
 	}
@@ -425,8 +425,4 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 	// from docker/distribution/reference.regexp.go, but other than that there
 	// are few semantically invalid strings.
 	return nil
-}
-
-func verboseName(r reference.Named) string {
-	return r.String()
 }

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -216,12 +216,12 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			// so refuse it.
 			return nil, errors.Errorf("invalid reference with digest @%s without a repository name", sum)
 		}
-		if id == "" { // Coverage: This could happen only on empty input, which is refused at the very top of the method.
-			return nil, errors.Errorf("error parsing reference")
-		}
 	}
 
-	result := newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, named, id)
+	result, err := newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, named, id)
+	if err != nil {
+		return nil, err
+	}
 	logrus.Debugf("parsed reference into %q", result.StringWithinTransport())
 	return result, nil
 }

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -221,7 +221,6 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 
 	// Convert the name back into a reference string, if we got a name.
 	refname := ""
-	tag := ""
 	if name != nil {
 		if sum.Validate() == nil {
 			canonical, err := reference.WithDigest(name, sum)
@@ -236,13 +235,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		} else {
 			name = reference.TagNameOnly(name)
 			completeReference = reference.TagNameOnly(completeReference)
-			if _, ok := name.(reference.Tagged); !ok { // Coverage: This should never happen; we check only to ensure that "tag" is set below.
-				return nil, errors.Errorf("error parsing possibly-tagless name %q", ref)
-			}
 			refname = name.String()
-		}
-		if tagged, ok := name.(reference.Tagged); ok {
-			tag = tagged.Tag()
 		}
 	}
 	if refname == "" {
@@ -252,7 +245,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	} else {
 		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+refname+"@"+id)
 	}
-	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id, name, tag, sum), nil
+	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id, name, sum), nil
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -218,7 +218,6 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	}
 	storeSpec := "[" + store.GraphDriverName() + "@" + store.GraphRoot() + "+" + store.RunRoot() + optionsList + "]"
 
-	// Convert the name back into a reference string, if we got a name.
 	refname := ""
 	if completeReference != nil {
 		if sum.Validate() == nil {
@@ -232,12 +231,12 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		}
 		refname = completeReference.String()
 	}
-	if refname == "" {
+	if completeReference == nil {
 		logrus.Debugf("parsed reference to id into %q", storeSpec+"@"+id)
 	} else if id == "" {
-		logrus.Debugf("parsed reference to refname into %q", storeSpec+refname)
+		logrus.Debugf("parsed reference to refname into %q", storeSpec+completeReference.String())
 	} else {
-		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+refname+"@"+id)
+		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+completeReference.String()+"@"+id)
 	}
 	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, completeReference, refname, id), nil
 }

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -236,11 +236,12 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		} else {
 			name = reference.TagNameOnly(name)
 			completeReference = reference.TagNameOnly(completeReference)
-			tagged, ok := name.(reference.Tagged)
-			if !ok {
+			if _, ok := name.(reference.Tagged); !ok { // Coverage: This should never happen; we check only to ensure that "tag" is set below.
 				return nil, errors.Errorf("error parsing possibly-tagless name %q", ref)
 			}
 			refname = name.String()
+		}
+		if tagged, ok := name.(reference.Tagged); ok {
 			tag = tagged.Tag()
 		}
 	}
@@ -271,7 +272,7 @@ func (s *storageTransport) GetStore() (storage.Store, error) {
 }
 
 // ParseReference takes a name and a tag or digest and/or ID
-// ("_name_"/"@_id_"/"_name_:_tag_"/"_name_:_tag_@_id_"/"_name_@_digest_"/"_name_@_digest_@_id_"),
+// ("_name_"/"@_id_"/"_name_:_tag_"/"_name_:_tag_@_id_"/"_name_@_digest_"/"_name_@_digest_@_id_"/"_name_:_tag_@_digest_"/"_name_:_tag_@_digest_@_id_"),
 // possibly prefixed with a store specifier in the form "[_graphroot_]" or
 // "[_driver_@_graphroot_]" or "[_driver_@_graphroot_+_runroot_]" or
 // "[_driver_@_graphroot_:_options_]" or "[_driver_@_graphroot_+_runroot_:_options_]",

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -427,10 +427,7 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 	return nil
 }
 
-func verboseName(r reference.Reference) string {
-	if r == nil {
-		return ""
-	}
+func verboseName(r reference.Named) string {
 	named, isNamed := r.(reference.Named)
 	digested, isDigested := r.(reference.Digested)
 	tagged, isTagged := r.(reference.Tagged)

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -38,8 +38,7 @@ func TestTransportParseStoreReference(t *testing.T) {
 		// FIXME: This test is now incorrect, this should not fail _if the image ID matches_
 		{sha256digestHex, "", ""},                    // Invalid single-component ID; not an ID without a "@" prefix, so it's parsed as a name, but names aren't allowed to look like IDs
 		{"@" + sha256digestHex, "", sha256digestHex}, // Valid single-component ID
-		// FIXME: This should fail it seems, everything else uses ref.digest only if ref.name != nil
-		// {"@sha256:" + sha256digestHex, "", ""},                                      // Valid single-component digest
+		{"@sha256:" + sha256digestHex, "", ""},       // Invalid un-named @digest
 		// "aaaa", either a valid image ID prefix, or a short form of docker.io/library/aaaa, untested
 		{"sha256:ab", "docker.io/library/sha256:ab", ""},                                   // Valid single-component name, explicit tag
 		{"busybox", "docker.io/library/busybox:latest", ""},                                // Valid single-component name, implicit tag

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -72,12 +72,12 @@ func TestTransportParseStoreReference(t *testing.T) {
 			require.NoError(t, err, c.input)
 			assert.Equal(t, store, storageRef.transport.store, c.input)
 			if c.expectedRef == "" {
-				assert.Nil(t, storageRef.completeReference, c.input)
+				assert.Nil(t, storageRef.named, c.input)
 			} else {
 				dockerRef, err := reference.ParseNormalizedNamed(c.expectedRef)
 				require.NoError(t, err)
-				require.NotNil(t, storageRef.completeReference, c.input)
-				assert.Equal(t, dockerRef.String(), storageRef.completeReference.String())
+				require.NotNil(t, storageRef.named, c.input)
+				assert.Equal(t, dockerRef.String(), storageRef.named.String())
 			}
 			assert.Equal(t, c.expectedID, storageRef.id, c.input)
 		}

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -139,18 +139,18 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 
 	// Valid inputs
 	for _, scope := range []string{
-		"[" + root + "suffix1]",                // driverlessStoreSpec in PolicyConfigurationNamespaces
-		"[" + driver + "@" + root + "suffix3]", // storeSpec in PolicyConfigurationNamespaces
-		// FIXME storeSpec + "@" + sha256digestHex,                                                          // ID only
-		storeSpec + "docker.io",                                              // Host name only
-		storeSpec + "docker.io/library",                                      // A repository namespace
-		storeSpec + "docker.io/library/busybox",                              // A repository name
-		storeSpec + "docker.io/library/busybox:notlatest",                    // name:tag
-		storeSpec + "docker.io/library/busybox:notlatest@" + sha256digestHex, // name@ID
-		// FIXME storeSpec + "docker.io/library/busybox@" + sha256Digest2,                                   // name@digest
-		// FIXME storeSpec + "docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex,           // name@digest@ID
-		// FIXME storeSpec + "docker.io/library/busybox:notlatest@" + sha256Digest2,                         // name:tag@digest
-		// FIXME storeSpec + "docker.io/library/busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex, // name:tag@digest@ID
+		"[" + root + "suffix1]",                                                                    // driverlessStoreSpec in PolicyConfigurationNamespaces
+		"[" + driver + "@" + root + "suffix3]",                                                     // storeSpec in PolicyConfigurationNamespaces
+		storeSpec + "@" + sha256digestHex,                                                          // ID only
+		storeSpec + "docker.io",                                                                    // Host name only
+		storeSpec + "docker.io/library",                                                            // A repository namespace
+		storeSpec + "docker.io/library/busybox",                                                    // A repository name
+		storeSpec + "docker.io/library/busybox:notlatest",                                          // name:tag
+		storeSpec + "docker.io/library/busybox:notlatest@" + sha256digestHex,                       // name@ID
+		storeSpec + "docker.io/library/busybox@" + sha256Digest2,                                   // name@digest
+		storeSpec + "docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex,           // name@digest@ID
+		storeSpec + "docker.io/library/busybox:notlatest@" + sha256Digest2,                         // name:tag@digest
+		storeSpec + "docker.io/library/busybox:notlatest@" + sha256Digest2 + "@" + sha256digestHex, // name:tag@digest@ID
 	} {
 		err := Transport.ValidatePolicyConfigurationScope(scope)
 		assert.NoError(t, err, scope)
@@ -164,13 +164,16 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 		"[relative/path]",                // Non-absolute graph root path
 		"[" + driver + "@relative/path]", // Non-absolute graph root path
 		// "[thisisunknown@" + root + "suffix2]", // Unknown graph driver FIXME: validate against storage.ListGraphDrivers() once that's available
-		storeSpec + sha256digestHex, // Almost a valid single-component name, but rejected because it looks like an ID that's missing its "@" prefix
-		storeSpec + "@",             // An incomplete two-component name
+		storeSpec + "@", // An incomplete two-component name
 
-		storeSpec + "UPPERCASEISINVALID",                    // Invalid single-component name
-		storeSpec + "UPPERCASEISINVALID@" + sha256digestHex, // Invalid name in name@ID
-		storeSpec + "docker.io/library/busybox@ab",          // Invalid ID in name@ID
-		storeSpec + "docker.io/library/busybox@",            // Empty ID in name@ID
+		storeSpec + "docker.io/library/busybox@sha256:ab",                    // Invalid digest in name@digest
+		storeSpec + "docker.io/library/busybox@ab",                           // Invalid ID in name@ID
+		storeSpec + "docker.io/library/busybox@",                             // Empty ID/digest in name@ID
+		storeSpec + "docker.io/library/busybox@@" + sha256digestHex,          // Empty digest in name@digest@ID
+		storeSpec + "docker.io/library/busybox@ab@" + sha256digestHex,        // Invalid digest in name@digest@ID
+		storeSpec + "docker.io/library/busybox@sha256:ab@" + sha256digestHex, // Invalid digest in name@digest@ID
+		storeSpec + "docker.io/library/busybox@" + sha256Digest2 + "@",       // Empty ID in name@digest@ID
+		storeSpec + "docker.io/library/busybox@" + sha256Digest2 + "@ab",     // Invalid ID in name@digest@ID
 	} {
 		err := Transport.ValidatePolicyConfigurationScope(scope)
 		assert.Error(t, err, scope)

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -179,21 +179,3 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 		assert.Error(t, err, scope)
 	}
 }
-
-func TestVerboseName(t *testing.T) {
-	newStore(t)
-
-	for _, c := range []struct{ input, expected string }{
-		{"busybox", "docker.io/library/busybox"}, // The normalization actually happens already in ParseAnyReference
-		{"docker.io/library/busybox", "docker.io/library/busybox"},
-		{"docker.io/library/busybox:latest", "docker.io/library/busybox:latest"},
-		{"docker.io/library/busybox:notlatest", "docker.io/library/busybox:notlatest"},
-		{"docker.io/library/busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex},
-		{"docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex},
-	} {
-		ref, err := reference.ParseNormalizedNamed(c.input)
-		require.NoError(t, err, c.input)
-		name := verboseName(ref)
-		assert.Equal(t, c.expected, name, c.input)
-	}
-}

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -183,10 +183,7 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 func TestVerboseName(t *testing.T) {
 	newStore(t)
 
-	assert.Equal(t, "", verboseName(nil))
-
 	for _, c := range []struct{ input, expected string }{
-		{"sha256:" + sha256digestHex, "@sha256:" + sha256digestHex},
 		{"busybox", "docker.io/library/busybox"}, // The normalization actually happens already in ParseAnyReference
 		{"docker.io/library/busybox", "docker.io/library/busybox"},
 		{"docker.io/library/busybox:latest", "docker.io/library/busybox:latest"},
@@ -194,7 +191,7 @@ func TestVerboseName(t *testing.T) {
 		{"docker.io/library/busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex},
 		{"docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex},
 	} {
-		ref, err := reference.ParseAnyReference(c.input)
+		ref, err := reference.ParseNormalizedNamed(c.input)
 		require.NoError(t, err, c.input)
 		name := verboseName(ref)
 		assert.Equal(t, c.expected, name, c.input)

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -63,8 +63,7 @@ func TestTransportParseStoreReference(t *testing.T) {
 		{"docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, sha256digestHex},                                       // name@digest@ID, everything explicit
 		{"docker.io/library/busybox:notlatest@sha256:" + sha256digestHex + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, sha256digestHex}, // name:tag@digest@ID, everything explicit
 		// "busybox@sha256:"+sha256digestHex+"@aaaa", a valid image ID prefix, untested
-		// FIXME FIXME: two digests
-		{"busybox:notlatest@" + sha256Digest2 + "@" + digest3 + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@" + digest3, sha256digestHex}, // name@digest@ID, with name containing a digest
+		{"busybox:notlatest@" + sha256Digest2 + "@" + digest3 + "@" + sha256digestHex, "", ""}, // name@digest@ID, with name containing another digest
 	} {
 		storageRef, err := Transport.ParseStoreReference(store, c.input)
 		if c.expectedRef == "" && c.expectedID == "" {

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -179,3 +179,24 @@ func TestTransportValidatePolicyConfigurationScope(t *testing.T) {
 		assert.Error(t, err, scope)
 	}
 }
+
+func TestVerboseName(t *testing.T) {
+	newStore(t)
+
+	assert.Equal(t, "", verboseName(nil))
+
+	for _, c := range []struct{ input, expected string }{
+		{"sha256:" + sha256digestHex, "@sha256:" + sha256digestHex},
+		{"busybox", "docker.io/library/busybox"}, // The normalization actually happens already in ParseAnyReference
+		{"docker.io/library/busybox", "docker.io/library/busybox"},
+		{"docker.io/library/busybox:latest", "docker.io/library/busybox:latest"},
+		{"docker.io/library/busybox:notlatest", "docker.io/library/busybox:notlatest"},
+		{"docker.io/library/busybox@sha256:" + sha256digestHex, "docker.io/library/busybox@sha256:" + sha256digestHex},
+		{"docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex},
+	} {
+		ref, err := reference.ParseAnyReference(c.input)
+		require.NoError(t, err, c.input)
+		name := verboseName(ref)
+		assert.Equal(t, c.expected, name, c.input)
+	}
+}

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -74,11 +74,11 @@ func TestTransportParseStoreReference(t *testing.T) {
 			assert.Equal(t, c.expectedRef, storageRef.reference, c.input)
 			assert.Equal(t, c.expectedID, storageRef.id, c.input)
 			if c.expectedRef == "" {
-				assert.Nil(t, storageRef.name, c.input)
+				assert.Nil(t, storageRef.completeReference, c.input)
 			} else {
 				dockerRef, err := reference.ParseNormalizedNamed(c.expectedRef)
 				require.NoError(t, err)
-				require.NotNil(t, storageRef.name, c.input)
+				require.NotNil(t, storageRef.completeReference, c.input)
 				assert.Equal(t, dockerRef.String(), storageRef.reference)
 				assert.Equal(t, dockerRef.String(), storageRef.DockerReference().String())
 			}

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -62,7 +62,6 @@ func TestTransportParseStoreReference(t *testing.T) {
 		{"busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, sha256digestHex},                                                         // name@digest@ID
 		{"docker.io/library/busybox@" + sha256Digest2 + "@" + sha256digestHex, "docker.io/library/busybox@" + sha256Digest2, sha256digestHex},                                       // name@digest@ID, everything explicit
 		{"docker.io/library/busybox:notlatest@sha256:" + sha256digestHex + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@sha256:" + sha256digestHex, sha256digestHex}, // name:tag@digest@ID, everything explicit
-		// FIXME: Is this supposed to work? the validation of idOrDigest seems to make this impossible.
 		// "busybox@sha256:"+sha256digestHex+"@aaaa", a valid image ID prefix, untested
 		// FIXME FIXME: two digests
 		{"busybox:notlatest@" + sha256Digest2 + "@" + digest3 + "@" + sha256digestHex, "docker.io/library/busybox:notlatest@" + digest3, sha256digestHex}, // name@digest@ID, with name containing a digest

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -71,17 +71,15 @@ func TestTransportParseStoreReference(t *testing.T) {
 		} else {
 			require.NoError(t, err, c.input)
 			assert.Equal(t, store, storageRef.transport.store, c.input)
-			assert.Equal(t, c.expectedRef, storageRef.reference, c.input)
-			assert.Equal(t, c.expectedID, storageRef.id, c.input)
 			if c.expectedRef == "" {
 				assert.Nil(t, storageRef.completeReference, c.input)
 			} else {
 				dockerRef, err := reference.ParseNormalizedNamed(c.expectedRef)
 				require.NoError(t, err)
 				require.NotNil(t, storageRef.completeReference, c.input)
-				assert.Equal(t, dockerRef.String(), storageRef.reference)
-				assert.Equal(t, dockerRef.String(), storageRef.DockerReference().String())
+				assert.Equal(t, dockerRef.String(), storageRef.completeReference.String())
 			}
+			assert.Equal(t, c.expectedID, storageRef.id, c.input)
 		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -174,6 +174,11 @@ type ImageDestination interface {
 	AcceptsForeignLayerURLs() bool
 	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
 	MustMatchRuntimeOS() bool
+	// IgnoresEmbeddedDockerReference() returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+	// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+	// Does not make a difference if Reference().DockerReference() is nil.
+	IgnoresEmbeddedDockerReference() bool
+
 	// PutBlob writes contents of stream and returns data representing the result.
 	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 	// inputInfo.Size is the expected length of stream, if known.


### PR DESCRIPTION
This is a follow-up, and on top of, #416.  Unlike that one, which should be overwhelmingly uncontroversial, this one involves a few design choices.

See individual commit messages for more details. (…and not to read #416 again; start at “Make TestStorageReferenceDockerDeference table-driven“.); please pay particular attention to the “RFC” and “UNTESTED” marked ones. I’ll be happy to break this up into several PRs if any part needs more discussion than others.

General themes:
- Increase test coverage of various accepted, and invalid, reference formats
- Fix various uncovered corner cases, e.g. reject `@`_digest_ without a name, or _name_`@`_digest_`@`_digest_`@`_ID_
- Support _name_`:`_tag_`@`_digest_, which is actually a recognized syntax.  (Or would we refuse it instead?)
- Eliminate `verboseName`
- Rewrite `storageReference` to be a (store, `reference.Named`, ID) triplet, without three redundant  string members, over about 20 tiny commits.
- Significantly simplify `ParseStoreReference` (unless I’m missing a reason for the code to be the way it is)
- Add `types.ImageDestination.EmbeddedDockerReference`, instead of inconsistently lying in `storageImageDestination.Reference.DockerReference()`.

@nalind @runcom PTAL.