### PR TITLE
dockerClient: skip TLS verification if configured in registries

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/pkg/docker/config"
+	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/pkg/tlsclientconfig"
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/client"
@@ -78,11 +79,13 @@ type bearerToken struct {
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
 	// The following members are set by newDockerClient and do not change afterwards.
-	sys           *types.SystemContext
-	registry      string
+	sys                   *types.SystemContext
+	registry              string
+	client                *http.Client
+	insecureSkipTLSVerify bool
+	// The following members are not set by newDockerClient and must be set by callers if needed.
 	username      string
 	password      string
-	client        *http.Client
 	signatureBase signatureStorageBase
 	scope         authScope
 	// The following members are detected registry properties:
@@ -194,13 +197,26 @@ func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write
 	if err != nil {
 		return nil, err
 	}
-	remoteName := reference.Path(ref.ref)
 
-	return newDockerClientWithDetails(sys, registry, username, password, actions, sigBase, remoteName)
+	client, err := newDockerClient(sys, registry, ref.ref.Name())
+	if err != nil {
+		return nil, err
+	}
+	client.username = username
+	client.password = password
+	client.signatureBase = sigBase
+	client.scope.actions = actions
+	client.scope.remoteName = reference.Path(ref.ref)
+	return client, nil
 }
 
-// newDockerClientWithDetails returns a new dockerClient instance for the given parameters
-func newDockerClientWithDetails(sys *types.SystemContext, registry, username, password, actions string, sigBase signatureStorageBase, remoteName string) (*dockerClient, error) {
+// newDockerClient returns a new dockerClient instance for the given registry
+// and reference.  The reference is used to query the registry configuration
+// and can either be a registry (e.g, "registry.com[:5000]"), a repository
+// (e.g., "registry.com[:5000][/some/namespace]/repo").
+// Please note that newDockerClient does not set all members of dockerClient
+// (e.g., username and password); those must be set by callers if necessary.
+func newDockerClient(sys *types.SystemContext, registry, reference string) (*dockerClient, error) {
 	hostName := registry
 	if registry == dockerHostname {
 		registry = dockerRegistry
@@ -221,33 +237,43 @@ func newDockerClientWithDetails(sys *types.SystemContext, registry, username, pa
 		return nil, err
 	}
 
-	if sys != nil && sys.DockerInsecureSkipTLSVerify {
-		tr.TLSClientConfig.InsecureSkipVerify = true
+	// Check if TLS verification shall be skipped (default=false) which can
+	// either be specified in the sysregistriesv2 configuration or via the
+	// SystemContext, whereas the SystemContext is prioritized.
+	skipVerify := false
+	if sys != nil && sys.DockerInsecureSkipTLSVerify != types.OptionalBoolUndefined {
+		// Only use the SystemContext if the actual value is defined.
+		skipVerify = sys.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue
+	} else {
+		reg, err := sysregistriesv2.FindRegistry(sys, reference)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error loading registries")
+		}
+		if reg != nil {
+			skipVerify = reg.Insecure
+		}
 	}
+	tr.TLSClientConfig.InsecureSkipVerify = skipVerify
 
 	return &dockerClient{
-		sys:           sys,
-		registry:      registry,
-		username:      username,
-		password:      password,
-		client:        &http.Client{Transport: tr},
-		signatureBase: sigBase,
-		scope: authScope{
-			actions:    actions,
-			remoteName: remoteName,
-		},
+		sys:                   sys,
+		registry:              registry,
+		client:                &http.Client{Transport: tr},
+		insecureSkipTLSVerify: skipVerify,
 	}, nil
 }
 
 // CheckAuth validates the credentials by attempting to log into the registry
 // returns an error if an error occcured while making the http request or the status code received was 401
 func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password, registry string) error {
-	newLoginClient, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
+	client, err := newDockerClient(sys, registry, registry)
 	if err != nil {
 		return errors.Wrapf(err, "error creating new docker client")
 	}
+	client.username = username
+	client.password = password
 
-	resp, err := newLoginClient.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth)
+	resp, err := client.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth)
 	if err != nil {
 		return err
 	}
@@ -299,16 +325,21 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}
 
-	// The /v2/_catalog endpoint has been disabled for docker.io therefore the call made to that endpoint will fail
-	// So using the v1 hostname for docker.io for simplicity of implementation and the fact that it returns search results
+	// The /v2/_catalog endpoint has been disabled for docker.io therefore
+	// the call made to that endpoint will fail.  So using the v1 hostname
+	// for docker.io for simplicity of implementation and the fact that it
+	// returns search results.
+	hostname := registry
 	if registry == dockerHostname {
-		registry = dockerV1Hostname
+		hostname = dockerV1Hostname
 	}
 
-	client, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
+	client, err := newDockerClient(sys, hostname, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating new docker client")
 	}
+	client.username = username
+	client.password = password
 
 	// Only try the v1 search endpoint if the search query is not empty. If it is
 	// empty skip to the v2 endpoint.
@@ -530,7 +561,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		return nil
 	}
 	err := ping("https")
-	if err != nil && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
+	if err != nil && c.insecureSkipTLSVerify {
 		err = ping("http")
 	}
 	if err != nil {
@@ -554,7 +585,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 			return true
 		}
 		isV1 := pingV1("https")
-		if !isV1 && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
+		if !isV1 && c.insecureSkipTLSVerify {
 			isV1 = pingV1("http")
 		}
 		if isV1 {

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -368,7 +368,7 @@ func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
 	reg := Registry{}
 	prefixLen := 0
 	for _, r := range registries {
-		if strings.HasPrefix(ref, r.Prefix) {
+		if strings.HasPrefix(ref, r.Prefix+"/") || ref == r.Prefix {
 			length := len(r.Prefix)
 			if length > prefixLen {
 				reg = r

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -280,7 +280,18 @@ var configMutex = sync.Mutex{}
 // are synchronized via configMutex.
 var configCache = make(map[string][]Registry)
 
+// InvalidateCache invalidates the registry cache.  This function is meant to be
+// used for long-running processes that need to reload potential changes made to
+// the cached registry config files.
+func InvalidateCache() {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+	configCache = make(map[string][]Registry)
+}
+
 // GetRegistries loads and returns the registries specified in the config.
+// Note the parsed content of registry config files is cached.  For reloading,
+// use `InvalidateCache` and re-call `GetRegistries`.
 func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	configPath := getConfigPath(ctx)
 

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -323,19 +323,29 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 
 // FindUnqualifiedSearchRegistries returns all registries that are configured
 // for unqualified image search (i.e., with Registry.Search == true).
-func FindUnqualifiedSearchRegistries(registries []Registry) []Registry {
+func FindUnqualifiedSearchRegistries(ctx *types.SystemContext) ([]Registry, error) {
+	registries, err := GetRegistries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	unqualified := []Registry{}
 	for _, reg := range registries {
 		if reg.Search {
 			unqualified = append(unqualified, reg)
 		}
 	}
-	return unqualified
+	return unqualified, nil
 }
 
 // FindRegistry returns the Registry with the longest prefix for ref.  If no
 // Registry prefixes the image, nil is returned.
-func FindRegistry(ref string, registries []Registry) *Registry {
+func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
+	registries, err := GetRegistries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	reg := Registry{}
 	prefixLen := 0
 	for _, r := range registries {
@@ -348,9 +358,9 @@ func FindRegistry(ref string, registries []Registry) *Registry {
 		}
 	}
 	if prefixLen != 0 {
-		return &reg
+		return &reg, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // Reads the global registry file from the filesystem. Returns a byte array.

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -293,6 +294,13 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	// load the config
 	config, err := loadRegistryConf(configPath)
 	if err != nil {
+		// Return an empty []Registry if we use the default config,
+		// which implies that the config path of the SystemContext
+		// isn't set.  Note: if ctx.SystemRegistriesConfPath points to
+		// the default config, we will still return an error.
+		if os.IsNotExist(err) && (ctx == nil || ctx.SystemRegistriesConfPath == "") {
+			return []Registry{}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -25,8 +25,7 @@ func TestParseURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid URL 'https://example.com': URI schemes are not supported")
 
 	_, err = parseURL("john.doe@example.com")
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "invalid URL 'john.doe@example.com': user/password are not supported")
+	assert.Nil(t, err)
 
 	// valid URLs
 	url, err = parseURL("example.com")

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -76,8 +76,8 @@ blocked = true`)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(registries))
 
-	var reg *Registry
-	reg = FindRegistry("registry.com/image:tag", registries)
+	reg, err := FindRegistry(nil, "registry.com/image:tag")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, 2, len(reg.Mirrors))
 	assert.Equal(t, "mirror-1.registry.com", reg.Mirrors[0].URL)
@@ -147,23 +147,26 @@ prefix = ""`)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(registries))
 
-	var reg *Registry
-	reg = FindRegistry("simple-prefix.com/foo/bar:latest", registries)
+	reg, err := FindRegistry(nil, "simple-prefix.com/foo/bar:latest")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "simple-prefix.com", reg.Prefix)
 	assert.Equal(t, reg.URL, "registry.com:5000")
 
-	reg = FindRegistry("complex-prefix.com:4000/with/path/and/beyond:tag", registries)
+	reg, err = FindRegistry(nil, "complex-prefix.com:4000/with/path/and/beyond:tag")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "complex-prefix.com:4000/with/path", reg.Prefix)
 	assert.Equal(t, "another-registry.com:5000", reg.URL)
 
-	reg = FindRegistry("no-prefix.com/foo:tag", registries)
+	reg, err = FindRegistry(nil, "no-prefix.com/foo:tag")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "no-prefix.com", reg.Prefix)
 	assert.Equal(t, "no-prefix.com", reg.URL)
 
-	reg = FindRegistry("empty-prefix.com/foo:tag", registries)
+	reg, err = FindRegistry(nil, "empty-prefix.com/foo:tag")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "empty-prefix.com", reg.Prefix)
 	assert.Equal(t, "empty-prefix.com", reg.URL)
@@ -201,7 +204,8 @@ unqualified-search = true
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 
-	unqRegs := FindUnqualifiedSearchRegistries(registries)
+	unqRegs, err := FindUnqualifiedSearchRegistries(nil)
+	assert.Nil(t, err)
 	assertSearchRegistryURLsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 }
 
@@ -301,11 +305,13 @@ registries = ["registry-d.com", "registry-e.com", "registry-a.com"]`)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(registries))
 
-	unqRegs := FindUnqualifiedSearchRegistries(registries)
+	unqRegs, err := FindUnqualifiedSearchRegistries(nil)
+	assert.Nil(t, err)
 	assertSearchRegistryURLsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 
 	// check if merging works
-	reg := FindRegistry("registry-a.com/bar/foo/barfoo:latest", registries)
+	reg, err := FindRegistry(nil, "registry-a.com/bar/foo/barfoo:latest")
+	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.True(t, reg.Search)
 	assert.True(t, reg.Insecure)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -153,6 +153,21 @@ prefix = ""`)
 	assert.Equal(t, "simple-prefix.com", reg.Prefix)
 	assert.Equal(t, reg.URL, "registry.com:5000")
 
+	// path match
+	reg, err = FindRegistry(nil, "simple-prefix.com/")
+	assert.Nil(t, err)
+	assert.NotNil(t, reg)
+
+	// hostname match
+	reg, err = FindRegistry(nil, "simple-prefix.com")
+	assert.Nil(t, err)
+	assert.NotNil(t, reg)
+
+	// invalid match
+	reg, err = FindRegistry(nil, "simple-prefix.comx")
+	assert.Nil(t, err)
+	assert.Nil(t, reg)
+
 	reg, err = FindRegistry(nil, "complex-prefix.com:4000/with/path/and/beyond:tag")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)

--- a/types/types.go
+++ b/types/types.go
@@ -324,6 +324,30 @@ type DockerAuthConfig struct {
 	Password string
 }
 
+// OptionalBool is a boolean with an additional undefined value, which is meant
+// to be used in the context of user input to distinguish between a
+// user-specified value and a default value.
+type OptionalBool byte
+
+const (
+	// OptionalBoolUndefined indicates that the OptionalBoolean hasn't been written.
+	OptionalBoolUndefined OptionalBool = iota
+	// OptionalBoolTrue represents the boolean true.
+	OptionalBoolTrue
+	// OptionalBoolFalse represents the boolean false.
+	OptionalBoolFalse
+)
+
+// NewOptionalBool converts the input bool into either OptionalBoolTrue or
+// OptionalBoolFalse.  The function is meant to avoid boilerplate code of users.
+func NewOptionalBool(b bool) OptionalBool {
+	o := OptionalBoolFalse
+	if b == true {
+		o = OptionalBoolTrue
+	}
+	return o
+}
+
 // SystemContext allows parameterizing access to implicitly-accessed resources,
 // like configuration files in /etc and users' login state in their home directory.
 // Various components can share the same field only if their semantics is exactly
@@ -376,7 +400,7 @@ type SystemContext struct {
 	// Ignored if DockerCertPath is non-empty.
 	DockerPerHostCertDirPath string
 	// Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
-	DockerInsecureSkipTLSVerify bool
+	DockerInsecureSkipTLSVerify OptionalBool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig
 	// if not "", an User-Agent header is added to each request when contacting a registry.


### PR DESCRIPTION
Based on a discussion from: https://github.com/containers/image/pull/464#issuecomment-397744605

- sysregistriesv2: adjust API to SystemContext
- dockerClient: skip TLS verification if configured in registries