### PR TITLE
sysregistriesv2: fallback to https for v1 backwards compat

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -185,7 +185,13 @@ func getV1Registries(config *tomlConfig) ([]Registry, error) {
 	getRegistry := func(s string) (*Registry, error) { // Note: _pointer_ to a long-lived object
 		url, err := parseURL(s)
 		if err != nil {
-			return nil, err
+			// fallback to https to be compatible with v1
+			if strings.Contains(err.Error(), "unspecified URI scheme: ") {
+				url, err = parseURL("https://" + s)
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 		prefix := stripURIScheme(url)
 		reg, exists := regMap[prefix]

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -234,7 +234,7 @@ insecure = true`)
 func TestV1BackwardsCompatibility(t *testing.T) {
 	testConfig = []byte(`
 [registries.search]
-registries = ["https://registry-a.com////", "https://registry-c.com"]
+registries = ["registry-a.com////", "https://registry-c.com"]
 
 [registries.block]
 registries = ["https://registry-b.com"]
@@ -252,6 +252,8 @@ registries = ["https://registry-d.com", "https://registry-e.com", "https://regis
 	// check if the expected images are actually in the array
 	var reg *Registry
 	reg = FindRegistry("registry-a.com/foo:bar", unqRegs)
+	// test https fallback for v1
+	assert.Equal(t, "https://registry-a.com", reg.URL.String())
 	assert.NotNil(t, reg)
 	reg = FindRegistry("registry-c.com/foo:bar", unqRegs)
 	assert.NotNil(t, reg)


### PR DESCRIPTION
To be backwards compatible with the v1 config format, fallback to using
https when no URI scheme is specified (e.g., "docker.io").

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>