### PR TITLE
errors.Wrapf doesn't return error when err is nil

### DIFF
--- a/oci/layout/fixtures/two_images_manifest/index.json
+++ b/oci/layout/fixtures/two_images_manifest/index.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "size": 7143,
+      "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "size": 7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "features": [
+          "sse4"
+        ]
+      }
+    }
+  ]
+}

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -23,8 +23,14 @@ func init() {
 	transports.Register(Transport)
 }
 
-// Transport is an ImageTransport for OCI directories.
-var Transport = ociTransport{}
+var (
+	// Transport is an ImageTransport for OCI directories.
+	Transport = ociTransport{}
+
+	// ErrMoreThanOneImage is an error returned when the manifest includes
+	// more than one image and the user should choose which one to use.
+	ErrMoreThanOneImage = errors.New("more than one image in oci, choose an image")
+)
 
 type ociTransport struct{}
 
@@ -184,7 +190,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 			d = &index.Manifests[0]
 		} else {
 			// ask user to choose image when more than one image in the oci directory
-			return imgspecv1.Descriptor{}, errors.Wrapf(err, "more than one image in oci, choose an image")
+			return imgspecv1.Descriptor{}, ErrMoreThanOneImage
 		}
 	} else {
 		// if image specified, look through all manifests for a match

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestGetManifestDescriptor is testing a regression issue where a nil error was being wrapped,
+// this causes the returned error to be nil as well and the user wasn't getting a proper error output.
+//
+// More info: https://github.com/projectatomic/skopeo/issues/496
+func TestGetManifestDescriptor(t *testing.T) {
+	imageRef, err := NewReference("fixtures/two_images_manifest", "")
+	require.NoError(t, err)
+
+	_, err = imageRef.(ociReference).getManifestDescriptor()
+	assert.EqualError(t, err, ErrMoreThanOneImage.Error())
+}
+
 func TestTransportName(t *testing.T) {
 	assert.Equal(t, "oci", Transport.Name())
 }


### PR DESCRIPTION
In this commit you can see how at the beginning of the function
`getManifestDescriptor` it was being checked for an error was different than
nil and returning in that case, however, few lines later that error (remember,
with nil value) was being wrapped. Since the original error was nil, the
wrapping was as well returning a nil.

A regression tests was added.

This commit should close the following issue in skopeo as per @mtrmac
suggestion: https://github.com/projectatomic/skopeo/issues/496