### PR TITLE
Only run git-validation on commits not already present upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,13 @@ lint:
 		exit 1; \
 	fi
 
-EPOCH_TEST_COMMIT ?= e68e0e1110e64f906f9b482e548f17d73e02e6b1
-
 # When this is running in travis, it will only check the travis commit range
 .gitvalidation:
 	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make clean && make tools'" && false)
 ifeq ($(TRAVIS),true)
 	git-validation -q -run DCO,short-subject,dangling-whitespace
 else
-	git-validation -q -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
+	git fetch -q "https://github.com/containers/image.git" "refs/heads/master"
+	upstream="$$(git rev-parse --verify FETCH_HEAD)" ; \
+		git-validation -q -run DCO,short-subject,dangling-whitespace -range $$upstream..HEAD
 endif


### PR DESCRIPTION
Right now, `make .gitvalidation` takes 2 minutes on my system, mostly re-validating commits that have been validated many times before. That means slow `make`, and slow CI.

Instead, inspired by `skopeo`'s `hack/make/.validate`, only validate commits not present in the upstream master brach.  This, even with the added network access, takes less than two seconds on short branches.
