### PR TITLE
Added OpenTracing for podman functions

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -43,6 +44,10 @@ func (os *orderedSet) append(s string) {
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
 func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string) (string, []string, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "determineManifestConversion")
+	span.SetTag("ref", "imageCopier")
+	defer span.Finish()
+
 	_, srcType, err := ic.src.Manifest(ctx)
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
@@ -113,6 +118,9 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 
 // isMultiImage returns true if img is a list of images
 func isMultiImage(ctx context.Context, img types.UnparsedImage) (bool, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "isMultiImage")
+	defer span.Finish()
+
 	_, mt, err := img.Manifest(ctx)
 	if err != nil {
 		return false, err

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -57,6 +58,10 @@ func (s *dirImageSource) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "getBlob")
+	span.SetTag("ref", "directory")
+	defer span.Finish()
+
 	r, err := os.Open(s.ref.layerPath(info.Digest))
 	if err != nil {
 		return nil, -1, err

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -147,12 +148,20 @@ func (ref dirReference) NewImage(ctx context.Context, sys *types.SystemContext) 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref dirReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "directory")
+	defer span.Finish()
+
 	return newImageSource(ref), nil
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref dirReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "directory")
+	defer span.Finish()
+
 	compress := false
 	if sys != nil {
 		compress = sys.DirForceCompress

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/docker/tarfile"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -68,5 +69,9 @@ func (d *archiveImageDestination) Close() error {
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (d *archiveImageDestination) Commit(ctx context.Context) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "commit")
+	span.SetTag("ref", "docker-archive")
+	defer span.Finish()
+
 	return d.Destination.Commit(ctx)
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -9,6 +9,7 @@ import (
 	ctrImage "github.com/containers/image/image"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -144,12 +145,20 @@ func (ref archiveReference) NewImage(ctx context.Context, sys *types.SystemConte
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref archiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "docker-archive")
+	defer span.Finish()
+
 	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "docker-archive")
+	defer span.Finish()
+
 	return newImageDestination(sys, ref)
 }
 

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/docker/tarfile"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/client"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -125,6 +126,10 @@ func (d *daemonImageDestination) Reference() types.ImageReference {
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (d *daemonImageDestination) Commit(ctx context.Context) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "commit")
+	span.SetTag("ref", "docker-daemon")
+	defer span.Finish()
+
 	logrus.Debugf("docker-daemon: Closing tar stream")
 	if err := d.Destination.Commit(ctx); err != nil {
 		return err

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -205,12 +206,20 @@ func (ref daemonReference) NewImage(ctx context.Context, sys *types.SystemContex
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref daemonReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "docker-daemon")
+	defer span.Finish()
+
 	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref daemonReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "docker-daemon")
+	defer span.Finish()
+
 	return newImageDestination(ctx, sys, ref)
 }
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/client"
 	digest "github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -248,6 +249,10 @@ func (s *dockerImageSource) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "getBlob")
+	span.SetTag("ref", "docker")
+	defer span.Finish()
+
 	if len(info.URLs) != 0 {
 		return s.getExternalBlob(ctx, info.URLs)
 	}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -141,12 +142,20 @@ func (ref dockerReference) NewImage(ctx context.Context, sys *types.SystemContex
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref dockerReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "docker")
+	defer span.Finish()
+
 	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref dockerReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "docker")
+	defer span.Finish()
+
 	return newImageDestination(sys, ref)
 }
 

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -95,6 +96,10 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "putBlob")
+	span.SetTag("ref", "docker-tarfile")
+	defer span.Finish()
+
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed datas.
 	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
@@ -165,6 +170,10 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "hasBlob")
+	span.SetTag("ref", "docker-tarfile")
+	defer span.Finish()
+
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf("Can not check for a blob with unknown digest")
 	}
@@ -403,5 +412,9 @@ func (d *Destination) PutSignatures(ctx context.Context, signatures [][]byte) er
 // Commit finishes writing data to the underlying io.Writer.
 // It is the caller's responsibility to close it, if necessary.
 func (d *Destination) Commit(ctx context.Context) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "commit")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return d.tar.Close()
 }

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -412,6 +413,10 @@ func (s *Source) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "getBlob")
+	span.SetTag("ref", "docker-tarfile")
+	defer span.Finish()
+
 	if err := s.ensureCachedDataIsPresent(); err != nil {
 		return nil, 0, err
 	}

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -5,7 +5,9 @@ package image
 
 import (
 	"context"
+
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // imageCloser implements types.ImageCloser, perhaps allowing simple users
@@ -65,6 +67,8 @@ type sourcedImage struct {
 //
 // The Image must not be used after the underlying ImageSource is Close()d.
 func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *UnparsedImage) (types.Image, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "fromUnparsedImage")
+	defer span.Finish()
 	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
 	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
 	// this is the only UnparsedImage implementation around, anyway.
@@ -99,5 +103,9 @@ func (i *sourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 }
 
 func (i *sourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "layersInfosForCopy")
+	span.SetTag("ref", "image-sourced")
+	defer span.Finish()
+
 	return i.UnparsedImage.src.LayerInfosForCopy(ctx)
 }

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/archive"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -91,6 +92,10 @@ func (d *ociArchiveImageDestination) HasThreadSafePutBlob() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "putBlob")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, cache, isConfig)
 }
 
@@ -102,6 +107,10 @@ func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Read
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "tryReuseBlob")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return d.unpackedDest.TryReusingBlob(ctx, info, cache, canSubstitute)
 }
 

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/types"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -85,6 +86,10 @@ func (s *ociArchiveImageSource) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *ociArchiveImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "hasBlob")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return s.unpackedSrc.GetBlob(ctx, info, cache)
 }
 

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/archive"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -133,12 +134,20 @@ func (ref ociArchiveReference) NewImage(ctx context.Context, sys *types.SystemCo
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ociArchiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "oci-archive")
+	defer span.Finish()
+
 	return newImageDestination(ctx, sys, ref)
 }
 

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -11,8 +11,9 @@ import (
 	"github.com/containers/image/pkg/tlsclientconfig"
 	"github.com/containers/image/types"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -101,6 +102,10 @@ func (s *ociImageSource) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "getBlob")
+	span.SetTag("ref", "oci-layout")
+	defer span.Finish()
+
 	if len(info.URLs) != 0 {
 		return s.getExternalBlob(ctx, info.URLs)
 	}

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -227,12 +228,20 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ociReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "oci-layout")
+	defer span.Finish()
+
 	return newImageSource(sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "oci-layout")
+	defer span.Finish()
+
 	return newImageDestination(sys, ref)
 }
 

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -11,6 +11,7 @@ import (
 	genericImage "github.com/containers/image/image"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -142,12 +143,20 @@ func (ref openshiftReference) NewImage(ctx context.Context, sys *types.SystemCon
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref openshiftReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "openshift")
+	defer span.Finish()
+
 	return newImageSource(sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref openshiftReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "openshift")
+	defer span.Finish()
+
 	return newImageDestination(ctx, sys, ref)
 }
 

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
+	opentracing "github.com/opentracing/opentracing-go"
 	glib "github.com/ostreedev/ostree-go/pkg/glibobject"
 	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/tar/asm"
@@ -264,6 +265,9 @@ func (s *ostreeImageSource) HasThreadSafeGetBlob() bool {
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "getBlob")
+	span.SetTag("ref", "ostree")
+	defer span.Finish()
 
 	blob := info.Digest.Hex()
 
@@ -369,6 +373,10 @@ func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
 func (s *ostreeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "layersInfosForCopy")
+	span.SetTag("ref", "ostree")
+	defer span.Finish()
+
 	updatedBlobInfos := []types.BlobInfo{}
 	manifestBlob, manifestType, err := s.GetManifest(ctx, nil)
 	if err != nil {

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/image"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -199,6 +200,10 @@ func (ref ostreeReference) NewImage(ctx context.Context, sys *types.SystemContex
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ostreeReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "ostree")
+	defer span.Finish()
+
 	var tmpDir string
 	if sys == nil || sys.OSTreeTmpDirPath == "" {
 		tmpDir = os.TempDir()
@@ -211,6 +216,10 @@ func (ref ostreeReference) NewImageSource(ctx context.Context, sys *types.System
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ostreeReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "ostree")
+	defer span.Finish()
+
 	var tmpDir string
 	if sys == nil || sys.OSTreeTmpDirPath == "" {
 		tmpDir = os.TempDir()

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/containers/image/types"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -257,6 +258,10 @@ func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(ctx context.Context, im
 // WARNING: This validates signatures and the manifest, but does not download or validate the
 // layers. Users must validate that the layers match their expected digests.
 func (pc *PolicyContext) IsRunningImageAllowed(ctx context.Context, image types.UnparsedImage) (res bool, finalErr error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "isRunningImageAllowed")
+	span.SetTag("ref", "policy")
+	defer span.Finish()
+
 	if err := pc.changeState(pcReady, pcInUse); err != nil {
 		return false, err
 	}

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -217,9 +218,17 @@ func (s storageReference) DeleteImage(ctx context.Context, sys *types.SystemCont
 }
 
 func (s storageReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "storage")
+	defer span.Finish()
+
 	return newImageSource(s)
 }
 
 func (s storageReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageDestination")
+	span.SetTag("ref", "storage")
+	defer span.Finish()
+
 	return newImageDestination(s)
 }

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/containers/image/types"
 	"github.com/klauspost/pgzip"
+	opentracing "github.com/opentracing/opentracing-go"
+
 	digest "github.com/opencontainers/go-digest"
 	imgspecs "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -34,6 +36,10 @@ type tarballImageSource struct {
 }
 
 func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "newImageSource")
+	span.SetTag("ref", "tarball")
+	defer span.Finish()
+
 	// Gather up the digests, sizes, and date information for all of the files.
 	filenames := []string{}
 	diffIDs := []digest.Digest{}

--- a/vendor.conf
+++ b/vendor.conf
@@ -18,6 +18,7 @@ github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc 6b1d0e76f239ffb435445e5ae316d2676c07c6e3
+github.com/opentracing/opentracing-go master
 github.com/pborman/uuid 1b00554d822231195d1babd97ff4a781231955c9
 github.com/pkg/errors 248dadf4e9068a0b3e79f02ed0a610d935de5302
 github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2


### PR DESCRIPTION
This is the `containers/image` side of the initial OpenTracing support [added to podman](https://github.com/containers/libpod/pull/1692).

My goal was to add spans to all common functions across the various libraries.