### PR TITLE
tmpdir: unixTempDirForBigFiles can be overridden at build time

### DIFF
--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -5,6 +5,16 @@ import (
 	"runtime"
 )
 
+// unixTempDirForBigFiles is the directory path to store big files on non Windows systems.
+// You can override this at build time with
+// -ldflags '-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=$your_path'
+var unixTempDirForBigFiles = builtinUnixTempDirForBigFiles
+
+// builtinUnixTempDirForBigFiles is the directory path to store big files.
+// Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
+// DO NOT change this, instead see unixTempDirForBigFiles above.
+const builtinUnixTempDirForBigFiles = "/var/tmp"
+
 // TemporaryDirectoryForBigFiles returns a directory for temporary (big) files.
 // On non Windows systems it avoids the use of os.TempDir(), because the default temporary directory usually falls under /tmp
 // which on systemd based systems could be the unsuitable tmpfs filesystem.
@@ -13,7 +23,7 @@ func TemporaryDirectoryForBigFiles() string {
 	if runtime.GOOS == "windows" {
 		temporaryDirectoryForBigFiles = os.TempDir()
 	} else {
-		temporaryDirectoryForBigFiles = "/var/tmp"
+		temporaryDirectoryForBigFiles = unixTempDirForBigFiles
 	}
 	return temporaryDirectoryForBigFiles
 }

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/image/image"
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -24,8 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-const temporaryDirectoryForBigFiles = "/var/tmp" // Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
 
 var (
 	// ErrBlobDigestMismatch is returned when PutBlob() is given a blob
@@ -240,7 +239,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
 // it's time to Commit() the image
 func newImageDestination(imageRef storageReference) (*storageImageDestination, error) {
-	directory, err := ioutil.TempDir(temporaryDirectoryForBigFiles, "storage")
+	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(), "storage")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
 	}


### PR DESCRIPTION
This commit exposes a variable `unixTempDirForBigFiles` to allow some
Linux distributions to use `/tmp`.
On NixOS for instance, `/tmp` is not a tmpfs and Nix sandboxed builds
do not allow to write to `/var/tmp`, only to `/tmp`.

Note the `tmpdir.TemporaryDirectoryForBigFiles()` is now also used in
the `storage` package to create temporary directories.

Signed-off-by: Antoine Eiche <lewo@abesis.fr>