### PR TITLE
Don't copy duplicate layers from containers-storage to docker, oci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ cross: vendor
 tools: tools.timestamp
 
 tools.timestamp: Makefile
-	@go get -u $(BUILDFLAGS) github.com/golang/lint/golint
+	@go get -u $(BUILDFLAGS) golang.org/x/lint/golint
 	@go get $(BUILDFLAGS) github.com/vbatts/git-validation
 	@go get -u github.com/rancher/trash
 	@touch tools.timestamp

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -56,7 +56,7 @@ func (f fakeImageSource) OCIConfig(context.Context) (*v1.Image, error) {
 func (f fakeImageSource) LayerInfos() []types.BlobInfo {
 	panic("Unexpected call to a mock function")
 }
-func (f fakeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (f fakeImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f fakeImageSource) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -84,6 +84,6 @@ func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when copying, in preference to values in the manifest, if specified.
-func (s *dirImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *dirImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -35,6 +35,6 @@ func (s *archiveImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *archiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *archiveImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -57,6 +57,6 @@ func (s *daemonImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *daemonImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *daemonImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -53,7 +53,7 @@ func (s *dockerImageSource) Close() error {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *dockerImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *dockerImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -38,7 +38,7 @@ func (f unusedImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io
 func (f unusedImageSource) GetSignatures(context.Context, *digest.Digest) ([][]byte, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f unusedImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (f unusedImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 

--- a/image/memory.go
+++ b/image/memory.go
@@ -60,6 +60,6 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *memoryImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (i *memoryImage) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/image/sourced.go
+++ b/image/sourced.go
@@ -98,6 +98,6 @@ func (i *sourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }
 
-func (i *sourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	return i.UnparsedImage.src.LayerInfosForCopy(ctx)
+func (i *sourcedImage) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
+	return i.UnparsedImage.src.LayerInfosForCopy(ctx, desiredLayerCompression)
 }

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -90,6 +90,6 @@ func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDiges
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociArchiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *ociArchiveImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -151,7 +151,7 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *ociImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -247,7 +247,7 @@ func (s *openshiftImageSource) GetSignatures(ctx context.Context, instanceDigest
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *openshiftImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *openshiftImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -262,7 +262,7 @@ func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (i
 
 	// Ensure s.compressed is initialized.  It is build by LayerInfosForCopy.
 	if s.compressed == nil {
-		_, err := s.LayerInfosForCopy(ctx)
+		_, err := s.LayerInfosForCopy(ctx, types.PreserveOriginal)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -366,7 +366,7 @@ func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
-func (s *ostreeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (s *ostreeImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	updatedBlobInfos := []types.BlobInfo{}
 	manifestBlob, manifestType, err := s.GetManifest(ctx, nil)
 	if err != nil {

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -67,7 +67,7 @@ func (ref refImageMock) Manifest(ctx context.Context) ([]byte, string, error) {
 func (ref refImageMock) Signatures(context.Context) ([][]byte, error) {
 	panic("unexpected call to a mock function")
 }
-func (ref refImageMock) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (ref refImageMock) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	panic("unexpected call to a mock function")
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1015,7 +1015,7 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("ImageSource is not a storage image")
 	}
 	layers := []string{}
-	layersInfo, err := img.LayerInfosForCopy(context.Background())
+	layersInfo, err := img.LayerInfosForCopy(context.Background(), types.PreserveOriginal)
 	if err != nil {
 		t.Fatalf("LayerInfosForCopy() returned error %v", err)
 	}

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -256,6 +256,6 @@ func (is *tarballImageSource) Reference() types.ImageReference {
 }
 
 // LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (*tarballImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (*tarballImageSource) LayerInfosForCopy(ctx context.Context, desiredLayerCompression types.LayerCompression) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -128,8 +128,10 @@ type ImageSource interface {
 	GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error)
 	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
 	// The Digest field is guaranteed to be provided; Size may be -1.
+	// Implementations may ignore desiredLayerCompression and always return
+	// digests for there internal compression format
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy(ctx context.Context) ([]BlobInfo, error)
+	LayerInfosForCopy(ctx context.Context, desiredLayerCompression LayerCompression) ([]BlobInfo, error)
 }
 
 // LayerCompression indicates if layers must be compressed, decompressed or preserved
@@ -259,8 +261,8 @@ type Image interface {
 	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
 	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy(context.Context) ([]BlobInfo, error)
-	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
+	LayerInfosForCopy(context.Context, LayerCompression) ([]BlobInfo, error)
+	// EmbeddedDockerReferenceConflicts whether a Dockeur reference embedded in the manifest, if any, conflicts with destination ref.
 	// It returns false if the manifest does not embed a Docker reference.
 	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
 	EmbeddedDockerReferenceConflicts(ref reference.Named) bool


### PR DESCRIPTION
This adds an argument to LayerInfosForCopy so that the image source
can return compressed digests *if* that source stores compressed
digests and implements returning them.

For compressed destinations like docker and oci, copy calls
LayerInfosForCopy() twice, and uses both compressed and uncompressed
digests to call HasBlob. This allows layer copy operations to be
skipped when the target has the compressed layer.

In this commit only containers-storage honors the requested
LayerCompression, but other sources can implement this in later
changes.

Fixes https://github.com/containers/skopeo/issues/532
Fixes https://github.com/containers/image/issues/475
Fixes https://github.com/containers/libpod/issues/1233