### PR TITLE
Document the subtleties of using url.Parse for validating registry prefixes

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -90,14 +90,33 @@ func parseURL(input string) (string, error) {
 		return "", &InvalidRegistries{s: "invalid URL: cannot be empty"}
 	}
 
+	// Ultimately, we expect input of the form example.com[/namespace/…], a prefix
+	// of a fully-expended reference (containers/image/docker/Reference.String()).
+	// c/image/docker/Reference does not currently provide such a parser.
+	// So, we use url.Parse("http://"+trimmed) below to ~verify the format, possibly
+	// letting some invalid input in, trading that off for a simpler parser.
+	//
+	// url.Parse("http://"+trimmed) is, sadly, too permissive, notably for
+	// trimmed == "http://example.com/…", url.Parse("http://http://example.com/…")
+	// is accepted and parsed as
+	// {Scheme: "http", Host: "http:", Path: "//example.com/…"}.
+	//
+	// So, first we do an explicit check for an unwanted scheme prefix:
+
+	// This will parse trimmed=="http://example.com/…" with Scheme: "http".  Perhaps surprisingly,
+	// it also succeeds for the input we want to accept, in different ways:
+	// "example.com" -> {Scheme:"", Opaque:"", Path:"example.com"}
+	// "example.com/repo" -> {Scheme:"", Opaque:"", Path:"example.com/repo"}
+	// "example.com:5000" -> {Scheme:"example.com", Opaque:"5000"}
+	// "example.com:5000/repo" -> {Scheme:"example.com", Opaque:"5000/repo"}
 	uri, err := url.Parse(trimmed)
 	if err != nil {
 		return "", &InvalidRegistries{s: fmt.Sprintf("invalid URL '%s': %v", input, err)}
 	}
 
-	// Check if a URI SCheme is set.
+	// Check if a URI Scheme is set.
 	// Note that URLs that do not start with a slash after the scheme are
-	// interpreted as `scheme:opaque[?query][#fragment]`.
+	// interpreted as `scheme:opaque[?query][#fragment]`; see above for examples.
 	if uri.Scheme != "" && uri.Opaque == "" {
 		msg := fmt.Sprintf("invalid URL '%s': URI schemes are not supported", input)
 		return "", &InvalidRegistries{s: msg}


### PR DESCRIPTION
This follows up on #464 to clarify why/how we expect both `url.Parse(input)` and `url.parse("http://"+input)` to succeed.