### PR TITLE
Put context.Context arguments on almost everything

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"context"
 	"strings"
 
 	"github.com/containers/image/manifest"
@@ -41,8 +42,8 @@ func (os *orderedSet) append(s string) {
 // Note that the conversion will only happen later, through ic.src.UpdatedImage
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
-func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMETypes []string, forceManifestMIMEType string) (string, []string, error) {
-	_, srcType, err := ic.src.Manifest()
+func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string) (string, []string, error) {
+	_, srcType, err := ic.src.Manifest(ctx)
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
@@ -111,8 +112,8 @@ func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMEType
 }
 
 // isMultiImage returns true if img is a list of images
-func isMultiImage(img types.UnparsedImage) (bool, error) {
-	_, mt, err := img.Manifest()
+func isMultiImage(ctx context.Context, img types.UnparsedImage) (bool, error) {
+	_, mt, err := img.Manifest(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -35,7 +35,7 @@ type fakeImageSource string
 func (f fakeImageSource) Reference() types.ImageReference {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) Manifest() ([]byte, string, error) {
+func (f fakeImageSource) Manifest(ctx context.Context) ([]byte, string, error) {
 	if string(f) == "" {
 		return nil, "", errors.New("Manifest() directed to fail")
 	}
@@ -47,28 +47,28 @@ func (f fakeImageSource) Signatures(context.Context) ([][]byte, error) {
 func (f fakeImageSource) ConfigInfo() types.BlobInfo {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) ConfigBlob() ([]byte, error) {
+func (f fakeImageSource) ConfigBlob(context.Context) ([]byte, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) OCIConfig() (*v1.Image, error) {
+func (f fakeImageSource) OCIConfig(context.Context) (*v1.Image, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) LayerInfos() []types.BlobInfo {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (f fakeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) Inspect() (*types.ImageInspectInfo, error) {
+func (f fakeImageSource) Inspect(context.Context) (*types.ImageInspectInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
+func (f fakeImageSource) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) Size() (int64, error) {
@@ -144,7 +144,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:               src,
 			canModifyManifest: true,
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(c.destTypes, "")
+		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, "")
 		require.NoError(t, err, c.description)
 		assert.Equal(t, c.expectedUpdate, ic.manifestUpdates.ManifestMIMEType, c.description)
 		if c.expectedUpdate == "" {
@@ -163,7 +163,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:               src,
 			canModifyManifest: false,
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(c.destTypes, "")
+		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, "")
 		require.NoError(t, err, c.description)
 		assert.Equal(t, "", ic.manifestUpdates.ManifestMIMEType, c.description)
 		assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), preferredMIMEType, c.description)
@@ -178,7 +178,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:               src,
 			canModifyManifest: true,
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(c.destTypes, v1.MediaTypeImageManifest)
+		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, v1.MediaTypeImageManifest)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, v1.MediaTypeImageManifest, ic.manifestUpdates.ManifestMIMEType, c.description)
 		assert.Equal(t, v1.MediaTypeImageManifest, preferredMIMEType, c.description)
@@ -191,7 +191,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 		src:               fakeImageSource(""),
 		canModifyManifest: true,
 	}
-	_, _, err := ic.determineManifestConversion(supportS1S2, "")
+	_, _, err := ic.determineManifestConversion(context.Background(), supportS1S2, "")
 	assert.Error(t, err)
 }
 
@@ -205,13 +205,13 @@ func TestIsMultiImage(t *testing.T) {
 		{manifest.DockerV2Schema2MediaType, false},
 	} {
 		src := fakeImageSource(c.mt)
-		res, err := isMultiImage(src)
+		res, err := isMultiImage(context.Background(), src)
 		require.NoError(t, err)
 		assert.Equal(t, c.expected, res, c.mt)
 	}
 
 	// Error getting manifest MIME type
 	src := fakeImageSource("")
-	_, err := isMultiImage(src)
+	_, err := isMultiImage(context.Background(), src)
 	assert.Error(t, err)
 }

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -42,7 +43,7 @@ func TestCreateSignature(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	dirRef, err := directory.NewReference(tempDir)
 	require.NoError(t, err)
-	dirDest, err := dirRef.NewImageDestination(nil)
+	dirDest, err := dirRef.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dirDest.Close()
 	c := &copier{
@@ -55,7 +56,8 @@ func TestCreateSignature(t *testing.T) {
 	// Set up a docker: reference
 	dockerRef, err := docker.ParseReference("//busybox")
 	require.NoError(t, err)
-	dockerDest, err := dockerRef.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
+	dockerDest, err := dockerRef.NewImageDestination(context.Background(),
+		&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	require.NoError(t, err)
 	defer dockerDest.Close()
 	c = &copier{

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -1,6 +1,7 @@
 package directory
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -94,7 +95,7 @@ func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *dirImageDestination) SupportsSignatures() error {
+func (d *dirImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 
@@ -122,7 +123,7 @@ func (d *dirImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	blobFile, err := ioutil.TempFile(d.ref.path, "dir-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -164,7 +165,7 @@ func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 // Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 // If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (d *dirImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+func (d *dirImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
@@ -179,7 +180,7 @@ func (d *dirImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) 
 	return true, finfo.Size(), nil
 }
 
-func (d *dirImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+func (d *dirImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
@@ -187,11 +188,11 @@ func (d *dirImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, 
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *dirImageDestination) PutManifest(manifest []byte) error {
+func (d *dirImageDestination) PutManifest(ctx context.Context, manifest []byte) error {
 	return ioutil.WriteFile(d.ref.manifestPath(), manifest, 0644)
 }
 
-func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {
+func (d *dirImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	for i, sig := range signatures {
 		if err := ioutil.WriteFile(d.ref.signaturePath(i), sig, 0644); err != nil {
 			return err
@@ -204,7 +205,7 @@ func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *dirImageDestination) Commit() error {
+func (d *dirImageDestination) Commit(ctx context.Context) error {
 	return nil
 }
 

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -37,7 +37,7 @@ func (s *dirImageSource) Close() error {
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (s *dirImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
 		return nil, "", errors.Errorf(`Getting target manifest not supported by "dir:"`)
 	}
@@ -49,7 +49,7 @@ func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, str
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *dirImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(info.Digest))
 	if err != nil {
 		return nil, -1, err
@@ -84,6 +84,6 @@ func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when copying, in preference to values in the manifest, if specified.
-func (s *dirImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *dirImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -19,7 +19,7 @@ func TestDestinationReference(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
 	ref2 := dest.Reference()
@@ -31,18 +31,18 @@ func TestGetPutManifest(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	man := []byte("test-manifest")
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	err = dest.PutManifest(man)
+	err = dest.PutManifest(context.Background(), man)
 	assert.NoError(t, err)
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
-	src, err := ref.NewImageSource(nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	defer src.Close()
-	m, mt, err := src.GetManifest(nil)
+	m, mt, err := src.GetManifest(context.Background(), nil)
 	assert.NoError(t, err)
 	assert.Equal(t, man, m)
 	assert.Equal(t, "", mt)
@@ -50,7 +50,7 @@ func TestGetPutManifest(t *testing.T) {
 	// Non-default instances are not supported
 	md, err := manifest.Digest(man)
 	require.NoError(t, err)
-	_, _, err = src.GetManifest(&md)
+	_, _, err = src.GetManifest(context.Background(), &md)
 	assert.Error(t, err)
 }
 
@@ -59,21 +59,21 @@ func TestGetPutBlob(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	blob := []byte("test-blob")
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
 	assert.Equal(t, types.PreserveOriginal, dest.DesiredLayerCompression())
-	info, err := dest.PutBlob(bytes.NewReader(blob), types.BlobInfo{Digest: digest.Digest("sha256:digest-test"), Size: int64(9)}, false)
+	info, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{Digest: digest.Digest("sha256:digest-test"), Size: int64(9)}, false)
 	assert.NoError(t, err)
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), info.Size)
 	assert.Equal(t, digest.FromBytes(blob), info.Digest)
 
-	src, err := ref.NewImageSource(nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	defer src.Close()
-	rc, size, err := src.GetBlob(info)
+	rc, size, err := src.GetBlob(context.Background(), info)
 	assert.NoError(t, err)
 	defer rc.Close()
 	b, err := ioutil.ReadAll(rc)
@@ -117,13 +117,13 @@ func TestPutBlobDigestFailure(t *testing.T) {
 		return 0, errors.Errorf(digestErrorString)
 	})
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	_, err = dest.PutBlob(reader, types.BlobInfo{Digest: blobDigest, Size: -1}, false)
+	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, false)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
@@ -135,7 +135,7 @@ func TestGetPutSignatures(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
 	man := []byte("test-manifest")
@@ -143,17 +143,17 @@ func TestGetPutSignatures(t *testing.T) {
 		[]byte("sig1"),
 		[]byte("sig2"),
 	}
-	err = dest.SupportsSignatures()
+	err = dest.SupportsSignatures(context.Background())
 	assert.NoError(t, err)
-	err = dest.PutManifest(man)
+	err = dest.PutManifest(context.Background(), man)
 	require.NoError(t, err)
 
-	err = dest.PutSignatures(signatures)
+	err = dest.PutSignatures(context.Background(), signatures)
 	assert.NoError(t, err)
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
-	src, err := ref.NewImageSource(nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	defer src.Close()
 	sigs, err := src.GetSignatures(context.Background(), nil)
@@ -171,7 +171,7 @@ func TestSourceReference(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	src, err := ref.NewImageSource(nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	defer src.Close()
 	ref2 := src.Reference()

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -1,6 +1,7 @@
 package directory
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -138,29 +139,29 @@ func (ref dirReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref dirReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref dirReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ref)
-	return image.FromSource(ctx, src)
+	return image.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dirReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref dirReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ref), nil
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref dirReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref dirReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	compress := false
-	if ctx != nil {
-		compress = ctx.DirForceCompress
+	if sys != nil {
+		compress = sys.DirForceCompress
 	}
 	return newImageDestination(ref, compress)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref dirReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return errors.Errorf("Deleting images not implemented for dir: images")
 }
 

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -1,6 +1,7 @@
 package directory
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -151,17 +152,17 @@ func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
 	mFixture, err := ioutil.ReadFile("../manifest/fixtures/v2s1.manifest.json")
 	require.NoError(t, err)
-	err = dest.PutManifest(mFixture)
+	err = dest.PutManifest(context.Background(), mFixture)
 	assert.NoError(t, err)
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
-	img, err := ref.NewImage(nil)
+	img, err := ref.NewImage(context.Background(), nil)
 	assert.NoError(t, err)
 	defer img.Close()
 }
@@ -170,22 +171,22 @@ func TestReferenceNewImageNoValidManifest(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	err = dest.PutManifest([]byte(`{"schemaVersion":1}`))
+	err = dest.PutManifest(context.Background(), []byte(`{"schemaVersion":1}`))
 	assert.NoError(t, err)
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
-	_, err = ref.NewImage(nil)
+	_, err = ref.NewImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	src, err := ref.NewImageSource(nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
 	defer src.Close()
 }
@@ -193,7 +194,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	assert.NoError(t, err)
 	defer dest.Close()
 }
@@ -201,7 +202,7 @@ func TestReferenceNewImageDestination(t *testing.T) {
 func TestReferenceDeleteImage(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
-	err := ref.DeleteImage(nil)
+	err := ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 

--- a/doc.go
+++ b/doc.go
@@ -13,12 +13,13 @@
 // 		if err != nil {
 // 			panic(err)
 // 		}
-// 		img, err := ref.NewImage(nil)
+//  	ctx := context.Background()
+// 		img, err := ref.NewImage(ctx)
 // 		if err != nil {
 // 			panic(err)
 // 		}
 // 		defer img.Close()
-// 		b, _, err := img.Manifest()
+// 		b, _, err := img.Manifest(ctx)
 // 		if err != nil {
 // 			panic(err)
 // 		}

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -15,7 +16,7 @@ type archiveImageDestination struct {
 	writer               io.Closer
 }
 
-func newImageDestination(ctx *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, ref archiveReference) (types.ImageDestination, error) {
 	if ref.destinationRef == nil {
 		return nil, errors.Errorf("docker-archive: destination reference not supplied (must be of form <path>:<reference:tag>)")
 	}
@@ -66,6 +67,6 @@ func (d *archiveImageDestination) Close() error {
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *archiveImageDestination) Commit() error {
-	return d.Destination.Commit()
+func (d *archiveImageDestination) Commit(ctx context.Context) error {
+	return d.Destination.Commit(ctx)
 }

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"github.com/containers/image/docker/tarfile"
 	"github.com/containers/image/types"
 	"github.com/sirupsen/logrus"
@@ -13,7 +14,7 @@ type archiveImageSource struct {
 
 // newImageSource returns a types.ImageSource for the specified image reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref archiveReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, ref archiveReference) (types.ImageSource, error) {
 	if ref.destinationRef != nil {
 		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
 	}
@@ -34,6 +35,6 @@ func (s *archiveImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *archiveImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *archiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -130,28 +131,28 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref archiveReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	return ctrImage.FromSource(ctx, src)
+	return ctrImage.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref archiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref archiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref archiveReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ctx, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref archiveReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref archiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	// Not really supported, for safety reasons.
 	return errors.New("Deleting images not implemented for docker-archive: images")
 }

--- a/docker/archive/transport_test.go
+++ b/docker/archive/transport_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -144,7 +145,7 @@ func TestReferenceNewImage(t *testing.T) {
 	for _, suffix := range []string{"", ":thisisignoredbutaccepted"} {
 		ref, err := ParseReference(tarFixture + suffix)
 		require.NoError(t, err, suffix)
-		img, err := ref.NewImage(nil)
+		img, err := ref.NewImage(context.Background(), nil)
 		assert.NoError(t, err, suffix)
 		defer img.Close()
 	}
@@ -154,7 +155,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 	for _, suffix := range []string{"", ":thisisignoredbutaccepted"} {
 		ref, err := ParseReference(tarFixture + suffix)
 		require.NoError(t, err, suffix)
-		src, err := ref.NewImageSource(nil)
+		src, err := ref.NewImageSource(context.Background(), nil)
 		assert.NoError(t, err, suffix)
 		defer src.Close()
 	}
@@ -167,12 +168,12 @@ func TestReferenceNewImageDestination(t *testing.T) {
 
 	ref, err := ParseReference(filepath.Join(tmpDir, "no-reference"))
 	require.NoError(t, err)
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	assert.Error(t, err)
 
 	ref, err = ParseReference(filepath.Join(tmpDir, "with-reference") + "busybox:latest")
 	require.NoError(t, err)
-	dest, err = ref.NewImageDestination(nil)
+	dest, err = ref.NewImageDestination(context.Background(), nil)
 	assert.NoError(t, err)
 	defer dest.Close()
 }
@@ -189,7 +190,7 @@ func TestReferenceDeleteImage(t *testing.T) {
 
 		ref, err := ParseReference(testFile + suffix)
 		require.NoError(t, err, suffix)
-		err = ref.DeleteImage(nil)
+		err = ref.DeleteImage(context.Background(), nil)
 		assert.Error(t, err, suffix)
 
 		_, err = os.Lstat(testFile)

--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -15,10 +15,10 @@ const (
 )
 
 // NewDockerClient initializes a new API client based on the passed SystemContext.
-func newDockerClient(ctx *types.SystemContext) (*dockerclient.Client, error) {
+func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	host := dockerclient.DefaultDockerHost
-	if ctx != nil && ctx.DockerDaemonHost != "" {
-		host = ctx.DockerDaemonHost
+	if sys != nil && sys.DockerDaemonHost != "" {
+		host = sys.DockerDaemonHost
 	}
 
 	// Sadly, unix:// sockets don't work transparently with dockerclient.NewClient.
@@ -39,7 +39,7 @@ func newDockerClient(ctx *types.SystemContext) (*dockerclient.Client, error) {
 		if proto == "http" {
 			httpClient = httpConfig()
 		} else {
-			hc, err := tlsConfig(ctx)
+			hc, err := tlsConfig(sys)
 			if err != nil {
 				return nil, err
 			}
@@ -50,16 +50,16 @@ func newDockerClient(ctx *types.SystemContext) (*dockerclient.Client, error) {
 	return dockerclient.NewClient(host, defaultAPIVersion, httpClient, nil)
 }
 
-func tlsConfig(ctx *types.SystemContext) (*http.Client, error) {
+func tlsConfig(sys *types.SystemContext) (*http.Client, error) {
 	options := tlsconfig.Options{}
-	if ctx != nil && ctx.DockerDaemonInsecureSkipTLSVerify {
+	if sys != nil && sys.DockerDaemonInsecureSkipTLSVerify {
 		options.InsecureSkipVerify = true
 	}
 
-	if ctx != nil && ctx.DockerDaemonCertPath != "" {
-		options.CAFile = filepath.Join(ctx.DockerDaemonCertPath, "ca.pem")
-		options.CertFile = filepath.Join(ctx.DockerDaemonCertPath, "cert.pem")
-		options.KeyFile = filepath.Join(ctx.DockerDaemonCertPath, "key.pem")
+	if sys != nil && sys.DockerDaemonCertPath != "" {
+		options.CAFile = filepath.Join(sys.DockerDaemonCertPath, "ca.pem")
+		options.CertFile = filepath.Join(sys.DockerDaemonCertPath, "cert.pem")
+		options.KeyFile = filepath.Join(sys.DockerDaemonCertPath, "key.pem")
 	}
 
 	tlsc, err := tlsconfig.Client(options)

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"github.com/pkg/errors"
 
 	"github.com/containers/image/docker/reference"
@@ -156,28 +157,28 @@ func (ref daemonReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, ref)
+func (ref daemonReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(ctx, src)
+	return image.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref daemonReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+func (ref daemonReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref daemonReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, ref)
+func (ref daemonReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref daemonReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref daemonReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	// Should this just untag the image? Should this stop running containers?
 	// The semantics is not quite as clear as for remote repositories.
 	// The user can run (docker rmi) directly anyway, so, for now(?), punt instead of trying to guess what the user meant.

--- a/docker/daemon/daemon_transport_test.go
+++ b/docker/daemon/daemon_transport_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/image/docker/reference"
@@ -216,13 +217,13 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceDeleteImage(t *testing.T) {
 	ref, err := ParseReference(sha256digest)
 	require.NoError(t, err)
-	err = ref.DeleteImage(nil)
+	err = ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 
 	for _, c := range validNamedReferenceTestCases {
 		ref, err := ParseReference(c.input)
 		require.NoError(t, err, c.input)
-		err = ref.DeleteImage(nil)
+		err = ref.DeleteImage(context.Background(), nil)
 		assert.Error(t, err, c.input)
 	}
 }

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -78,7 +78,7 @@ type bearerToken struct {
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
 	// The following members are set by newDockerClient and do not change afterwards.
-	ctx           *types.SystemContext
+	sys           *types.SystemContext
 	registry      string
 	username      string
 	password      string
@@ -131,12 +131,12 @@ func serverDefault() *tls.Config {
 }
 
 // dockerCertDir returns a path to a directory to be consumed by tlsclientconfig.SetupCertificates() depending on ctx and hostPort.
-func dockerCertDir(ctx *types.SystemContext, hostPort string) (string, error) {
-	if ctx != nil && ctx.DockerCertPath != "" {
-		return ctx.DockerCertPath, nil
+func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
+	if sys != nil && sys.DockerCertPath != "" {
+		return sys.DockerCertPath, nil
 	}
-	if ctx != nil && ctx.DockerPerHostCertDirPath != "" {
-		return filepath.Join(ctx.DockerPerHostCertDirPath, hostPort), nil
+	if sys != nil && sys.DockerPerHostCertDirPath != "" {
+		return filepath.Join(sys.DockerPerHostCertDirPath, hostPort), nil
 	}
 
 	var (
@@ -144,8 +144,8 @@ func dockerCertDir(ctx *types.SystemContext, hostPort string) (string, error) {
 		fullCertDirPath string
 	)
 	for _, systemPerHostCertDirPath := range systemPerHostCertDirPaths {
-		if ctx != nil && ctx.RootForImplicitAbsolutePaths != "" {
-			hostCertDir = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemPerHostCertDirPath)
+		if sys != nil && sys.RootForImplicitAbsolutePaths != "" {
+			hostCertDir = filepath.Join(sys.RootForImplicitAbsolutePaths, systemPerHostCertDirPath)
 		} else {
 			hostCertDir = systemPerHostCertDirPath
 		}
@@ -171,23 +171,23 @@ func dockerCertDir(ctx *types.SystemContext, hostPort string) (string, error) {
 
 // newDockerClientFromRef returns a new dockerClient instance for refHostname (a host a specified in the Docker image reference, not canonicalized to dockerRegistry)
 // “write” specifies whether the client will be used for "write" access (in particular passed to lookaside.go:toplevelFromSection)
-func newDockerClientFromRef(ctx *types.SystemContext, ref dockerReference, write bool, actions string) (*dockerClient, error) {
+func newDockerClientFromRef(ctx context.Context, sys *types.SystemContext, ref dockerReference, write bool, actions string) (*dockerClient, error) {
 	registry := reference.Domain(ref.ref)
-	username, password, err := config.GetAuthentication(ctx, reference.Domain(ref.ref))
+	username, password, err := config.GetAuthentication(sys, reference.Domain(ref.ref))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}
-	sigBase, err := configuredSignatureStorageBase(ctx, ref, write)
+	sigBase, err := configuredSignatureStorageBase(sys, ref, write)
 	if err != nil {
 		return nil, err
 	}
 	remoteName := reference.Path(ref.ref)
 
-	return newDockerClientWithDetails(ctx, registry, username, password, actions, sigBase, remoteName)
+	return newDockerClientWithDetails(sys, registry, username, password, actions, sigBase, remoteName)
 }
 
 // newDockerClientWithDetails returns a new dockerClient instance for the given parameters
-func newDockerClientWithDetails(ctx *types.SystemContext, registry, username, password, actions string, sigBase signatureStorageBase, remoteName string) (*dockerClient, error) {
+func newDockerClientWithDetails(sys *types.SystemContext, registry, username, password, actions string, sigBase signatureStorageBase, remoteName string) (*dockerClient, error) {
 	hostName := registry
 	if registry == dockerHostname {
 		registry = dockerRegistry
@@ -200,7 +200,7 @@ func newDockerClientWithDetails(ctx *types.SystemContext, registry, username, pa
 	// dockerHostname here, because it is more symmetrical to read the configuration in that case as well, and because
 	// generally the UI hides the existence of the different dockerRegistry.  But note that this behavior is
 	// undocumented and may change if docker/docker changes.
-	certDir, err := dockerCertDir(ctx, hostName)
+	certDir, err := dockerCertDir(sys, hostName)
 	if err != nil {
 		return nil, err
 	}
@@ -208,12 +208,12 @@ func newDockerClientWithDetails(ctx *types.SystemContext, registry, username, pa
 		return nil, err
 	}
 
-	if ctx != nil && ctx.DockerInsecureSkipTLSVerify {
+	if sys != nil && sys.DockerInsecureSkipTLSVerify {
 		tr.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	return &dockerClient{
-		ctx:           ctx,
+		sys:           sys,
 		registry:      registry,
 		username:      username,
 		password:      password,
@@ -228,8 +228,8 @@ func newDockerClientWithDetails(ctx *types.SystemContext, registry, username, pa
 
 // CheckAuth validates the credentials by attempting to log into the registry
 // returns an error if an error occcured while making the http request or the status code received was 401
-func CheckAuth(ctx context.Context, sCtx *types.SystemContext, username, password, registry string) error {
-	newLoginClient, err := newDockerClientWithDetails(sCtx, registry, username, password, "", nil, "")
+func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password, registry string) error {
+	newLoginClient, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
 	if err != nil {
 		return errors.Wrapf(err, "error creating new docker client")
 	}
@@ -268,7 +268,7 @@ type SearchResult struct {
 // The limit is the max number of results desired
 // Note: The limit value doesn't work with all registries
 // for example registry.access.redhat.com returns all the results without limiting it to the limit value
-func SearchRegistry(ctx context.Context, sCtx *types.SystemContext, registry, image string, limit int) ([]SearchResult, error) {
+func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, image string, limit int) ([]SearchResult, error) {
 	type V2Results struct {
 		// Repositories holds the results returned by the /v2/_catalog endpoint
 		Repositories []string `json:"repositories"`
@@ -286,7 +286,7 @@ func SearchRegistry(ctx context.Context, sCtx *types.SystemContext, registry, im
 		registry = dockerV1Hostname
 	}
 
-	client, err := newDockerClientWithDetails(sCtx, registry, "", "", "", nil, "")
+	client, err := newDockerClientWithDetails(sys, registry, "", "", "", nil, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating new docker client")
 	}
@@ -374,8 +374,8 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 			req.Header.Add(n, hh)
 		}
 	}
-	if c.ctx != nil && c.ctx.DockerRegistryUserAgent != "" {
-		req.Header.Add("User-Agent", c.ctx.DockerRegistryUserAgent)
+	if c.sys != nil && c.sys.DockerRegistryUserAgent != "" {
+		req.Header.Add("User-Agent", c.sys.DockerRegistryUserAgent)
 	}
 	if sendAuth {
 		if err := c.setupRequestAuth(req); err != nil {
@@ -503,12 +503,12 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		return nil
 	}
 	err := ping("https")
-	if err != nil && c.ctx != nil && c.ctx.DockerInsecureSkipTLSVerify {
+	if err != nil && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
 		err = ping("http")
 	}
 	if err != nil {
 		err = errors.Wrap(err, "pinging docker registry returned")
-		if c.ctx != nil && c.ctx.DockerDisableV1Ping {
+		if c.sys != nil && c.sys.DockerDisableV1Ping {
 			return err
 		}
 		// best effort to understand if we're talking to a V1 registry
@@ -527,7 +527,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 			return true
 		}
 		isV1 := pingV1("https")
-		if !isV1 && c.ctx != nil && c.ctx.DockerInsecureSkipTLSVerify {
+		if !isV1 && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
 			isV1 = pingV1("http")
 		}
 		if isV1 {

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -29,7 +29,7 @@ func TestDockerCertDir(t *testing.T) {
 
 	systemPerHostResult := filepath.Join(systemPerHostCertDirPaths[len(systemPerHostCertDirPaths)-1], registryHostPort)
 	for _, c := range []struct {
-		ctx      *types.SystemContext
+		sys      *types.SystemContext
 		expected string
 	}{
 		// The common case
@@ -87,7 +87,7 @@ func TestDockerCertDir(t *testing.T) {
 			filepath.Join(variableReference, registryHostPort),
 		},
 	} {
-		path, err := dockerCertDir(c.ctx, registryHostPort)
+		path, err := dockerCertDir(c.sys, registryHostPort)
 		require.Equal(t, nil, err)
 		assert.Equal(t, c.expected, path)
 	}
@@ -144,7 +144,7 @@ func TestGetAuth(t *testing.T) {
 			expectedUsername string
 			expectedPassword string
 			expectedError    error
-			ctx              *types.SystemContext
+			sys              *types.SystemContext
 		}{
 			{
 				name:       "empty hostname",
@@ -240,7 +240,7 @@ func TestGetAuth(t *testing.T) {
 				}),
 				expectedUsername: "foo",
 				expectedPassword: "bar",
-				ctx: &types.SystemContext{
+				sys: &types.SystemContext{
 					DockerAuthConfig: &types.DockerAuthConfig{
 						Username: "foo",
 						Password: "bar",
@@ -258,11 +258,11 @@ func TestGetAuth(t *testing.T) {
 				continue
 			}
 
-			var ctx *types.SystemContext
-			if tc.ctx != nil {
-				ctx = tc.ctx
+			var sys *types.SystemContext
+			if tc.sys != nil {
+				sys = tc.sys
 			}
-			username, password, err := config.GetAuthentication(ctx, tc.hostname)
+			username, password, err := config.GetAuthentication(sys, tc.hostname)
 			if err == nil && tc.expectedError != nil {
 				t.Errorf("[%s] got unexpected non error and username=%q, password=%q", tc.name, username, password)
 				continue

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -22,12 +22,12 @@ type Image struct {
 // newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
-func newImage(ctx *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
-	s, err := newImageSource(ctx, ref)
+func newImage(ctx context.Context, sys *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
+	s, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(ctx, s)
+	img, err := image.FromSource(ctx, sys, s)
 	if err != nil {
 		return nil, err
 	}
@@ -40,10 +40,10 @@ func (i *Image) SourceRefFullName() string {
 }
 
 // GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
-func (i *Image) GetRepositoryTags() ([]string, error) {
+func (i *Image) GetRepositoryTags(ctx context.Context) ([]string, error) {
 	path := fmt.Sprintf(tagsPath, reference.Path(i.src.ref.ref))
 	// FIXME: Pass the context.Context
-	res, err := i.src.c.makeRequest(context.TODO(), "GET", path, nil, nil)
+	res, err := i.src.c.makeRequest(ctx, "GET", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -33,8 +33,8 @@ type dockerImageDestination struct {
 }
 
 // newImageDestination creates a new ImageDestination for the specified image reference.
-func newImageDestination(ctx *types.SystemContext, ref dockerReference) (types.ImageDestination, error) {
-	c, err := newDockerClientFromRef(ctx, ref, true, "pull,push")
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref dockerReference) (types.ImageDestination, error) {
+	c, err := newDockerClientFromRef(ctx, sys, ref, true, "pull,push")
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *dockerImageDestination) SupportsSignatures() error {
-	if err := d.c.detectProperties(context.TODO()); err != nil {
+func (d *dockerImageDestination) SupportsSignatures(ctx context.Context) error {
+	if err := d.c.detectProperties(ctx); err != nil {
 		return err
 	}
 	switch {
@@ -109,9 +109,9 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	if inputInfo.Digest.String() != "" {
-		haveBlob, size, err := d.HasBlob(inputInfo)
+		haveBlob, size, err := d.HasBlob(ctx, inputInfo)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
@@ -123,7 +123,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	// FIXME? Chunked upload, progress reporting, etc.
 	uploadPath := fmt.Sprintf(blobUploadPath, reference.Path(d.ref.ref))
 	logrus.Debugf("Uploading %s", uploadPath)
-	res, err := d.c.makeRequest(context.TODO(), "POST", uploadPath, nil, nil)
+	res, err := d.c.makeRequest(ctx, "POST", uploadPath, nil, nil)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -140,7 +140,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	digester := digest.Canonical.Digester()
 	sizeCounter := &sizeCounter{}
 	tee := io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter))
-	res, err = d.c.makeRequestToResolvedURL(context.TODO(), "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, true)
+	res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, true)
 	if err != nil {
 		logrus.Debugf("Error uploading layer chunked, response %#v", res)
 		return types.BlobInfo{}, err
@@ -159,7 +159,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	// TODO: check inputInfo.Digest == computedDigest https://github.com/containers/image/pull/70#discussion_r77646717
 	locationQuery.Set("digest", computedDigest.String())
 	uploadLocation.RawQuery = locationQuery.Encode()
-	res, err = d.c.makeRequestToResolvedURL(context.TODO(), "PUT", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, true)
+	res, err = d.c.makeRequestToResolvedURL(ctx, "PUT", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, true)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -177,14 +177,14 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 // Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 // If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (d *dockerImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+func (d *dockerImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
 	checkPath := fmt.Sprintf(blobsPath, reference.Path(d.ref.ref), info.Digest.String())
 
 	logrus.Debugf("Checking %s", checkPath)
-	res, err := d.c.makeRequest(context.TODO(), "HEAD", checkPath, nil, nil)
+	res, err := d.c.makeRequest(ctx, "HEAD", checkPath, nil, nil)
 	if err != nil {
 		return false, -1, err
 	}
@@ -204,7 +204,7 @@ func (d *dockerImageDestination) HasBlob(info types.BlobInfo) (bool, int64, erro
 	}
 }
 
-func (d *dockerImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+func (d *dockerImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
@@ -212,7 +212,7 @@ func (d *dockerImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInf
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *dockerImageDestination) PutManifest(m []byte) error {
+func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte) error {
 	digest, err := manifest.Digest(m)
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 	if mimeType != "" {
 		headers["Content-Type"] = []string{mimeType}
 	}
-	res, err := d.c.makeRequest(context.TODO(), "PUT", path, headers, bytes.NewReader(m))
+	res, err := d.c.makeRequest(ctx, "PUT", path, headers, bytes.NewReader(m))
 	if err != nil {
 		return err
 	}
@@ -267,19 +267,19 @@ func isManifestInvalidError(err error) bool {
 	return ec.ErrorCode() == v2.ErrorCodeManifestInvalid || ec.ErrorCode() == v2.ErrorCodeTagInvalid
 }
 
-func (d *dockerImageDestination) PutSignatures(signatures [][]byte) error {
+func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	// Do not fail if we don’t really need to support signatures.
 	if len(signatures) == 0 {
 		return nil
 	}
-	if err := d.c.detectProperties(context.TODO()); err != nil {
+	if err := d.c.detectProperties(ctx); err != nil {
 		return err
 	}
 	switch {
 	case d.c.signatureBase != nil:
 		return d.putSignaturesToLookaside(signatures)
 	case d.c.supportsSignatures:
-		return d.putSignaturesToAPIExtension(signatures)
+		return d.putSignaturesToAPIExtension(ctx, signatures)
 	default:
 		return errors.Errorf("X-Registry-Supports-Signatures extension not supported, and lookaside is not configured")
 	}
@@ -378,7 +378,7 @@ func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error
 }
 
 // putSignaturesToAPIExtension implements PutSignatures() using the X-Registry-Supports-Signatures API extension.
-func (d *dockerImageDestination) putSignaturesToAPIExtension(signatures [][]byte) error {
+func (d *dockerImageDestination) putSignaturesToAPIExtension(ctx context.Context, signatures [][]byte) error {
 	// Skip dealing with the manifest digest, or reading the old state, if not necessary.
 	if len(signatures) == 0 {
 		return nil
@@ -393,7 +393,7 @@ func (d *dockerImageDestination) putSignaturesToAPIExtension(signatures [][]byte
 	// always adds signatures.  Eventually we should also allow removing signatures,
 	// but the X-Registry-Supports-Signatures API extension does not support that yet.
 
-	existingSignatures, err := d.c.getExtensionsSignatures(context.TODO(), d.ref, d.manifestDigest)
+	existingSignatures, err := d.c.getExtensionsSignatures(ctx, d.ref, d.manifestDigest)
 	if err != nil {
 		return err
 	}
@@ -435,7 +435,7 @@ sigExists:
 		}
 
 		path := fmt.Sprintf(extensionsSignaturePath, reference.Path(d.ref.ref), d.manifestDigest.String())
-		res, err := d.c.makeRequest(context.TODO(), "PUT", path, nil, bytes.NewReader(body))
+		res, err := d.c.makeRequest(ctx, "PUT", path, nil, bytes.NewReader(body))
 		if err != nil {
 			return err
 		}
@@ -457,6 +457,6 @@ sigExists:
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *dockerImageDestination) Commit() error {
+func (d *dockerImageDestination) Commit(ctx context.Context) error {
 	return nil
 }

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -30,8 +30,8 @@ type dockerImageSource struct {
 
 // newImageSource creates a new ImageSource for the specified image reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
-	c, err := newDockerClientFromRef(ctx, ref, false, "pull")
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
+	c, err := newDockerClientFromRef(ctx, sys, ref, false, "pull")
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (s *dockerImageSource) Close() error {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *dockerImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *dockerImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 
@@ -74,11 +74,11 @@ func simplifyContentType(contentType string) string {
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *dockerImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
-		return s.fetchManifest(context.TODO(), instanceDigest.String())
+		return s.fetchManifest(ctx, instanceDigest.String())
 	}
-	err := s.ensureManifestIsLoaded(context.TODO())
+	err := s.ensureManifestIsLoaded(ctx)
 	if err != nil {
 		return nil, "", err
 	}
@@ -108,7 +108,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 //
 // ImageSource implementations are not required or expected to do any caching,
 // but because our signatures are “attached” to the manifest digest,
-// we need to ensure that the digest of the manifest returned by GetManifest(nil)
+// we need to ensure that the digest of the manifest returned by GetManifest(ctx, nil)
 // and used by GetSignatures(ctx, nil) are consistent, otherwise we would get spurious
 // signature verification failures when pulling while a tag is being updated.
 func (s *dockerImageSource) ensureManifestIsLoaded(ctx context.Context) error {
@@ -131,13 +131,13 @@ func (s *dockerImageSource) ensureManifestIsLoaded(ctx context.Context) error {
 	return nil
 }
 
-func (s *dockerImageSource) getExternalBlob(urls []string) (io.ReadCloser, int64, error) {
+func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
 	var (
 		resp *http.Response
 		err  error
 	)
 	for _, url := range urls {
-		resp, err = s.c.makeRequestToResolvedURL(context.TODO(), "GET", url, nil, nil, -1, false)
+		resp, err = s.c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, false)
 		if err == nil {
 			if resp.StatusCode != http.StatusOK {
 				err = errors.Errorf("error fetching external blob from %q: %d", url, resp.StatusCode)
@@ -162,14 +162,14 @@ func getBlobSize(resp *http.Response) int64 {
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *dockerImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {
-		return s.getExternalBlob(info.URLs)
+		return s.getExternalBlob(ctx, info.URLs)
 	}
 
 	path := fmt.Sprintf(blobsPath, reference.Path(s.ref.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
-	res, err := s.c.makeRequest(context.TODO(), "GET", path, nil, nil)
+	res, err := s.c.makeRequest(ctx, "GET", path, nil, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -309,8 +309,8 @@ func (s *dockerImageSource) getSignaturesFromAPIExtension(ctx context.Context, i
 }
 
 // deleteImage deletes the named image from the registry, if supported.
-func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
-	c, err := newDockerClientFromRef(ctx, ref, true, "push")
+func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerReference) error {
+	c, err := newDockerClientFromRef(ctx, sys, ref, true, "push")
 	if err != nil {
 		return err
 	}
@@ -325,7 +325,7 @@ func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
 		return err
 	}
 	getPath := fmt.Sprintf(manifestPath, reference.Path(ref.ref), refTail)
-	get, err := c.makeRequest(context.TODO(), "GET", getPath, headers, nil)
+	get, err := c.makeRequest(ctx, "GET", getPath, headers, nil)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
 
 	// When retrieving the digest from a registry >= 2.3 use the following header:
 	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-	delete, err := c.makeRequest(context.TODO(), "DELETE", deletePath, headers, nil)
+	delete, err := c.makeRequest(ctx, "DELETE", deletePath, headers, nil)
 	if err != nil {
 		return err
 	}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -127,25 +128,25 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	return newImage(ctx, ref)
+func (ref dockerReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	return newImage(ctx, sys, ref)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dockerReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+func (ref dockerReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref dockerReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, ref)
+func (ref dockerReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref dockerReference) DeleteImage(ctx *types.SystemContext) error {
-	return deleteImage(ctx, ref)
+func (ref dockerReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
+	return deleteImage(ctx, sys, ref)
 }
 
 // tagOrDigest returns a tag or digest from the reference.

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/image/docker/reference"
@@ -152,7 +153,7 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	img, err := ref.NewImage(&types.SystemContext{
+	img, err := ref.NewImage(context.Background(), &types.SystemContext{
 		RegistriesDirPath:        "/this/doesnt/exist",
 		DockerPerHostCertDirPath: "/this/doesnt/exist",
 		ArchitectureChoice:       "amd64",
@@ -165,7 +166,8 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	src, err := ref.NewImageSource(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
+	src, err := ref.NewImageSource(context.Background(),
+		&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	assert.NoError(t, err)
 	defer src.Close()
 }
@@ -173,7 +175,8 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, err := ParseReference("//busybox")
 	require.NoError(t, err)
-	dest, err := ref.NewImageDestination(&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
+	dest, err := ref.NewImageDestination(context.Background(),
+		&types.SystemContext{RegistriesDirPath: "/this/doesnt/exist", DockerPerHostCertDirPath: "/this/doesnt/exist"})
 	require.NoError(t, err)
 	defer dest.Close()
 }

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -45,9 +45,9 @@ type registryNamespace struct {
 type signatureStorageBase *url.URL // The only documented value is nil, meaning storage is not supported.
 
 // configuredSignatureStorageBase reads configuration to find an appropriate signature storage URL for ref, for write access if “write”.
-func configuredSignatureStorageBase(ctx *types.SystemContext, ref dockerReference, write bool) (signatureStorageBase, error) {
+func configuredSignatureStorageBase(sys *types.SystemContext, ref dockerReference, write bool) (signatureStorageBase, error) {
 	// FIXME? Loading and parsing the config could be cached across calls.
-	dirPath := registriesDirPath(ctx)
+	dirPath := registriesDirPath(sys)
 	logrus.Debugf(`Using registries.d directory %s for sigstore configuration`, dirPath)
 	config, err := loadAndMergeConfig(dirPath)
 	if err != nil {
@@ -74,13 +74,13 @@ func configuredSignatureStorageBase(ctx *types.SystemContext, ref dockerReferenc
 }
 
 // registriesDirPath returns a path to registries.d
-func registriesDirPath(ctx *types.SystemContext) string {
-	if ctx != nil {
-		if ctx.RegistriesDirPath != "" {
-			return ctx.RegistriesDirPath
+func registriesDirPath(sys *types.SystemContext) string {
+	if sys != nil {
+		if sys.RegistriesDirPath != "" {
+			return sys.RegistriesDirPath
 		}
-		if ctx.RootForImplicitAbsolutePaths != "" {
-			return filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesDirPath)
+		if sys.RootForImplicitAbsolutePaths != "" {
+			return filepath.Join(sys.RootForImplicitAbsolutePaths, systemRegistriesDirPath)
 		}
 	}
 	return systemRegistriesDirPath

--- a/docker/lookaside_test.go
+++ b/docker/lookaside_test.go
@@ -55,7 +55,7 @@ func TestRegistriesDirPath(t *testing.T) {
 	const rootPrefix = "/root/prefix"
 
 	for _, c := range []struct {
-		ctx      *types.SystemContext
+		sys      *types.SystemContext
 		expected string
 	}{
 		// The common case
@@ -80,7 +80,7 @@ func TestRegistriesDirPath(t *testing.T) {
 		// No environment expansion happens in the overridden paths
 		{&types.SystemContext{RegistriesDirPath: variableReference}, variableReference},
 	} {
-		path := registriesDirPath(c.ctx)
+		path := registriesDirPath(c.sys)
 		assert.Equal(t, c.expected, path)
 	}
 }

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -3,6 +3,7 @@ package tarfile
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func (d *Destination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *Destination) SupportsSignatures() error {
+func (d *Destination) SupportsSignatures(ctx context.Context) error {
 	return errors.Errorf("Storing signatures for docker tar files is not supported")
 }
 
@@ -71,7 +72,7 @@ func (d *Destination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed datas.
 	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
@@ -102,7 +103,7 @@ func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConf
 	}
 
 	// Maybe the blob has been already sent
-	ok, size, err := d.HasBlob(inputInfo)
+	ok, size, err := d.HasBlob(ctx, inputInfo)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -139,7 +140,7 @@ func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConf
 // the blob must also be returned.  If the destination does not contain the
 // blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil); it
 // returns a non-nil error only on an unexpected failure.
-func (d *Destination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+func (d *Destination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf("Can not check for a blob with unknown digest")
 	}
@@ -154,7 +155,7 @@ func (d *Destination) HasBlob(info types.BlobInfo) (bool, int64, error) {
 // returned false.  Like HasBlob and unlike PutBlob, the digest can not be
 // empty.  If the blob is a filesystem layer, this signifies that the changes
 // it describes need to be applied again when composing a filesystem tree.
-func (d *Destination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+func (d *Destination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
@@ -175,7 +176,7 @@ func (d *Destination) createRepositoriesFile(rootLayerID string) error {
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *Destination) PutManifest(m []byte) error {
+func (d *Destination) PutManifest(ctx context.Context, m []byte) error {
 	// We do not bother with types.ManifestTypeRejectedError; our .SupportedManifestMIMETypes() above is already providing only one alternative,
 	// so the caller trying a different manifest kind would be pointless.
 	var man manifest.Schema2
@@ -364,7 +365,7 @@ func (d *Destination) sendFile(path string, expectedSize int64, stream io.Reader
 // PutSignatures adds the given signatures to the docker tarfile (currently not
 // supported). MUST be called after PutManifest (signatures reference manifest
 // contents)
-func (d *Destination) PutSignatures(signatures [][]byte) error {
+func (d *Destination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	if len(signatures) != 0 {
 		return errors.Errorf("Storing signatures for docker tar files is not supported")
 	}
@@ -373,6 +374,6 @@ func (d *Destination) PutSignatures(signatures [][]byte) error {
 
 // Commit finishes writing data to the underlying io.Writer.
 // It is the caller's responsibility to close it, if necessary.
-func (d *Destination) Commit() error {
+func (d *Destination) Commit(ctx context.Context) error {
 	return d.tar.Close()
 }

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -306,9 +306,9 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *Source) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (s *Source) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
-		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
 		return nil, "", errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
 	}
 	if s.generatedManifest == nil {
@@ -358,7 +358,7 @@ func (r readCloseWrapper) Close() error {
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *Source) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if err := s.ensureCachedDataIsPresent(); err != nil {
 		return nil, 0, err
 	}
@@ -414,7 +414,7 @@ func (s *Source) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 // (e.g. if the source never returns manifest lists).
 func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	if instanceDigest != nil {
-		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
 		return nil, errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
 	}
 	return [][]byte{}, nil

--- a/image/docker_schema1.go
+++ b/image/docker_schema1.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/containers/image/docker/reference"
@@ -44,19 +45,19 @@ func (m *manifestSchema1) ConfigInfo() types.BlobInfo {
 
 // ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
 // The result is cached; it is OK to call this however often you need.
-func (m *manifestSchema1) ConfigBlob() ([]byte, error) {
+func (m *manifestSchema1) ConfigBlob(context.Context) ([]byte, error) {
 	return nil, nil
 }
 
 // OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
 // layers in the resulting configuration isn't guaranteed to be returned to due how
 // old image manifests work (docker v2s1 especially).
-func (m *manifestSchema1) OCIConfig() (*imgspecv1.Image, error) {
+func (m *manifestSchema1) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) {
 	v2s2, err := m.convertToManifestSchema2(nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return v2s2.OCIConfig()
+	return v2s2.OCIConfig(ctx)
 }
 
 // LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
@@ -88,7 +89,7 @@ func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 }
 
 // Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
-func (m *manifestSchema1) Inspect() (*types.ImageInspectInfo, error) {
+func (m *manifestSchema1) Inspect(context.Context) (*types.ImageInspectInfo, error) {
 	return m.m.Inspect(nil)
 }
 
@@ -101,7 +102,7 @@ func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUp
 
 // UpdatedImage returns a types.Image modified according to options.
 // This does not change the state of the original Image object.
-func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error) {
+func (m *manifestSchema1) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
 	copy := manifestSchema1{m: manifest.Schema1Clone(m.m)}
 	if options.LayerInfos != nil {
 		if err := copy.m.UpdateLayerInfos(options.LayerInfos); err != nil {
@@ -134,7 +135,7 @@ func (m *manifestSchema1) UpdatedImage(options types.ManifestUpdateOptions) (typ
 		if err != nil {
 			return nil, err
 		}
-		return m2.UpdatedImage(types.ManifestUpdateOptions{
+		return m2.UpdatedImage(ctx, types.ManifestUpdateOptions{
 			ManifestMIMEType: imgspecv1.MediaTypeImageManifest,
 			InformationOnly:  options.InformationOnly,
 		})

--- a/image/memory.go
+++ b/image/memory.go
@@ -39,7 +39,7 @@ func (i *memoryImage) Size() (int64, error) {
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
-func (i *memoryImage) Manifest() ([]byte, string, error) {
+func (i *memoryImage) Manifest(ctx context.Context) ([]byte, string, error) {
 	if i.serializedManifest == nil {
 		m, err := i.genericManifest.serialize()
 		if err != nil {
@@ -60,6 +60,6 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *memoryImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (i *memoryImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -168,7 +169,7 @@ func TestManifestOCI1ConfigBlob(t *testing.T) {
 			src = nil
 		}
 		m := manifestOCI1FromFixture(t, src, "oci1.json")
-		blob, err := m.ConfigBlob()
+		blob, err := m.ConfigBlob(context.Background())
 		if c.blob != nil {
 			assert.NoError(t, err)
 			assert.Equal(t, c.blob, blob)
@@ -184,7 +185,7 @@ func TestManifestOCI1ConfigBlob(t *testing.T) {
 	// This just tests that the manifest can be created; we test that the parsed
 	// values are correctly returned in tests for the individual getter methods.
 	m := manifestOCI1FromComponentsLikeFixture(configBlob)
-	cb, err := m.ConfigBlob()
+	cb, err := m.ConfigBlob(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, configBlob, cb)
 }
@@ -249,7 +250,7 @@ func TestManifestOCI1Inspect(t *testing.T) {
 	require.NoError(t, err)
 
 	m := manifestOCI1FromComponentsLikeFixture(configJSON)
-	ii, err := m.Inspect()
+	ii, err := m.Inspect(context.Background())
 	require.NoError(t, err)
 	created := time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)
 	assert.Equal(t, types.ImageInspectInfo{
@@ -270,11 +271,11 @@ func TestManifestOCI1Inspect(t *testing.T) {
 
 	// nil configBlob will trigger an error in m.ConfigBlob()
 	m = manifestOCI1FromComponentsLikeFixture(nil)
-	_, err = m.Inspect()
+	_, err = m.Inspect(context.Background())
 	assert.Error(t, err)
 
 	m = manifestOCI1FromComponentsLikeFixture([]byte("invalid JSON"))
-	_, err = m.Inspect()
+	_, err = m.Inspect(context.Background())
 	assert.Error(t, err)
 }
 
@@ -322,12 +323,12 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 
 	// LayerInfos:
 	layerInfos := append(original.LayerInfos()[1:], original.LayerInfos()[0])
-	res, err := original.UpdatedImage(types.ManifestUpdateOptions{
+	res, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		LayerInfos: layerInfos,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, layerInfos, res.LayerInfos())
-	_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+	_, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		LayerInfos: append(layerInfos, layerInfos[0]),
 	})
 	assert.Error(t, err)
@@ -336,7 +337,7 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 	// … is ignored
 	embeddedRef, err := reference.ParseNormalizedNamed("busybox")
 	require.NoError(t, err)
-	res, err = original.UpdatedImage(types.ManifestUpdateOptions{
+	res, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		EmbeddedDockerReference: embeddedRef,
 	})
 	require.NoError(t, err)
@@ -350,7 +351,7 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 	for _, mime := range []string{
 		manifest.DockerV2Schema2MediaType,
 	} {
-		_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+		_, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 			ManifestMIMEType: mime,
 			InformationOnly: types.ManifestUpdateInformation{
 				Destination: &memoryImageDest{ref: originalSrc.ref},
@@ -362,7 +363,7 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 		imgspecv1.MediaTypeImageManifest, // This indicates a confused caller, not a no-op.
 		"this is invalid",
 	} {
-		_, err = original.UpdatedImage(types.ManifestUpdateOptions{
+		_, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 			ManifestMIMEType: mime,
 		})
 		assert.Error(t, err, mime)
@@ -380,12 +381,12 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 func TestConvertToManifestSchema2(t *testing.T) {
 	originalSrc := newOCI1ImageSource(t, "httpd-copy:latest")
 	original := manifestOCI1FromFixture(t, originalSrc, "oci1.json")
-	res, err := original.UpdatedImage(types.ManifestUpdateOptions{
+	res, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
 	})
 	require.NoError(t, err)
 
-	convertedJSON, mt, err := res.Manifest()
+	convertedJSON, mt, err := res.Manifest(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, manifest.DockerV2Schema2MediaType, mt)
 

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -41,9 +41,9 @@ func (i *UnparsedImage) Reference() types.ImageReference {
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
-func (i *UnparsedImage) Manifest() ([]byte, string, error) {
+func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest(i.instanceDigest)
+		m, mt, err := i.src.GetManifest(ctx, i.instanceDigest)
 		if err != nil {
 			return nil, "", err
 		}

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -16,12 +17,12 @@ type ociArchiveImageDestination struct {
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ctx *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
 	tempDirRef, err := createOCIRef(ref.image)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating oci reference")
 	}
-	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx)
+	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
 			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)
@@ -50,8 +51,8 @@ func (d *ociArchiveImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures
-func (d *ociArchiveImageDestination) SupportsSignatures() error {
-	return d.unpackedDest.SupportsSignatures()
+func (d *ociArchiveImageDestination) SupportsSignatures(ctx context.Context) error {
+	return d.unpackedDest.SupportsSignatures(ctx)
 }
 
 func (d *ociArchiveImageDestination) DesiredLayerCompression() types.LayerCompression {
@@ -72,32 +73,32 @@ func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
-func (d *ociArchiveImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
-	return d.unpackedDest.PutBlob(stream, inputInfo, isConfig)
+func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, isConfig)
 }
 
 // HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob
-func (d *ociArchiveImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
-	return d.unpackedDest.HasBlob(info)
+func (d *ociArchiveImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
+	return d.unpackedDest.HasBlob(ctx, info)
 }
 
-func (d *ociArchiveImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
-	return d.unpackedDest.ReapplyBlob(info)
+func (d *ociArchiveImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
+	return d.unpackedDest.ReapplyBlob(ctx, info)
 }
 
 // PutManifest writes manifest to the destination
-func (d *ociArchiveImageDestination) PutManifest(m []byte) error {
-	return d.unpackedDest.PutManifest(m)
+func (d *ociArchiveImageDestination) PutManifest(ctx context.Context, m []byte) error {
+	return d.unpackedDest.PutManifest(ctx, m)
 }
 
-func (d *ociArchiveImageDestination) PutSignatures(signatures [][]byte) error {
-	return d.unpackedDest.PutSignatures(signatures)
+func (d *ociArchiveImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
+	return d.unpackedDest.PutSignatures(ctx, signatures)
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted
 // after the directory is made, it is tarred up into a file and the directory is deleted
-func (d *ociArchiveImageDestination) Commit() error {
-	if err := d.unpackedDest.Commit(); err != nil {
+func (d *ociArchiveImageDestination) Commit(ctx context.Context) error {
+	if err := d.unpackedDest.Commit(ctx); err != nil {
 		return errors.Wrapf(err, "error storing image %q", d.ref.image)
 	}
 

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -19,13 +19,13 @@ type ociArchiveImageSource struct {
 
 // newImageSource returns an ImageSource for reading from an existing directory.
 // newImageSource untars the file and saves it in a temp directory
-func newImageSource(ctx *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp directory")
 	}
 
-	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx)
+	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
 			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)
@@ -72,13 +72,13 @@ func (s *ociArchiveImageSource) Close() error {
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *ociArchiveImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
-	return s.unpackedSrc.GetManifest(instanceDigest)
+func (s *ociArchiveImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	return s.unpackedSrc.GetManifest(ctx, instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ociArchiveImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
-	return s.unpackedSrc.GetBlob(info)
+func (s *ociArchiveImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+	return s.unpackedSrc.GetBlob(ctx, info)
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
@@ -90,6 +90,6 @@ func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDiges
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociArchiveImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *ociArchiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -121,28 +122,28 @@ func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, ref)
+func (ref ociArchiveReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(ctx, src)
+	return image.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+func (ref ociArchiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref ociArchiveReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, ref)
+func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref ociArchiveReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref ociArchiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return errors.Errorf("Deleting images not implemented for oci: images")
 }
 

--- a/oci/archive/oci_transport_test.go
+++ b/oci/archive/oci_transport_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -260,21 +261,21 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImage(nil)
+	_, err := ref.NewImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpTarFile := refToTempOCIArchive(t)
 	defer os.RemoveAll(tmpTarFile)
-	_, err := ref.NewImageSource(nil)
+	_, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	assert.NoError(t, err)
 	defer dest.Close()
 }
@@ -282,6 +283,6 @@ func TestReferenceNewImageDestination(t *testing.T) {
 func TestReferenceDeleteImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	err := ref.DeleteImage(nil)
+	err := ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -24,7 +25,7 @@ type ociImageDestination struct {
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ctx *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
 	if ref.image == "" {
 		return nil, errors.Errorf("cannot save image with empty image.ref.name")
 	}
@@ -45,8 +46,8 @@ func newImageDestination(ctx *types.SystemContext, ref ociReference) (types.Imag
 	}
 
 	d := &ociImageDestination{ref: ref, index: *index}
-	if ctx != nil {
-		d.sharedBlobDir = ctx.OCISharedBlobDirPath
+	if sys != nil {
+		d.sharedBlobDir = sys.OCISharedBlobDirPath
 	}
 
 	if err := ensureDirectoryExists(d.ref.dir); err != nil {
@@ -80,7 +81,7 @@ func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *ociImageDestination) SupportsSignatures() error {
+func (d *ociImageDestination) SupportsSignatures(ctx context.Context) error {
 	return errors.Errorf("Pushing signatures for OCI images is not supported")
 }
 
@@ -105,7 +106,7 @@ func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	blobFile, err := ioutil.TempFile(d.ref.dir, "oci-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -168,7 +169,7 @@ func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 // Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 // If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (d *ociImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+func (d *ociImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
@@ -186,7 +187,7 @@ func (d *ociImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) 
 	return true, finfo.Size(), nil
 }
 
-func (d *ociImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+func (d *ociImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
@@ -194,7 +195,7 @@ func (d *ociImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, 
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *ociImageDestination) PutManifest(m []byte) error {
+func (d *ociImageDestination) PutManifest(ctx context.Context, m []byte) error {
 	digest, err := manifest.Digest(m)
 	if err != nil {
 		return err
@@ -243,7 +244,7 @@ func (d *ociImageDestination) addManifest(desc *imgspecv1.Descriptor) {
 	d.index.Manifests = append(d.index.Manifests, *desc)
 }
 
-func (d *ociImageDestination) PutSignatures(signatures [][]byte) error {
+func (d *ociImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	if len(signatures) != 0 {
 		return errors.Errorf("Pushing signatures for OCI images is not supported")
 	}
@@ -254,7 +255,7 @@ func (d *ociImageDestination) PutSignatures(signatures [][]byte) error {
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *ociImageDestination) Commit() error {
+func (d *ociImageDestination) Commit(ctx context.Context) error {
 	if err := ioutil.WriteFile(d.ref.ociLayoutPath(), []byte(`{"imageLayoutVersion": "1.0.0"}`), 0644); err != nil {
 		return err
 	}

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -48,13 +49,13 @@ func TestPutBlobDigestFailure(t *testing.T) {
 		return 0, errors.Errorf(digestErrorString)
 	})
 
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	_, err = dest.PutBlob(reader, types.BlobInfo{Digest: blobDigest, Size: -1}, false)
+	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, false)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
-	err = dest.Commit()
+	err = dest.Commit(context.Background())
 	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
@@ -103,14 +104,14 @@ func TestPutManifestTwice(t *testing.T) {
 }
 
 func putTestManifest(t *testing.T, ociRef ociReference, tmpDir string) {
-	imageDest, err := newImageDestination(nil, ociRef)
+	imageDest, err := newImageDestination(context.Background(), nil, ociRef)
 	assert.NoError(t, err)
 
 	data := []byte("abc")
-	err = imageDest.PutManifest(data)
+	err = imageDest.PutManifest(context.Background(), data)
 	assert.NoError(t, err)
 
-	err = imageDest.Commit()
+	err = imageDest.Commit(context.Background())
 	assert.NoError(t, err)
 
 	paths := []string{}

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -24,15 +24,15 @@ type ociImageSource struct {
 }
 
 // newImageSource returns an ImageSource for reading from an existing directory.
-func newImageSource(ctx *types.SystemContext, ref ociReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociReference) (types.ImageSource, error) {
 	tr := tlsclientconfig.NewTransport()
 	tr.TLSClientConfig = tlsconfig.ServerDefault()
 
-	if ctx != nil && ctx.OCICertPath != "" {
-		if err := tlsclientconfig.SetupCertificates(ctx.OCICertPath, tr.TLSClientConfig); err != nil {
+	if sys != nil && sys.OCICertPath != "" {
+		if err := tlsclientconfig.SetupCertificates(sys.OCICertPath, tr.TLSClientConfig); err != nil {
 			return nil, err
 		}
-		tr.TLSClientConfig.InsecureSkipVerify = ctx.OCIInsecureSkipTLSVerify
+		tr.TLSClientConfig.InsecureSkipVerify = sys.OCIInsecureSkipTLSVerify
 	}
 
 	client := &http.Client{}
@@ -42,9 +42,9 @@ func newImageSource(ctx *types.SystemContext, ref ociReference) (types.ImageSour
 		return nil, err
 	}
 	d := &ociImageSource{ref: ref, descriptor: descriptor, client: client}
-	if ctx != nil {
+	if sys != nil {
 		// TODO(jonboulle): check dir existence?
-		d.sharedBlobDir = ctx.OCISharedBlobDirPath
+		d.sharedBlobDir = sys.OCISharedBlobDirPath
 	}
 	return d, nil
 }
@@ -63,7 +63,7 @@ func (s *ociImageSource) Close() error {
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *ociImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	var dig digest.Digest
 	var mimeType string
 	if instanceDigest == nil {
@@ -93,9 +93,9 @@ func (s *ociImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, str
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ociImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {
-		return s.getExternalBlob(info.URLs)
+		return s.getExternalBlob(ctx, info.URLs)
 	}
 
 	path, err := s.ref.blobPath(info.Digest, s.sharedBlobDir)
@@ -122,10 +122,17 @@ func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 	return [][]byte{}, nil
 }
 
-func (s *ociImageSource) getExternalBlob(urls []string) (io.ReadCloser, int64, error) {
+func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
 	errWrap := errors.New("failed fetching external blob from all urls")
 	for _, url := range urls {
-		resp, err := s.client.Get(url)
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
+			continue
+		}
+
+		resp, err := s.client.Do(req.WithContext(ctx))
 		if err != nil {
 			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
 			continue
@@ -144,7 +151,7 @@ func (s *ociImageSource) getExternalBlob(urls []string) (io.ReadCloser, int64, e
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *ociImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 

--- a/oci/layout/oci_src_test.go
+++ b/oci/layout/oci_src_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -50,7 +51,7 @@ func TestGetBlobForRemoteLayers(t *testing.T) {
 		},
 	}
 
-	reader, _, err := imageSource.GetBlob(layerInfo)
+	reader, _, err := imageSource.GetBlob(context.Background(), layerInfo)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -64,7 +65,7 @@ func TestGetBlobForRemoteLayersWithTLS(t *testing.T) {
 		OCICertPath: "fixtures/accepted_certs",
 	})
 
-	layer, size, err := imageSource.GetBlob(types.BlobInfo{
+	layer, size, err := imageSource.GetBlob(context.Background(), types.BlobInfo{
 		URLs: []string{httpServerAddr},
 	})
 	require.NoError(t, err)
@@ -78,7 +79,7 @@ func TestGetBlobForRemoteLayersOnTLSFailure(t *testing.T) {
 	imageSource := createImageSource(t, &types.SystemContext{
 		OCICertPath: "fixtures/rejected_certs",
 	})
-	layer, size, err := imageSource.GetBlob(types.BlobInfo{
+	layer, size, err := imageSource.GetBlob(context.Background(), types.BlobInfo{
 		URLs: []string{httpServerAddr},
 	})
 
@@ -123,10 +124,10 @@ func startRemoteLayerServer() (*httptest.Server, error) {
 	return httpServer, nil
 }
 
-func createImageSource(t *testing.T, context *types.SystemContext) types.ImageSource {
+func createImageSource(t *testing.T, sys *types.SystemContext) types.ImageSource {
 	imageRef, err := NewReference("fixtures/manifest", "")
 	require.NoError(t, err)
-	imageSource, err := imageRef.NewImageSource(context)
+	imageSource, err := imageRef.NewImageSource(context.Background(), sys)
 	require.NoError(t, err)
 	return imageSource
 }

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -144,12 +145,12 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref ociReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, ref)
+func (ref ociReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(ctx, src)
+	return image.FromSource(ctx, sys, src)
 }
 
 // getIndex returns a pointer to the index references by this ociReference. If an error occurs opening an index nil is returned together
@@ -217,18 +218,18 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+func (ref ociReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref ociReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, ref)
+func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref ociReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref ociReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return errors.Errorf("Deleting images not implemented for oci: images")
 }
 

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -228,21 +229,21 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImage(nil)
+	_, err := ref.NewImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	_, err := ref.NewImageSource(nil)
+	_, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	dest, err := ref.NewImageDestination(nil)
+	dest, err := ref.NewImageDestination(context.Background(), nil)
 	assert.NoError(t, err)
 	defer dest.Close()
 }
@@ -250,7 +251,7 @@ func TestReferenceNewImageDestination(t *testing.T) {
 func TestReferenceDeleteImage(t *testing.T) {
 	ref, tmpDir := refToTempOCI(t)
 	defer os.RemoveAll(tmpDir)
-	err := ref.DeleteImage(nil)
+	err := ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -162,7 +162,7 @@ func (c *openshiftClient) convertDockerImageReference(ref string) (string, error
 type openshiftImageSource struct {
 	client *openshiftClient
 	// Values specific to this image
-	ctx *types.SystemContext
+	sys *types.SystemContext
 	// State
 	docker               types.ImageSource // The Docker Registry endpoint, or nil if not resolved yet
 	imageStreamImageName string            // Resolved image identifier, or "" if not known yet
@@ -170,7 +170,7 @@ type openshiftImageSource struct {
 
 // newImageSource creates a new ImageSource for the specified reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref openshiftReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref openshiftReference) (types.ImageSource, error) {
 	client, err := newOpenshiftClient(ref)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func newImageSource(ctx *types.SystemContext, ref openshiftReference) (types.Ima
 
 	return &openshiftImageSource{
 		client: client,
-		ctx:    ctx,
+		sys:    sys,
 	}, nil
 }
 
@@ -204,19 +204,19 @@ func (s *openshiftImageSource) Close() error {
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (s *openshiftImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
-	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
+func (s *openshiftImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	if err := s.ensureImageIsResolved(ctx); err != nil {
 		return nil, "", err
 	}
-	return s.docker.GetManifest(instanceDigest)
+	return s.docker.GetManifest(ctx, instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *openshiftImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
-	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
+func (s *openshiftImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+	if err := s.ensureImageIsResolved(ctx); err != nil {
 		return nil, 0, err
 	}
-	return s.docker.GetBlob(info)
+	return s.docker.GetBlob(ctx, info)
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
@@ -247,7 +247,7 @@ func (s *openshiftImageSource) GetSignatures(ctx context.Context, instanceDigest
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *openshiftImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *openshiftImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 
@@ -291,7 +291,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
-	d, err := dockerRef.NewImageSource(s.ctx)
+	d, err := dockerRef.NewImageSource(ctx, s.sys)
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ type openshiftImageDestination struct {
 }
 
 // newImageDestination creates a new ImageDestination for the specified reference.
-func newImageDestination(ctx *types.SystemContext, ref openshiftReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref openshiftReference) (types.ImageDestination, error) {
 	client, err := newOpenshiftClient(ref)
 	if err != nil {
 		return nil, err
@@ -322,7 +322,7 @@ func newImageDestination(ctx *types.SystemContext, ref openshiftReference) (type
 	if err != nil {
 		return nil, err
 	}
-	docker, err := dockerRef.NewImageDestination(ctx)
+	docker, err := dockerRef.NewImageDestination(ctx, sys)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *openshiftImageDestination) SupportsSignatures() error {
+func (d *openshiftImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 
@@ -375,37 +375,37 @@ func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *openshiftImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
-	return d.docker.PutBlob(stream, inputInfo, isConfig)
+func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	return d.docker.PutBlob(ctx, stream, inputInfo, isConfig)
 }
 
 // HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
 // Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 // If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (d *openshiftImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
-	return d.docker.HasBlob(info)
+func (d *openshiftImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
+	return d.docker.HasBlob(ctx, info)
 }
 
-func (d *openshiftImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
-	return d.docker.ReapplyBlob(info)
+func (d *openshiftImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
+	return d.docker.ReapplyBlob(ctx, info)
 }
 
 // PutManifest writes manifest to the destination.
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *openshiftImageDestination) PutManifest(m []byte) error {
+func (d *openshiftImageDestination) PutManifest(ctx context.Context, m []byte) error {
 	manifestDigest, err := manifest.Digest(m)
 	if err != nil {
 		return err
 	}
 	d.imageStreamImageName = manifestDigest.String()
 
-	return d.docker.PutManifest(m)
+	return d.docker.PutManifest(ctx, m)
 }
 
-func (d *openshiftImageDestination) PutSignatures(signatures [][]byte) error {
+func (d *openshiftImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	if d.imageStreamImageName == "" {
 		return errors.Errorf("Internal error: Unknown manifest digest, can't add signatures")
 	}
@@ -416,7 +416,7 @@ func (d *openshiftImageDestination) PutSignatures(signatures [][]byte) error {
 		return nil // No need to even read the old state.
 	}
 
-	image, err := d.client.getImage(context.TODO(), d.imageStreamImageName)
+	image, err := d.client.getImage(ctx, d.imageStreamImageName)
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ sigExists:
 			Content:    newSig,
 		}
 		body, err := json.Marshal(sig)
-		_, err = d.client.doRequest(context.TODO(), "POST", "/oapi/v1/imagesignatures", body)
+		_, err = d.client.doRequest(ctx, "POST", "/oapi/v1/imagesignatures", body)
 		if err != nil {
 			return err
 		}
@@ -470,8 +470,8 @@ sigExists:
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *openshiftImageDestination) Commit() error {
-	return d.docker.Commit()
+func (d *openshiftImageDestination) Commit(ctx context.Context) error {
+	return d.docker.Commit(ctx)
 }
 
 // These structs are subsets of github.com/openshift/origin/pkg/image/api/v1 and its dependencies.

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -130,27 +131,27 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, ref)
+func (ref openshiftReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
-	return genericImage.FromSource(ctx, src)
+	return genericImage.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref openshiftReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+func (ref openshiftReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref openshiftReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, ref)
+func (ref openshiftReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	return newImageDestination(ctx, sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref openshiftReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref openshiftReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return errors.Errorf("Deleting images not implemented for atomic: images")
 }

--- a/openshift/openshift_transport_test.go
+++ b/openshift/openshift_transport_test.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/image/docker/reference"
@@ -120,6 +121,6 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceDeleteImage(t *testing.T) {
 	ref, err := ParseReference("registry.example.com:8443/ns/stream:notlatest")
 	require.NoError(t, err)
-	err = ref.DeleteImage(nil)
+	err = ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -5,6 +5,7 @@ package ostree
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -103,7 +104,7 @@ func (d *ostreeImageDestination) SupportedManifestMIMETypes() []string {
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *ostreeImageDestination) SupportsSignatures() error {
+func (d *ostreeImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 
@@ -123,7 +124,7 @@ func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }
 
-func (d *ostreeImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -310,7 +311,7 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 	return d.ostreeCommit(repo, ostreeBranch, destinationPath, []string{fmt.Sprintf("docker.size=%d", blob.Size)})
 }
 
-func (d *ostreeImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) {
+func (d *ostreeImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
 
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
@@ -344,7 +345,7 @@ func (d *ostreeImageDestination) HasBlob(info types.BlobInfo) (bool, int64, erro
 	return true, size, nil
 }
 
-func (d *ostreeImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
+func (d *ostreeImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
@@ -352,7 +353,7 @@ func (d *ostreeImageDestination) ReapplyBlob(info types.BlobInfo) (types.BlobInf
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *ostreeImageDestination) PutManifest(manifestBlob []byte) error {
+func (d *ostreeImageDestination) PutManifest(ctx context.Context, manifestBlob []byte) error {
 	d.manifest = string(manifestBlob)
 
 	if err := json.Unmarshal(manifestBlob, &d.schema); err != nil {
@@ -373,7 +374,7 @@ func (d *ostreeImageDestination) PutManifest(manifestBlob []byte) error {
 	return ioutil.WriteFile(manifestPath, manifestBlob, 0644)
 }
 
-func (d *ostreeImageDestination) PutSignatures(signatures [][]byte) error {
+func (d *ostreeImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	path := filepath.Join(d.tmpDirPath, d.ref.signaturePath(0))
 	if err := ensureParentDirectoryExists(path); err != nil {
 		return err
@@ -389,7 +390,7 @@ func (d *ostreeImageDestination) PutSignatures(signatures [][]byte) error {
 	return nil
 }
 
-func (d *ostreeImageDestination) Commit() error {
+func (d *ostreeImageDestination) Commit(ctx context.Context) error {
 	repo, err := otbuiltin.OpenRepo(d.ref.repo)
 	if err != nil {
 		return err

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -42,7 +42,7 @@ type ostreeImageSource struct {
 }
 
 // newImageSource returns an ImageSource for reading from an existing directory.
-func newImageSource(ctx *types.SystemContext, tmpDir string, ref ostreeReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, tmpDir string, ref ostreeReference) (types.ImageSource, error) {
 	return &ostreeImageSource{ref: ref, tmpDir: tmpDir, compressed: nil}, nil
 }
 
@@ -92,7 +92,7 @@ func (s *ostreeImageSource) getTarSplitData(blob string) ([]byte, error) {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *ostreeImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (s *ostreeImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
 		return nil, "", errors.Errorf(`Manifest lists are not supported by "ostree:"`)
 	}
@@ -256,13 +256,13 @@ func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, 
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ostreeImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 
 	blob := info.Digest.Hex()
 
 	// Ensure s.compressed is initialized.  It is build by LayerInfosForCopy.
 	if s.compressed == nil {
-		_, err := s.LayerInfosForCopy()
+		_, err := s.LayerInfosForCopy(ctx)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -366,9 +366,9 @@ func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
-func (s *ostreeImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *ostreeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	updatedBlobInfos := []types.BlobInfo{}
-	manifestBlob, manifestType, err := s.GetManifest(nil)
+	manifestBlob, manifestType, err := s.GetManifest(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -4,6 +4,7 @@ package ostree
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -181,46 +182,46 @@ func (s *ostreeImageCloser) Size() (int64, error) {
 // The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref ostreeReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref ostreeReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	var tmpDir string
-	if ctx == nil || ctx.OSTreeTmpDirPath == "" {
+	if sys == nil || sys.OSTreeTmpDirPath == "" {
 		tmpDir = os.TempDir()
 	} else {
-		tmpDir = ctx.OSTreeTmpDirPath
+		tmpDir = sys.OSTreeTmpDirPath
 	}
 	src, err := newImageSource(ctx, tmpDir, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(ctx, src)
+	return image.FromSource(ctx, sys, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ostreeReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref ostreeReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	var tmpDir string
-	if ctx == nil || ctx.OSTreeTmpDirPath == "" {
+	if sys == nil || sys.OSTreeTmpDirPath == "" {
 		tmpDir = os.TempDir()
 	} else {
-		tmpDir = ctx.OSTreeTmpDirPath
+		tmpDir = sys.OSTreeTmpDirPath
 	}
 	return newImageSource(ctx, tmpDir, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref ostreeReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref ostreeReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	var tmpDir string
-	if ctx == nil || ctx.OSTreeTmpDirPath == "" {
+	if sys == nil || sys.OSTreeTmpDirPath == "" {
 		tmpDir = os.TempDir()
 	} else {
-		tmpDir = ctx.OSTreeTmpDirPath
+		tmpDir = sys.OSTreeTmpDirPath
 	}
 	return newImageDestination(ref, tmpDir)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref ostreeReference) DeleteImage(ctx *types.SystemContext) error {
+func (ref ostreeReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return errors.Errorf("Deleting images not implemented for ostree: images")
 }
 

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -3,6 +3,7 @@
 package ostree
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -243,14 +244,14 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 func TestReferenceNewImage(t *testing.T) {
 	ref, err := Transport.ParseReference("busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImage(nil)
+	_, err = ref.NewImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := Transport.ParseReference("busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImageSource(nil)
+	_, err = ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 }
 
@@ -260,7 +261,7 @@ func TestReferenceNewImageDestination(t *testing.T) {
 	defer os.RemoveAll(otherTmpDir)
 
 	for _, c := range []struct {
-		ctx    *types.SystemContext
+		sys    *types.SystemContext
 		tmpDir string
 	}{
 		{nil, os.TempDir()},
@@ -269,7 +270,7 @@ func TestReferenceNewImageDestination(t *testing.T) {
 	} {
 		ref, err := Transport.ParseReference("busybox")
 		require.NoError(t, err)
-		dest, err := ref.NewImageDestination(c.ctx)
+		dest, err := ref.NewImageDestination(context.Background(), c.sys)
 		require.NoError(t, err)
 		ostreeDest, ok := dest.(*ostreeImageDestination)
 		require.True(t, ok)
@@ -285,7 +286,7 @@ func TestReferenceDeleteImage(t *testing.T) {
 
 	ref, err := Transport.ParseReference(withTmpDir("busybox@$TMP/this-repo-does-not-exist", tmpDir))
 	require.NoError(t, err)
-	err = ref.DeleteImage(nil)
+	err = ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 

--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -41,13 +41,13 @@ func normalizeRegistries(regs *registries) {
 
 // Reads the global registry file from the filesystem. Returns
 // a byte array
-func readRegistryConf(ctx *types.SystemContext) ([]byte, error) {
+func readRegistryConf(sys *types.SystemContext) ([]byte, error) {
 	dirPath := systemRegistriesConfPath
-	if ctx != nil {
-		if ctx.SystemRegistriesConfPath != "" {
-			dirPath = ctx.SystemRegistriesConfPath
-		} else if ctx.RootForImplicitAbsolutePaths != "" {
-			dirPath = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
+	if sys != nil {
+		if sys.SystemRegistriesConfPath != "" {
+			dirPath = sys.SystemRegistriesConfPath
+		} else if sys.RootForImplicitAbsolutePaths != "" {
+			dirPath = filepath.Join(sys.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
 		}
 	}
 	configBytes, err := ioutil.ReadFile(dirPath)
@@ -59,10 +59,10 @@ var readConf = readRegistryConf
 
 // Loads the registry configuration file from the filesystem and
 // then unmarshals it.  Returns the unmarshalled object.
-func loadRegistryConf(ctx *types.SystemContext) (*tomlConfig, error) {
+func loadRegistryConf(sys *types.SystemContext) (*tomlConfig, error) {
 	config := &tomlConfig{}
 
-	configBytes, err := readConf(ctx)
+	configBytes, err := readConf(sys)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +78,8 @@ func loadRegistryConf(ctx *types.SystemContext) (*tomlConfig, error) {
 // of the registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined
-func GetRegistries(ctx *types.SystemContext) ([]string, error) {
-	config, err := loadRegistryConf(ctx)
+func GetRegistries(sys *types.SystemContext) ([]string, error) {
+	config, err := loadRegistryConf(sys)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func GetRegistries(ctx *types.SystemContext) ([]string, error) {
 // of the insecure registries as defined in the system-wide
 // registries file.  it returns an empty array if none are
 // defined
-func GetInsecureRegistries(ctx *types.SystemContext) ([]string, error) {
-	config, err := loadRegistryConf(ctx)
+func GetInsecureRegistries(sys *types.SystemContext) ([]string, error) {
+	config, err := loadRegistryConf(sys)
 	if err != nil {
 		return nil, err
 	}

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -44,21 +44,21 @@ func (err InvalidPolicyFormatError) Error() string {
 // DefaultPolicy returns the default policy of the system.
 // Most applications should be using this method to get the policy configured
 // by the system administrator.
-// ctx should usually be nil, can be set to override the default.
+// sys should usually be nil, can be set to override the default.
 // NOTE: When this function returns an error, report it to the user and abort.
 // DO NOT hard-code fallback policies in your application.
-func DefaultPolicy(ctx *types.SystemContext) (*Policy, error) {
-	return NewPolicyFromFile(defaultPolicyPath(ctx))
+func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
+	return NewPolicyFromFile(defaultPolicyPath(sys))
 }
 
 // defaultPolicyPath returns a path to the default policy of the system.
-func defaultPolicyPath(ctx *types.SystemContext) string {
-	if ctx != nil {
-		if ctx.SignaturePolicyPath != "" {
-			return ctx.SignaturePolicyPath
+func defaultPolicyPath(sys *types.SystemContext) string {
+	if sys != nil {
+		if sys.SignaturePolicyPath != "" {
+			return sys.SignaturePolicyPath
 		}
-		if ctx.RootForImplicitAbsolutePaths != "" {
-			return filepath.Join(ctx.RootForImplicitAbsolutePaths, systemDefaultPolicyPath)
+		if sys.RootForImplicitAbsolutePaths != "" {
+			return filepath.Join(sys.RootForImplicitAbsolutePaths, systemDefaultPolicyPath)
 		}
 	}
 	return systemDefaultPolicyPath

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -94,7 +94,7 @@ func TestDefaultPolicyPath(t *testing.T) {
 	const rootPrefix = "/root/prefix"
 
 	for _, c := range []struct {
-		ctx      *types.SystemContext
+		sys      *types.SystemContext
 		expected string
 	}{
 		// The common case
@@ -119,7 +119,7 @@ func TestDefaultPolicyPath(t *testing.T) {
 		// No environment expansion happens in the overridden paths
 		{&types.SystemContext{SignaturePolicyPath: variableReference}, variableReference},
 	} {
-		path := defaultPolicyPath(c.ctx)
+		path := defaultPolicyPath(c.sys)
 		assert.Equal(t, c.expected, path)
 	}
 }

--- a/signature/policy_eval_baselayer.go
+++ b/signature/policy_eval_baselayer.go
@@ -3,15 +3,17 @@
 package signature
 
 import (
+	"context"
+
 	"github.com/containers/image/types"
 	"github.com/sirupsen/logrus"
 )
 
-func (pr *prSignedBaseLayer) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prSignedBaseLayer) isSignatureAuthorAccepted(ctx context.Context, image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	return sarUnknown, nil, nil
 }
 
-func (pr *prSignedBaseLayer) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
+func (pr *prSignedBaseLayer) isRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (bool, error) {
 	// FIXME? Reject this at policy parsing time already?
 	logrus.Errorf("signedBaseLayer not implemented yet!")
 	return false, PolicyRequirementError("signedBaseLayer not implemented yet!")

--- a/signature/policy_eval_baselayer_test.go
+++ b/signature/policy_eval_baselayer_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,7 +11,7 @@ func TestPRSignedBaseLayerIsSignatureAuthorAccepted(t *testing.T) {
 	pr, err := NewPRSignedBaseLayer(NewPRMMatchRepository())
 	require.NoError(t, err)
 	// Pass nil pointers to, kind of, test that the return value does not depend on the parameters.
-	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nil, nil)
+	sar, parsedSig, err := pr.isSignatureAuthorAccepted(context.Background(), nil, nil)
 	assertSARUnknown(t, sar, parsedSig, err)
 }
 
@@ -19,6 +20,6 @@ func TestPRSignedBaseLayerIsRunningImageAllowed(t *testing.T) {
 	pr, err := NewPRSignedBaseLayer(NewPRMMatchRepository())
 	require.NoError(t, err)
 	// Pass a nil pointer to, kind of, test that the return value does not depend on the image.
-	res, err := pr.isRunningImageAllowed(nil)
+	res, err := pr.isRunningImageAllowed(context.Background(), nil)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 }

--- a/signature/policy_eval_simple.go
+++ b/signature/policy_eval_simple.go
@@ -3,26 +3,27 @@
 package signature
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 )
 
-func (pr *prInsecureAcceptAnything) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prInsecureAcceptAnything) isSignatureAuthorAccepted(ctx context.Context, image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	// prInsecureAcceptAnything semantics: Every image is allowed to run,
 	// but this does not consider the signature as verified.
 	return sarUnknown, nil, nil
 }
 
-func (pr *prInsecureAcceptAnything) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
+func (pr *prInsecureAcceptAnything) isRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (bool, error) {
 	return true, nil
 }
 
-func (pr *prReject) isSignatureAuthorAccepted(image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
+func (pr *prReject) isSignatureAuthorAccepted(ctx context.Context, image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
 	return sarRejected, nil, PolicyRequirementError(fmt.Sprintf("Any signatures for image %s are rejected by policy.", transports.ImageName(image.Reference())))
 }
 
-func (pr *prReject) isRunningImageAllowed(image types.UnparsedImage) (bool, error) {
+func (pr *prReject) isRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (bool, error) {
 	return false, PolicyRequirementError(fmt.Sprintf("Running image %s is rejected by policy.", transports.ImageName(image.Reference())))
 }

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/image/docker/reference"
@@ -34,41 +35,41 @@ func (ref nameOnlyImageReferenceMock) PolicyConfigurationIdentity() string {
 func (ref nameOnlyImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref nameOnlyImageReferenceMock) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref nameOnlyImageReferenceMock) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref nameOnlyImageReferenceMock) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref nameOnlyImageReferenceMock) DeleteImage(ctx *types.SystemContext) error {
+func (ref nameOnlyImageReferenceMock) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	panic("unexpected call to a mock function")
 }
 
 func TestPRInsecureAcceptAnythingIsSignatureAuthorAccepted(t *testing.T) {
 	pr := NewPRInsecureAcceptAnything()
 	// Pass nil signature to, kind of, test that the return value does not depend on it.
-	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nameOnlyImageMock{}, nil)
+	sar, parsedSig, err := pr.isSignatureAuthorAccepted(context.Background(), nameOnlyImageMock{}, nil)
 	assertSARUnknown(t, sar, parsedSig, err)
 }
 
 func TestPRInsecureAcceptAnythingIsRunningImageAllowed(t *testing.T) {
 	pr := NewPRInsecureAcceptAnything()
-	res, err := pr.isRunningImageAllowed(nameOnlyImageMock{})
+	res, err := pr.isRunningImageAllowed(context.Background(), nameOnlyImageMock{})
 	assertRunningAllowed(t, res, err)
 }
 
 func TestPRRejectIsSignatureAuthorAccepted(t *testing.T) {
 	pr := NewPRReject()
 	// Pass nil signature to, kind of, test that the return value does not depend on it.
-	sar, parsedSig, err := pr.isSignatureAuthorAccepted(nameOnlyImageMock{}, nil)
+	sar, parsedSig, err := pr.isSignatureAuthorAccepted(context.Background(), nameOnlyImageMock{}, nil)
 	assertSARRejectedPolicyRequirement(t, sar, parsedSig, err)
 }
 
 func TestPRRejectIsRunningImageAllowed(t *testing.T) {
 	pr := NewPRReject()
-	res, err := pr.isRunningImageAllowed(nameOnlyImageMock{})
+	res, err := pr.isRunningImageAllowed(context.Background(), nameOnlyImageMock{})
 	assertRunningRejectedPolicyRequirement(t, res, err)
 }

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -92,16 +93,16 @@ func (ref pcImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	}
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
-func (ref pcImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref pcImageReferenceMock) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref pcImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref pcImageReferenceMock) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref pcImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref pcImageReferenceMock) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref pcImageReferenceMock) DeleteImage(ctx *types.SystemContext) error {
+func (ref pcImageReferenceMock) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	panic("unexpected call to a mock function")
 }
 
@@ -257,7 +258,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// Success
 	img, closer := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	defer closer()
-	sigs, err := pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err := pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
@@ -265,76 +266,76 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	// FIXME? Use really different signatures for this?
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig, expectedSig}, sigs)
 
 	// No signatures
 	img, closer = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Only invalid signatures
 	img, closer = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// 1 invalid, 1 valid signature (in this order)
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// Two sarAccepted results for one signature
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:twoAccepts")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarAccepted+sarRejected for a signature
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptReject")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarAccepted+sarUnknown for a signature
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:acceptUnknown")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Equal(t, []*Signature{expectedSig}, sigs)
 
 	// sarRejected+sarUnknown for a signature
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:rejectUnknown")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// sarUnknown only
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:unknown2")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
 	// Empty list of requirements (invalid)
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	require.NoError(t, err)
 	assert.Empty(t, sigs)
 
@@ -347,7 +348,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	require.NoError(t, err)
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	defer closer()
-	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = destroyedPC.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
@@ -359,7 +360,7 @@ func TestPolicyContextGetSignaturesWithAcceptedAuthor(t *testing.T) {
 	defer os.RemoveAll(invalidSigDir)
 	img, closer = pcImageMock(t, invalidSigDir, "testing/manifest:latest")
 	defer closer()
-	sigs, err = pc.GetSignaturesWithAcceptedAuthor(img)
+	sigs, err = pc.GetSignaturesWithAcceptedAuthor(context.Background(), img)
 	assert.Error(t, err)
 	assert.Nil(t, sigs)
 }
@@ -396,62 +397,62 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	// Success
 	img, closer := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	defer closer()
-	res, err := pc.IsRunningImageAllowed(img)
+	res, err := pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningAllowed(t, res, err)
 
 	// Two signatures
 	// FIXME? Use really different signatures for this?
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid-2", "testing/manifest:latest")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningAllowed(t, res, err)
 
 	// No signatures
 	img, closer = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:latest")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Only invalid signatures
 	img, closer = pcImageMock(t, "fixtures/dir-img-modified-manifest", "testing/manifest:latest")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// 1 invalid, 1 valid signature (in this order)
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:latest")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningAllowed(t, res, err)
 
 	// Two allowed results
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:twoAllows")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningAllowed(t, res, err)
 
 	// Allow + deny results
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:allowDeny")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prReject works
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:reject")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// prInsecureAcceptAnything works
 	img, closer = pcImageMock(t, "fixtures/dir-img-mixed", "testing/manifest:acceptAnything")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningAllowed(t, res, err)
 
 	// Empty list of requirements (invalid)
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:invalidEmptyRequirements")
 	defer closer()
-	res, err = pc.IsRunningImageAllowed(img)
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejectedPolicyRequirement(t, res, err)
 
 	// Unexpected state (context already destroyed)
@@ -461,7 +462,7 @@ func TestPolicyContextIsRunningImageAllowed(t *testing.T) {
 	require.NoError(t, err)
 	img, closer = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:latest")
 	defer closer()
-	res, err = destroyedPC.IsRunningImageAllowed(img)
+	res, err = destroyedPC.IsRunningImageAllowed(context.Background(), img)
 	assertRunningRejected(t, res, err)
 	// Not testing the pcInUse->pcReady transition, that would require custom PolicyRequirement
 	// implementations meddling with the state, or threads. This is for catching trivial programmer

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -61,13 +61,13 @@ func (ref refImageMock) Reference() types.ImageReference {
 func (ref refImageMock) Close() error {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageMock) Manifest() ([]byte, string, error) {
+func (ref refImageMock) Manifest(ctx context.Context) ([]byte, string, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref refImageMock) Signatures(context.Context) ([][]byte, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageMock) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (ref refImageMock) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 
@@ -97,16 +97,16 @@ func (ref refImageReferenceMock) PolicyConfigurationIdentity() string {
 func (ref refImageReferenceMock) PolicyConfigurationNamespaces() []string {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+func (ref refImageReferenceMock) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (ref refImageReferenceMock) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (ref refImageReferenceMock) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageReferenceMock) DeleteImage(ctx *types.SystemContext) error {
+func (ref refImageReferenceMock) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	panic("unexpected call to a mock function")
 }
 
@@ -329,13 +329,13 @@ func (ref forbiddenImageMock) Reference() types.ImageReference {
 func (ref forbiddenImageMock) Close() error {
 	panic("unexpected call to a mock function")
 }
-func (ref forbiddenImageMock) Manifest() ([]byte, string, error) {
+func (ref forbiddenImageMock) Manifest(ctx context.Context) ([]byte, string, error) {
 	panic("unexpected call to a mock function")
 }
 func (ref forbiddenImageMock) Signatures(context.Context) ([][]byte, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref forbiddenImageMock) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (ref forbiddenImageMock) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -102,7 +102,7 @@ func (s storageImageSource) Close() error {
 }
 
 // GetBlob reads the data blob or filesystem layer which matches the digest and size, if given.
-func (s *storageImageSource) GetBlob(info types.BlobInfo) (rc io.ReadCloser, n int64, err error) {
+func (s *storageImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (rc io.ReadCloser, n int64, err error) {
 	rc, n, _, err = s.getBlobAndLayerID(info)
 	return rc, n, err
 }
@@ -158,7 +158,7 @@ func (s *storageImageSource) getBlobAndLayerID(info types.BlobInfo) (rc io.ReadC
 }
 
 // GetManifest() reads the image's manifest.
-func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifestBlob []byte, MIMEType string, err error) {
+func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) (manifestBlob []byte, MIMEType string, err error) {
 	if instanceDigest != nil {
 		return nil, "", ErrNoManifestLists
 	}
@@ -175,9 +175,9 @@ func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifes
 
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
-func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (s *storageImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	updatedBlobInfos := []types.BlobInfo{}
-	_, manifestType, err := s.GetManifest(nil)
+	_, manifestType, err := s.GetManifest(ctx, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading image manifest for %q", s.image.ID)
 	}
@@ -239,7 +239,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
 // it's time to Commit() the image
-func newImageDestination(ctx *types.SystemContext, imageRef storageReference) (*storageImageDestination, error) {
+func newImageDestination(ctx context.Context, imageRef storageReference) (*storageImageDestination, error) {
 	directory, err := ioutil.TempDir(temporaryDirectoryForBigFiles, "storage")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
@@ -283,7 +283,7 @@ func (s storageImageDestination) DesiredLayerCompression() types.LayerCompressio
 
 // PutBlob stores a layer or data blob in our temporary directory, checking that any information
 // in the blobinfo matches the incoming data.
-func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	errorBlobInfo := types.BlobInfo{
 		Digest: "",
 		Size:   -1,
@@ -346,7 +346,7 @@ func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobI
 // Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 // If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (s *storageImageDestination) HasBlob(blobinfo types.BlobInfo) (bool, int64, error) {
+func (s *storageImageDestination) HasBlob(ctx context.Context, blobinfo types.BlobInfo) (bool, int64, error) {
 	if blobinfo.Digest == "" {
 		return false, -1, errors.Errorf(`Can not check for a blob with unknown digest`)
 	}
@@ -383,8 +383,8 @@ func (s *storageImageDestination) HasBlob(blobinfo types.BlobInfo) (bool, int64,
 
 // ReapplyBlob is now a no-op, assuming HasBlob() says we already have it, since Commit() can just apply the
 // same one when it walks the list in the manifest.
-func (s *storageImageDestination) ReapplyBlob(blobinfo types.BlobInfo) (types.BlobInfo, error) {
-	present, size, err := s.HasBlob(blobinfo)
+func (s *storageImageDestination) ReapplyBlob(ctx context.Context, blobinfo types.BlobInfo) (types.BlobInfo, error) {
+	present, size, err := s.HasBlob(ctx, blobinfo)
 	if !present {
 		return types.BlobInfo{}, errors.Errorf("error reapplying blob %+v: blob was not previously applied", blobinfo)
 	}
@@ -459,7 +459,7 @@ func (s *storageImageDestination) getConfigBlob(info types.BlobInfo) ([]byte, er
 	return nil, errors.New("blob not found")
 }
 
-func (s *storageImageDestination) Commit() error {
+func (s *storageImageDestination) Commit(ctx context.Context) error {
 	// Find the list of layer blobs.
 	if len(s.manifest) == 0 {
 		return errors.New("Internal error: storageImageDestination.Commit() called without PutManifest()")
@@ -481,7 +481,7 @@ func (s *storageImageDestination) Commit() error {
 			// Check if it's elsewhere and the caller just forgot to pass it to us in a PutBlob(),
 			// or to even check if we had it.
 			logrus.Debugf("looking for diffID for blob %+v", blob.Digest)
-			has, _, err := s.HasBlob(blob)
+			has, _, err := s.HasBlob(ctx, blob)
 			if err != nil {
 				return errors.Wrapf(err, "error checking for a layer based on blob %q", blob.Digest.String())
 			}
@@ -679,7 +679,7 @@ func (s *storageImageDestination) SupportedManifestMIMETypes() []string {
 }
 
 // PutManifest writes the manifest to the destination.
-func (s *storageImageDestination) PutManifest(manifest []byte) error {
+func (s *storageImageDestination) PutManifest(ctx context.Context, manifest []byte) error {
 	s.manifest = make([]byte, len(manifest))
 	copy(s.manifest, manifest)
 	return nil
@@ -687,7 +687,7 @@ func (s *storageImageDestination) PutManifest(manifest []byte) error {
 
 // SupportsSignatures returns an error if we can't expect GetSignatures() to return data that was
 // previously supplied to PutSignatures().
-func (s *storageImageDestination) SupportsSignatures() error {
+func (s *storageImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 
@@ -703,7 +703,7 @@ func (s *storageImageDestination) MustMatchRuntimeOS() bool {
 }
 
 // PutSignatures records the image's signatures for committing as a single data blob.
-func (s *storageImageDestination) PutSignatures(signatures [][]byte) error {
+func (s *storageImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
 	sizes := []int{}
 	sigblob := []byte{}
 	for _, sig := range signatures {
@@ -769,12 +769,12 @@ func (s *storageImageCloser) Size() (int64, error) {
 }
 
 // newImage creates an image that also knows its size
-func newImage(ctx *types.SystemContext, s storageReference) (types.ImageCloser, error) {
+func newImage(ctx context.Context, sys *types.SystemContext, s storageReference) (types.ImageCloser, error) {
 	src, err := newImageSource(s)
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(ctx, src)
+	img, err := image.FromSource(ctx, sys, src)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"context"
 	"strings"
 
 	"github.com/containers/image/docker/reference"
@@ -181,11 +182,11 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (s storageReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	return newImage(ctx, s)
+func (s storageReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	return newImage(ctx, sys, s)
 }
 
-func (s storageReference) DeleteImage(ctx *types.SystemContext) error {
+func (s storageReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	img, err := s.resolveImage()
 	if err != nil {
 		return err
@@ -200,10 +201,10 @@ func (s storageReference) DeleteImage(ctx *types.SystemContext) error {
 	return err
 }
 
-func (s storageReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (s storageReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(s)
 }
 
-func (s storageReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (s storageReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(ctx, s)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -352,7 +352,7 @@ func TestWriteRead(t *testing.T) {
 	}
 
 	for _, manifestFmt := range manifests {
-		dest, err := ref.NewImageDestination(systemContext())
+		dest, err := ref.NewImageDestination(context.Background(), systemContext())
 		if err != nil {
 			t.Fatalf("NewImageDestination(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -363,7 +363,7 @@ func TestWriteRead(t *testing.T) {
 			t.Fatalf("NewImageDestination(%q) changed the reference to %q", ref.StringWithinTransport(), dest.Reference().StringWithinTransport())
 		}
 		t.Logf("supported manifest MIME types: %v", dest.SupportedManifestMIMETypes())
-		if err := dest.SupportsSignatures(); err != nil {
+		if err := dest.SupportsSignatures(context.Background()); err != nil {
 			t.Fatalf("Destination image doesn't support signatures: %v", err)
 		}
 		t.Logf("compress layers: %v", dest.DesiredLayerCompression())
@@ -372,14 +372,14 @@ func TestWriteRead(t *testing.T) {
 			compression = archive.Gzip
 		}
 		digest, decompressedSize, size, blob := makeLayer(t, compression)
-		if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+		if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 			Size:   size,
 			Digest: digest,
 		}, false); err != nil {
 			t.Fatalf("Error saving randomly-generated layer to destination: %v", err)
 		}
 		t.Logf("Wrote randomly-generated layer %q (%d/%d bytes) to destination", digest, size, decompressedSize)
-		if _, err := dest.PutBlob(bytes.NewBufferString(config), configInfo, false); err != nil {
+		if _, err := dest.PutBlob(context.Background(), bytes.NewBufferString(config), configInfo, false); err != nil {
 			t.Fatalf("Error saving config to destination: %v", err)
 		}
 		manifest := strings.Replace(manifestFmt, "%lh", digest.String(), -1)
@@ -390,24 +390,24 @@ func TestWriteRead(t *testing.T) {
 		manifest = strings.Replace(manifest, "%li", li, -1)
 		manifest = strings.Replace(manifest, "%ci", sum.Hex(), -1)
 		t.Logf("this manifest is %q", manifest)
-		if err := dest.PutManifest([]byte(manifest)); err != nil {
+		if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 			t.Fatalf("Error saving manifest to destination: %v", err)
 		}
-		if err := dest.PutSignatures(signatures); err != nil {
+		if err := dest.PutSignatures(context.Background(), signatures); err != nil {
 			t.Fatalf("Error saving signatures to destination: %v", err)
 		}
-		if err := dest.Commit(); err != nil {
+		if err := dest.Commit(context.Background()); err != nil {
 			t.Fatalf("Error committing changes to destination: %v", err)
 		}
 		dest.Close()
 
-		img, err := ref.NewImage(systemContext())
+		img, err := ref.NewImage(context.Background(), systemContext())
 		if err != nil {
 			t.Fatalf("NewImage(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
 		imageConfigInfo := img.ConfigInfo()
 		if imageConfigInfo.Digest != "" {
-			blob, err := img.ConfigBlob()
+			blob, err := img.ConfigBlob(context.Background())
 			if err != nil {
 				t.Fatalf("image %q claimed there was a config blob, but couldn't produce it: %v", ref.StringWithinTransport(), err)
 			}
@@ -423,7 +423,7 @@ func TestWriteRead(t *testing.T) {
 		if layerInfos == nil {
 			t.Fatalf("image for %q returned empty layer list", ref.StringWithinTransport())
 		}
-		imageInfo, err := img.Inspect()
+		imageInfo, err := img.Inspect(context.Background())
 		if err != nil {
 			t.Fatalf("Inspect(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -431,7 +431,7 @@ func TestWriteRead(t *testing.T) {
 			t.Fatalf("Image %q claims to have been created at time 0", ref.StringWithinTransport())
 		}
 
-		src, err := ref.NewImageSource(systemContext())
+		src, err := ref.NewImageSource(context.Background(), systemContext())
 		if err != nil {
 			t.Fatalf("NewImageSource(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -445,13 +445,13 @@ func TestWriteRead(t *testing.T) {
 				t.Fatalf("NewImageSource(%q) changed the reference to %q", ref.StringWithinTransport(), src.Reference().StringWithinTransport())
 			}
 		}
-		_, manifestType, err := src.GetManifest(nil)
+		_, manifestType, err := src.GetManifest(context.Background(), nil)
 		if err != nil {
 			t.Fatalf("GetManifest(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
 		t.Logf("this manifest's type appears to be %q", manifestType)
 		sum = ddigest.SHA256.FromBytes([]byte(manifest))
-		_, _, err = src.GetManifest(&sum)
+		_, _, err = src.GetManifest(context.Background(), &sum)
 		if err == nil {
 			t.Fatalf("GetManifest(%q) with an instanceDigest is supposed to fail", ref.StringWithinTransport())
 		}
@@ -476,7 +476,7 @@ func TestWriteRead(t *testing.T) {
 		}
 		for _, layerInfo := range layerInfos {
 			buf := bytes.Buffer{}
-			layer, size, err := src.GetBlob(layerInfo)
+			layer, size, err := src.GetBlob(context.Background(), layerInfo)
 			if err != nil {
 				t.Fatalf("Error reading layer %q from %q", layerInfo.Digest, ref.StringWithinTransport())
 			}
@@ -502,7 +502,7 @@ func TestWriteRead(t *testing.T) {
 		}
 		src.Close()
 		img.Close()
-		err = ref.DeleteImage(systemContext())
+		err = ref.DeleteImage(context.Background(), systemContext())
 		if err != nil {
 			t.Fatalf("DeleteImage(%q) returned error %v", ref.StringWithinTransport(), err)
 		}
@@ -524,7 +524,7 @@ func TestDuplicateName(t *testing.T) {
 		t.Fatalf("ParseReference returned nil reference")
 	}
 
-	dest, err := ref.NewImageDestination(systemContext())
+	dest, err := ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, first pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -532,7 +532,7 @@ func TestDuplicateName(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Uncompressed)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, false); err != nil {
@@ -551,15 +551,15 @@ func TestDuplicateName(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination, first pass: %v", err)
 	}
 	dest.Close()
 
-	dest, err = ref.NewImageDestination(systemContext())
+	dest, err = ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -567,7 +567,7 @@ func TestDuplicateName(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
 	}, false); err != nil {
@@ -586,10 +586,10 @@ func TestDuplicateName(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination, second pass: %v", err)
 	}
 	dest.Close()
@@ -610,7 +610,7 @@ func TestDuplicateID(t *testing.T) {
 		t.Fatalf("ParseReference returned nil reference")
 	}
 
-	dest, err := ref.NewImageDestination(systemContext())
+	dest, err := ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, first pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -618,7 +618,7 @@ func TestDuplicateID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, false); err != nil {
@@ -637,15 +637,15 @@ func TestDuplicateID(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination, first pass: %v", err)
 	}
 	dest.Close()
 
-	dest, err = ref.NewImageDestination(systemContext())
+	dest, err = ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -653,7 +653,7 @@ func TestDuplicateID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
 	}, false); err != nil {
@@ -672,10 +672,10 @@ func TestDuplicateID(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); errors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background()); errors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
@@ -699,7 +699,7 @@ func TestDuplicateNameID(t *testing.T) {
 		t.Fatalf("ParseReference returned nil reference")
 	}
 
-	dest, err := ref.NewImageDestination(systemContext())
+	dest, err := ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, first pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -707,7 +707,7 @@ func TestDuplicateNameID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, false); err != nil {
@@ -726,15 +726,15 @@ func TestDuplicateNameID(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination, first pass: %v", err)
 	}
 	dest.Close()
 
-	dest, err = ref.NewImageDestination(systemContext())
+	dest, err = ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q, second pass) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -742,7 +742,7 @@ func TestDuplicateNameID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   int64(size),
 		Digest: digest,
 	}, false); err != nil {
@@ -761,10 +761,10 @@ func TestDuplicateNameID(t *testing.T) {
 		    ]
 		}
 	`, digest, size)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); errors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background()); errors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
@@ -834,25 +834,25 @@ func TestSize(t *testing.T) {
 		t.Fatalf("ParseReference returned nil reference")
 	}
 
-	dest, err := ref.NewImageDestination(systemContext())
+	dest, err := ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
 	if dest == nil {
 		t.Fatalf("NewImageDestination(%q) returned no destination", ref.StringWithinTransport())
 	}
-	if _, err := dest.PutBlob(bytes.NewBufferString(config), configInfo, false); err != nil {
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBufferString(config), configInfo, false); err != nil {
 		t.Fatalf("Error saving config to destination: %v", err)
 	}
 	digest1, usize1, size1, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination: %v", err)
 	}
 	digest2, usize2, size2, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, false); err != nil {
@@ -881,15 +881,15 @@ func TestSize(t *testing.T) {
 		    ]
 		}
 	`, configInfo.Size, configInfo.Digest, digest1, size1, digest2, size2)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination: %v", err)
 	}
 	dest.Close()
 
-	img, err := ref.NewImage(systemContext())
+	img, err := ref.NewImage(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImage(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -925,7 +925,7 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("ParseReference returned nil reference")
 	}
 
-	dest, err := ref.NewImageDestination(systemContext())
+	dest, err := ref.NewImageDestination(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageDestination(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -933,26 +933,26 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q) returned no destination", ref.StringWithinTransport())
 	}
 	digest1, _, size1, blob1 := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob1), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob1), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination (first copy): %v", err)
 	}
 	digest2, _, size2, blob2 := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob2), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob2), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 2 to destination (first copy): %v", err)
 	}
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob1), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob1), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination (second copy): %v", err)
 	}
-	if _, err := dest.PutBlob(bytes.NewBuffer(blob2), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob2), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, false); err != nil {
@@ -991,19 +991,19 @@ func TestDuplicateBlob(t *testing.T) {
 		    ]
 		}
 	`, configInfo.Size, configInfo.Digest, digest1, size1, digest2, size2, digest1, size1, digest2, size2)
-	if err := dest.PutManifest([]byte(manifest)); err != nil {
+	if err := dest.PutManifest(context.Background(), []byte(manifest)); err != nil {
 		t.Fatalf("Error storing manifest to destination: %v", err)
 	}
-	if err := dest.Commit(); err != nil {
+	if err := dest.Commit(context.Background()); err != nil {
 		t.Fatalf("Error committing changes to destination: %v", err)
 	}
 	dest.Close()
 
-	img, err := ref.NewImage(systemContext())
+	img, err := ref.NewImage(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImage(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
-	src, err := ref.NewImageSource(systemContext())
+	src, err := ref.NewImageSource(context.Background(), systemContext())
 	if err != nil {
 		t.Fatalf("NewImageSource(%q) returned error %v", ref.StringWithinTransport(), err)
 	}
@@ -1012,7 +1012,7 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("ImageSource is not a storage image")
 	}
 	layers := []string{}
-	layersInfo, err := img.LayerInfosForCopy()
+	layersInfo, err := img.LayerInfosForCopy(context.Background())
 	if err != nil {
 		t.Fatalf("LayerInfosForCopy() returned error %v", err)
 	}

--- a/tarball/tarball_reference.go
+++ b/tarball/tarball_reference.go
@@ -1,6 +1,7 @@
 package tarball
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -66,12 +67,12 @@ func (r *tarballReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
-	src, err := r.NewImageSource(ctx)
+func (r *tarballReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := r.NewImageSource(ctx, sys)
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(ctx, src)
+	img, err := image.FromSource(ctx, sys, src)
 	if err != nil {
 		src.Close()
 		return nil, err
@@ -79,7 +80,7 @@ func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.ImageCloser
 	return img, nil
 }
 
-func (r *tarballReference) DeleteImage(ctx *types.SystemContext) error {
+func (r *tarballReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	for _, filename := range r.filenames {
 		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("error removing %q: %v", filename, err)
@@ -88,6 +89,6 @@ func (r *tarballReference) DeleteImage(ctx *types.SystemContext) error {
 	return nil
 }
 
-func (r *tarballReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+func (r *tarballReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	return nil, fmt.Errorf(`"tarball:" locations can only be read from, not written to`)
 }

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -34,7 +34,7 @@ type tarballImageSource struct {
 	manifest   []byte
 }
 
-func (r *tarballReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	// Gather up the digests, sizes, and date information for all of the files.
 	filenames := []string{}
 	diffIDs := []digest.Digest{}
@@ -206,7 +206,7 @@ func (is *tarballImageSource) Close() error {
 	return nil
 }
 
-func (is *tarballImageSource) GetBlob(blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
+func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
 	// We should only be asked about things in the manifest.  Maybe the configuration blob.
 	if blobinfo.Digest == is.configID {
 		return ioutil.NopCloser(bytes.NewBuffer(is.config)), is.configSize, nil
@@ -232,7 +232,7 @@ func (is *tarballImageSource) GetBlob(blobinfo types.BlobInfo) (io.ReadCloser, i
 // It may use a remote (= slow) service.
 // If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
 // this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
-func (is *tarballImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+func (is *tarballImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
 		return nil, "", fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
 	}
@@ -255,6 +255,6 @@ func (is *tarballImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (*tarballImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
+func (*tarballImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,3 +1,5 @@
+github.com/containers/image
+
 github.com/sirupsen/logrus v1.0.0
 github.com/containers/storage master
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76


### PR DESCRIPTION
This is a pretty huge change, and it breaks api, so consider this first steps :)

After this change:
 * Network IO paths should react to cancels now.
 * File IO paths generally still won't.
 * `SystemContext` objects have been renamed to `sys` to leave `ctx` available for the stdlib context objects.
