### PR TITLE
storageImageDestination.Commit(): ignore ErrDuplicateID

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -577,7 +577,7 @@ func (s *storageImageDestination) Commit(ctx context.Context) error {
 		// Build the new layer using the diff, regardless of where it came from.
 		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 		layer, _, err := s.imageRef.transport.store.PutLayer(id, lastLayer, nil, "", false, nil, diff)
-		if err != nil {
+		if err != nil && errors.Cause(err) != storage.ErrDuplicateID {
 			return errors.Wrapf(err, "error adding layer with blob %q", blob.Digest)
 		}
 		lastLayer = layer.ID


### PR DESCRIPTION
If we get a `storage.ErrDuplicateID` error back from `PutLayer()`, assume that some other party has created the layer that we were attempting to create, and continue with committing the image.