### PR TITLE
Blob info caching + mount/reuse

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containers/image/image"
+	"github.com/containers/image/pkg/blobinfocache"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
@@ -77,6 +78,7 @@ type copier struct {
 	reportWriter     io.Writer
 	progressInterval time.Duration
 	progress         chan types.ProgressProperties
+	blobInfoCache    types.BlobInfoCache
 }
 
 // imageCopier tracks state specific to a single image (possibly an item of a manifest list)
@@ -147,6 +149,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		reportWriter:     reportWriter,
 		progressInterval: options.ProgressInterval,
 		progress:         options.Progress,
+		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
+		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
+		// we might want to add a separate CommonCtx — or would that be too confusing?
+		blobInfoCache: blobinfocache.DefaultCache(options.DestinationCtx),
 	}
 
 	unparsedToplevel := image.UnparsedInstance(rawSource, nil)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -507,7 +507,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo) (t
 
 	// If we already have the blob, and we don't need to compute the diffID, then we don't need to read it from the source.
 	if !diffIDIsNeeded {
-		reused, blobInfo, err := ic.c.dest.TryReusingBlob(ctx, srcInfo)
+		reused, blobInfo, err := ic.c.dest.TryReusingBlob(ctx, srcInfo, ic.c.blobInfoCache)
 		if err != nil {
 			return types.BlobInfo{}, "", errors.Wrapf(err, "Error trying to reuse blob %s at destination", srcInfo.Digest)
 		}
@@ -519,7 +519,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo) (t
 
 	// Fallback: copy the layer, computing the diffID if we need to do so
 	ic.c.Printf("Copying blob %s\n", srcInfo.Digest)
-	srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(ctx, srcInfo)
+	srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(ctx, srcInfo, ic.c.blobInfoCache)
 	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error reading blob %s", srcInfo.Digest)
 	}
@@ -697,7 +697,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	}
 
 	// === Finally, send the layer stream to dest.
-	uploadedInfo, err := c.dest.PutBlob(ctx, destStream, inputInfo, isConfig)
+	uploadedInfo, err := c.dest.PutBlob(ctx, destStream, inputInfo, c.blobInfoCache, isConfig)
 	if err != nil {
 		return types.BlobInfo{}, errors.Wrap(err, "Error writing blob")
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -502,28 +502,19 @@ type diffIDResult struct {
 // copyLayer copies a layer with srcInfo (with known Digest and possibly known Size) in src to dest, perhaps compressing it if canCompress,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo) (types.BlobInfo, digest.Digest, error) {
-	// Check if we already have a blob with this digest
-	haveBlob, extantBlobSize, err := ic.c.dest.HasBlob(ctx, srcInfo)
-	if err != nil {
-		return types.BlobInfo{}, "", errors.Wrapf(err, "Error checking for blob %s at destination", srcInfo.Digest)
-	}
-	// If we already have a cached diffID for this blob, we don't need to compute it
 	cachedDiffID := ic.c.blobInfoCache.UncompressedDigest(srcInfo.Digest) // May be ""
 	diffIDIsNeeded := ic.diffIDsAreNeeded && cachedDiffID == ""
-	// If we already have the blob, and we don't need to recompute the diffID, then we might be able to avoid reading it again
-	if haveBlob && !diffIDIsNeeded {
-		// Check the blob sizes match, if we were given a size this time
-		if srcInfo.Size != -1 && srcInfo.Size != extantBlobSize {
-			return types.BlobInfo{}, "", errors.Errorf("Error: blob %s is already present, but with size %d instead of %d", srcInfo.Digest, extantBlobSize, srcInfo.Size)
-		}
-		srcInfo.Size = extantBlobSize
-		// Tell the image destination that this blob's delta is being applied again.  For some image destinations, this can be faster than using GetBlob/PutBlob
-		blobinfo, err := ic.c.dest.ReapplyBlob(ctx, srcInfo)
+
+	// If we already have the blob, and we don't need to compute the diffID, then we don't need to read it from the source.
+	if !diffIDIsNeeded {
+		reused, blobInfo, err := ic.c.dest.TryReusingBlob(ctx, srcInfo)
 		if err != nil {
-			return types.BlobInfo{}, "", errors.Wrapf(err, "Error reapplying blob %s at destination", srcInfo.Digest)
+			return types.BlobInfo{}, "", errors.Wrapf(err, "Error trying to reuse blob %s at destination", srcInfo.Digest)
 		}
-		ic.c.Printf("Skipping fetch of repeat blob %s\n", srcInfo.Digest)
-		return blobinfo, cachedDiffID, err
+		if reused {
+			ic.c.Printf("Skipping fetch of repeat blob %s\n", srcInfo.Digest)
+			return blobInfo, cachedDiffID, nil
+		}
 	}
 
 	// Fallback: copy the layer, computing the diffID if we need to do so

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -25,14 +25,16 @@ import (
 )
 
 type digestingReader struct {
-	source           io.Reader
-	digester         digest.Digester
-	expectedDigest   digest.Digest
-	validationFailed bool
+	source              io.Reader
+	digester            digest.Digester
+	expectedDigest      digest.Digest
+	validationFailed    bool
+	validationSucceeded bool
 }
 
 // newDigestingReader returns an io.Reader implementation with contents of source, which will eventually return a non-EOF error
-// and set validationFailed to true if the source stream does not match expectedDigest.
+// or set validationSucceeded/validationFailed to true if the source stream does/does not match expectedDigest.
+// (neither is set if EOF is never reached).
 func newDigestingReader(source io.Reader, expectedDigest digest.Digest) (*digestingReader, error) {
 	if err := expectedDigest.Validate(); err != nil {
 		return nil, errors.Errorf("Invalid digest specification %s", expectedDigest)
@@ -65,6 +67,7 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 			d.validationFailed = true
 			return 0, errors.Errorf("Digest did not match, expected %s, got %s", d.expectedDigest, actualDigest)
 		}
+		d.validationSucceeded = true
 	}
 	return n, err
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -173,10 +173,11 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -127,10 +127,11 @@ func (d *dirImageDestination) IgnoresEmbeddedDockerReference() bool {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
+// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	blobFile, err := ioutil.TempFile(d.ref.path, "dir-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -174,7 +175,8 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+// May use and/or update cache.
+func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -169,27 +169,25 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
 }
 
-// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
-// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
-// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
-// it returns a non-nil error only on an unexpected failure.
-func (d *dirImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
 	blobPath := d.ref.layerPath(info.Digest)
 	finfo, err := os.Stat(blobPath)
 	if err != nil && os.IsNotExist(err) {
-		return false, -1, nil
+		return false, types.BlobInfo{}, nil
 	}
 	if err != nil {
-		return false, -1, err
+		return false, types.BlobInfo{}, err
 	}
-	return true, finfo.Size(), nil
-}
+	return true, types.BlobInfo{Digest: info.Digest, Size: finfo.Size()}, nil
 
-func (d *dirImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
-	return info, nil
 }
 
 // PutManifest writes manifest to the destination.

--- a/directory/directory_src.go
+++ b/directory/directory_src.go
@@ -49,7 +49,9 @@ func (s *dirImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *dirImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	r, err := os.Open(s.ref.layerPath(info.Digest))
 	if err != nil {
 		return nil, -1, err

--- a/docker/cache.go
+++ b/docker/cache.go
@@ -1,0 +1,23 @@
+package docker
+
+import (
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/types"
+)
+
+// bicTransportScope returns a BICTransportScope appropriate for ref.
+func bicTransportScope(ref dockerReference) types.BICTransportScope {
+	// Blobs can be reused across the whole registry.
+	return types.BICTransportScope{Opaque: reference.Domain(ref.ref)}
+}
+
+// newBICLocationReference returns a BICLocationReference appropriate for ref.
+func newBICLocationReference(ref dockerReference) types.BICLocationReference {
+	// Blobs are scoped to repositories (the tag/digest are not necessary to reuse a blob).
+	return types.BICLocationReference{Opaque: ref.ref.Name()}
+}
+
+// parseBICLocationReference returns a repository for encoded lr.
+func parseBICLocationReference(lr types.BICLocationReference) (reference.Named, error) {
+	return reference.ParseNormalizedNamed(lr.Opaque)
+}

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -486,11 +486,6 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 	if !ok {
 		return nil, errors.Errorf("missing realm in bearer auth challenge")
 	}
-	service, _ := challenge.Parameters["service"] // Will be "" if not present
-	var scopeString string
-	if c.scope.remoteName != "" && c.scope.actions != "" {
-		scopeString = fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions)
-	}
 
 	authReq, err := http.NewRequest("GET", realm, nil)
 	if err != nil {
@@ -501,11 +496,11 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 	if c.username != "" {
 		getParams.Add("account", c.username)
 	}
-	if service != "" {
+	if service, ok := challenge.Parameters["service"]; ok && service != "" {
 		getParams.Add("service", service)
 	}
-	if scopeString != "" {
-		getParams.Add("scope", scopeString)
+	if c.scope.remoteName != "" && c.scope.actions != "" {
+		getParams.Add("scope", fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions))
 	}
 	authReq.URL.RawQuery = getParams.Encode()
 	if c.username != "" && c.password != "" {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -464,16 +464,7 @@ func (c *dockerClient) setupRequestAuth(req *http.Request) error {
 			return nil
 		case "bearer":
 			if c.token == nil || time.Now().After(c.tokenExpiration) {
-				realm, ok := challenge.Parameters["realm"]
-				if !ok {
-					return errors.Errorf("missing realm in bearer auth challenge")
-				}
-				service, _ := challenge.Parameters["service"] // Will be "" if not present
-				var scope string
-				if c.scope.remoteName != "" && c.scope.actions != "" {
-					scope = fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions)
-				}
-				token, err := c.getBearerToken(req.Context(), realm, service, scope)
+				token, err := c.getBearerToken(req.Context(), challenge, c.scope)
 				if err != nil {
 					return err
 				}
@@ -490,7 +481,17 @@ func (c *dockerClient) setupRequestAuth(req *http.Request) error {
 	return nil
 }
 
-func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope string) (*bearerToken, error) {
+func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, scope authScope) (*bearerToken, error) {
+	realm, ok := challenge.Parameters["realm"]
+	if !ok {
+		return nil, errors.Errorf("missing realm in bearer auth challenge")
+	}
+	service, _ := challenge.Parameters["service"] // Will be "" if not present
+	var scopeString string
+	if c.scope.remoteName != "" && c.scope.actions != "" {
+		scopeString = fmt.Sprintf("repository:%s:%s", c.scope.remoteName, c.scope.actions)
+	}
+
 	authReq, err := http.NewRequest("GET", realm, nil)
 	if err != nil {
 		return nil, err
@@ -503,8 +504,8 @@ func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope
 	if service != "" {
 		getParams.Add("service", service)
 	}
-	if scope != "" {
-		getParams.Add("scope", scope)
+	if scopeString != "" {
+		getParams.Add("scope", scopeString)
 	}
 	authReq.URL.RawQuery = getParams.Encode()
 	if c.username != "" && c.password != "" {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -119,7 +119,7 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	if inputInfo.Digest.String() != "" {
-		haveBlob, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache)
+		haveBlob, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache, false)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
@@ -184,10 +184,11 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -118,12 +118,12 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	if inputInfo.Digest.String() != "" {
-		haveBlob, size, err := d.HasBlob(ctx, inputInfo)
+		haveBlob, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
 		if haveBlob {
-			return types.BlobInfo{Digest: inputInfo.Digest, Size: size}, nil
+			return reusedInfo, nil
 		}
 	}
 
@@ -180,39 +180,36 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	return types.BlobInfo{Digest: computedDigest, Size: sizeCounter.size}, nil
 }
 
-// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
-// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
-// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
-// it returns a non-nil error only on an unexpected failure.
-func (d *dockerImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
-	checkPath := fmt.Sprintf(blobsPath, reference.Path(d.ref.ref), info.Digest.String())
 
+	checkPath := fmt.Sprintf(blobsPath, reference.Path(d.ref.ref), info.Digest.String())
 	logrus.Debugf("Checking %s", checkPath)
 	res, err := d.c.makeRequest(ctx, "HEAD", checkPath, nil, nil, v2Auth)
 	if err != nil {
-		return false, -1, err
+		return false, types.BlobInfo{}, err
 	}
 	defer res.Body.Close()
 	switch res.StatusCode {
 	case http.StatusOK:
 		logrus.Debugf("... already exists")
-		return true, getBlobSize(res), nil
+		return true, types.BlobInfo{Digest: info.Digest, Size: getBlobSize(res)}, nil
 	case http.StatusUnauthorized:
 		logrus.Debugf("... not authorized")
-		return false, -1, errors.Wrapf(client.HandleErrorResponse(res), "Error checking whether a blob %s exists in %s", info.Digest, d.ref.ref.Name())
+		return false, types.BlobInfo{}, errors.Wrapf(client.HandleErrorResponse(res), "Error checking whether a blob %s exists in %s", info.Digest, d.ref.ref.Name())
 	case http.StatusNotFound:
 		logrus.Debugf("... not present")
-		return false, -1, nil
+		return false, types.BlobInfo{}, nil
 	default:
-		return false, -1, errors.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
+		return false, types.BlobInfo{}, errors.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
 	}
-}
-
-func (d *dockerImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
-	return info, nil
 }
 
 // PutManifest writes manifest to the destination.

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -113,12 +113,13 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
+// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	if inputInfo.Digest.String() != "" {
-		haveBlob, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo)
+		haveBlob, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
@@ -185,7 +186,8 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+// May use and/or update cache.
+func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -179,6 +179,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 		// print url also
 		return nil, 0, errors.Errorf("Invalid status code returned when fetching blob %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
 	}
+	cache.RecordKnownLocation(s.ref.Transport(), bicTransportScope(s.ref), info.Digest, newBICLocationReference(s.ref))
 	return res.Body, getBlobSize(res), nil
 }
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -162,7 +162,9 @@ func getBlobSize(resp *http.Response) int64 {
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {
 		return s.getExternalBlob(ctx, info.URLs)
 	}

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -85,10 +85,11 @@ func (d *Destination) IgnoresEmbeddedDockerReference() bool {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
+// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed datas.
 	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
@@ -120,7 +121,7 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 	}
 
 	// Maybe the blob has been already sent
-	ok, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo)
+	ok, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -156,7 +157,8 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+// May use and/or update cache.
+func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf("Can not check for a blob with unknown digest")
 	}

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -121,7 +121,7 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 	}
 
 	// Maybe the blob has been already sent
-	ok, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache)
+	ok, reusedInfo, err := d.TryReusingBlob(ctx, inputInfo, cache, false)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -155,10 +155,11 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf("Can not check for a blob with unknown digest")
 	}

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -398,7 +398,9 @@ func (r uncompressedReadCloser) Close() error {
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	if err := s.ensureCachedDataIsPresent(); err != nil {
 		return nil, 0, err
 	}

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -409,10 +409,7 @@ func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputIn
 	d.storedBlobs[inputInfo.Digest] = contents
 	return types.BlobInfo{Digest: inputInfo.Digest, Size: int64(len(contents))}, nil
 }
-func (d *memoryImageDest) HasBlob(ctx context.Context, inputInfo types.BlobInfo) (bool, int64, error) {
-	panic("Unexpected call to a mock function")
-}
-func (d *memoryImageDest) ReapplyBlob(ctx context.Context, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+func (d *memoryImageDest) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (d *memoryImageDest) PutManifest(ctx context.Context, m []byte) error {

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -32,7 +32,7 @@ func (f unusedImageSource) Close() error {
 func (f unusedImageSource) GetManifest(context.Context, *digest.Digest) ([]byte, string, error) {
 	panic("Unexpected call to a mock function")
 }
-func (f unusedImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (f unusedImageSource) GetBlob(context.Context, types.BlobInfo, types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	panic("Unexpected call to a mock function")
 }
 func (f unusedImageSource) GetSignatures(context.Context, *digest.Digest) ([][]byte, error) {
@@ -152,7 +152,7 @@ type configBlobImageSource struct {
 	f                 func(digest digest.Digest) (io.ReadCloser, int64, error)
 }
 
-func (f configBlobImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+func (f configBlobImageSource) GetBlob(ctx context.Context, info types.BlobInfo, _ types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	if info.Digest.String() != "sha256:9ca4bda0a6b3727a6ffcc43e981cad0f24e2ec79d338f6ba325b4dfd0756fb8f" {
 		panic("Unexpected digest in GetBlob")
 	}
@@ -395,7 +395,7 @@ func (d *memoryImageDest) MustMatchRuntimeOS() bool {
 func (d *memoryImageDest) IgnoresEmbeddedDockerReference() bool {
 	panic("Unexpected call to a mock function")
 }
-func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	if d.storedBlobs == nil {
 		d.storedBlobs = make(map[digest.Digest][]byte)
 	}
@@ -409,7 +409,7 @@ func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputIn
 	d.storedBlobs[inputInfo.Digest] = contents
 	return types.BlobInfo{Digest: inputInfo.Digest, Size: int64(len(contents))}, nil
 }
-func (d *memoryImageDest) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+func (d *memoryImageDest) TryReusingBlob(context.Context, types.BlobInfo, types.BlobInfoCache) (bool, types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (d *memoryImageDest) PutManifest(ctx context.Context, m []byte) error {

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -409,7 +409,7 @@ func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputIn
 	d.storedBlobs[inputInfo.Digest] = contents
 	return types.BlobInfo{Digest: inputInfo.Digest, Size: int64(len(contents))}, nil
 }
-func (d *memoryImageDest) TryReusingBlob(context.Context, types.BlobInfo, types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *memoryImageDest) TryReusingBlob(context.Context, types.BlobInfo, types.BlobInfoCache, bool) (bool, types.BlobInfo, error) {
 	panic("Unexpected call to a mock function")
 }
 func (d *memoryImageDest) PutManifest(ctx context.Context, m []byte) error {

--- a/image/oci.go
+++ b/image/oci.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
+	"github.com/containers/image/pkg/blobinfocache"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -60,7 +61,7 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 		if m.src == nil {
 			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestOCI1")
 		}
-		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromOCI1Descriptor(m.m.Config))
+		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromOCI1Descriptor(m.m.Config), blobinfocache.NoCache)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/testing/mocks/imagetransport.go
+++ b/internal/testing/mocks/imagetransport.go
@@ -1,0 +1,24 @@
+package mocks
+
+import "github.com/containers/image/types"
+
+// NameImageTransport is a mock of types.ImageTransport which returns itself in Name.
+type NameImageTransport string
+
+// Name returns the name of the transport, which must be unique among other transports.
+func (name NameImageTransport) Name() string {
+	return string(name)
+}
+
+// ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
+func (name NameImageTransport) ParseReference(reference string) (types.ImageReference, error) {
+	panic("unexpected call to a mock function")
+}
+
+// ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
+// (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
+// It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
+// scope passed to this function will not be "", that value is always allowed.
+func (name NameImageTransport) ValidatePolicyConfigurationScope(scope string) error {
+	panic("unexpected call to a mock function")
+}

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -84,13 +84,13 @@ func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Read
 	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, isConfig)
 }
 
-// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob
-func (d *ociArchiveImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
-	return d.unpackedDest.HasBlob(ctx, info)
-}
-
-func (d *ociArchiveImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
-	return d.unpackedDest.ReapplyBlob(ctx, info)
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+	return d.unpackedDest.TryReusingBlob(ctx, info)
 }
 
 // PutManifest writes manifest to the destination

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -92,11 +92,12 @@ func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Read
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
-	return d.unpackedDest.TryReusingBlob(ctx, info, cache)
+func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	return d.unpackedDest.TryReusingBlob(ctx, info, cache, canSubstitute)
 }
 
 // PutManifest writes manifest to the destination

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -77,11 +77,16 @@ func (d *ociArchiveImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return d.unpackedDest.IgnoresEmbeddedDockerReference()
 }
 
-// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
+// PutBlob writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
-func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
-	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, isConfig)
+// inputInfo.MediaType describes the blob format, if known.
+// May update cache.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, cache, isConfig)
 }
 
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
@@ -89,8 +94,9 @@ func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Read
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
-	return d.unpackedDest.TryReusingBlob(ctx, info)
+// May use and/or update cache.
+func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+	return d.unpackedDest.TryReusingBlob(ctx, info, cache)
 }
 
 // PutManifest writes manifest to the destination

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -76,9 +76,11 @@ func (s *ociArchiveImageSource) GetManifest(ctx context.Context, instanceDigest 
 	return s.unpackedSrc.GetManifest(ctx, instanceDigest)
 }
 
-// GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ociArchiveImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
-	return s.unpackedSrc.GetBlob(ctx, info)
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *ociArchiveImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	return s.unpackedSrc.GetBlob(ctx, info, cache)
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -178,10 +178,11 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -3,10 +3,10 @@ package layout
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"path/filepath"
-
+	"github.com/containers/image/pkg/blobinfocache"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +31,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	require.True(t, ok)
 	blobPath, err := dirRef.blobPath(blobDigest, "")
 	assert.NoError(t, err)
+	cache := blobinfocache.NewMemoryCache()
 
 	firstRead := true
 	reader := readerFromFunc(func(p []byte) (int, error) {
@@ -52,7 +53,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	dest, err := ref.NewImageDestination(context.Background(), nil)
 	require.NoError(t, err)
 	defer dest.Close()
-	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, false)
+	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, cache, false)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
 	err = dest.Commit(context.Background())

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -92,8 +92,10 @@ func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 	return m, mimeType, nil
 }
 
-// GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *ociImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	if len(info.URLs) != 0 {
 		return s.getExternalBlob(ctx, info.URLs)
 	}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -386,16 +386,13 @@ func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reade
 	return d.docker.PutBlob(ctx, stream, inputInfo, isConfig)
 }
 
-// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
-// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
-// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
-// it returns a non-nil error only on an unexpected failure.
-func (d *openshiftImageDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
-	return d.docker.HasBlob(ctx, info)
-}
-
-func (d *openshiftImageDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
-	return d.docker.ReapplyBlob(ctx, info)
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+	return d.docker.TryReusingBlob(ctx, info)
 }
 
 // PutManifest writes manifest to the destination.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -212,11 +212,13 @@ func (s *openshiftImageSource) GetManifest(ctx context.Context, instanceDigest *
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-func (s *openshiftImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *openshiftImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	if err := s.ensureImageIsResolved(ctx); err != nil {
 		return nil, 0, err
 	}
-	return s.docker.GetBlob(ctx, info)
+	return s.docker.GetBlob(ctx, info, cache)
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
@@ -379,11 +381,12 @@ func (d *openshiftImageDestination) IgnoresEmbeddedDockerReference() bool {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
+// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
-	return d.docker.PutBlob(ctx, stream, inputInfo, isConfig)
+func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	return d.docker.PutBlob(ctx, stream, inputInfo, cache, isConfig)
 }
 
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
@@ -391,8 +394,9 @@ func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reade
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
-	return d.docker.TryReusingBlob(ctx, info)
+// May use and/or update cache.
+func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+	return d.docker.TryReusingBlob(ctx, info, cache)
 }
 
 // PutManifest writes manifest to the destination.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -392,11 +392,12 @@ func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reade
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
-	return d.docker.TryReusingBlob(ctx, info, cache)
+func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	return d.docker.TryReusingBlob(ctx, info, cache, canSubstitute)
 }
 
 // PutManifest writes manifest to the destination.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -333,10 +333,11 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
 		if err != nil {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -132,7 +132,15 @@ func (d *ostreeImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return false // N/A, DockerReference() returns nil.
 }
 
-func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+// PutBlob writes contents of stream and returns data representing the result.
+// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Size is the expected length of stream, if known.
+// inputInfo.MediaType describes the blob format, if known.
+// May update cache.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -327,7 +335,8 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // info.Digest must not be empty.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo) (bool, types.BlobInfo, error) {
+// May use and/or update cache.
+func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
 		if err != nil {

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -255,8 +255,10 @@ func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, 
 	return getter.Get(path)
 }
 
-// GetBlob returns a stream for the specified blob, and the blob's size.
-func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadCloser, int64, error) {
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 
 	blob := info.Digest.Hex()
 

--- a/pkg/blobinfocache/boltdb.go
+++ b/pkg/blobinfocache/boltdb.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// NOTE: There is no versioning data inside the file; this is a “cache”, so on an incompatible format upgrade
-	// we can simply start over with a different filename.
+	// we can simply start over with a different filename; update blobInfoCacheFilename.
 
 	// FIXME: For CRI-O, does this need to hide information between different users?
 

--- a/pkg/blobinfocache/boltdb.go
+++ b/pkg/blobinfocache/boltdb.go
@@ -1,0 +1,329 @@
+package blobinfocache
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// NOTE: There is no versioning data inside the file; this is a “cache”, so on an incompatible format upgrade
+	// we can simply start over with a different filename.
+
+	// FIXME: For CRI-O, does this need to hide information between different users?
+
+	// uncompressedDigestBucket stores a mapping from any digest to an uncompressed digest.
+	uncompressedDigestBucket = []byte("uncompressedDigest")
+	// digestByUncompressedBucket stores a bucket per uncompressed digest, with the bucket containing a set of digests for that uncompressed digest
+	// (as a set of key=digest, value="" pairs)
+	digestByUncompressedBucket = []byte("digestByUncompressed")
+	// knownLocationsBucket stores a nested structure of buckets, keyed by (transport name, scope string, blob digest), ultimately containing
+	// a bucket of (opaque location reference, BinaryMarshaller-encoded time.Time value).
+	knownLocationsBucket = []byte("knownLocations")
+)
+
+// Concurrency:
+// See https://www.sqlite.org/src/artifact/c230a7a24?ln=994-1081 for all the issues with locks, which make it extremely
+// difficult to use a single BoltDB file from multiple threads/goroutines inside a process.  So, we punt and only allow one at a time.
+
+// pathLock contains a lock for a specific BoltDB database path.
+type pathLock struct {
+	refCount int64      // Number of threads/goroutines owning or waiting on this lock.  Protected by global pathLocksMutex, NOT by the mutex field below!
+	mutex    sync.Mutex // Owned by the thread/goroutine allowed to access the BoltDB database.
+}
+
+var (
+	// pathLocks contains a lock for each currently open file.
+	// This must be global so that independently created instances of boltDBCache exclude each other.
+	// The map is protected by pathLocksMutex.
+	// FIXME? Should this be based on device:inode numbers instead of paths instead?
+	pathLocks      = map[string]*pathLock{}
+	pathLocksMutex = sync.Mutex{}
+)
+
+// lockPath obtains the pathLock for path.
+// The caller must call unlockPath eventually.
+func lockPath(path string) {
+	pl := func() *pathLock { // A scope for defer
+		pathLocksMutex.Lock()
+		defer pathLocksMutex.Unlock()
+		pl, ok := pathLocks[path]
+		if ok {
+			pl.refCount++
+		} else {
+			pl = &pathLock{refCount: 1, mutex: sync.Mutex{}}
+			pathLocks[path] = pl
+		}
+		return pl
+	}()
+	pl.mutex.Lock()
+}
+
+// unlockPath releases the pathLock for path.
+func unlockPath(path string) {
+	pathLocksMutex.Lock()
+	defer pathLocksMutex.Unlock()
+	pl, ok := pathLocks[path]
+	if !ok {
+		// Should this return an error instead? BlobInfoCache ultimately ignores errors…
+		panic(fmt.Sprintf("Internal error: unlocking nonexistent lock for path %s", path))
+	}
+	pl.mutex.Unlock()
+	pl.refCount--
+	if pl.refCount == 0 {
+		delete(pathLocks, path)
+	}
+}
+
+// boltDBCache si a BlobInfoCache implementation which uses a BoltDB file at the specified path.
+//
+// Note that we don’t keep the database open across operations, because that would lock the file and block any other
+// users; instead, we need to open/close it for every single write or lookup.
+type boltDBCache struct {
+	path string
+}
+
+// NewBoltDBCache returns a BlobInfoCache implementation which uses a BoltDB file at path.
+// Most users should call DefaultCache instead.
+func NewBoltDBCache(path string) types.BlobInfoCache {
+	return &boltDBCache{path: path}
+}
+
+// view returns runs the specified fn within a read-only transaction on the database.
+func (bdc *boltDBCache) view(fn func(tx *bolt.Tx) error) (retErr error) {
+	// bolt.Open(bdc.path, 0600, &bolt.Options{ReadOnly: true}) will, if the file does not exist,
+	// nevertheless create it, but with an O_RDONLY file descriptor, try to initialize it, and fail — while holding
+	// a read lock, blocking any future writes.
+	// Hence this preliminary check, which is RACY: Another process could remove the file
+	// between the Lstat call and opening the database.
+	if _, err := os.Lstat(bdc.path); err != nil && os.IsNotExist(err) {
+		return err
+	}
+
+	lockPath(bdc.path)
+	defer unlockPath(bdc.path)
+	db, err := bolt.Open(bdc.path, 0600, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := db.Close(); retErr == nil && err != nil {
+			retErr = err
+		}
+	}()
+
+	return db.View(fn)
+}
+
+// update returns runs the specified fn within a read-write transaction on the database.
+func (bdc *boltDBCache) update(fn func(tx *bolt.Tx) error) (retErr error) {
+	lockPath(bdc.path)
+	defer unlockPath(bdc.path)
+	db, err := bolt.Open(bdc.path, 0600, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := db.Close(); retErr == nil && err != nil {
+			retErr = err
+		}
+	}()
+
+	return db.Update(fn)
+}
+
+// uncompressedDigest implements BlobInfoCache.UncompressedDigest within the provided read-only transaction.
+func (bdc *boltDBCache) uncompressedDigest(tx *bolt.Tx, anyDigest digest.Digest) digest.Digest {
+	if b := tx.Bucket(uncompressedDigestBucket); b != nil {
+		if uncompressedBytes := b.Get([]byte(anyDigest.String())); uncompressedBytes != nil {
+			d, err := digest.Parse(string(uncompressedBytes))
+			if err == nil {
+				return d
+			}
+			// FIXME? Log err (but throttle the log volume on repeated accesses)?
+		}
+	}
+	// Presence in digestsByUncompressedBucket implies that anyDigest must already refer to an uncompressed digest.
+	// This way we don't have to waste storage space with trivial (uncompressed, uncompressed) mappings
+	// when we already record a (compressed, uncompressed) pair.
+	if b := tx.Bucket(digestByUncompressedBucket); b != nil {
+		if b = b.Bucket([]byte(anyDigest.String())); b != nil {
+			c := b.Cursor()
+			if k, _ := c.First(); k != nil { // The bucket is non-empty
+				return anyDigest
+			}
+		}
+	}
+	return ""
+}
+
+// UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
+// May return anyDigest if it is known to be uncompressed.
+// Returns "" if nothing is known about the digest (it may be compressed or uncompressed).
+func (bdc *boltDBCache) UncompressedDigest(anyDigest digest.Digest) digest.Digest {
+	var res digest.Digest
+	if err := bdc.view(func(tx *bolt.Tx) error {
+		res = bdc.uncompressedDigest(tx, anyDigest)
+		return nil
+	}); err != nil { // Including os.IsNotExist(err)
+		return "" // FIXME? Log err (but throttle the log volume on repeated accesses)?
+	}
+	return res
+}
+
+// RecordDigestUncompressedPair records that the uncompressed version of anyDigest is uncompressed.
+// It’s allowed for anyDigest == uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (bdc *boltDBCache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompressed digest.Digest) {
+	_ = bdc.update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(uncompressedDigestBucket)
+		if err != nil {
+			return err
+		}
+		key := []byte(anyDigest.String())
+		if previousBytes := b.Get(key); previousBytes != nil {
+			previous, err := digest.Parse(string(previousBytes))
+			if err != nil {
+				return err
+			}
+			if previous != uncompressed {
+				logrus.Warnf("Uncompressed digest for blob %s previously recorded as %s, now %s", anyDigest, previous, uncompressed)
+			}
+		}
+		if err := b.Put(key, []byte(uncompressed.String())); err != nil {
+			return err
+		}
+
+		b, err = tx.CreateBucketIfNotExists(digestByUncompressedBucket)
+		if err != nil {
+			return err
+		}
+		b, err = b.CreateBucketIfNotExists([]byte(uncompressed.String()))
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte(anyDigest.String()), []byte{}); err != nil { // Possibly writing the same []byte{} presence marker again.
+			return err
+		}
+		return nil
+	}) // FIXME? Log error (but throttle the log volume on repeated accesses)?
+}
+
+// RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,
+// and can be reused given the opaque location data.
+func (bdc *boltDBCache) RecordKnownLocation(transport types.ImageTransport, scope types.BICTransportScope, blobDigest digest.Digest, location types.BICLocationReference) {
+	_ = bdc.update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(knownLocationsBucket)
+		if err != nil {
+			return err
+		}
+		b, err = b.CreateBucketIfNotExists([]byte(transport.Name()))
+		if err != nil {
+			return err
+		}
+		b, err = b.CreateBucketIfNotExists([]byte(scope.Opaque))
+		if err != nil {
+			return err
+		}
+		b, err = b.CreateBucketIfNotExists([]byte(blobDigest.String()))
+		if err != nil {
+			return err
+		}
+		value, err := time.Now().MarshalBinary()
+		if err != nil {
+			return err
+		}
+		if err := b.Put([]byte(location.Opaque), value); err != nil { // Possibly overwriting an older entry.
+			return err
+		}
+		return nil
+	}) // FIXME? Log error (but throttle the log volume on repeated accesses)?
+}
+
+// appendReplacementCandiates creates candidateWithTime values for digest in scopeBucket, and returns the result of appending them to candidates.
+func (bdc *boltDBCache) appendReplacementCandidates(candidates []candidateWithTime, scopeBucket *bolt.Bucket, digest digest.Digest) []candidateWithTime {
+	b := scopeBucket.Bucket([]byte(digest.String()))
+	if b == nil {
+		return candidates
+	}
+	_ = b.ForEach(func(k, v []byte) error {
+		t := time.Time{}
+		if err := t.UnmarshalBinary(v); err != nil {
+			return err
+		}
+		candidates = append(candidates, candidateWithTime{
+			candidate: types.BICReplacementCandidate{
+				Digest:   digest,
+				Location: types.BICLocationReference{Opaque: string(k)},
+			},
+			lastSeen: t,
+		})
+		return nil
+	}) // FIXME? Log error (but throttle the log volume on repeated accesses)?
+	return candidates
+}
+
+// CandidateLocations returns a prioritized, limited, number of blobs and their locations that could possibly be reused
+// within the specified (transport scope) (if they still exist, which is not guaranteed).
+//
+// If !canSubstitute, the returned cadidates will match the submitted digest exactly; if canSubstitute,
+// data from previous RecordDigestUncompressedPair calls is used to also look up variants of the blob which have the same
+// uncompressed digest.
+func (bdc *boltDBCache) CandidateLocations(transport types.ImageTransport, scope types.BICTransportScope, primaryDigest digest.Digest, canSubstitute bool) []types.BICReplacementCandidate {
+	res := []candidateWithTime{}
+	var uncompressedDigestValue digest.Digest // = ""
+	if err := bdc.view(func(tx *bolt.Tx) error {
+		scopeBucket := tx.Bucket(knownLocationsBucket)
+		if scopeBucket == nil {
+			return nil
+		}
+		scopeBucket = scopeBucket.Bucket([]byte(transport.Name()))
+		if scopeBucket == nil {
+			return nil
+		}
+		scopeBucket = scopeBucket.Bucket([]byte(scope.Opaque))
+		if scopeBucket == nil {
+			return nil
+		}
+
+		res = bdc.appendReplacementCandidates(res, scopeBucket, primaryDigest)
+		if canSubstitute {
+			if uncompressedDigestValue = bdc.uncompressedDigest(tx, primaryDigest); uncompressedDigestValue != "" {
+				b := tx.Bucket(digestByUncompressedBucket)
+				if b != nil {
+					b = b.Bucket([]byte(uncompressedDigestValue.String()))
+					if b != nil {
+						if err := b.ForEach(func(k, _ []byte) error {
+							d, err := digest.Parse(string(k))
+							if err != nil {
+								return err
+							}
+							if d != primaryDigest && d != uncompressedDigestValue {
+								res = bdc.appendReplacementCandidates(res, scopeBucket, d)
+							}
+							return nil
+						}); err != nil {
+							return err
+						}
+					}
+				}
+				if uncompressedDigestValue != primaryDigest {
+					res = bdc.appendReplacementCandidates(res, scopeBucket, uncompressedDigestValue)
+				}
+			}
+		}
+		return nil
+	}); err != nil { // Including os.IsNotExist(err)
+		return []types.BICReplacementCandidate{} // FIXME? Log err (but throttle the log volume on repeated accesses)?
+	}
+
+	return destructivelyPrioritizeReplacementCandidates(res, primaryDigest, uncompressedDigestValue)
+}

--- a/pkg/blobinfocache/boltdb_test.go
+++ b/pkg/blobinfocache/boltdb_test.go
@@ -1,0 +1,30 @@
+package blobinfocache
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBoltDBCache(t *testing.T) (types.BlobInfoCache, func(t *testing.T)) {
+	// We need a separate temporary directory here, because bolt.Open(…, &bolt.Options{Readonly:true}) can't deal with
+	// an existing but empty file, and incorrectly fails without releasing the lock - which in turn causes
+	// any future writes to hang.  Creating a temporary directory allows us to use a path to a
+	// non-existent file, thus replicating the expected conditions for creating a new DB.
+	dir, err := ioutil.TempDir("", "boltdb")
+	require.NoError(t, err)
+	return NewBoltDBCache(filepath.Join(dir, "db")), func(t *testing.T) {
+		err = os.RemoveAll(dir)
+		require.NoError(t, err)
+	}
+}
+
+func TestNewBoltDBCache(t *testing.T) {
+	testGenericCache(t, newTestBoltDBCache)
+}
+
+// FIXME: Tests for the various corner cases / failure cases of boltDBCache should be added here.

--- a/pkg/blobinfocache/default.go
+++ b/pkg/blobinfocache/default.go
@@ -1,0 +1,63 @@
+package blobinfocache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/image/types"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// blobInfoCacheFilename is the file name used for blob info caches.
+	// If the format changes in an incompatible way, increase the version number.
+	blobInfoCacheFilename = "blob-info-cache-v1.boltdb"
+	// systemBlobInfoCacheDir is the directory containing the blob info cache (in blobInfocacheFilename) for root-running processes.
+	systemBlobInfoCacheDir = "/var/lib/containers/cache"
+)
+
+// blobInfoCacheDir returns a path to a blob info cache appropripate for sys and euid.
+// euid is used so that (sudo …) does not write root-owned files into the unprivileged users’ home directory.
+func blobInfoCacheDir(sys *types.SystemContext, euid int) (string, error) {
+	if sys != nil && sys.BlobInfoCacheDir != "" {
+		return sys.BlobInfoCacheDir, nil
+	}
+
+	// FIXME? On Windows, os.Geteuid() returns -1.  What should we do?  Right now we treat it as unprivileged
+	// and fail (fall back to memory-only) if neither HOME nor XDG_DATA_HOME is set, which is, at least, safe.
+	if euid == 0 {
+		if sys != nil && sys.RootForImplicitAbsolutePaths != "" {
+			return filepath.Join(sys.RootForImplicitAbsolutePaths, systemBlobInfoCacheDir), nil
+		}
+		return systemBlobInfoCacheDir, nil
+	}
+
+	// This is intended to mirror the GraphRoot determination in github.com/containers/libpod/pkg/util.GetRootlessStorageOpts.
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return "", fmt.Errorf("neither XDG_DATA_HOME nor HOME was set non-empty")
+		}
+		dataDir = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataDir, "containers", "cache"), nil
+}
+
+// DefaultCache returns the default BlobInfoCache implementation appropriate for sys.
+func DefaultCache(sys *types.SystemContext) types.BlobInfoCache {
+	dir, err := blobInfoCacheDir(sys, os.Geteuid())
+	if err != nil {
+		logrus.Debugf("Error determining a location for %s, using a memory-only cache", blobInfoCacheFilename)
+		return NewMemoryCache()
+	}
+	path := filepath.Join(dir, blobInfoCacheFilename)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		logrus.Debugf("Error creating parent directories for %s, using a memory-only cache: %v", err)
+		return NewMemoryCache()
+	}
+
+	logrus.Debugf("Using blob info cache at %s", path)
+	return NewBoltDBCache(path)
+}

--- a/pkg/blobinfocache/default_test.go
+++ b/pkg/blobinfocache/default_test.go
@@ -1,0 +1,162 @@
+package blobinfocache
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/containers/image/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlobInfoCacheDir(t *testing.T) {
+	const nondefaultDir = "/this/is/not/the/default/cache/dir"
+	const rootPrefix = "/root/prefix"
+	const homeDir = "/fake/home/directory"
+	const xdgDataHome = "/fake/home/directory/XDG"
+
+	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
+	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.
+	oldXRD, hasXRD := os.LookupEnv("XDG_RUNTIME_DIR")
+	defer func() {
+		if hasXRD {
+			os.Setenv("XDG_RUNTIME_DIR", oldXRD)
+		} else {
+			os.Unsetenv("XDG_RUNTIME_DIR")
+		}
+	}()
+	// FIXME: This should be a shared helper in internal/testing
+	oldHome, hasHome := os.LookupEnv("HOME")
+	defer func() {
+		if hasHome {
+			os.Setenv("HOME", oldHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	}()
+
+	os.Setenv("HOME", homeDir)
+	os.Setenv("XDG_DATA_HOME", xdgDataHome)
+
+	// The default paths and explicit overrides
+	for _, c := range []struct {
+		sys      *types.SystemContext
+		euid     int
+		expected string
+	}{
+		// The common case
+		{nil, 0, systemBlobInfoCacheDir},
+		{nil, 1, filepath.Join(xdgDataHome, "containers", "cache")},
+		// There is a context, but it does not override the path.
+		{&types.SystemContext{}, 0, systemBlobInfoCacheDir},
+		{&types.SystemContext{}, 1, filepath.Join(xdgDataHome, "containers", "cache")},
+		// Path overridden
+		{&types.SystemContext{BlobInfoCacheDir: nondefaultDir}, 0, nondefaultDir},
+		{&types.SystemContext{BlobInfoCacheDir: nondefaultDir}, 1, nondefaultDir},
+		// Root overridden
+		{&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix}, 0, filepath.Join(rootPrefix, systemBlobInfoCacheDir)},
+		{&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix}, 1, filepath.Join(xdgDataHome, "containers", "cache")},
+		// Root and path overrides present simultaneously,
+		{
+			&types.SystemContext{
+				RootForImplicitAbsolutePaths: rootPrefix,
+				BlobInfoCacheDir:             nondefaultDir,
+			},
+			0, nondefaultDir,
+		},
+		{
+			&types.SystemContext{
+				RootForImplicitAbsolutePaths: rootPrefix,
+				BlobInfoCacheDir:             nondefaultDir,
+			},
+			1, nondefaultDir,
+		},
+	} {
+		path, err := blobInfoCacheDir(c.sys, c.euid)
+		require.NoError(t, err)
+		assert.Equal(t, c.expected, path)
+	}
+
+	// Paths used by unprivileged users
+	for _, c := range []struct {
+		xdgDH, home, expected string
+	}{
+		{"", homeDir, filepath.Join(homeDir, ".local", "share", "containers", "cache")}, // HOME only
+		{xdgDataHome, "", filepath.Join(xdgDataHome, "containers", "cache")},            // XDG_DATA_HOME only
+		{xdgDataHome, homeDir, filepath.Join(xdgDataHome, "containers", "cache")},       // both
+		{"", "", ""}, // neither
+	} {
+		if c.xdgDH != "" {
+			os.Setenv("XDG_DATA_HOME", c.xdgDH)
+		} else {
+			os.Unsetenv("XDG_DATA_HOME")
+		}
+		if c.home != "" {
+			os.Setenv("HOME", c.home)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		for _, sys := range []*types.SystemContext{nil, {}} {
+			path, err := blobInfoCacheDir(sys, 1)
+			if c.expected != "" {
+				require.NoError(t, err)
+				assert.Equal(t, c.expected, path)
+			} else {
+				assert.Error(t, err)
+			}
+		}
+	}
+}
+
+func TestDefaultCache(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestDefaultCache")
+	require.NoError(t, err)
+	//defer os.RemoveAll(tmpDir)
+
+	// Success
+	normalDir := filepath.Join(tmpDir, "normal")
+	c := DefaultCache(&types.SystemContext{BlobInfoCacheDir: normalDir})
+	// This is ugly hard-coding internals of boltDBCache:
+	assert.Equal(t, &boltDBCache{path: filepath.Join(normalDir, blobInfoCacheFilename)}, c)
+
+	// Error running blobInfoCacheDir:
+	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
+	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.
+	oldXRD, hasXRD := os.LookupEnv("XDG_RUNTIME_DIR")
+	defer func() {
+		if hasXRD {
+			os.Setenv("XDG_RUNTIME_DIR", oldXRD)
+		} else {
+			os.Unsetenv("XDG_RUNTIME_DIR")
+		}
+	}()
+	// FIXME: This should be a shared helper in internal/testing
+	oldHome, hasHome := os.LookupEnv("HOME")
+	defer func() {
+		if hasHome {
+			os.Setenv("HOME", oldHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	}()
+	os.Unsetenv("HOME")
+	os.Unsetenv("XDG_DATA_HOME")
+	c = DefaultCache(nil)
+	assert.IsType(t, NewMemoryCache(), c)
+
+	// Error creating the parent directory:
+	unwritableDir := filepath.Join(tmpDir, "unwritable")
+	err = os.Mkdir(unwritableDir, 700)
+	require.NoError(t, err)
+	defer os.Chmod(unwritableDir, 0700) // To make it possible to remove it again
+	err = os.Chmod(unwritableDir, 0500)
+	require.NoError(t, err)
+	st, _ := os.Stat(unwritableDir)
+	logrus.Errorf("%s: %#v", unwritableDir, st)
+	c = DefaultCache(&types.SystemContext{BlobInfoCacheDir: filepath.Join(unwritableDir, "subdirectory")})
+	assert.IsType(t, NewMemoryCache(), c)
+}

--- a/pkg/blobinfocache/generic_test.go
+++ b/pkg/blobinfocache/generic_test.go
@@ -1,0 +1,170 @@
+package blobinfocache
+
+import (
+	"testing"
+
+	"github.com/containers/image/internal/testing/mocks"
+
+	"github.com/containers/image/types"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	digestUnknown             = digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111")
+	digestUncompressed        = digest.Digest("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+	digestCompressedA         = digest.Digest("sha256:3333333333333333333333333333333333333333333333333333333333333333")
+	digestCompressedB         = digest.Digest("sha256:4444444444444444444444444444444444444444444444444444444444444444")
+	digestCompressedUnrelated = digest.Digest("sha256:5555555555555555555555555555555555555555555555555555555555555555")
+	digestCompressedPrimary   = digest.Digest("sha256:6666666666666666666666666666666666666666666666666666666666666666")
+)
+
+// testGenericCache runs an implementation-independent set of tests, given a
+// newTestCache, which can be called repeatedly and always returns a (cache, cleanup callback) pair
+func testGenericCache(t *testing.T, newTestCache func(t *testing.T) (types.BlobInfoCache, func(t *testing.T))) {
+	for _, s := range []struct {
+		name string
+		fn   func(t *testing.T, cache types.BlobInfoCache)
+	}{
+		{"UncompressedDigest", testGenericUncompressedDigest},
+		{"RecordDigestUncompressedPair", testGenericRecordDigestUncompressedPair},
+		{"RecordKnownLocations", testGenericRecordKnownLocations},
+		{"CandidateLocations", testGenericCandidateLocations},
+	} {
+		t.Run(s.name, func(t *testing.T) {
+			cache, cleanup := newTestCache(t)
+			defer cleanup(t)
+			s.fn(t, cache)
+		})
+	}
+}
+
+func testGenericUncompressedDigest(t *testing.T, cache types.BlobInfoCache) {
+	// Nothing is known.
+	assert.Equal(t, digest.Digest(""), cache.UncompressedDigest(digestUnknown))
+
+	cache.RecordDigestUncompressedPair(digestCompressedA, digestUncompressed)
+	cache.RecordDigestUncompressedPair(digestCompressedB, digestUncompressed)
+	// Known compressed→uncompressed mapping
+	assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestCompressedA))
+	assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestCompressedB))
+	// This implicitly marks digestUncompressed as uncompressed.
+	assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestUncompressed))
+
+	// Known uncompressed→self mapping
+	cache.RecordDigestUncompressedPair(digestCompressedUnrelated, digestCompressedUnrelated)
+	assert.Equal(t, digestCompressedUnrelated, cache.UncompressedDigest(digestCompressedUnrelated))
+}
+
+func testGenericRecordDigestUncompressedPair(t *testing.T, cache types.BlobInfoCache) {
+	for i := 0; i < 2; i++ { // Record the same data twice to ensure redundant writes don’t break things.
+		// Known compressed→uncompressed mapping
+		cache.RecordDigestUncompressedPair(digestCompressedA, digestUncompressed)
+		assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestCompressedA))
+		// Two mappings to the same uncompressed digest
+		cache.RecordDigestUncompressedPair(digestCompressedB, digestUncompressed)
+		assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestCompressedB))
+
+		// Mapping an uncompresesd digest to self
+		cache.RecordDigestUncompressedPair(digestUncompressed, digestUncompressed)
+		assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestUncompressed))
+	}
+}
+
+func testGenericRecordKnownLocations(t *testing.T, cache types.BlobInfoCache) {
+	transport := mocks.NameImageTransport("==BlobInfocache transport mock")
+	for i := 0; i < 2; i++ { // Record the same data twice to ensure redundant writes don’t break things.
+		for _, scopeName := range []string{"A", "B"} { // Run the test in two different scopes to verify they don't affect each other.
+			scope := types.BICTransportScope{Opaque: scopeName}
+			for _, digest := range []digest.Digest{digestCompressedA, digestCompressedB} { // Two different digests should not affect each other either.
+				lr1 := types.BICLocationReference{Opaque: scopeName + "1"}
+				lr2 := types.BICLocationReference{Opaque: scopeName + "2"}
+				cache.RecordKnownLocation(transport, scope, digest, lr2)
+				cache.RecordKnownLocation(transport, scope, digest, lr1)
+				assert.Equal(t, []types.BICReplacementCandidate{
+					{Digest: digest, Location: lr1},
+					{Digest: digest, Location: lr2},
+				}, cache.CandidateLocations(transport, scope, digest, false))
+			}
+		}
+	}
+}
+
+// candidate is a shorthand for types.BICReplacementCandiddate
+type candidate struct {
+	d  digest.Digest
+	lr string
+}
+
+func assertCandidatesMatch(t *testing.T, scopeName string, expected []candidate, actual []types.BICReplacementCandidate) {
+	e := make([]types.BICReplacementCandidate, len(expected))
+	for i, ev := range expected {
+		e[i] = types.BICReplacementCandidate{Digest: ev.d, Location: types.BICLocationReference{Opaque: scopeName + ev.lr}}
+	}
+	assert.Equal(t, e, actual)
+}
+
+func testGenericCandidateLocations(t *testing.T, cache types.BlobInfoCache) {
+	transport := mocks.NameImageTransport("==BlobInfocache transport mock")
+	cache.RecordDigestUncompressedPair(digestCompressedA, digestUncompressed)
+	cache.RecordDigestUncompressedPair(digestCompressedB, digestUncompressed)
+	cache.RecordDigestUncompressedPair(digestUncompressed, digestUncompressed)
+	digestNameSet := []struct {
+		n string
+		d digest.Digest
+	}{
+		{"U", digestUncompressed},
+		{"A", digestCompressedA},
+		{"B", digestCompressedB},
+		{"CU", digestCompressedUnrelated},
+	}
+
+	for _, scopeName := range []string{"A", "B"} { // Run the test in two different scopes to verify they don't affect each other.
+		scope := types.BICTransportScope{Opaque: scopeName}
+		// Nothing is known.
+		assert.Equal(t, []types.BICReplacementCandidate{}, cache.CandidateLocations(transport, scope, digestUnknown, false))
+		assert.Equal(t, []types.BICReplacementCandidate{}, cache.CandidateLocations(transport, scope, digestUnknown, true))
+
+		// Record "2" entries before "1" entries; then results should sort "1" (more recent) before "2" (older)
+		for _, suffix := range []string{"2", "1"} {
+			for _, e := range digestNameSet {
+				cache.RecordKnownLocation(transport, scope, e.d, types.BICLocationReference{Opaque: scopeName + e.n + suffix})
+			}
+		}
+
+		// No substitutions allowed:
+		for _, e := range digestNameSet {
+			assertCandidatesMatch(t, scopeName, []candidate{
+				{d: e.d, lr: e.n + "1"}, {d: e.d, lr: e.n + "2"},
+			}, cache.CandidateLocations(transport, scope, e.d, false))
+		}
+
+		// With substitutions: The original digest is always preferred, then other compressed, then the uncompressed one.
+		assertCandidatesMatch(t, scopeName, []candidate{
+			{d: digestCompressedA, lr: "A1"}, {d: digestCompressedA, lr: "A2"},
+			{d: digestCompressedB, lr: "B1"}, {d: digestCompressedB, lr: "B2"},
+			{d: digestUncompressed, lr: "U1"}, // Beyond the replacementAttempts limit: {d: digestUncompressed, lr: "U2"},
+		}, cache.CandidateLocations(transport, scope, digestCompressedA, true))
+
+		assertCandidatesMatch(t, scopeName, []candidate{
+			{d: digestCompressedB, lr: "B1"}, {d: digestCompressedB, lr: "B2"},
+			{d: digestCompressedA, lr: "A1"}, {d: digestCompressedA, lr: "A2"},
+			{d: digestUncompressed, lr: "U1"}, // Beyond the replacementAttempts limit: {d: digestUncompressed, lr: "U2"},
+		}, cache.CandidateLocations(transport, scope, digestCompressedB, true))
+
+		assertCandidatesMatch(t, scopeName, []candidate{
+			{d: digestUncompressed, lr: "U1"}, {d: digestUncompressed, lr: "U2"},
+			// "1" entries were added after "2", and A/Bs are sorted in the reverse of digestNameSet order
+			{d: digestCompressedB, lr: "B1"},
+			{d: digestCompressedA, lr: "A1"},
+			{d: digestCompressedB, lr: "B2"},
+			// Beyond the replacementAttempts limit: {d: digestCompressedA, lr: "A2"},
+		}, cache.CandidateLocations(transport, scope, digestUncompressed, true))
+
+		// Locations are known, but no relationships
+		assertCandidatesMatch(t, scopeName, []candidate{
+			{d: digestCompressedUnrelated, lr: "CU1"}, {d: digestCompressedUnrelated, lr: "CU2"},
+		}, cache.CandidateLocations(transport, scope, digestCompressedUnrelated, true))
+
+	}
+}

--- a/pkg/blobinfocache/memory.go
+++ b/pkg/blobinfocache/memory.go
@@ -1,0 +1,123 @@
+package blobinfocache
+
+import (
+	"time"
+
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+)
+
+// locationKey only exists to make lookup in knownLocations easier.
+type locationKey struct {
+	transport  string
+	scope      types.BICTransportScope
+	blobDigest digest.Digest
+}
+
+// memoryCache implements an in-memory-only BlobInfoCache
+type memoryCache struct {
+	uncompressedDigests   map[digest.Digest]digest.Digest
+	digestsByUncompressed map[digest.Digest]map[digest.Digest]struct{}             // stores a set of digests for each uncompressed digest
+	knownLocations        map[locationKey]map[types.BICLocationReference]time.Time // stores last known existence time for each location reference
+}
+
+// NewMemoryCache returns a BlobInfoCache implementation which is in-memory only.
+// This is primarily intended for tests, but also used as a fallback if DefaultCache
+// can’t determine, or set up, the location for a persistent cache.
+// Manual users of types.{ImageSource,ImageDestination} might also use this instead of a persistent cache.
+func NewMemoryCache() types.BlobInfoCache {
+	return &memoryCache{
+		uncompressedDigests:   map[digest.Digest]digest.Digest{},
+		digestsByUncompressed: map[digest.Digest]map[digest.Digest]struct{}{},
+		knownLocations:        map[locationKey]map[types.BICLocationReference]time.Time{},
+	}
+}
+
+// UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
+// May return anyDigest if it is known to be uncompressed.
+// Returns "" if nothing is known about the digest (it may be compressed or uncompressed).
+func (mem *memoryCache) UncompressedDigest(anyDigest digest.Digest) digest.Digest {
+	if d, ok := mem.uncompressedDigests[anyDigest]; ok {
+		return d
+	}
+	// Presence in digestsByUncompressed implies that anyDigest must already refer to an uncompressed digest.
+	// This way we don't have to waste storage space with trivial (uncompressed, uncompressed) mappings
+	// when we already record a (compressed, uncompressed) pair.
+	if m, ok := mem.digestsByUncompressed[anyDigest]; ok && len(m) > 0 {
+		return anyDigest
+	}
+	return ""
+}
+
+// RecordDigestUncompressedPair records that the uncompressed version of anyDigest is uncompressed.
+// It’s allowed for anyDigest == uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (mem *memoryCache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompressed digest.Digest) {
+	if previous, ok := mem.uncompressedDigests[anyDigest]; ok && previous != uncompressed {
+		logrus.Warnf("Uncompressed digest for blob %s previously recorded as %s, now %s", anyDigest, previous, uncompressed)
+	}
+	mem.uncompressedDigests[anyDigest] = uncompressed
+
+	anyDigestSet, ok := mem.digestsByUncompressed[uncompressed]
+	if !ok {
+		anyDigestSet = map[digest.Digest]struct{}{}
+		mem.digestsByUncompressed[uncompressed] = anyDigestSet
+	}
+	anyDigestSet[anyDigest] = struct{}{} // Possibly writing the same struct{}{} presence marker again.
+}
+
+// RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,
+// and can be reused given the opaque location data.
+func (mem *memoryCache) RecordKnownLocation(transport types.ImageTransport, scope types.BICTransportScope, blobDigest digest.Digest, location types.BICLocationReference) {
+	key := locationKey{transport: transport.Name(), scope: scope, blobDigest: blobDigest}
+	locationScope, ok := mem.knownLocations[key]
+	if !ok {
+		locationScope = map[types.BICLocationReference]time.Time{}
+		mem.knownLocations[key] = locationScope
+	}
+	locationScope[location] = time.Now() // Possibly overwriting an older entry.
+}
+
+// appendReplacementCandiates creates candidateWithTime values for (transport, scope, digest), and returns the result of appending them to candidates.
+func (mem *memoryCache) appendReplacementCandidates(candidates []candidateWithTime, transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest) []candidateWithTime {
+	locations := mem.knownLocations[locationKey{transport: transport.Name(), scope: scope, blobDigest: digest}] // nil if not present
+	for l, t := range locations {
+		candidates = append(candidates, candidateWithTime{
+			candidate: types.BICReplacementCandidate{
+				Digest:   digest,
+				Location: l,
+			},
+			lastSeen: t,
+		})
+	}
+	return candidates
+}
+
+// CandidateLocations returns a prioritized, limited, number of blobs and their locations that could possibly be reused
+// within the specified (transport scope) (if they still exist, which is not guaranteed).
+//
+// If !canSubstitute, the returned cadidates will match the submitted digest exactly; if canSubstitute,
+// data from previous RecordDigestUncompressedPair calls is used to also look up variants of the blob which have the same
+// uncompressed digest.
+func (mem *memoryCache) CandidateLocations(transport types.ImageTransport, scope types.BICTransportScope, primaryDigest digest.Digest, canSubstitute bool) []types.BICReplacementCandidate {
+	res := []candidateWithTime{}
+	res = mem.appendReplacementCandidates(res, transport, scope, primaryDigest)
+	var uncompressedDigest digest.Digest // = ""
+	if canSubstitute {
+		if uncompressedDigest = mem.UncompressedDigest(primaryDigest); uncompressedDigest != "" {
+			otherDigests := mem.digestsByUncompressed[uncompressedDigest] // nil if not present in the map
+			for d := range otherDigests {
+				if d != primaryDigest && d != uncompressedDigest {
+					res = mem.appendReplacementCandidates(res, transport, scope, d)
+				}
+			}
+			if uncompressedDigest != primaryDigest {
+				res = mem.appendReplacementCandidates(res, transport, scope, uncompressedDigest)
+			}
+		}
+	}
+	return destructivelyPrioritizeReplacementCandidates(res, primaryDigest, uncompressedDigest)
+}

--- a/pkg/blobinfocache/memory_test.go
+++ b/pkg/blobinfocache/memory_test.go
@@ -1,0 +1,15 @@
+package blobinfocache
+
+import (
+	"testing"
+
+	"github.com/containers/image/types"
+)
+
+func newTestMemoryCache(t *testing.T) (types.BlobInfoCache, func(t *testing.T)) {
+	return NewMemoryCache(), func(t *testing.T) {}
+}
+
+func TestNewMemoryCache(t *testing.T) {
+	testGenericCache(t, newTestMemoryCache)
+}

--- a/pkg/blobinfocache/none.go
+++ b/pkg/blobinfocache/none.go
@@ -1,0 +1,47 @@
+package blobinfocache
+
+import (
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// noCache implements a dummy BlobInfoCache which records no data.
+type noCache struct {
+}
+
+// NoCache implements BlobInfoCache by not recording any data.
+//
+// This exists primarily for implementations of configGetter for Manifest.Inspect,
+// because configs only have one representation.
+// Any use of BlobInfoCache with blobs should usually use at least a short-lived cache.
+var NoCache types.BlobInfoCache = noCache{}
+
+// UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
+// May return anyDigest if it is known to be uncompressed.
+// Returns "" if nothing is known about the digest (it may be compressed or uncompressed).
+func (noCache) UncompressedDigest(anyDigest digest.Digest) digest.Digest {
+	return ""
+}
+
+// RecordDigestUncompressedPair records that the uncompressed version of anyDigest is uncompressed.
+// It’s allowed for anyDigest == uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (noCache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompressed digest.Digest) {
+}
+
+// RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,
+// and can be reused given the opaque location data.
+func (noCache) RecordKnownLocation(transport types.ImageTransport, scope types.BICTransportScope, blobDigest digest.Digest, location types.BICLocationReference) {
+}
+
+// CandidateLocations returns a prioritized, limited, number of blobs and their locations that could possibly be reused
+// within the specified (transport scope) (if they still exist, which is not guaranteed).
+//
+// If !canSubstitute, the returned cadidates will match the submitted digest exactly; if canSubstitute,
+// data from previous RecordDigestUncompressedPair calls is used to also look up variants of the blob which have the same
+// uncompressed digest.
+func (noCache) CandidateLocations(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []types.BICReplacementCandidate {
+	return nil
+}

--- a/pkg/blobinfocache/prioritize.go
+++ b/pkg/blobinfocache/prioritize.go
@@ -1,0 +1,108 @@
+package blobinfocache
+
+import (
+	"sort"
+	"time"
+
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// replacementAttempts is the number of blob replacement candidates returned by destructivelyPrioritizeReplacementCandidates,
+// and therefore ultimately by types.BlobInfoCache.CandidateLocations.
+// This is a heuristic/guess, and could well use a different value.
+const replacementAttempts = 5
+
+// candidateWithTime is the input to types.BICReplacementCandidate prioritization.
+type candidateWithTime struct {
+	candidate types.BICReplacementCandidate // The replacement candidate
+	lastSeen  time.Time                     // Time the candidate was last known to exist (either read or written)
+}
+
+// candidateSortState is a local state implementing sort.Interface on candidates to prioritize,
+// along with the specially-treated digest values for the implementation of sort.Interface.Less
+type candidateSortState struct {
+	cs                 []candidateWithTime // The entries to sort
+	primaryDigest      digest.Digest       // The digest the user actually asked for
+	uncompressedDigest digest.Digest       // The uncompressed digest corresponding to primaryDigest. May be "", or even equal to primaryDigest
+}
+
+func (css *candidateSortState) Len() int {
+	return len(css.cs)
+}
+
+func (css *candidateSortState) Less(i, j int) bool {
+	xi := css.cs[i]
+	xj := css.cs[j]
+
+	// primaryDigest entries come first, more recent first.
+	// uncompressedDigest entries, if uncompressedDigest is set and != primaryDigest, come last, more recent entry first.
+	// Other digest values are primarily sorted by time (more recent first), secondarily by digest (to provide a deterministic order)
+
+	// First, deal with the primaryDigest/uncompressedDigest cases:
+	if xi.candidate.Digest != xj.candidate.Digest {
+		// - The two digests are different, and one (or both) of the digests is primaryDigest or uncompressedDigest: time does not matter
+		if xi.candidate.Digest == css.primaryDigest {
+			return true
+		}
+		if xj.candidate.Digest == css.primaryDigest {
+			return false
+		}
+		if css.uncompressedDigest != "" {
+			if xi.candidate.Digest == css.uncompressedDigest {
+				return false
+			}
+			if xj.candidate.Digest == css.uncompressedDigest {
+				return true
+			}
+		}
+	} else { // xi.candidate.Digest == xj.candidate.Digest
+		// The two digests are the same, and are either primaryDigest or uncompressedDigest: order by time
+		if xi.candidate.Digest == css.primaryDigest || (css.uncompressedDigest != "" && xi.candidate.Digest == css.uncompressedDigest) {
+			return xi.lastSeen.After(xj.lastSeen)
+		}
+	}
+
+	// Neither of the digests are primaryDigest/uncompressedDigest:
+	if !xi.lastSeen.Equal(xj.lastSeen) { // Order primarily by time
+		return xi.lastSeen.After(xj.lastSeen)
+	}
+	// Fall back to digest, if timestamps end up _exactly_ the same (how?!)
+	return xi.candidate.Digest < xj.candidate.Digest
+}
+
+func (css *candidateSortState) Swap(i, j int) {
+	css.cs[i], css.cs[j] = css.cs[j], css.cs[i]
+}
+
+// destructivelyPrioritizeReplacementCandidatesWithMax is destructivelyPrioritizeReplacementCandidates with a parameter for the
+// number of entries to limit, only to make testing simpler.
+func destructivelyPrioritizeReplacementCandidatesWithMax(cs []candidateWithTime, primaryDigest, uncompressedDigest digest.Digest, maxCandidates int) []types.BICReplacementCandidate {
+	// We don't need to use sort.Stable() because nanosecond timestamps are (presumably?) unique, so no two elements should
+	// compare equal.
+	sort.Sort(&candidateSortState{
+		cs:                 cs,
+		primaryDigest:      primaryDigest,
+		uncompressedDigest: uncompressedDigest,
+	})
+
+	resLength := len(cs)
+	if resLength > maxCandidates {
+		resLength = maxCandidates
+	}
+	res := make([]types.BICReplacementCandidate, resLength)
+	for i := range res {
+		res[i] = cs[i].candidate
+	}
+	return res
+}
+
+// destructivelyPrioritizeReplacementCandidates consumes AND DESTROYS an array of possible replacement candidates with their last known existence times,
+// the primary digest the user actually asked for, and the corresponding uncompressed digest (if known, possibly equal to the primary digest),
+// and returns an appropriately prioritized and/or trimmed result suitable for a return value from types.BlobInfoCache.CandidateLocations.
+//
+// WARNING: The array of candidates is destructively modified. (The implementation of this function could of course
+// make a copy, but all CandidateLocations implementations build the slice of candidates only for the single purpose of calling this function anyway.)
+func destructivelyPrioritizeReplacementCandidates(cs []candidateWithTime, primaryDigest, uncompressedDigest digest.Digest) []types.BICReplacementCandidate {
+	return destructivelyPrioritizeReplacementCandidatesWithMax(cs, primaryDigest, uncompressedDigest, replacementAttempts)
+}

--- a/pkg/blobinfocache/prioritize_test.go
+++ b/pkg/blobinfocache/prioritize_test.go
@@ -1,0 +1,163 @@
+package blobinfocache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/containers/image/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// cssLiteral contains a non-trivial candidateSortState shared among several tests below.
+	cssLiteral = candidateSortState{
+		cs: []candidateWithTime{
+			{types.BICReplacementCandidate{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A1"}}, time.Unix(1, 0)},
+			{types.BICReplacementCandidate{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U2"}}, time.Unix(1, 1)},
+			{types.BICReplacementCandidate{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A2"}}, time.Unix(1, 1)},
+			{types.BICReplacementCandidate{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P1"}}, time.Unix(1, 0)},
+			{types.BICReplacementCandidate{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B1"}}, time.Unix(1, 1)},
+			{types.BICReplacementCandidate{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P2"}}, time.Unix(1, 1)},
+			{types.BICReplacementCandidate{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B2"}}, time.Unix(2, 0)},
+			{types.BICReplacementCandidate{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U1"}}, time.Unix(1, 0)},
+		},
+		primaryDigest:      digestCompressedPrimary,
+		uncompressedDigest: digestUncompressed,
+	}
+	// cssExpectedReplacementCandidates is the fully-sorted, unlimited, result of prioritizing cssLiteral.
+	cssExpectedReplacementCandidates = []types.BICReplacementCandidate{
+		{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P2"}},
+		{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P1"}},
+		{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B2"}},
+		{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A2"}},
+		{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B1"}},
+		{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A1"}},
+		{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U2"}},
+		{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U1"}},
+	}
+)
+
+func TestCandidateSortStateLen(t *testing.T) {
+	css := cssLiteral
+	assert.Equal(t, 8, css.Len())
+
+	css.cs = []candidateWithTime{}
+	assert.Equal(t, 0, css.Len())
+}
+
+func TestCandidateSortStateLess(t *testing.T) {
+	type p struct {
+		d digest.Digest
+		t int64
+	}
+
+	// Primary criteria: Also ensure that time does not matter
+	for _, c := range []struct {
+		name   string
+		res    int
+		d0, d1 digest.Digest
+	}{
+		{"primary < any", -1, digestCompressedPrimary, digestCompressedA},
+		{"any < uncompressed", -1, digestCompressedA, digestUncompressed},
+		{"primary < uncompressed", -1, digestCompressedPrimary, digestUncompressed},
+	} {
+		for _, tms := range [][2]int64{{1, 2}, {2, 1}, {1, 1}} {
+			caseName := fmt.Sprintf("%s %v", c.name, tms)
+			css := candidateSortState{
+				cs: []candidateWithTime{
+					{types.BICReplacementCandidate{Digest: c.d0, Location: types.BICLocationReference{Opaque: "L0"}}, time.Unix(tms[0], 0)},
+					{types.BICReplacementCandidate{Digest: c.d1, Location: types.BICLocationReference{Opaque: "L1"}}, time.Unix(tms[1], 0)},
+				},
+				primaryDigest:      digestCompressedPrimary,
+				uncompressedDigest: digestUncompressed,
+			}
+			assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
+			assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+
+			if c.d0 != digestUncompressed && c.d1 != digestUncompressed {
+				css.uncompressedDigest = ""
+				assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
+				assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+
+				css.uncompressedDigest = css.primaryDigest
+				assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
+				assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+			}
+		}
+	}
+
+	// Ordering within the three primary groups
+	for _, c := range []struct {
+		name   string
+		res    int
+		p0, p1 p
+	}{
+		{"primary: t=2 < t=1", -1, p{digestCompressedPrimary, 2}, p{digestCompressedPrimary, 1}},
+		{"primary: t=1 == t=1", 0, p{digestCompressedPrimary, 1}, p{digestCompressedPrimary, 1}},
+		{"uncompressed: t=2 < t=1", -1, p{digestUncompressed, 2}, p{digestUncompressed, 1}},
+		{"uncompressed: t=1 == t=1", 0, p{digestUncompressed, 1}, p{digestUncompressed, 1}},
+		{"any: t=2 < t=1, [d=A vs. d=B lower-priority]", -1, p{digestCompressedA, 2}, p{digestCompressedB, 1}},
+		{"any: t=2 < t=1, [d=B vs. d=A lower-priority]", -1, p{digestCompressedB, 2}, p{digestCompressedA, 1}},
+		{"any: t=2 < t=1, [d=A vs. d=A lower-priority]", -1, p{digestCompressedA, 2}, p{digestCompressedA, 1}},
+		{"any: t=1 == t=1, d=A < d=B", -1, p{digestCompressedA, 1}, p{digestCompressedB, 1}},
+		{"any: t=1 == t=1, d=A == d=A", 0, p{digestCompressedA, 1}, p{digestCompressedA, 1}},
+	} {
+		css := candidateSortState{
+			cs: []candidateWithTime{
+				{types.BICReplacementCandidate{Digest: c.p0.d, Location: types.BICLocationReference{Opaque: "L0"}}, time.Unix(c.p0.t, 0)},
+				{types.BICReplacementCandidate{Digest: c.p1.d, Location: types.BICLocationReference{Opaque: "L1"}}, time.Unix(c.p1.t, 0)},
+			},
+			primaryDigest:      digestCompressedPrimary,
+			uncompressedDigest: digestUncompressed,
+		}
+		assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
+		assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+
+		if c.p0.d != digestUncompressed && c.p1.d != digestUncompressed {
+			css.uncompressedDigest = ""
+			assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
+			assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+
+			css.uncompressedDigest = css.primaryDigest
+			assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
+			assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+		}
+	}
+}
+
+func TestCandidateSortStateSwap(t *testing.T) {
+	freshCSS := func() candidateSortState { // Return a deep copy of cssLiteral which is safe to modify.
+		res := cssLiteral
+		res.cs = append([]candidateWithTime{}, cssLiteral.cs...)
+		return res
+	}
+
+	css := freshCSS()
+	css.Swap(0, 1)
+	assert.Equal(t, cssLiteral.cs[1], css.cs[0])
+	assert.Equal(t, cssLiteral.cs[0], css.cs[1])
+	assert.Equal(t, cssLiteral.cs[2], css.cs[2])
+
+	css = freshCSS()
+	css.Swap(1, 1)
+	assert.Equal(t, cssLiteral, css)
+}
+
+func TestDestructivelyPrioritizeReplacementCandidatesWithMax(t *testing.T) {
+	for _, max := range []int{0, 1, replacementAttempts, 100} {
+		// Just a smoke test; we mostly rely on test coverage in TestCandidateSortStateLess
+		res := destructivelyPrioritizeReplacementCandidatesWithMax(append([]candidateWithTime{}, cssLiteral.cs...), digestCompressedPrimary, digestUncompressed, max)
+		if max > len(cssExpectedReplacementCandidates) {
+			max = len(cssExpectedReplacementCandidates)
+		}
+		assert.Equal(t, cssExpectedReplacementCandidates[:max], res)
+	}
+}
+
+func TestDestructivelyPrioritizeReplacementCandidates(t *testing.T) {
+	// Just a smoke test; we mostly rely on test coverage in TestCandidateSortStateLess
+	res := destructivelyPrioritizeReplacementCandidates(append([]candidateWithTime{}, cssLiteral.cs...), digestCompressedPrimary, digestUncompressed)
+	assert.Equal(t, cssExpectedReplacementCandidates[:replacementAttempts], res)
+}

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/testing/mocks"
 	"github.com/containers/image/types"
 )
 
@@ -21,7 +22,7 @@ func (nameOnlyImageMock) Reference() types.ImageReference {
 type nameOnlyImageReferenceMock string
 
 func (ref nameOnlyImageReferenceMock) Transport() types.ImageTransport {
-	return nameImageTransportMock("== Transport mock")
+	return mocks.NameImageTransport("== Transport mock")
 }
 func (ref nameOnlyImageReferenceMock) StringWithinTransport() string {
 	return string(ref)

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/docker"
 	"github.com/containers/image/docker/policyconfiguration"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/testing/mocks"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,7 @@ type pcImageReferenceMock struct {
 }
 
 func (ref pcImageReferenceMock) Transport() types.ImageTransport {
-	return nameImageTransportMock(ref.transportName)
+	return mocks.NameImageTransport(ref.transportName)
 }
 func (ref pcImageReferenceMock) StringWithinTransport() string {
 	// We use this in error messages, so sadly we must return something.

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/testing/mocks"
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,7 +78,7 @@ type refImageReferenceMock struct{ reference.Named }
 func (ref refImageReferenceMock) Transport() types.ImageTransport {
 	// We use this in error messages, so sady we must return something. But right now we do so only when DockerReference is nil, so restrict to that.
 	if ref.Named == nil {
-		return nameImageTransportMock("== Transport mock")
+		return mocks.NameImageTransport("== Transport mock")
 	}
 	panic("unexpected call to a mock function")
 }
@@ -107,19 +108,6 @@ func (ref refImageReferenceMock) NewImageDestination(ctx context.Context, sys *t
 	panic("unexpected call to a mock function")
 }
 func (ref refImageReferenceMock) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	panic("unexpected call to a mock function")
-}
-
-// nameImageTransportMock is a mock of types.ImageTransport which returns itself in Name.
-type nameImageTransportMock string
-
-func (name nameImageTransportMock) Name() string {
-	return string(name)
-}
-func (name nameImageTransportMock) ParseReference(reference string) (types.ImageReference, error) {
-	panic("unexpected call to a mock function")
-}
-func (name nameImageTransportMock) ValidatePolicyConfigurationScope(scope string) error {
 	panic("unexpected call to a mock function")
 }
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -391,10 +391,11 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
-func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache) (bool, types.BlobInfo, error) {
+func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if blobinfo.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`Can not check for a blob with unknown digest`)
 	}
@@ -528,7 +529,7 @@ func (s *storageImageDestination) Commit(ctx context.Context) error {
 			// Check if it's elsewhere and the caller just forgot to pass it to us in a PutBlob(),
 			// or to even check if we had it.
 			logrus.Debugf("looking for diffID for blob %+v", blob.Digest)
-			has, _, err := s.TryReusingBlob(ctx, blob.BlobInfo, blobinfocache.NoCache)
+			has, _, err := s.TryReusingBlob(ctx, blob.BlobInfo, blobinfocache.NoCache, false)
 			if err != nil {
 				return errors.Wrapf(err, "error checking for a layer based on blob %q", blob.Digest.String())
 			}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -381,6 +381,8 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 	if blobSize < 0 {
 		blobSize = counter.Count
 	}
+	// This is safe because we have just computed both values ourselves.
+	cache.RecordDigestUncompressedPair(blobDigest, diffID.Digest())
 	return types.BlobInfo{
 		Digest:    blobDigest,
 		Size:      blobSize,

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -207,7 +207,10 @@ func (is *tarballImageSource) Close() error {
 	return nil
 }
 
-func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	// We should only be asked about things in the manifest.  Maybe the configuration blob.
 	if blobinfo.Digest == is.configID {
 		return ioutil.NopCloser(bytes.NewBuffer(is.config)), is.configSize, nil

--- a/types/types.go
+++ b/types/types.go
@@ -451,6 +451,8 @@ type SystemContext struct {
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
+	// If not "", overrides the system's default directory containing a blob info cache.
+	BlobInfoCacheDir string
 
 	// Additional tags when creating or copying a docker-archive.
 	DockerArchiveAdditionalTags []reference.NamedTagged

--- a/types/types.go
+++ b/types/types.go
@@ -267,10 +267,11 @@ type ImageDestination interface {
 	// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 	// info.Digest must not be empty.
+	// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 	// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
 	// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 	// May use and/or update cache.
-	TryReusingBlob(ctx context.Context, info BlobInfo, cache BlobInfoCache) (bool, BlobInfo, error)
+	TryReusingBlob(ctx context.Context, info BlobInfo, cache BlobInfoCache, canSubstitute bool) (bool, BlobInfo, error)
 	// PutManifest writes manifest to the destination.
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),

--- a/types/types.go
+++ b/types/types.go
@@ -224,8 +224,7 @@ const (
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
 //
 // There is a specific required order for some of the calls:
-// PutBlob on the various blobs, if any, MUST be called before PutManifest (manifest references blobs, which may be created or compressed only at push time)
-// ReapplyBlob, if used, MUST only be called if HasBlob returned true for the same blob digest
+// TryReusingBlob/PutBlob on the various blobs, if any, MUST be called before PutManifest (manifest references blobs, which may be created or compressed only at push time)
 // PutSignatures, if called, MUST be called after PutManifest (signatures reference manifest contents)
 // Finally, Commit MUST be called if the caller wants the image, as formed by the components saved above, to persist.
 //
@@ -263,13 +262,12 @@ type ImageDestination interface {
 	// to any other readers for download using the supplied digest.
 	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 	PutBlob(ctx context.Context, stream io.Reader, inputInfo BlobInfo, isConfig bool) (BlobInfo, error)
-	// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
-	// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
-	// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
-	// it returns a non-nil error only on an unexpected failure.
-	HasBlob(ctx context.Context, info BlobInfo) (bool, int64, error)
-	// ReapplyBlob informs the image destination that a blob for which HasBlob previously returned true would have been passed to PutBlob if it had returned false.  Like HasBlob and unlike PutBlob, the digest can not be empty.  If the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree.
-	ReapplyBlob(ctx context.Context, info BlobInfo) (BlobInfo, error)
+	// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+	// info.Digest must not be empty.
+	// If the blob has been succesfully reused, returns (true, info, nil); info must contain at least a digest and size.
+	// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+	TryReusingBlob(ctx context.Context, info BlobInfo) (bool, BlobInfo, error)
 	// PutManifest writes manifest to the destination.
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,3 +43,4 @@ github.com/syndtr/gocapability master
 github.com/Microsoft/go-winio ab35fc04b6365e8fcb18e6e9e41ea4a02b10b175
 github.com/Microsoft/hcsshim eca7177590cdcbd25bbc5df27e3b693a54b53a6a
 github.com/ulikunitz/xz v0.5.4
+github.com/boltdb/bolt master


### PR DESCRIPTION
This adds types.BlobInfoCache recording the encountered compressed/uncompressed digest relationships and `docker://` blob locations, and using them to:
- Mount blobs on `docker://` destinations instead of copying the data again
- Reuse local layers on `containers-storage:` destinations instead of pulling them
- Avoid blob decompression when converting from schema1 just to figure out the DiffID values

The blob info cache is stored in `/var/lib/containers/blob-info-cache-v1.boltdb` for EUID=0 users, and `$XDG_DATA_HOME/containers/blob-info-cache-v1.boltdb` for unprivileged users.

See individual commit messages for more details.

WIP items:
- <s>When `canSubstitute`, `dockerImageDestination` makes a mount request even within the same repo, which is unnecessary.</s>
- <s>Documentation of the `BlobInfoCache` interface and possibly other code</s>
- Tests for corner cases of the BoltDB code
- Logging on failures in the BoltDB code
