### PR TITLE
ostree: make libselinux optional

### DIFF
--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/coreos/pkg/dlopen"
 	"github.com/klauspost/pgzip"
 	"github.com/opencontainers/go-digest"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -32,7 +33,7 @@ import (
 	"github.com/vbatts/tar-split/tar/storage"
 )
 
-// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1 libselinux
+// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1
 // #include <glib.h>
 // #include <glib-object.h>
 // #include <gio/gio.h>
@@ -41,6 +42,85 @@ import (
 // #include <gio/ginputstream.h>
 // #include <selinux/selinux.h>
 // #include <selinux/label.h>
+//
+// struct selabel_handle *
+//   my_selabel_open(
+//		void *function,
+//		unsigned int backend,
+//		const struct selinux_opt *opts,
+//		unsigned nopts)
+// {
+//		struct selabel_handle *(*ptr_selabel_open)(
+//			unsigned int,
+//			const struct selinux_opt *,
+//			unsigned);
+//		ptr_selabel_open = (struct selabel_handle *(*)(
+//				unsigned int,
+//				const struct selinux_opt *,
+//				unsigned))function;
+//		return ptr_selabel_open(backend, opts, nopts);
+// }
+//
+// void
+//   my_selabel_close(
+//		void *function,
+//		struct selabel_handle *handle)
+// {
+//		void (*ptr_selabel_close)(
+//			struct selabel_handle *);
+//		ptr_selabel_close = (void (*)(
+//				struct selabel_handle *))function;
+//		return ptr_selabel_close(handle);
+// }
+//
+// int
+//   my_selabel_lookup_raw(
+//		void *function,
+//		struct selabel_handle *handle,
+//		char **con,
+//		const char *key,
+//		int type)
+// {
+//		int (*ptr_selabel_lookup_raw)(
+//				struct selabel_handle *,
+//				char **,
+//				const char*,
+//				int);
+//		ptr_selabel_lookup_raw = (int (*)(
+//				struct selabel_handle *,
+//				char **,
+//				const char*,
+//				int))function;
+//		return ptr_selabel_lookup_raw(handle, con, key, type);
+// }
+//
+// int
+//   my_lsetfilecon_raw(
+//		void *function,
+//		const char *path,
+//		const char *con)
+// {
+//		int (*ptr_lsetfilecon_raw)(
+//				const char *,
+//				const char *);
+//		ptr_lsetfilecon_raw = (int (*)(
+//				const char *,
+//				const char *))function;
+//		return ptr_lsetfilecon_raw(path, con);
+// }
+//
+// void
+//   my_freecon(
+//		void *function,
+//		char *con)
+// {
+//		void (*ptr_freecon)(
+//				char *);
+//		ptr_freecon = (void (*)(
+//				char *))function;
+//		return ptr_freecon(con);
+// }
+//
 import "C"
 
 type blobToImport struct {
@@ -73,6 +153,8 @@ type ostreeImageDestination struct {
 	signaturesLen int
 	repo          *C.struct_OstreeRepo
 }
+
+var selinuxFunctions map[string]unsafe.Pointer
 
 // newImageDestination returns an ImageDestination for writing to an existing ostree.
 func newImageDestination(ref ostreeReference, tmpDirPath string) (types.ImageDestination, error) {
@@ -208,15 +290,17 @@ func fixFiles(selinuxHnd *C.struct_selabel_handle, root string, dir string, user
 			defer C.free(unsafe.Pointer(relPathC))
 			var context *C.char
 
-			res, err := C.selabel_lookup_raw(selinuxHnd, &context, relPathC, C.int(info.Mode()&os.ModePerm))
+			res, err := C.my_selabel_lookup_raw(selinuxFunctions["selabel_lookup_raw"],
+				selinuxHnd, &context, relPathC, C.int(info.Mode()&os.ModePerm))
 			if int(res) < 0 && err != syscall.ENOENT {
 				return errors.Wrapf(err, "cannot selabel_lookup_raw %s", relPath)
 			}
 			if int(res) == 0 {
-				defer C.freecon(context)
+				defer C.my_freecon(selinuxFunctions["freecon"], context)
 				fullpathC := C.CString(fullpath)
 				defer C.free(unsafe.Pointer(fullpathC))
-				res, err = C.lsetfilecon_raw(fullpathC, context)
+				res, err := C.my_lsetfilecon_raw(selinuxFunctions["lsetfilecon_raw"],
+					fullpathC, context)
 				if int(res) < 0 {
 					return errors.Wrapf(err, "cannot setfilecon_raw %s", fullpath)
 				}
@@ -433,12 +517,35 @@ func (d *ostreeImageDestination) Commit(ctx context.Context) error {
 	var selinuxHnd *C.struct_selabel_handle
 
 	if os.Getuid() == 0 && selinux.GetEnabled() {
-		selinuxHnd, err = C.selabel_open(C.SELABEL_CTX_FILE, nil, 0)
+		// dlopen.GetHandle will fail if libselinux.so is not available
+		// following block will be completely jump over and
+		// selinuxHnd = nil (important in fixFiles)
+		// so the absence of SElinux will be simply ignored
+		libselinuxHnd, err := dlopen.GetHandle([]string{"libselinux.so.1"})
+		if err != nil {
+			return errors.Wrapf(err, "SELinux enabled, but libselinux not available")
+		}
+
+		defer libselinuxHnd.Close()
+
+		selinuxFunctionNames := []string{"selabel_open", "selabel_close",
+			"selabel_lookup_raw", "lsetfilecon_raw", "freecon"}
+
+		for _, function := range selinuxFunctionNames {
+			ptrFunction, err := libselinuxHnd.GetSymbolPointer(function)
+			selinuxFunctions[function] = ptrFunction
+			if err != nil {
+				return fmt.Errorf(`couldn't get symbol %q: %v`, function, err)
+			}
+		}
+
+		selinuxHnd, err = C.my_selabel_open(selinuxFunctions["selabel_open"],
+			C.SELABEL_CTX_FILE, nil, 0)
 		if selinuxHnd == nil {
 			return errors.Wrapf(err, "cannot open the SELinux DB")
 		}
 
-		defer C.selabel_close(selinuxHnd)
+		defer C.my_selabel_close(selinuxFunctions["selabel_close"], selinuxHnd)
 	}
 
 	checkLayer := func(hash string) error {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -33,94 +33,98 @@ import (
 	"github.com/vbatts/tar-split/tar/storage"
 )
 
-// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1
-// #include <glib.h>
-// #include <glib-object.h>
-// #include <gio/gio.h>
-// #include <stdlib.h>
-// #include <ostree.h>
-// #include <gio/ginputstream.h>
-// #include <selinux/selinux.h>
-// #include <selinux/label.h>
-//
-// struct selabel_handle *
-//   my_selabel_open(
-//		void *function,
-//		unsigned int backend,
-//		const struct selinux_opt *opts,
-//		unsigned nopts)
-// {
-//		struct selabel_handle *(*ptr_selabel_open)(
-//			unsigned int,
-//			const struct selinux_opt *,
-//			unsigned);
-//		ptr_selabel_open = (struct selabel_handle *(*)(
-//				unsigned int,
-//				const struct selinux_opt *,
-//				unsigned))function;
-//		return ptr_selabel_open(backend, opts, nopts);
-// }
-//
-// void
-//   my_selabel_close(
-//		void *function,
-//		struct selabel_handle *handle)
-// {
-//		void (*ptr_selabel_close)(
-//			struct selabel_handle *);
-//		ptr_selabel_close = (void (*)(
-//				struct selabel_handle *))function;
-//		return ptr_selabel_close(handle);
-// }
-//
-// int
-//   my_selabel_lookup_raw(
-//		void *function,
-//		struct selabel_handle *handle,
-//		char **con,
-//		const char *key,
-//		int type)
-// {
-//		int (*ptr_selabel_lookup_raw)(
-//				struct selabel_handle *,
-//				char **,
-//				const char*,
-//				int);
-//		ptr_selabel_lookup_raw = (int (*)(
-//				struct selabel_handle *,
-//				char **,
-//				const char*,
-//				int))function;
-//		return ptr_selabel_lookup_raw(handle, con, key, type);
-// }
-//
-// int
-//   my_lsetfilecon_raw(
-//		void *function,
-//		const char *path,
-//		const char *con)
-// {
-//		int (*ptr_lsetfilecon_raw)(
-//				const char *,
-//				const char *);
-//		ptr_lsetfilecon_raw = (int (*)(
-//				const char *,
-//				const char *))function;
-//		return ptr_lsetfilecon_raw(path, con);
-// }
-//
-// void
-//   my_freecon(
-//		void *function,
-//		char *con)
-// {
-//		void (*ptr_freecon)(
-//				char *);
-//		ptr_freecon = (void (*)(
-//				char *))function;
-//		return ptr_freecon(con);
-// }
-//
+// Following block comment contains inline C code to make functions of
+// libselinux usable.
+
+/*
+#cgo pkg-config: glib-2.0 gobject-2.0 ostree-1
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <stdlib.h>
+#include <ostree.h>
+#include <gio/ginputstream.h>
+#include <selinux/selinux.h>
+#include <selinux/label.h>
+
+struct selabel_handle *
+  my_selabel_open(
+		void *function,
+		unsigned int backend,
+		const struct selinux_opt *opts,
+		unsigned nopts)
+{
+		struct selabel_handle *(*ptr_selabel_open)(
+			unsigned int,
+			const struct selinux_opt *,
+			unsigned);
+		ptr_selabel_open = (struct selabel_handle *(*)(
+				unsigned int,
+				const struct selinux_opt *,
+				unsigned))function;
+		return ptr_selabel_open(backend, opts, nopts);
+}
+
+void
+  my_selabel_close(
+		void *function,
+		struct selabel_handle *handle)
+{
+		void (*ptr_selabel_close)(
+			struct selabel_handle *);
+		ptr_selabel_close = (void (*)(
+				struct selabel_handle *))function;
+		return ptr_selabel_close(handle);
+}
+
+int
+  my_selabel_lookup_raw(
+		void *function,
+		struct selabel_handle *handle,
+		char **con,
+		const char *key,
+		int type)
+{
+		int (*ptr_selabel_lookup_raw)(
+				struct selabel_handle *,
+				char **,
+				const char*,
+				int);
+		ptr_selabel_lookup_raw = (int (*)(
+				struct selabel_handle *,
+				char **,
+				const char*,
+				int))function;
+		return ptr_selabel_lookup_raw(handle, con, key, type);
+}
+
+int
+  my_lsetfilecon_raw(
+		void *function,
+		const char *path,
+		const char *con)
+{
+		int (*ptr_lsetfilecon_raw)(
+				const char *,
+				const char *);
+		ptr_lsetfilecon_raw = (int (*)(
+				const char *,
+				const char *))function;
+		return ptr_lsetfilecon_raw(path, con);
+}
+
+void
+  my_freecon(
+		void *function,
+		char *con)
+{
+		void (*ptr_freecon)(
+				char *);
+		ptr_freecon = (void (*)(
+				char *))function;
+		return ptr_freecon(con);
+}
+*/
 import "C"
 
 type blobToImport struct {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -154,7 +154,8 @@ type ostreeImageDestination struct {
 	repo          *C.struct_OstreeRepo
 }
 
-var selinuxFunctions map[string]unsafe.Pointer
+// map to hold references to the required libselinux functions
+selinuxFunctions := make(map[string]unsafe.Pointer)
 
 // newImageDestination returns an ImageDestination for writing to an existing ostree.
 func newImageDestination(ref ostreeReference, tmpDirPath string) (types.ImageDestination, error) {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -540,7 +540,7 @@ func (d *ostreeImageDestination) Commit(ctx context.Context) error {
 			ptrFunction, err := libselinuxHnd.GetSymbolPointer(function)
 			selinuxFunctions[function] = ptrFunction
 			if err != nil {
-				return fmt.Errorf(`couldn't get symbol %q: %v`, function, err)
+				return fmt.Errorf("couldn't get symbol %q: %v", function, err)
 			}
 		}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -48,3 +48,4 @@ github.com/boltdb/bolt master
 github.com/klauspost/pgzip v1.2.1
 github.com/klauspost/compress v1.4.1
 github.com/klauspost/cpuid v1.2.0
+github.com/coreos/pkg v4


### PR DESCRIPTION
This pull request is more a draft for addressing issue #432 than a final realization, therefore please consider it a request for comments (RFC). I'd refactor a couple of places to have easier to maintain and more elegant code if I get positive feedback.

I don't have either a testing setup or use-case for SElinux features.

Decouple adding support for `libselinux` on build-time from requiring it on run-time.

More controlled linking of the library enables not failing if the library is supported, but missing.

Initial request done by @barthalion.