### PR TITLE
Return error when response code is not 200

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -346,7 +346,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logrus.Errorf("error getting search results from v2 endpoint %q, status code %d", registry, resp.StatusCode)
+			return nil, errors.Errorf("error getting search results from v2 endpoint %q, status code %d", registry, resp.StatusCode)
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(v2Res); err != nil {
 				return nil, err


### PR DESCRIPTION
After trying the v2 search endpoint, if the response code is not
200, return an error instead of logging it.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>