### PR TITLE
ostree: add missing error check on commit

### DIFF
--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -467,7 +467,9 @@ func (d *ostreeImageDestination) Commit(ctx context.Context) error {
 	metadata := []string{fmt.Sprintf("docker.manifest=%s", string(d.manifest)),
 		fmt.Sprintf("signatures=%d", d.signaturesLen),
 		fmt.Sprintf("docker.digest=%s", string(d.digest))}
-	err = d.ostreeCommit(repo, fmt.Sprintf("ociimage/%s", d.ref.branchName), manifestPath, metadata)
+	if err := d.ostreeCommit(repo, fmt.Sprintf("ociimage/%s", d.ref.branchName), manifestPath, metadata); err != nil {
+		return err
+	}
 
 	_, err = repo.CommitTransaction()
 	return err


### PR DESCRIPTION
This adds error checking on ostree commit, which was previously
missing.

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>