### PR TITLE
Don’t ignore errors reading pkg/docker/config config files

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -165,9 +165,12 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 	var auths dockerConfigFile
 
 	raw, err := ioutil.ReadFile(path)
-	if os.IsNotExist(err) {
-		auths.AuthConfigs = map[string]dockerAuthConfig{}
-		return auths, nil
+	if err != nil {
+		if os.IsNotExist(err) {
+			auths.AuthConfigs = map[string]dockerAuthConfig{}
+			return auths, nil
+		}
+		return dockerConfigFile{}, err
 	}
 
 	if legacyFormat {


### PR DESCRIPTION
Non-`IsNotExist` errors are currently ignored, causing misleading failures like
```
error unmarshaling JSON at "/run/containers/1000/auth.json": unexpected end of JSON input
```
    
Fix that.
