### PR TITLE
Add functions to return Registries paths, tools can use them to help users debug

### DIFF
--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -42,16 +42,7 @@ func normalizeRegistries(regs *registries) {
 // Reads the global registry file from the filesystem. Returns
 // a byte array
 func readRegistryConf(sys *types.SystemContext) ([]byte, error) {
-	dirPath := systemRegistriesConfPath
-	if sys != nil {
-		if sys.SystemRegistriesConfPath != "" {
-			dirPath = sys.SystemRegistriesConfPath
-		} else if sys.RootForImplicitAbsolutePaths != "" {
-			dirPath = filepath.Join(sys.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
-		}
-	}
-	configBytes, err := ioutil.ReadFile(dirPath)
-	return configBytes, err
+	return ioutil.ReadFile(RegistriesConfPath(sys))
 }
 
 // For mocking in unittests
@@ -96,4 +87,17 @@ func GetInsecureRegistries(sys *types.SystemContext) ([]string, error) {
 		return nil, err
 	}
 	return config.Registries.Insecure.Registries, nil
+}
+
+// RegistriesConfPath is the path to the system-wide registry configuration file
+func RegistriesConfPath(ctx *types.SystemContext) string {
+	path := systemRegistriesConfPath
+	if ctx != nil {
+		if ctx.SystemRegistriesConfPath != "" {
+			path = ctx.SystemRegistriesConfPath
+		} else if ctx.RootForImplicitAbsolutePaths != "" {
+			path = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
+		}
+	}
+	return path
 }


### PR DESCRIPTION
We are seeing lots of issues with people taking podman and buildah and just
building them and installing them without greating registries.conf file.

They end up doing

buildah from fedora
or
podman from fedora

And we report that fedora does not exist.

I would like to make podman/buildah smarter so that they could state something like
podman from fedora
fedora does not exist.  
/etc/containers/registries.conf and /etc/containers/registries.d directory are missing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
