### PR TITLE
getPathToAuth(): bail on any error, not just ENOENT

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -155,6 +155,8 @@ func getPathToAuth(sys *types.SystemContext) (string, error) {
 			// or made a typo while setting the environment variable
 			// so we log the error and return an empty string as the path
 			return "", errors.Wrapf(err, "%q directory set by $XDG_RUNTIME_DIR does not exist. Either create the directory or unset $XDG_RUNTIME_DIR.", runtimeDir)
+		} else if err != nil {
+			return "", err
 		}
 		runtimeDir = filepath.Join(runtimeDir, authCfg)
 	} else {


### PR DESCRIPTION
It's possible for stat() to fail in ways other than ENOENT.
If it does, bail out instead of silently cascading an
error condition.

Signed-off-by: Ed Santiago <santiago@redhat.com>