### PR TITLE
Makefile: fix golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ cross: vendor
 tools: tools.timestamp
 
 tools.timestamp: Makefile
-	@go get -u $(BUILDFLAGS) github.com/golang/lint/golint
+	@go get -u $(BUILDFLAGS) golang.org/x/lint/golint
 	@go get $(BUILDFLAGS) github.com/vbatts/git-validation
 	@go get -u github.com/rancher/trash
 	@touch tools.timestamp


### PR DESCRIPTION
Fix the following error in CI:

```
package github.com/golang/lint/golint: code in directory /gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
Makefile:48: recipe for target 'tools.timestamp' failed
make: *** [tools.timestamp] Error 1
```

Signed-off-by: Antonio Murdaca <runcom@linux.com>