### PR TITLE
sysregistries: remove trailing slash from registries

### DIFF
--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -38,6 +38,17 @@ func TestGetRegistriesWithBadData(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGetRegistriesWithTrailingSlash(t *testing.T) {
+	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com/"}
+	testConfig = []byte(`[registries.search]
+	registries= ['no-slash.com:5000/path', 'one-slash.com/', 'two-slashes.com//']
+`)
+	// note: only one trailing gets removed
+	registriesConfig, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, registriesConfig, answer)
+}
+
 func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
 	answer := []string(nil)
 	testConfig = []byte("")


### PR DESCRIPTION
It is a common pitfall to add a trailing slash when specifying a
registry (e.g., "docker.io/library/" version "docker.io/library").
Remove trailing slashes to normalize the representation of registries.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>