### PR TITLE
Update the version of github.com/opencontainers/selinux used for tests

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -34,7 +34,7 @@ github.com/xeipuuv/gojsonschema master
 github.com/xeipuuv/gojsonreference master
 github.com/xeipuuv/gojsonpointer master
 github.com/tchap/go-patricia v2.2.6
-github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d
+github.com/opencontainers/selinux 077c8b6d1c18456fb7c792bc0de52295a0d1900e
 github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0
 github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/gogo/protobuf fcdc5011193ff531a548e9b0301828d5a5b97fd8


### PR DESCRIPTION
c/storage now depends on https://github.com/opencontainers/selinux/pull/36/files .
