### PR TITLE
In debug logs of Docker v1 ping, only call err.Error() if err != nil

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -542,8 +542,8 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		pingV1 := func(scheme string) bool {
 			url := fmt.Sprintf(resolvedPingV1URL, scheme, c.registry)
 			resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth)
-			logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 			if err != nil {
+				logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 				return false
 			}
 			defer resp.Body.Close()


### PR DESCRIPTION
For me, this seems to work and only results in a weird
```
Ping https://registry-1.docker.io/v1/_ping err <nil>
```
(with the last `(%#v)` element completely lost;

OTOH https://github.com/containers/buildah/issues/1079 reports a crash most likely attributable to this.
