### PR TITLE
docker: export functions and variables for a distribution-spec cert tests

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -24,7 +24,7 @@ type Image struct {
 // newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
-func newImage(ctx context.Context, sys *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
+func newImage(ctx context.Context, sys *types.SystemContext, ref DockerReference) (types.ImageCloser, error) {
 	s, err := newImageSource(sys, ref)
 	if err != nil {
 		return nil, err
@@ -52,13 +52,13 @@ func (i *Image) GetRepositoryTags(ctx context.Context) ([]string, error) {
 // GetRepositoryTags list all tags available in the repository. The tag
 // provided inside the ImageReference will be ignored.
 func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) ([]string, error) {
-	dr, ok := ref.(dockerReference)
+	dr, ok := ref.(DockerReference)
 	if !ok {
-		return nil, errors.Errorf("ref must be a dockerReference")
+		return nil, errors.Errorf("ref must be a DockerReference")
 	}
 
 	path := fmt.Sprintf(tagsPath, reference.Path(dr.ref))
-	client, err := newDockerClientFromRef(sys, dr, false, "pull")
+	client, err := NewDockerClientFromRef(sys, dr, false, "pull")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create client")
 	}
@@ -66,7 +66,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 	tags := make([]string, 0)
 
 	for {
-		res, err := client.makeRequest(ctx, "GET", path, nil, nil, v2Auth)
+		res, err := client.MakeRequest(ctx, "GET", path, nil, nil, V2Auth)
 		if err != nil {
 			return nil, err
 		}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -41,8 +41,8 @@ func (t dockerTransport) ValidatePolicyConfigurationScope(scope string) error {
 	return nil
 }
 
-// dockerReference is an ImageReference for Docker images.
-type dockerReference struct {
+// DockerReference is an ImageReference for Docker images.
+type DockerReference struct {
 	ref reference.Named // By construction we know that !reference.IsNameOnly(ref)
 }
 
@@ -74,12 +74,12 @@ func NewReference(ref reference.Named) (types.ImageReference, error) {
 	if isTagged && isDigested {
 		return nil, errors.Errorf("Docker references with both a tag and digest are currently not supported")
 	}
-	return dockerReference{
+	return DockerReference{
 		ref: ref,
 	}, nil
 }
 
-func (ref dockerReference) Transport() types.ImageTransport {
+func (ref DockerReference) Transport() types.ImageTransport {
 	return Transport
 }
 
@@ -88,14 +88,14 @@ func (ref dockerReference) Transport() types.ImageTransport {
 // NOTE: The returned string is not promised to be equal to the original input to ParseReference;
 // e.g. default attribute values omitted by the user may be filled in in the return value, or vice versa.
 // WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix.
-func (ref dockerReference) StringWithinTransport() string {
+func (ref DockerReference) StringWithinTransport() string {
 	return "//" + reference.FamiliarString(ref.ref)
 }
 
 // DockerReference returns a Docker reference associated with this reference
 // (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
 // not e.g. after redirect or alias processing), or nil if unknown/not applicable.
-func (ref dockerReference) DockerReference() reference.Named {
+func (ref DockerReference) DockerReference() reference.Named {
 	return ref.ref
 }
 
@@ -106,7 +106,7 @@ func (ref dockerReference) DockerReference() reference.Named {
 // It is fine for the return value to be equal to StringWithinTransport(), and it is desirable but
 // not required/guaranteed that it will be a valid input to Transport().ParseReference().
 // Returns "" if configuration identities for these references are not supported.
-func (ref dockerReference) PolicyConfigurationIdentity() string {
+func (ref DockerReference) PolicyConfigurationIdentity() string {
 	res, err := policyconfiguration.DockerReferenceIdentity(ref.ref)
 	if res == "" || err != nil { // Coverage: Should never happen, NewReference above should refuse values which could cause a failure.
 		panic(fmt.Sprintf("Internal inconsistency: policyconfiguration.DockerReferenceIdentity returned %#v, %v", res, err))
@@ -119,7 +119,7 @@ func (ref dockerReference) PolicyConfigurationIdentity() string {
 // in order, terminating on first match, and an implicit "" is always checked at the end.
 // It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
 // and each following element to be a prefix of the element preceding it.
-func (ref dockerReference) PolicyConfigurationNamespaces() []string {
+func (ref DockerReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
 
@@ -128,29 +128,29 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
-func (ref dockerReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+func (ref DockerReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	return newImage(ctx, sys, ref)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dockerReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+func (ref DockerReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
-func (ref dockerReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+func (ref DockerReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	return newImageDestination(sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
-func (ref dockerReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
+func (ref DockerReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	return deleteImage(ctx, sys, ref)
 }
 
-// tagOrDigest returns a tag or digest from the reference.
-func (ref dockerReference) tagOrDigest() (string, error) {
+// TagOrDigest returns a tag or digest from the reference.
+func (ref DockerReference) TagOrDigest() (string, error) {
 	if ref, ok := ref.ref.(reference.Canonical); ok {
 		return ref.Digest().String(), nil
 	}

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -59,7 +59,7 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 			assert.Error(t, err, c.input)
 		} else {
 			require.NoError(t, err, c.input)
-			dockerRef, ok := ref.(dockerReference)
+			dockerRef, ok := ref.(DockerReference)
 			require.True(t, ok, c.input)
 			assert.Equal(t, c.expected, dockerRef.ref.String(), c.input)
 		}
@@ -80,7 +80,7 @@ func TestNewReference(t *testing.T) {
 		require.NoError(t, err)
 		ref, err := NewReference(parsed)
 		require.NoError(t, err, c.input)
-		dockerRef, ok := ref.(dockerReference)
+		dockerRef, ok := ref.(DockerReference)
 		require.True(t, ok, c.input)
 		assert.Equal(t, c.dockerRef, dockerRef.ref.String(), c.input)
 	}
@@ -188,9 +188,9 @@ func TestReferenceTagOrDigest(t *testing.T) {
 	} {
 		ref, err := ParseReference(input)
 		require.NoError(t, err, input)
-		dockerRef, ok := ref.(dockerReference)
+		dockerRef, ok := ref.(DockerReference)
 		require.True(t, ok, input)
-		tod, err := dockerRef.tagOrDigest()
+		tod, err := dockerRef.TagOrDigest()
 		require.NoError(t, err, input)
 		assert.Equal(t, expected, tod, input)
 	}
@@ -198,7 +198,7 @@ func TestReferenceTagOrDigest(t *testing.T) {
 	// Invalid input
 	ref, err := reference.ParseNormalizedNamed("busybox")
 	require.NoError(t, err)
-	dockerRef := dockerReference{ref: ref}
-	_, err = dockerRef.tagOrDigest()
+	dockerRef := DockerReference{ref: ref}
+	_, err = dockerRef.TagOrDigest()
 	assert.Error(t, err)
 }

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -30,7 +30,7 @@ const builtinRegistriesDirPath = "/etc/containers/registries.d"
 // NOTE: Keep this in sync with docs/registries.d.md!
 type registryConfiguration struct {
 	DefaultDocker *registryNamespace `json:"default-docker"`
-	// The key is a namespace, using fully-expanded Docker reference format or parent namespaces (per dockerReference.PolicyConfiguration*),
+	// The key is a namespace, using fully-expanded Docker reference format or parent namespaces (per DockerReference.PolicyConfiguration*),
 	Docker map[string]registryNamespace `json:"docker"`
 }
 
@@ -45,7 +45,7 @@ type registryNamespace struct {
 type signatureStorageBase *url.URL // The only documented value is nil, meaning storage is not supported.
 
 // configuredSignatureStorageBase reads configuration to find an appropriate signature storage URL for ref, for write access if “write”.
-func configuredSignatureStorageBase(sys *types.SystemContext, ref dockerReference, write bool) (signatureStorageBase, error) {
+func configuredSignatureStorageBase(sys *types.SystemContext, ref DockerReference, write bool) (signatureStorageBase, error) {
 	// FIXME? Loading and parsing the config could be cached across calls.
 	dirPath := registriesDirPath(sys)
 	logrus.Debugf(`Using registries.d directory %s for sigstore configuration`, dirPath)
@@ -143,7 +143,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 
 // config.signatureTopLevel returns an URL string configured in config for ref, for write access if “write”.
 // (the top level of the storage, namespaced by repo.FullName etc.), or "" if no signature storage should be used.
-func (config *registryConfiguration) signatureTopLevel(ref dockerReference, write bool) string {
+func (config *registryConfiguration) signatureTopLevel(ref DockerReference, write bool) string {
 	if config.Docker != nil {
 		// Look for a full match.
 		identity := ref.PolicyConfigurationIdentity()

--- a/docker/lookaside_test.go
+++ b/docker/lookaside_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func dockerRefFromString(t *testing.T, s string) dockerReference {
+func dockerRefFromString(t *testing.T, s string) DockerReference {
 	ref, err := ParseReference(s)
 	require.NoError(t, err, s)
-	dockerRef, ok := ref.(dockerReference)
+	dockerRef, ok := ref.(DockerReference)
 	require.True(t, ok, s)
 	return dockerRef
 }


### PR DESCRIPTION
Export the following functions and variables to be used by tests for certification of the distribution-spec.

* DockerReference
* MakeRequest
* NewDockerClientFromRef
* SendAuth, V2Auth, NoAuth
* TagOrDigest

Does it make sense? If not, please let me know.
See also my work-in-progress pull request: https://github.com/kinvolk/ocicert/pull/1