### PR TITLE
Fix the RootForImplicitAbsolutePaths case of getPathToAuth

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/containers/image/types"
@@ -27,16 +26,12 @@ type dockerConfigFile struct {
 	CredHelpers map[string]string           `json:"credHelpers,omitempty"`
 }
 
-const (
-	defaultPath       = "/run"
-	authCfg           = "containers"
-	authCfgFileName   = "auth.json"
-	dockerCfg         = ".docker"
-	dockerCfgFileName = "config.json"
-	dockerLegacyCfg   = ".dockercfg"
-)
-
 var (
+	defaultPerUIDPathFormat = filepath.FromSlash("/run/containers/%d/auth.json")
+	xdgRuntimeDirPath       = filepath.FromSlash("containers/auth.json")
+	dockerHomePath          = filepath.FromSlash(".docker/config.json")
+	dockerLegacyHomePath    = ".dockercfg"
+
 	// ErrNotLoggedIn is returned for users not logged into a registry
 	// that they are trying to logout of
 	ErrNotLoggedIn = errors.New("not logged in")
@@ -64,7 +59,7 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		return sys.DockerAuthConfig.Username, sys.DockerAuthConfig.Password, nil
 	}
 
-	dockerLegacyPath := filepath.Join(homedir.Get(), dockerLegacyCfg)
+	dockerLegacyPath := filepath.Join(homedir.Get(), dockerLegacyHomePath)
 	var paths []string
 	pathToAuth, err := getPathToAuth(sys)
 	if err == nil {
@@ -75,7 +70,7 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		// Logging the error as a warning instead and moving on to pulling the image
 		logrus.Warnf("%v: Trying to pull image in the event that it is a public image.", err)
 	}
-	paths = append(paths, filepath.Join(homedir.Get(), dockerCfg, dockerCfgFileName), dockerLegacyPath)
+	paths = append(paths, filepath.Join(homedir.Get(), dockerHomePath), dockerLegacyPath)
 
 	for _, path := range paths {
 		legacyFormat := path == dockerLegacyPath
@@ -143,7 +138,7 @@ func getPathToAuth(sys *types.SystemContext) (string, error) {
 			return sys.AuthFilePath, nil
 		}
 		if sys.RootForImplicitAbsolutePaths != "" {
-			return filepath.Join(sys.RootForImplicitAbsolutePaths, defaultPath, authCfg, strconv.Itoa(os.Getuid()), authCfgFileName), nil
+			return filepath.Join(sys.RootForImplicitAbsolutePaths, fmt.Sprintf(defaultPerUIDPathFormat, os.Getuid())), nil
 		}
 	}
 
@@ -155,14 +150,12 @@ func getPathToAuth(sys *types.SystemContext) (string, error) {
 		if os.IsNotExist(err) {
 			// This means the user set the XDG_RUNTIME_DIR variable and either forgot to create the directory
 			// or made a typo while setting the environment variable,
-			// so return an error referring to $XDG_RUNTIME_DIR instead of …/authCfgFileName inside.
+			// so return an error referring to $XDG_RUNTIME_DIR instead of xdgRuntimeDirPath inside.
 			return "", errors.Wrapf(err, "%q directory set by $XDG_RUNTIME_DIR does not exist. Either create the directory or unset $XDG_RUNTIME_DIR.", runtimeDir)
-		} // else ignore err and let the caller fail accessing …/authCfgFileName.
-		runtimeDir = filepath.Join(runtimeDir, authCfg)
-	} else {
-		runtimeDir = filepath.Join(defaultPath, authCfg, strconv.Itoa(os.Getuid()))
+		} // else ignore err and let the caller fail accessing xdgRuntimeDirPath.
+		return filepath.Join(runtimeDir, xdgRuntimeDirPath), nil
 	}
-	return filepath.Join(runtimeDir, authCfgFileName), nil
+	return fmt.Sprintf(defaultPerUIDPathFormat, os.Getuid()), nil
 }
 
 // readJSONFile unmarshals the authentications stored in the auth.json file and returns it

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -135,15 +135,15 @@ func RemoveAllAuthentication(sys *types.SystemContext) error {
 
 // getPath gets the path of the auth.json file
 // The path can be overriden by the user if the overwrite-path flag is set
-// If the flag is not set and XDG_RUNTIME_DIR is ser, the auth.json file is saved in XDG_RUNTIME_DIR/containers
-// Otherwise, the auth.json file is stored in /run/user/UID/containers
+// If the flag is not set and XDG_RUNTIME_DIR is set, the auth.json file is saved in XDG_RUNTIME_DIR/containers
+// Otherwise, the auth.json file is stored in /run/containers/UID
 func getPathToAuth(sys *types.SystemContext) (string, error) {
 	if sys != nil {
 		if sys.AuthFilePath != "" {
 			return sys.AuthFilePath, nil
 		}
 		if sys.RootForImplicitAbsolutePaths != "" {
-			return filepath.Join(sys.RootForImplicitAbsolutePaths, defaultPath, strconv.Itoa(os.Getuid()), authCfg, authCfgFileName), nil
+			return filepath.Join(sys.RootForImplicitAbsolutePaths, defaultPath, authCfg, strconv.Itoa(os.Getuid()), authCfgFileName), nil
 		}
 	}
 

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPathToAuth(t *testing.T) {
+	uid := fmt.Sprintf("%d", os.Getuid())
+
+	tmpDir, err := ioutil.TempDir("", "TestGetPathToAuth")
+	require.NoError(t, err)
+
+	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
+	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.
+	oldXRD, hasXRD := os.LookupEnv("XDG_RUNTIME_DIR")
+	defer func() {
+		if hasXRD {
+			os.Setenv("XDG_RUNTIME_DIR", oldXRD)
+		} else {
+			os.Unsetenv("XDG_RUNTIME_DIR")
+		}
+	}()
+
+	for _, c := range []struct {
+		sys      *types.SystemContext
+		xrd      string
+		expected string
+	}{
+		// Default paths
+		{&types.SystemContext{}, "", "/run/containers/" + uid + "/auth.json"},
+		{nil, "", "/run/containers/" + uid + "/auth.json"},
+		// SystemContext overrides
+		{&types.SystemContext{AuthFilePath: "/absolute/path"}, "", "/absolute/path"},
+		{&types.SystemContext{RootForImplicitAbsolutePaths: "/prefix"}, "", "/prefix/run/containers/" + uid + "/auth.json"},
+		// XDG_RUNTIME_DIR defined
+		{nil, tmpDir, tmpDir + "/containers/auth.json"},
+		{nil, tmpDir + "/thisdoesnotexist", ""},
+	} {
+		if c.xrd != "" {
+			os.Setenv("XDG_RUNTIME_DIR", c.xrd)
+		} else {
+			os.Unsetenv("XDG_RUNTIME_DIR")
+		}
+		res, err := getPathToAuth(c.sys)
+		if c.expected == "" {
+			assert.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, res)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #471 , adds unit tests, and cleans up the constants a bit.

See individual commit messages for more details.

@umohnani8 (@runcom ) PTAL