### PR TITLE
Do not run validation when HEAD equals origin/master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,5 +99,7 @@ ifeq ($(TRAVIS),true)
 else
 	git fetch -q "https://github.com/containers/image.git" "refs/heads/master"
 	upstream="$$(git rev-parse --verify FETCH_HEAD)" ; \
+		ours=$$(git rev-parse --verify HEAD); \
+		[ $$upstream = $$ours ] ||\
 		git-validation -q -run DCO,short-subject,dangling-whitespace -range $$upstream..HEAD
 endif


### PR DESCRIPTION
Addressing:
```
git fetch -q "https://github.com/containers/image.git" "refs/heads/master"
upstream="$(git rev-parse --verify FETCH_HEAD)" ; \
	git-validation -q -run DCO,short-subject,dangling-whitespace -range $upstream..HEAD
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
ERRO[0000] [git] cmd: "git --no-pager log -1 --pretty=format:%p "
2018/11/04 20:04:53 exit status 128
make: *** [Makefile:98: .gitvalidation] Error 1
```
