### PR TITLE
Allow image to be saved without a reference name

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -17,10 +17,6 @@ type archiveImageDestination struct {
 }
 
 func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
-	if ref.destinationRef == nil {
-		return nil, errors.Errorf("docker-archive: destination reference not supplied (must be of form <path>:<reference:tag>)")
-	}
-
 	// ref.path can be either a pipe or a regular file
 	// in the case of a pipe, we require that we can open it for write
 	// in the case of a regular file, we don't want to overwrite any pre-existing file

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -41,7 +41,9 @@ func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 
 // archiveReference is an ImageReference for Docker images.
 type archiveReference struct {
-	destinationRef reference.NamedTagged // only used for destinations
+	// only used for destinations
+	// archiveReference.destinationRef is optional and can be nil for destinations as well.
+	destinationRef reference.NamedTagged
 	path           string
 }
 

--- a/docker/archive/transport_test.go
+++ b/docker/archive/transport_test.go
@@ -169,7 +169,8 @@ func TestReferenceNewImageDestination(t *testing.T) {
 	ref, err := ParseReference(filepath.Join(tmpDir, "no-reference"))
 	require.NoError(t, err)
 	dest, err := ref.NewImageDestination(context.Background(), nil)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	dest.Close()
 
 	ref, err = ParseReference(filepath.Join(tmpDir, "with-reference") + "busybox:latest")
 	require.NoError(t, err)

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -25,10 +25,6 @@ type ociImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
-	if ref.image == "" {
-		return nil, errors.Errorf("cannot save image with empty reference name (syntax must be of form <transport>:<path>:<reference>)")
-	}
-
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error
@@ -217,13 +213,11 @@ func (d *ociImageDestination) PutManifest(ctx context.Context, m []byte) error {
 		return err
 	}
 
-	if d.ref.image == "" {
-		return errors.Errorf("cannot save image with empyt image.ref.name")
+	if d.ref.image != "" {
+		annotations := make(map[string]string)
+		annotations["org.opencontainers.image.ref.name"] = d.ref.image
+		desc.Annotations = annotations
 	}
-
-	annotations := make(map[string]string)
-	annotations["org.opencontainers.image.ref.name"] = d.ref.image
-	desc.Annotations = annotations
 	desc.Platform = &imgspecv1.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -55,7 +55,9 @@ type ociReference struct {
 	// (But in general, we make no attempt to be completely safe against concurrent hostile filesystem modifications.)
 	dir         string // As specified by the user. May be relative, contain symlinks, etc.
 	resolvedDir string // Absolute path with no symlinks, at least at the time of its creation. Primarily used for policy namespaces.
-	image       string // If image=="", it means the only image in the index.json is used
+	// If image=="", it means the "only image" in the index.json is used in the case it is a source
+	// for destinations, the image name annotation "image.ref.name" is not added to the index.json
+	image string
 }
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.


### PR DESCRIPTION
The docker-archive and oci-archive transport should allow the
destination of the image to be valid without the reference part also.
Format is transport:path[:reference] where reference is optional.
This is for the case where a user just wants to save/push an image with
the image ID only and not the name.
Creates archives with empty repotags.

Fixes one of the issues in https://github.com/projectatomic/libpod/issues/649

Signed-off-by: umohnani8 <umohnani@redhat.com>