### PR TITLE
Accept a registry prefix of the form 'IP:port'

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -28,6 +28,10 @@ func TestParseURL(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid URL 'john.doe@example.com': user/password are not supported")
 
+	_, err = parseURL("127.0.0.1:123456")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid port number '123456' in numeric IPv4 address")
+
 	// valid URLs
 	url, err = parseURL("example.com")
 	assert.Nil(t, err)
@@ -44,6 +48,18 @@ func TestParseURL(t *testing.T) {
 	url, err = parseURL("example.com:5000/with/path")
 	assert.Nil(t, err)
 	assert.Equal(t, "example.com:5000/with/path", url)
+
+	url, err = parseURL("example.com:5000")
+	assert.Nil(t, err)
+	assert.Equal(t, "example.com:5000", url)
+
+	url, err = parseURL("172.30.0.1")
+	assert.Nil(t, err)
+	assert.Equal(t, "172.30.0.1", url)
+
+	url, err = parseURL("172.30.0.1:5000") // often used in OpenShift
+	assert.Nil(t, err)
+	assert.Equal(t, "172.30.0.1:5000", url)
 }
 
 func TestEmptyConfig(t *testing.T) {


### PR DESCRIPTION
My not-using-TLS registry is located at 172.30.1.1:5000, and I can't push images to it because attempts to parse a specification that uses the port number fail with a `error reading system registries configuration: invalid URL '172.30.0.1:5000': parse 172.30.0.1:5000: first path segment in URL cannot contain colon` error.  (The error may be specific to the standard library from Go 1.10.3.)  Removing the port number causes the entry in the insecure registries list to fail to be matched.

This patch checks for the case where the trimmed value is of the form 'IP:port', and skips the scheme check for those cases.