### PR TITLE
Fix godoc code formatting

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,31 +1,31 @@
 // Package image provides libraries and commands to interact with containers images.
 //
-// package main
+//  package main
 //
-// import (
-// 	"context"
-// 	"fmt"
+//  import (
+//   	"context"
+//  	"fmt"
 //
-// 	"github.com/containers/image/docker"
-// )
+//  	"github.com/containers/image/docker"
+//  )
 //
-// func main() {
-// 	ref, err := docker.ParseReference("//fedora")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	ctx := context.Background()
-// 	img, err := ref.NewImage(ctx, nil)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	defer img.Close()
-// 	b, _, err := img.Manifest(ctx)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	fmt.Printf("%s", string(b))
-// }
+//  func main() {
+//  	ref, err := docker.ParseReference("//fedora")
+//  	if err != nil {
+//  		panic(err)
+//  	}
+//  	ctx := context.Background()
+//  	img, err := ref.NewImage(ctx, nil)
+//  	if err != nil {
+//  		panic(err)
+//  	}
+//  	defer img.Close()
+//  	b, _, err := img.Manifest(ctx)
+//  	if err != nil {
+//  		panic(err)
+//  	}
+//  	fmt.Printf("%s", string(b))
+//  }
 //
 //
 // TODO(runcom)


### PR DESCRIPTION
The example code in godoc were formatted inconsistently due to
indentations issues. This fixes the indentations, moving the example
into proper code block.

Signed-off-by: Sunny <me@darkowlzz.space>