### PR TITLE
Get token to search V2 registries without creds

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -100,6 +100,14 @@ type authScope struct {
 	actions    string
 }
 
+type sendAuth int
+
+const (
+	v2Auth sendAuth = iota
+	v1Search
+	v1Basic
+)
+
 func newBearerTokenFromJSONBlob(blob []byte) (*bearerToken, error) {
 	token := new(bearerToken)
 	if err := json.Unmarshal(blob, &token); err != nil {
@@ -234,7 +242,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 		return errors.Wrapf(err, "error creating new docker client")
 	}
 
-	resp, err := newLoginClient.makeRequest(ctx, "GET", "/v2/", nil, nil)
+	resp, err := newLoginClient.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth)
 	if err != nil {
 		return err
 	}
@@ -297,14 +305,43 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		return nil, errors.Wrapf(err, "error creating new docker client")
 	}
 
+	// Only try the v1 search endpoint if the search query is not empty. If it is
+	// empty skip to the v2 endpoint.
+	if image != "" {
+		// set up the query values for the v1 endpoint
+		u := url.URL{
+			Path: "/v1/search",
+		}
+		q := u.Query()
+		q.Set("q", image)
+		q.Set("n", strconv.Itoa(limit))
+		u.RawQuery = q.Encode()
+
+		logrus.Debugf("trying to talk to v1 search endpoint\n")
+		resp, err := client.makeRequest(ctx, "GET", u.String(), nil, nil, v1Search)
+		if err != nil {
+			logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, err)
+		} else {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				logrus.Debugf("error getting search results from v1 endpoint %q, status code %d", registry, resp.StatusCode)
+			} else {
+				if err := json.NewDecoder(resp.Body).Decode(v1Res); err != nil {
+					return nil, err
+				}
+				return v1Res.Results, nil
+			}
+		}
+	}
+
 	logrus.Debugf("trying to talk to v2 search endpoint\n")
-	resp, err := client.makeRequest(ctx, "GET", "/v2/_catalog", nil, nil)
+	resp, err := client.makeRequest(ctx, "GET", "/v2/_catalog", nil, nil, v2Auth)
 	if err != nil {
 		logrus.Debugf("error getting search results from v2 endpoint %q: %v", registry, err)
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logrus.Debugf("error getting search results from v2 endpoint %q, status code %q", registry, resp.StatusCode)
+			logrus.Errorf("error getting search results from v2 endpoint %q, status code %d", registry, resp.StatusCode)
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(v2Res); err != nil {
 				return nil, err
@@ -322,50 +359,25 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		}
 	}
 
-	// set up the query values for the v1 endpoint
-	u := url.URL{
-		Path: "/v1/search",
-	}
-	q := u.Query()
-	q.Set("q", image)
-	q.Set("n", strconv.Itoa(limit))
-	u.RawQuery = q.Encode()
-
-	logrus.Debugf("trying to talk to v1 search endpoint\n")
-	resp, err = client.makeRequest(ctx, "GET", u.String(), nil, nil)
-	if err != nil {
-		logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, err)
-	} else {
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			logrus.Debugf("error getting search results from v1 endpoint %q, status code %q", registry, resp.StatusCode)
-		} else {
-			if err := json.NewDecoder(resp.Body).Decode(v1Res); err != nil {
-				return nil, err
-			}
-			return v1Res.Results, nil
-		}
-	}
-
 	return nil, errors.Wrapf(err, "couldn't search registry %q", registry)
 }
 
 // makeRequest creates and executes a http.Request with the specified parameters, adding authentication and TLS options for the Docker client.
 // The host name and schema is taken from the client or autodetected, and the path is relative to it, i.e. the path usually starts with /v2/.
-func (c *dockerClient) makeRequest(ctx context.Context, method, path string, headers map[string][]string, stream io.Reader) (*http.Response, error) {
+func (c *dockerClient) makeRequest(ctx context.Context, method, path string, headers map[string][]string, stream io.Reader, auth sendAuth) (*http.Response, error) {
 	if err := c.detectProperties(ctx); err != nil {
 		return nil, err
 	}
 
 	url := fmt.Sprintf("%s://%s%s", c.scheme, c.registry, path)
-	return c.makeRequestToResolvedURL(ctx, method, url, headers, stream, -1, true)
+	return c.makeRequestToResolvedURL(ctx, method, url, headers, stream, -1, auth)
 }
 
 // makeRequestToResolvedURL creates and executes a http.Request with the specified parameters, adding authentication and TLS options for the Docker client.
 // streamLen, if not -1, specifies the length of the data expected on stream.
 // makeRequest should generally be preferred.
 // TODO(runcom): too many arguments here, use a struct
-func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url string, headers map[string][]string, stream io.Reader, streamLen int64, sendAuth bool) (*http.Response, error) {
+func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url string, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, stream)
 	if err != nil {
 		return nil, err
@@ -383,7 +395,7 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 	if c.sys != nil && c.sys.DockerRegistryUserAgent != "" {
 		req.Header.Add("User-Agent", c.sys.DockerRegistryUserAgent)
 	}
-	if sendAuth {
+	if auth != v1Search {
 		if err := c.setupRequestAuth(req); err != nil {
 			return nil, err
 		}
@@ -497,7 +509,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 
 	ping := func(scheme string) error {
 		url := fmt.Sprintf(resolvedPingV2URL, scheme, c.registry)
-		resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, true)
+		resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, v2Auth)
 		if err != nil {
 			logrus.Debugf("Ping %s err %#v", url, err)
 			return err
@@ -524,7 +536,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		// best effort to understand if we're talking to a V1 registry
 		pingV1 := func(scheme string) bool {
 			url := fmt.Sprintf(resolvedPingV1URL, scheme, c.registry)
-			resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, true)
+			resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, v1Basic)
 			logrus.Debugf("Ping %s err %#v", url, err)
 			if err != nil {
 				return false
@@ -551,7 +563,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 // using the original data structures.
 func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
 	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
-	res, err := c.makeRequest(ctx, "GET", path, nil, nil)
+	res, err := c.makeRequest(ctx, "GET", path, nil, nil, v2Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -66,7 +66,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 	tags := make([]string, 0)
 
 	for {
-		res, err := client.makeRequest(ctx, "GET", path, nil, nil)
+		res, err := client.makeRequest(ctx, "GET", path, nil, nil, v2Auth)
 		if err != nil {
 			return nil, err
 		}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -130,7 +130,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	// FIXME? Chunked upload, progress reporting, etc.
 	uploadPath := fmt.Sprintf(blobUploadPath, reference.Path(d.ref.ref))
 	logrus.Debugf("Uploading %s", uploadPath)
-	res, err := d.c.makeRequest(ctx, "POST", uploadPath, nil, nil)
+	res, err := d.c.makeRequest(ctx, "POST", uploadPath, nil, nil, v2Auth)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -147,7 +147,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	digester := digest.Canonical.Digester()
 	sizeCounter := &sizeCounter{}
 	tee := io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter))
-	res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, true)
+	res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, v2Auth)
 	if err != nil {
 		logrus.Debugf("Error uploading layer chunked, response %#v", res)
 		return types.BlobInfo{}, err
@@ -166,7 +166,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	// TODO: check inputInfo.Digest == computedDigest https://github.com/containers/image/pull/70#discussion_r77646717
 	locationQuery.Set("digest", computedDigest.String())
 	uploadLocation.RawQuery = locationQuery.Encode()
-	res, err = d.c.makeRequestToResolvedURL(ctx, "PUT", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, true)
+	res, err = d.c.makeRequestToResolvedURL(ctx, "PUT", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, v2Auth)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -191,7 +191,7 @@ func (d *dockerImageDestination) HasBlob(ctx context.Context, info types.BlobInf
 	checkPath := fmt.Sprintf(blobsPath, reference.Path(d.ref.ref), info.Digest.String())
 
 	logrus.Debugf("Checking %s", checkPath)
-	res, err := d.c.makeRequest(ctx, "HEAD", checkPath, nil, nil)
+	res, err := d.c.makeRequest(ctx, "HEAD", checkPath, nil, nil, v2Auth)
 	if err != nil {
 		return false, -1, err
 	}
@@ -237,7 +237,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte) erro
 	if mimeType != "" {
 		headers["Content-Type"] = []string{mimeType}
 	}
-	res, err := d.c.makeRequest(ctx, "PUT", path, headers, bytes.NewReader(m))
+	res, err := d.c.makeRequest(ctx, "PUT", path, headers, bytes.NewReader(m), v2Auth)
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ sigExists:
 		}
 
 		path := fmt.Sprintf(extensionsSignaturePath, reference.Path(d.ref.ref), d.manifestDigest.String())
-		res, err := d.c.makeRequest(ctx, "PUT", path, nil, bytes.NewReader(body))
+		res, err := d.c.makeRequest(ctx, "PUT", path, nil, bytes.NewReader(body), v2Auth)
 		if err != nil {
 			return err
 		}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -89,7 +89,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	path := fmt.Sprintf(manifestPath, reference.Path(s.ref.ref), tagOrDigest)
 	headers := make(map[string][]string)
 	headers["Accept"] = manifest.DefaultRequestedManifestMIMETypes
-	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil)
+	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil, v2Auth)
 	if err != nil {
 		return nil, "", err
 	}
@@ -137,7 +137,7 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 		err  error
 	)
 	for _, url := range urls {
-		resp, err = s.c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, false)
+		resp, err = s.c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, v1Search)
 		if err == nil {
 			if resp.StatusCode != http.StatusOK {
 				err = errors.Errorf("error fetching external blob from %q: %d", url, resp.StatusCode)
@@ -169,7 +169,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (i
 
 	path := fmt.Sprintf(blobsPath, reference.Path(s.ref.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
-	res, err := s.c.makeRequest(ctx, "GET", path, nil, nil)
+	res, err := s.c.makeRequest(ctx, "GET", path, nil, nil, v2Auth)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -332,7 +332,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 	getPath := fmt.Sprintf(manifestPath, reference.Path(ref.ref), refTail)
-	get, err := c.makeRequest(ctx, "GET", getPath, headers, nil)
+	get, err := c.makeRequest(ctx, "GET", getPath, headers, nil, v2Auth)
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 
 	// When retrieving the digest from a registry >= 2.3 use the following header:
 	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-	delete, err := c.makeRequest(ctx, "DELETE", deletePath, headers, nil)
+	delete, err := c.makeRequest(ctx, "DELETE", deletePath, headers, nil, v2Auth)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Update the search functionality to be able to search registries
with a V2 endpoint by generating a token.

Signed-off-by: umohnani8 <umohnani@redhat.com>