### PR TITLE
Include http.StatusText with every HTTP status code in errors

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -259,7 +259,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 	case http.StatusUnauthorized:
 		return ErrUnauthorizedForCredentials
 	default:
-		return errors.Errorf("error occured with status code %q (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return errors.Errorf("error occured with status code %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 }
 

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -259,7 +259,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 	case http.StatusUnauthorized:
 		return ErrUnauthorizedForCredentials
 	default:
-		return errors.Errorf("error occured with status code %q", resp.StatusCode)
+		return errors.Errorf("error occured with status code %q (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 }
 
@@ -329,7 +329,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				logrus.Debugf("error getting search results from v1 endpoint %q, status code %d", registry, resp.StatusCode)
+				logrus.Debugf("error getting search results from v1 endpoint %q, status code %d (%s)", registry, resp.StatusCode, http.StatusText(resp.StatusCode))
 			} else {
 				if err := json.NewDecoder(resp.Body).Decode(v1Res); err != nil {
 					return nil, err
@@ -346,7 +346,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logrus.Errorf("error getting search results from v2 endpoint %q, status code %d", registry, resp.StatusCode)
+			logrus.Errorf("error getting search results from v2 endpoint %q, status code %d (%s)", registry, resp.StatusCode, http.StatusText(resp.StatusCode))
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(v2Res); err != nil {
 				return nil, err
@@ -495,7 +495,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope
 	case http.StatusOK:
 		break
 	default:
-		return nil, errors.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, authReq.URL)
+		return nil, errors.Errorf("unexpected http code: %d (%s), URL: %s", res.StatusCode, http.StatusText(res.StatusCode), authReq.URL)
 	}
 	tokenBlob, err := ioutil.ReadAll(res.Body)
 	if err != nil {
@@ -522,7 +522,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		defer resp.Body.Close()
 		logrus.Debugf("Ping %s status %d", url, resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-			return errors.Errorf("error pinging registry %s, response code %d", c.registry, resp.StatusCode)
+			return errors.Errorf("error pinging registry %s, response code %d (%s)", c.registry, resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -73,7 +73,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusOK {
 			// print url also
-			return nil, errors.Errorf("Invalid status code returned when fetching tags list %d", res.StatusCode)
+			return nil, errors.Errorf("Invalid status code returned when fetching tags list %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
 		}
 
 		var tagsHolder struct {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -207,7 +207,7 @@ func (d *dockerImageDestination) HasBlob(ctx context.Context, info types.BlobInf
 		logrus.Debugf("... not present")
 		return false, -1, nil
 	default:
-		return false, -1, errors.Errorf("failed to read from destination repository %s: %v", reference.Path(d.ref.ref), http.StatusText(res.StatusCode))
+		return false, -1, errors.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -140,7 +140,7 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 		resp, err = s.c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth)
 		if err == nil {
 			if resp.StatusCode != http.StatusOK {
-				err = errors.Errorf("error fetching external blob from %q: %d", url, resp.StatusCode)
+				err = errors.Errorf("error fetching external blob from %q: %d (%s)", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 				logrus.Debug(err)
 				continue
 			}
@@ -175,7 +175,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (i
 	}
 	if res.StatusCode != http.StatusOK {
 		// print url also
-		return nil, 0, errors.Errorf("Invalid status code returned when fetching blob %d", res.StatusCode)
+		return nil, 0, errors.Errorf("Invalid status code returned when fetching blob %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
 	}
 	return res.Body, getBlobSize(res), nil
 }
@@ -274,7 +274,7 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 		if res.StatusCode == http.StatusNotFound {
 			return nil, true, nil
 		} else if res.StatusCode != http.StatusOK {
-			return nil, false, errors.Errorf("Error reading signature from %s: status %d", url.String(), res.StatusCode)
+			return nil, false, errors.Errorf("Error reading signature from %s: status %d (%s)", url.String(), res.StatusCode, http.StatusText(res.StatusCode))
 		}
 		sig, err := ioutil.ReadAll(res.Body)
 		if err != nil {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -127,7 +127,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		if statusValid {
 			return nil, errors.New(status.Message)
 		}
-		return nil, errors.Errorf("HTTP error: status code: %d, body: %s", res.StatusCode, string(body))
+		return nil, errors.Errorf("HTTP error: status code: %d (%s), body: %s", res.StatusCode, http.StatusText(res.StatusCode), string(body))
 	}
 
 	return body, nil


### PR DESCRIPTION
e.g. `504 (Gateway timeout)` instead of just `504`.

Note that for unknown status codes this will output `99999 ()`; this seems not worth worrying about and building a helper for right now.

(Also fixes one instance of using `%q` for integer parameters, which results in gibberish.)