### PR TITLE
Define PolicyRequirementError as struct for better error detection

### DIFF
--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -14,10 +14,20 @@ import (
 )
 
 // PolicyRequirementError is an explanatory text for rejecting a signature or an image.
-type PolicyRequirementError string
+type PolicyRequirementError struct {
+	message string
+}
 
-func (err PolicyRequirementError) Error() string {
-	return string(err)
+// NewPolicyRequirementError is used to create a new PolicyRequirementError
+func NewPolicyRequirementError(message string) *PolicyRequirementError {
+	return &PolicyRequirementError{
+		message: message,
+	}
+}
+
+// Error returns the message from a PolicyRequirementError
+func (e *PolicyRequirementError) Error() string {
+	return e.message
 }
 
 // signatureAcceptanceResult is the principal value returned by isSignatureAuthorAccepted.
@@ -271,7 +281,7 @@ func (pc *PolicyContext) IsRunningImageAllowed(ctx context.Context, image types.
 	reqs := pc.requirementsForImageRef(image.Reference())
 
 	if len(reqs) == 0 {
-		return false, PolicyRequirementError("List of verification policy requirements must not be empty")
+		return false, NewPolicyRequirementError("List of verification policy requirements must not be empty")
 	}
 
 	for reqNumber, req := range reqs {

--- a/signature/policy_eval_baselayer.go
+++ b/signature/policy_eval_baselayer.go
@@ -16,5 +16,5 @@ func (pr *prSignedBaseLayer) isSignatureAuthorAccepted(ctx context.Context, imag
 func (pr *prSignedBaseLayer) isRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (bool, error) {
 	// FIXME? Reject this at policy parsing time already?
 	logrus.Errorf("signedBaseLayer not implemented yet!")
-	return false, PolicyRequirementError("signedBaseLayer not implemented yet!")
+	return false, NewPolicyRequirementError("signedBaseLayer not implemented yet!")
 }

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -48,7 +48,7 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types
 	}
 	defer mech.Close()
 	if len(trustedIdentities) == 0 {
-		return sarRejected, nil, PolicyRequirementError("No public keys imported")
+		return sarRejected, nil, NewPolicyRequirementError("No public keys imported")
 	}
 
 	signature, err := verifyAndExtractSignature(mech, sig, signatureAcceptanceRules{
@@ -60,11 +60,11 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types
 			}
 			// Coverage: We use a private GPG home directory and only import trusted keys, so this should
 			// not be reachable.
-			return PolicyRequirementError(fmt.Sprintf("Signature by key %s is not accepted", keyIdentity))
+			return NewPolicyRequirementError(fmt.Sprintf("Signature by key %s is not accepted", keyIdentity))
 		},
 		validateSignedDockerReference: func(ref string) error {
 			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
-				return PolicyRequirementError(fmt.Sprintf("Signature for identity %s is not accepted", ref))
+				return NewPolicyRequirementError(fmt.Sprintf("Signature for identity %s is not accepted", ref))
 			}
 			return nil
 		},
@@ -78,7 +78,7 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types
 				return err
 			}
 			if !digestMatches {
-				return PolicyRequirementError(fmt.Sprintf("Signature for digest %s does not match", digest))
+				return NewPolicyRequirementError(fmt.Sprintf("Signature for digest %s does not match", digest))
 			}
 			return nil
 		},
@@ -116,7 +116,7 @@ func (pr *prSignedBy) isRunningImageAllowed(ctx context.Context, image types.Unp
 	var summary error
 	switch len(rejections) {
 	case 0:
-		summary = PolicyRequirementError("A signature was required, but no signature exists")
+		summary = NewPolicyRequirementError("A signature was required, but no signature exists")
 	case 1:
 		summary = rejections[0]
 	default:
@@ -124,7 +124,7 @@ func (pr *prSignedBy) isRunningImageAllowed(ctx context.Context, image types.Unp
 		for _, e := range rejections {
 			msgs = append(msgs, e.Error())
 		}
-		summary = PolicyRequirementError(fmt.Sprintf("None of the signatures were accepted, reasons: %s",
+		summary = NewPolicyRequirementError(fmt.Sprintf("None of the signatures were accepted, reasons: %s",
 			strings.Join(msgs, "; ")))
 	}
 	return false, summary

--- a/signature/policy_eval_simple.go
+++ b/signature/policy_eval_simple.go
@@ -21,9 +21,9 @@ func (pr *prInsecureAcceptAnything) isRunningImageAllowed(ctx context.Context, i
 }
 
 func (pr *prReject) isSignatureAuthorAccepted(ctx context.Context, image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {
-	return sarRejected, nil, PolicyRequirementError(fmt.Sprintf("Any signatures for image %s are rejected by policy.", transports.ImageName(image.Reference())))
+	return sarRejected, nil, NewPolicyRequirementError(fmt.Sprintf("Any signatures for image %s are rejected by policy.", transports.ImageName(image.Reference())))
 }
 
 func (pr *prReject) isRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (bool, error) {
-	return false, PolicyRequirementError(fmt.Sprintf("Running image %s is rejected by policy.", transports.ImageName(image.Reference())))
+	return false, NewPolicyRequirementError(fmt.Sprintf("Running image %s is rejected by policy.", transports.ImageName(image.Reference())))
 }

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -18,7 +18,7 @@ import (
 func TestPolicyRequirementError(t *testing.T) {
 	// A stupid test just to keep code coverage
 	s := "test"
-	err := PolicyRequirementError(s)
+	err := NewPolicyRequirementError(s)
 	assert.Equal(t, s, err.Error())
 }
 
@@ -490,7 +490,7 @@ func assertSARRejected(t *testing.T, sar signatureAcceptanceResult, parsedSig *S
 // and that the returned error is a PolicyRequirementError..
 func assertSARRejectedPolicyRequirement(t *testing.T, sar signatureAcceptanceResult, parsedSig *Signature, err error) {
 	assertSARRejected(t, sar, parsedSig, err)
-	assert.IsType(t, PolicyRequirementError(""), err)
+	assert.IsType(t, NewPolicyRequirementError(""), err)
 }
 
 // assertSARRejected verifies that isSignatureAuthorAccepted returns a consistent sarUnknown result.
@@ -518,5 +518,5 @@ func assertRunningRejected(t *testing.T, allowed bool, err error) {
 // and that the returned error is a PolicyRequirementError.
 func assertRunningRejectedPolicyRequirement(t *testing.T, allowed bool, err error) {
 	assertRunningRejected(t, allowed, err)
-	assert.IsType(t, PolicyRequirementError(""), err)
+	assert.IsType(t, NewPolicyRequirementError(""), err)
 }

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -14,7 +14,7 @@ import (
 func parseImageAndDockerReference(image types.UnparsedImage, s2 string) (reference.Named, reference.Named, error) {
 	r1 := image.Reference().DockerReference()
 	if r1 == nil {
-		return nil, nil, PolicyRequirementError(fmt.Sprintf("Docker reference match attempted on image %s with no known Docker reference identity",
+		return nil, nil, NewPolicyRequirementError(fmt.Sprintf("Docker reference match attempted on image %s with no known Docker reference identity",
 			transports.ImageName(image.Reference())))
 	}
 	r2, err := reference.ParseNormalizedNamed(s2)

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -36,7 +36,7 @@ func TestParseImageAndDockerReference(t *testing.T) {
 	// Unidentified images are rejected.
 	_, _, err = parseImageAndDockerReference(refImageMock{nil}, ok2)
 	require.Error(t, err)
-	assert.IsType(t, PolicyRequirementError(""), err)
+	assert.IsType(t, NewPolicyRequirementError(""), err)
 
 	// Failures
 	for _, refs := range [][]string{


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Changes PolicyRequirementError from a string to a struct to allow for easier detection in Buildah.  Currently I need to do something like this in Buildah to detect the policy error:
```
if strings.Contains(err.Error(), "rejected by policy") {
```

With this change I can do something like:

```
      switch err.(type) {
                case *signature.PolicyRequirementError:
                        logrus.Debugf("TOM: 1  FOUND POLICY ERROR")
```
Which I think is cleaner/safer, I can then check the contains to verify it's the policy error I was expecting if I need to differentiate.

If I missed an easier/safer way to detect the error from Buildah with the current setup, please feel free to slap me silly.