### PR TITLE
sysregistries: remove all trailing slashes

### DIFF
--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -31,11 +31,11 @@ type tomlConfig struct {
 	} `toml:"registries"`
 }
 
-// normalizeRegistries removes a trailing slash from registries, which is a
+// normalizeRegistries removes trailing slashes from registries, which is a
 // common pitfall when configuring registries (e.g., "docker.io/library/).
 func normalizeRegistries(regs *registries) {
 	for i := range regs.Registries {
-		regs.Registries[i] = strings.TrimSuffix(regs.Registries[i], "/")
+		regs.Registries[i] = strings.TrimRight(regs.Registries[i], "/")
 	}
 }
 

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -39,9 +39,9 @@ func TestGetRegistriesWithBadData(t *testing.T) {
 }
 
 func TestGetRegistriesWithTrailingSlash(t *testing.T) {
-	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com/"}
+	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com", "three-slashes.com:5000"}
 	testConfig = []byte(`[registries.search]
-	registries= ['no-slash.com:5000/path', 'one-slash.com/', 'two-slashes.com//']
+	registries= ['no-slash.com:5000/path', 'one-slash.com', 'two-slashes.com//', 'three-slashes.com:5000///']
 `)
 	// note: only one trailing gets removed
 	registriesConfig, err := GetRegistries(nil)


### PR DESCRIPTION
Remove all (instead of one) trailing slashes from any specified
registry string.

Notice: that's a follow-up fix for https://github.com/projectatomic/registries/pull/32#discussion_r175369710

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>