### PR TITLE
Add DockerV2Schema2LayerUncompressedMediaType to manifest

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -24,6 +24,8 @@ const (
 	DockerV2Schema2ConfigMediaType = "application/vnd.docker.container.image.v1+json"
 	// DockerV2Schema2LayerMediaType is the MIME type used for schema 2 layers.
 	DockerV2Schema2LayerMediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// DockerV2Schema2LayerUncompressedMediaType is the Uncompressed MIME type used for schema 2 layers.
+	DockerV2Schema2LayerUncompressedMediaType = "application/vnd.docker.image.rootfs.diff.tar"
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list
 	DockerV2ListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for schema 2 foreign layers.


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds the DockerV2Schema2LayerUncompressedMediaType , which is the uncompressed variant of DockerV2Schema2LayerMediaType and is used by Buildah.  Moving here to keep the manifest definitions for the tools in one central location.

Initial Buildah PR: https://github.com/projectatomic/buildah/pull/870