### PR TITLE
dockerClient.detectProperties: debug log the error string

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -516,7 +516,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		url := fmt.Sprintf(resolvedPingV2URL, scheme, c.registry)
 		resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth)
 		if err != nil {
-			logrus.Debugf("Ping %s err %#v", url, err)
+			logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 			return err
 		}
 		defer resp.Body.Close()
@@ -542,7 +542,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		pingV1 := func(scheme string) bool {
 			url := fmt.Sprintf(resolvedPingV1URL, scheme, c.registry)
 			resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth)
-			logrus.Debugf("Ping %s err %#v", url, err)
+			logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
When logging a debug message about an error that we get back when trying to ping a registry, log the error text, too.