### PR TITLE
vendor latest ostree

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/xeipuuv/gojsonpointer master
 github.com/tchap/go-patricia v2.2.6
 github.com/opencontainers/selinux 077c8b6d1c18456fb7c792bc0de52295a0d1900e
 github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0
-github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
+github.com/ostreedev/ostree-go 56f3a639dbc0f2f5051c6d52dade28a882ba78ce
 github.com/gogo/protobuf fcdc5011193ff531a548e9b0301828d5a5b97fd8
 github.com/pquerna/ffjson master
 github.com/syndtr/gocapability master


### PR DESCRIPTION
Vendor the latest ostree commit 56f3a639dbc0f2f5051c6d52dade28a882ba78ce
to fix build warnings poluting the output.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>