### PR TITLE
Add more information to error returned for oci

### DIFF
--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -9,13 +9,12 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/pkg/errors"
-
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 type ociImageDestination struct {
@@ -27,7 +26,7 @@ type ociImageDestination struct {
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
 	if ref.image == "" {
-		return nil, errors.Errorf("cannot save image with empty image.ref.name")
+		return nil, errors.Errorf("cannot save image with empty reference name (syntax must be of form <transport>:<path>:<reference>)")
 	}
 
 	var index *imgspecv1.Index


### PR DESCRIPTION
Add what the syntax of the oci and oci-archive transport should be if an error
is returned when preparing the destination.

Signed-off-by: umohnani8 <umohnani@redhat.com>