### PR TITLE
Ignore but log an error on IsNotExist errors reading root CAs

### DIFF
--- a/pkg/tlsclientconfig/tlsclientconfig_test.go
+++ b/pkg/tlsclientconfig/tlsclientconfig_test.go
@@ -90,7 +90,8 @@ func TestSetupCertificates(t *testing.T) {
 	// Unreadable CA certificate
 	tlsc = tls.Config{}
 	err = SetupCertificates("testdata/unreadable-ca", &tlsc)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.Nil(t, tlsc.RootCAs)
 
 	// Misssing key file
 	tlsc = tls.Config{}


### PR DESCRIPTION
When we encounter an IsNotExist error when reading root CA certificates as part of setting up a TLS client, log the error but continue.  Continue to bail if we encounter errors loading client credentials.  This should resolve https://github.com/containers/buildah/issues/1065.