### PR TITLE
Copy layers concurrently

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -124,6 +124,12 @@ func (d *dirImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return false // N/A, DockerReference() returns nil.
 }
 
+// ConcurrentPutBlob returns true as this destination supports concurrent
+// calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *dirImageDestination) ConcurrentPutBlob() (bool) {
+	return true
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -48,6 +48,12 @@ func (s *dirImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 	return m, manifest.GuessMIMEType(m), err
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *dirImageSource) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(info.Digest))

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -110,6 +110,12 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+// ConcurrentPutBlob returns true as this destination supports concurrent
+// calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *dockerImageDestination) ConcurrentPutBlob() (bool) {
+	return true
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -161,6 +161,12 @@ func getBlobSize(resp *http.Response) int64 {
 	return size
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *dockerImageSource) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -82,6 +82,12 @@ func (d *Destination) IgnoresEmbeddedDockerReference() bool {
 	return false // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
 }
 
+// ConcurrentPutBlob returns false as this destination does not support concurrent
+// calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *Destination) ConcurrentPutBlob() (bool) {
+	return false
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -397,6 +397,12 @@ func (r uncompressedReadCloser) Close() error {
 	return res
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *Source) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if err := s.ensureCachedDataIsPresent(); err != nil {

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -32,6 +32,9 @@ func (f unusedImageSource) Close() error {
 func (f unusedImageSource) GetManifest(context.Context, *digest.Digest) ([]byte, string, error) {
 	panic("Unexpected call to a mock function")
 }
+func (f unusedImageSource) ConcurrentGetBlob() (bool) {
+	panic("Unexpected call to a mock function")
+}
 func (f unusedImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	panic("Unexpected call to a mock function")
 }
@@ -152,6 +155,9 @@ type configBlobImageSource struct {
 	f                 func(digest digest.Digest) (io.ReadCloser, int64, error)
 }
 
+func (f configBlobImageSource) ConcurrentGetBlob() (bool) {
+	return false
+}
 func (f configBlobImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if info.Digest.String() != "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f" {
 		panic("Unexpected digest in GetBlob")
@@ -394,6 +400,9 @@ func (d *memoryImageDest) MustMatchRuntimeOS() bool {
 }
 func (d *memoryImageDest) IgnoresEmbeddedDockerReference() bool {
 	panic("Unexpected call to a mock function")
+}
+func (d *memoryImageDest) ConcurrentPutBlob() (bool) {
+	return false
 }
 func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	if d.storedBlobs == nil {

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -77,6 +77,11 @@ func (d *ociArchiveImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return d.unpackedDest.IgnoresEmbeddedDockerReference()
 }
 
+// ConcurrentPutBlob delegates to the unpacked destination image
+func (d *ociArchiveImageDestination) ConcurrentPutBlob() (bool) {
+	return d.unpackedDest.ConcurrentPutBlob()
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -76,6 +76,12 @@ func (s *ociArchiveImageSource) GetManifest(ctx context.Context, instanceDigest 
 	return s.unpackedSrc.GetManifest(ctx, instanceDigest)
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *ociArchiveImageSource) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 // GetBlob returns a stream for the specified blob, and the blob's size.
 func (s *ociArchiveImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	return s.unpackedSrc.GetBlob(ctx, info)

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -107,6 +107,12 @@ func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return false // N/A, DockerReference() returns nil.
 }
 
+// ConcurrentPutBlob returns true as this destination supports concurrent
+// calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *ociImageDestination) ConcurrentPutBlob() (bool) {
+	return true
+}
+
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -92,6 +92,12 @@ func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 	return m, mimeType, nil
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *ociImageSource) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 // GetBlob returns a stream for the specified blob, and the blob's size.
 func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -211,6 +211,14 @@ func (s *openshiftImageSource) GetManifest(ctx context.Context, instanceDigest *
 	return s.docker.GetManifest(ctx, instanceDigest)
 }
 
+// ConcurrentGetBlob delegates to the docker source ConcurrentGetBlob
+func (s *openshiftImageSource) ConcurrentGetBlob() (bool) {
+	if s.docker != nil {
+		return s.docker.ConcurrentGetBlob()
+	}
+	return false
+}
+
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 func (s *openshiftImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 	if err := s.ensureImageIsResolved(ctx); err != nil {
@@ -375,6 +383,15 @@ func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 func (d *openshiftImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return d.docker.IgnoresEmbeddedDockerReference()
 }
+
+// ConcurrentPutBlob delegates to the docker destination ConcurrentPutBlob
+func (d *openshiftImageDestination) ConcurrentPutBlob() (bool) {
+	if d.docker != nil {
+		return d.docker.ConcurrentPutBlob()
+	}
+	return false
+}
+
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -132,6 +132,12 @@ func (d *ostreeImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return false // N/A, DockerReference() returns nil.
 }
 
+// ConcurrentPutBlob returns false as it is not known if this destination
+// supports concurrent calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *ostreeImageDestination) ConcurrentPutBlob() (bool) {
+	return false
+}
+
 func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -255,6 +255,12 @@ func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, 
 	return getter.Get(path)
 }
 
+// ConcurrentGetBlob returns false as it is unknown whether this source
+// supports concurrent calls to GetBlob
+func (s *ostreeImageSource) ConcurrentGetBlob() (bool) {
+	return false
+}
+
 // GetBlob returns a stream for the specified blob, and the blob's size.
 func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -99,6 +99,12 @@ func (s storageImageSource) Close() error {
 	return nil
 }
 
+// ConcurrentGetBlob returns false as this source does not
+// support concurrent calls to GetBlob
+func (s *storageImageSource) ConcurrentGetBlob() (bool) {
+	return false
+}
+
 // GetBlob reads the data blob or filesystem layer which matches the digest and size, if given.
 func (s *storageImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (rc io.ReadCloser, n int64, err error) {
 	if info.Digest == image.GzippedEmptyLayerDigest {
@@ -315,6 +321,12 @@ func (s storageImageDestination) DesiredLayerCompression() types.LayerCompressio
 
 func (s *storageImageDestination) computeNextBlobCacheFile() string {
 	return filepath.Join(s.directory, fmt.Sprintf("%d", atomic.AddInt32(&s.nextTempFileID, 1)))
+}
+
+// ConcurrentPutBlob returns false as this destination does not support concurrent
+// calls to PutBlob, HasBlob, ReapplyBlob 
+func (d *storageImageDestination) ConcurrentPutBlob() (bool) {
+	return false
 }
 
 // PutBlob stores a layer or data blob in our temporary directory, checking that any information

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -207,6 +207,12 @@ func (is *tarballImageSource) Close() error {
 	return nil
 }
 
+// ConcurrentGetBlob returns true as this source supports concurrent calls to
+// GetBlob
+func (s *tarballImageSource) ConcurrentGetBlob() (bool) {
+	return true
+}
+
 func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
 	// We should only be asked about things in the manifest.  Maybe the configuration blob.
 	if blobinfo.Digest == is.configID {

--- a/types/types.go
+++ b/types/types.go
@@ -130,6 +130,9 @@ type ImageSource interface {
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfosForCopy(ctx context.Context) ([]BlobInfo, error)
+	// ConcurrentGetBlob returns true if multiple concurrent calls to GetBlob
+	// is supported by this source
+	ConcurrentGetBlob() (bool)
 }
 
 // LayerCompression indicates if layers must be compressed, decompressed or preserved
@@ -205,6 +208,9 @@ type ImageDestination interface {
 	// - Uploaded data MAY be visible to others before Commit() is called
 	// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 	Commit(ctx context.Context) error
+	// ConcurrentPutBlob returns true if multiple concurrent calls to PutBlob,
+	// HasBlob, ReapplyBlob is supported by this destination
+	ConcurrentPutBlob() (bool)
 }
 
 // ManifestTypeRejectedError is returned by ImageDestination.PutManifest if the destination is in principle available,

--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/imdario/mergo 50d4dbd4eb0e84778abe37cefef140271d96fade
 github.com/mattn/go-runewidth 14207d285c6c197daabb5c9793d63e7af9ab2d50
 github.com/mistifyio/go-zfs c0224de804d438efd11ea6e52ada8014537d6062
 github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
-github.com/opencontainers/go-digest aa2ec055abd10d26d539eb630a92241b781ce4bc
+github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc 6b1d0e76f239ffb435445e5ae316d2676c07c6e3
 github.com/pborman/uuid 1b00554d822231195d1babd97ff4a781231955c9


### PR DESCRIPTION
Copy layers concurrently                                                              
                                                                                      
This implements concurrent copying by using a simplified worker                       
pattern. Unless the source and destination both support concurrency,                  
only a single worker will perform blob transfers.                                     
                                                                                      
Concurrency support for transports are as follows:                                    
                                                                                      
Concurrency disabled:                                                                 
containers-storage, docker-daemon, ostree                                             
                                                                                      
Concurrency enabled:                                                                  
dir, docker, oci                                                                      
                                                                                      
Concurrency for source only:                                                          
docker-archive                                                                        
                                                                                      
Currently worker count is hard-coded to 4. It is hard to know what the                
optimal worker count is since its not obvious if a copy will be CPU,                  
network or storage bound. Maybe an OK compromise is min(4, cpucount).