### PR TITLE
Remove unused dependencies from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -10,11 +10,9 @@ github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/go-units 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
 github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
-github.com/gorilla/context 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 github.com/gorilla/mux 94e7d24fd285520f3d12ae998f7fdd6b5393d453
 github.com/imdario/mergo 50d4dbd4eb0e84778abe37cefef140271d96fade
 github.com/mattn/go-runewidth 14207d285c6c197daabb5c9793d63e7af9ab2d50
-github.com/mattn/go-shellwords 005a0944d84452842197c2108bd9168ced206f78
 github.com/mistifyio/go-zfs c0224de804d438efd11ea6e52ada8014537d6062
 github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
 github.com/opencontainers/go-digest aa2ec055abd10d26d539eb630a92241b781ce4bc


### PR DESCRIPTION
This commit closes #443, however, some of the dependencies listed in the issue were transitive dependencies that were still needed.

I have check that everything still works without these deps running a `make test`, if you require something else please let me know.