### PR TITLE
introduce sysregistriesv2

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -1,0 +1,322 @@
+package sysregistriesv2
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containers/image/types"
+)
+
+// systemRegistriesConfPath is the path to the system-wide registry
+// configuration file and is used to add/subtract potential registries for
+// obtaining images.  You can override this at build time with
+// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfPath=$your_path'
+var systemRegistriesConfPath = builtinRegistriesConfPath
+
+// builtinRegistriesConfPath is the path to the registry configuration file.
+// DO NOT change this, instead see systemRegistriesConfPath above.
+const builtinRegistriesConfPath = "/etc/containers/registries.conf"
+
+// tomlURL is an abstraction required to unmarshal the non-primitive and
+// non-local url.URL type when loading the toml config.
+type tomlURL struct {
+	url url.URL
+}
+
+// UnmashalText interprets and parses text as a net.URL type and assigns it to
+// the tomlURL's url field.
+func (r *tomlURL) UnmarshalText(text []byte) (err error) {
+	r.url, err = parseURL(string(text))
+	return err
+}
+
+// mirror is an internal type including all mirror data but the URL.
+type mirror struct {
+	// If true, certs verification will be skipped and HTTP (non-TLS)
+	// connections will be allowed.
+	Insecure bool `toml:"insecure"`
+}
+
+// Mirror represents a mirror. Mirrors can be used as pull-through caches for
+// registries.
+type Mirror struct {
+	// The mirror's URL.
+	URL url.URL
+	mirror
+}
+
+// tomlMirror is a serializable Mirror.
+type tomlMirror struct {
+	// Serializable mirror URL.
+	URL tomlURL `toml:"url"`
+	mirror
+}
+
+// toMirror transforms tmirror to a Mirror.
+func (tmir *tomlMirror) toMirror() (Mirror, error) {
+	if len(tmir.URL.url.String()) == 0 {
+		return Mirror{}, fmt.Errorf("mirror must include a URL")
+	}
+	mir := Mirror{URL: tmir.URL.url, mirror: tmir.mirror}
+	return mir, nil
+}
+
+// registry is an internal type including all registry data but the URL and the
+// array of associated mirrors.
+type registry struct {
+	// If true, pulling from the registry will be blocked.
+	Blocked bool `toml:"blocked"`
+	// If true, certs verification will be skipped and HTTP (non-TLS)
+	// connections will be allowed.
+	Insecure bool `toml:"insecure"`
+	// If true, the registry can be used when pulling an unqualified image.
+	Search bool `toml:"unqualified-search"`
+	// Prefix is used for matching images, and to translate one namespace to
+	// another.  If `Prefix="example.com/bar"`, `URL="https://example.com/foo/bar"`
+	// and we pull from "example.com/bar/myimage:latest", the image will
+	// effectively be pulled from https://example.com/foo/bar/myimage:latest.
+	// If no Prefix is specified, it defaults to the specified URL.
+	Prefix string `toml:"prefix"`
+}
+
+// Registry represents a registry.
+type Registry struct {
+	// Serializable registry URL.
+	URL url.URL
+	// The registry's mirrors.
+	Mirrors []Mirror
+	registry
+}
+
+// tomlRegistry is serializable Registry.
+type tomlRegistry struct {
+	URL     tomlURL      `toml:"url"`
+	Mirrors []tomlMirror `toml:"mirror"`
+	registry
+}
+
+// stripURIScheme strips the URI scheme from the given URL and returns it as
+// as string.
+func stripURIScheme(url url.URL) string {
+	return strings.TrimPrefix(url.String(), url.Scheme+"://")
+}
+
+// toRegistry transforms treg to a Registry.
+func (treg *tomlRegistry) toRegistry() (Registry, error) {
+	if len(treg.URL.url.String()) == 0 {
+		return Registry{}, fmt.Errorf("registry must include a URL")
+	}
+	reg := Registry{URL: treg.URL.url, registry: treg.registry}
+	// if no prefix is specified, default to the specified URL with
+	// stripped URI scheme
+	if reg.Prefix == "" {
+		reg.Prefix = stripURIScheme(reg.URL)
+	}
+
+	for _, tmir := range treg.Mirrors {
+		mir, err := tmir.toMirror()
+		if err != nil {
+			return Registry{}, err
+		}
+		reg.Mirrors = append(reg.Mirrors, mir)
+	}
+	return reg, nil
+}
+
+// backwards compatability to sysregistries v1
+type v1TOMLregistries struct {
+	Registries []string `toml:"registries"`
+}
+
+// tomlConfig is the data type used to unmarshal the toml config.
+type tomlConfig struct {
+	TOMLRegistries []tomlRegistry `toml:"registry"`
+	// backwards compatability to sysregistries v1
+	V1Registries struct {
+		Search   v1TOMLregistries `toml:"search"`
+		Insecure v1TOMLregistries `toml:"insecure"`
+		Block    v1TOMLregistries `toml:"block"`
+	} `toml:"registries"`
+}
+
+// parseURL parses the input string, performs some sanity checks and returns
+// a url.URL.  The input must be a valid URI with an "http" or "https" scheme,
+// a specified host and an empty URI user.  Otherwise, an error is returned.
+func parseURL(input string) (url.URL, error) {
+	input = strings.TrimRight(input, "/")
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return url.URL{}, fmt.Errorf("error parsing URL %s: %v", input, err)
+	}
+
+	// only https and http are valid URI schemes
+	if uri.Scheme == "" {
+		return url.URL{}, fmt.Errorf("unspecified URI scheme: %s", input)
+	}
+	if uri.Scheme != "https" && uri.Scheme != "http" {
+		return url.URL{}, fmt.Errorf("unsupported URI scheme: %s", input)
+	}
+
+	// a host must be specified
+	if uri.Host == "" {
+		return url.URL{}, fmt.Errorf("unspecified URI host: %s", input)
+	}
+
+	// user must be empty
+	if uri.User != nil {
+		// strip password for security reasons
+		uri.User = url.UserPassword(uri.User.Username(), "xxxxxx")
+		return url.URL{}, fmt.Errorf("unsupported username/password: %q", uri)
+	}
+
+	return *uri, nil
+}
+
+// getV1Registries transforms v1 registries in the config into an array of v2
+// registries of type Registry.
+func getV1Registries(config *tomlConfig) ([]Registry, error) {
+	regMap := make(map[string]*Registry)
+
+	getRegistry := func(s string) (*Registry, error) { // Note: _pointer_ to a long-lived object
+		url, err := parseURL(s)
+		if err != nil {
+			return nil, err
+		}
+		prefix := stripURIScheme(url)
+		reg, exists := regMap[prefix]
+		if !exists {
+			reg = &Registry{URL: url,
+				Mirrors:  []Mirror{},
+				registry: registry{Prefix: prefix}}
+			regMap[prefix] = reg
+		}
+		return reg, nil
+	}
+
+	for _, search := range config.V1Registries.Search.Registries {
+		reg, err := getRegistry(search)
+		if err != nil {
+			return nil, err
+		}
+		reg.Search = true
+	}
+	for _, blocked := range config.V1Registries.Block.Registries {
+		reg, err := getRegistry(blocked)
+		if err != nil {
+			return nil, err
+		}
+		reg.Blocked = true
+	}
+	for _, insecure := range config.V1Registries.Insecure.Registries {
+		reg, err := getRegistry(insecure)
+		if err != nil {
+			return nil, err
+		}
+		reg.Insecure = true
+	}
+
+	registries := []Registry{}
+	for _, reg := range regMap {
+		registries = append(registries, *reg)
+	}
+	return registries, nil
+}
+
+// GetRegistries loads and returns the registries specified in the config.
+func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
+	config, err := loadRegistryConf(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	registries := []Registry{}
+	for _, treg := range config.TOMLRegistries {
+		reg, err := treg.toRegistry()
+		if err != nil {
+			return nil, err
+		}
+		registries = append(registries, reg)
+	}
+
+	// backwards compatibility for v1 configs
+	v1Registries, err := getV1Registries(config)
+	if err != nil {
+		return nil, err
+	}
+	if len(v1Registries) > 0 {
+		if len(registries) > 0 {
+			return nil, fmt.Errorf("mixing sysregistry v1/v2 is not supported")
+		}
+		registries = v1Registries
+	}
+
+	return registries, nil
+}
+
+// FindUnqualifiedSearchRegistries returns all registries that are configured
+// for unqualified image search (i.e., with Registry.Search == true).
+func FindUnqualifiedSearchRegistries(registries []Registry) []Registry {
+	unqualified := []Registry{}
+	for _, reg := range registries {
+		if reg.Search {
+			unqualified = append(unqualified, reg)
+		}
+	}
+	return unqualified
+}
+
+// FindRegistry returns the Registry with the longest prefix for ref.  If no
+// Registry prefixes the image, nil is returned.
+func FindRegistry(ref string, registries []Registry) *Registry {
+	reg := Registry{}
+	prefixLen := 0
+	for _, r := range registries {
+		if strings.HasPrefix(ref, r.Prefix) {
+			length := len(r.Prefix)
+			if length > prefixLen {
+				reg = r
+				prefixLen = length
+			}
+		}
+	}
+	if prefixLen != 0 {
+		return &reg
+	}
+	return nil
+}
+
+// Reads the global registry file from the filesystem. Returns a byte array.
+func readRegistryConf(ctx *types.SystemContext) ([]byte, error) {
+	dirPath := systemRegistriesConfPath
+	if ctx != nil {
+		if ctx.SystemRegistriesConfPath != "" {
+			dirPath = ctx.SystemRegistriesConfPath
+		} else if ctx.RootForImplicitAbsolutePaths != "" {
+			dirPath = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
+		}
+	}
+	configBytes, err := ioutil.ReadFile(dirPath)
+	return configBytes, err
+}
+
+// Used in unittests to parse custom configs without a types.SystemContext.
+var readConf = readRegistryConf
+
+// Loads the registry configuration file from the filesystem and then unmarshals
+// it.  Returns the unmarshalled object.
+func loadRegistryConf(ctx *types.SystemContext) (*tomlConfig, error) {
+	config := &tomlConfig{}
+
+	configBytes, err := readConf(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(configBytes, &config)
+	return config, err
+}

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -1,0 +1,292 @@
+package sysregistriesv2
+
+import (
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+var testConfig = []byte("")
+
+func init() {
+	readConf = func(_ *types.SystemContext) ([]byte, error) {
+		return testConfig, nil
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	var err error
+	var url url.URL
+
+	// invalid URLs
+	_, err = parseURL("unspecified.scheme")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unspecified URI scheme:")
+
+	_, err = parseURL("httpx://unsupported.scheme")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unsupported URI scheme:")
+
+	_, err = parseURL("http://")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unspecified URI host:")
+
+	_, err = parseURL("https://user:password@unsupported.com")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unsupported username/password:")
+
+	// valid URLs
+	url, err = parseURL("http://example.com")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://example.com", url.String())
+
+	url, err = parseURL("http://example.com/")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://example.com", url.String())
+
+	url, err = parseURL("http://example.com//////")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://example.com", url.String())
+
+	url, err = parseURL("http://example.com:5000/with/path")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://example.com:5000/with/path", url.String())
+}
+
+func TestEmptyConfig(t *testing.T) {
+	testConfig = []byte(``)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(registries))
+}
+
+func TestMirrors(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry.com"
+
+[[registry.mirror]]
+url = "https://mirror-1.registry.com"
+
+[[registry.mirror]]
+url = "https://mirror-2.registry.com"
+insecure = true
+
+[[registry]]
+url = "https://blocked.registry.com"
+blocked = true`)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(registries))
+
+	var reg *Registry
+	reg = FindRegistry("registry.com/image:tag", registries)
+	assert.NotNil(t, reg)
+	assert.Equal(t, 2, len(reg.Mirrors))
+	assert.Equal(t, "https://mirror-1.registry.com", reg.Mirrors[0].URL.String())
+	assert.False(t, reg.Mirrors[0].Insecure)
+	assert.Equal(t, "https://mirror-2.registry.com", reg.Mirrors[1].URL.String())
+	assert.True(t, reg.Mirrors[1].Insecure)
+}
+
+func TestMissingRegistryURL(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry-a.com"
+unqualified-search = true
+
+[[registry]]
+url = "https://registry-b.com"
+
+[[registry]]
+unqualified-search = true`)
+	_, err := GetRegistries(nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, "registry must include a URL", err.Error())
+}
+
+func TestMissingMirrorURL(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry-a.com"
+unqualified-search = true
+
+[[registry]]
+url = "https://registry-b.com"
+[[registry.mirror]]
+url = "https://mirror-b.com"
+[[registry.mirror]]
+`)
+	_, err := GetRegistries(nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, "mirror must include a URL", err.Error())
+}
+
+func TestFindRegistry(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry.com:5000"
+prefix = "simple-prefix.com"
+
+[[registry]]
+url = "https://another-registry.com:5000"
+prefix = "complex-prefix.com:4000/with/path"
+
+[[registry]]
+url = "https://registry.com:5000"
+prefix = "another-registry.com"
+
+[[registry]]
+url = "https://no-prefix.com"
+
+[[registry]]
+url = "https://empty-prefix.com"
+prefix = ""`)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(registries))
+
+	var reg *Registry
+	reg = FindRegistry("simple-prefix.com/foo/bar:latest", registries)
+	assert.NotNil(t, reg)
+	assert.Equal(t, "simple-prefix.com", reg.Prefix)
+	assert.Equal(t, reg.URL.String(), "https://registry.com:5000")
+
+	reg = FindRegistry("complex-prefix.com:4000/with/path/and/beyond:tag", registries)
+	assert.NotNil(t, reg)
+	assert.Equal(t, "complex-prefix.com:4000/with/path", reg.Prefix)
+	assert.Equal(t, "https://another-registry.com:5000", reg.URL.String())
+
+	reg = FindRegistry("no-prefix.com/foo:tag", registries)
+	assert.NotNil(t, reg)
+	assert.Equal(t, "no-prefix.com", reg.Prefix)
+	assert.Equal(t, "https://no-prefix.com", reg.URL.String())
+
+	reg = FindRegistry("empty-prefix.com/foo:tag", registries)
+	assert.NotNil(t, reg)
+	assert.Equal(t, "empty-prefix.com", reg.Prefix)
+	assert.Equal(t, "https://empty-prefix.com", reg.URL.String())
+}
+
+func TestFindUnqualifiedSearchRegistries(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry-a.com"
+unqualified-search = true
+
+[[registry]]
+url = "https://registry-b.com"
+
+[[registry]]
+url = "https://registry-c.com"
+unqualified-search = true`)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(registries))
+
+	unqRegs := FindUnqualifiedSearchRegistries(registries)
+	assert.Equal(t, 2, len(unqRegs))
+
+	// check if the expected images are actually in the array
+	var reg *Registry
+	reg = FindRegistry("registry-a.com/foo:bar", unqRegs)
+	assert.NotNil(t, reg)
+	reg = FindRegistry("registry-c.com/foo:bar", unqRegs)
+	assert.NotNil(t, reg)
+}
+
+func TestUnmarshalConfig(t *testing.T) {
+	testConfig = []byte(`
+[[registry]]
+url = "https://registry.com"
+
+[[registry.mirror]]
+url = "https://mirror-1.registry.com"
+
+[[registry.mirror]]
+url = "https://mirror-2.registry.com"
+
+
+[[registry]]
+url = "https://blocked.registry.com"
+blocked = true
+
+
+[[registry]]
+url = "http://insecure.registry.com"
+insecure = true
+
+
+[[registry]]
+url = "https://untrusted.registry.com"
+insecure = true`)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(registries))
+}
+
+func TestV1BackwardsCompatibility(t *testing.T) {
+	testConfig = []byte(`
+[registries.search]
+registries = ["https://registry-a.com////", "https://registry-c.com"]
+
+[registries.block]
+registries = ["https://registry-b.com"]
+
+[registries.insecure]
+registries = ["https://registry-d.com", "https://registry-e.com", "https://registry-a.com"]`)
+
+	registries, err := GetRegistries(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(registries))
+
+	unqRegs := FindUnqualifiedSearchRegistries(registries)
+	assert.Equal(t, 2, len(unqRegs))
+
+	// check if the expected images are actually in the array
+	var reg *Registry
+	reg = FindRegistry("registry-a.com/foo:bar", unqRegs)
+	assert.NotNil(t, reg)
+	reg = FindRegistry("registry-c.com/foo:bar", unqRegs)
+	assert.NotNil(t, reg)
+
+	// check if merging works
+	reg = FindRegistry("registry-a.com/bar/foo/barfoo:latest", registries)
+	assert.NotNil(t, reg)
+	assert.True(t, reg.Search)
+	assert.True(t, reg.Insecure)
+	assert.False(t, reg.Blocked)
+}
+
+func TestMixingV1andV2(t *testing.T) {
+	testConfig = []byte(`
+[registries.search]
+registries = ["https://registry-a.com", "https://registry-c.com"]
+
+[registries.block]
+registries = ["https://registry-b.com"]
+
+[registries.insecure]
+registries = ["https://registry-d.com", "https://registry-e.com", "https://registry-a.com"]
+
+[[registry]]
+url = "https://registry-a.com"
+unqualified-search = true
+
+[[registry]]
+url = "https://registry-b.com"
+
+[[registry]]
+url = "https://registry-c.com"
+unqualified-search = true `)
+
+	_, err := GetRegistries(nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, "mixing sysregistry v1/v2 is not supported", err.Error())
+}


### PR DESCRIPTION
Introduce sysregistriesv2, which changes the format of the
`registries.conf` TOML configuration.  Instead of having different lists
to specify search registries, blocked and insecure ones, all data is
encapsulated into one registry type.  The registry type allows to
specify a list of mirrors, which can be used in the endpoint lookup to
serve, for instance, as pull through caches for the associated registry.

An example configuration may look as follows:

```toml
[[registry]]
url = "https://registry.com"
prefix = "another-registry.com"

[[registry.mirror]]
url = "http://registry-mirror.com"
insecure = true
```

The upper example shows the configuration for `https://registry.com`.
The prefix is used for matching images, and to translate one namespace
to another.  If `prefix="example.com/bar"`, `url="https://example.com/foo/bar"`
and we pull from `example.com/bar/myimage:latest`, the image will
effectively be pulled from `example.com/foo/bar/myimage:latest`. If no
prefix is specified, it defaults to the specified URL.

Ease migration from sysregistries v1 to v2 by also loading
configurations in the v1 TOML format.  Throw an error in case a config
tries to mix both formats.  This allows a smoother migration for
developers, maintainers and the user, who can switch to the new config
format once all tools have been updated to v2.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>
Closes: https://github.com/containers/image/issues/397