### PR TITLE
Make the docker-daemon transport stubbable

### DIFF
--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -9,7 +9,6 @@ import (
 	_ "github.com/containers/image/directory"
 	_ "github.com/containers/image/docker"
 	_ "github.com/containers/image/docker/archive"
-	_ "github.com/containers/image/docker/daemon"
 	_ "github.com/containers/image/oci/archive"
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -29,8 +29,6 @@ func TestImageNameHandling(t *testing.T) {
 		{"dir", "/etc", "/etc"},
 		{"docker", "//busybox", "//busybox:latest"},
 		{"docker", "//busybox:notlatest", "//busybox:notlatest"}, // This also tests handling of multiple ":" characters
-		{"docker-daemon", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
-		{"docker-daemon", "busybox:latest", "busybox:latest"},
 		{"docker-archive", "/var/lib/oci/busybox.tar:busybox:latest", "/var/lib/oci/busybox.tar:docker.io/library/busybox:latest"},
 		{"docker-archive", "busybox.tar:busybox:latest", "busybox.tar:docker.io/library/busybox:latest"},
 		{"oci", "/etc:someimage", "/etc:someimage"},
@@ -48,7 +46,7 @@ func TestImageNameHandling(t *testing.T) {
 	}
 
 	// Possibly stubbed-out transports: Only verify that something is registered.
-	for _, c := range []string{"ostree"} {
+	for _, c := range []string{"docker-daemon", "ostree"} {
 		transport := transports.Get(c)
 		assert.NotNil(t, transport, c)
 	}

--- a/transports/alltransports/docker_daemon.go
+++ b/transports/alltransports/docker_daemon.go
@@ -1,0 +1,8 @@
+// +build !containers_image_docker_daemon_stub
+
+package alltransports
+
+import (
+	// Register the docker-daemon transport
+	_ "github.com/containers/image/docker/daemon"
+)

--- a/transports/alltransports/docker_daemon_stub.go
+++ b/transports/alltransports/docker_daemon_stub.go
@@ -1,0 +1,9 @@
+// +build containers_image_docker_daemon_stub
+
+package alltransports
+
+import "github.com/containers/image/transports"
+
+func init() {
+	transports.Register(transports.NewStubTransport("docker-daemon"))
+}


### PR DESCRIPTION
Make the docker-daemon transport something that can be stubbed out by supplying the `containers_image_docker_daemon_stub` build tag.  While this is currently useful for letting me bypass a difference between the versions of the docker client package used here and the one used in `openshift/source-to-image`, it could be useful elsewhere.