### PR TITLE
docker: mark localhost as insecure

### DIFF
--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -20,6 +20,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSkipTLSVerifyOnLocalhost(t *testing.T) {
+	client, err := newDockerClient(nil, "localhost:5000", "localhost:5000")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+	assert.True(t, client.insecureSkipTLSVerify)
+
+	client, err = newDockerClient(nil, "localhost", "localhost")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+	assert.False(t, client.insecureSkipTLSVerify)
+
+	client, err = newDockerClient(nil, "127.0.0.1", "127.0.0.1")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+	assert.True(t, client.insecureSkipTLSVerify)
+}
+
 func TestDockerCertDir(t *testing.T) {
 	const nondefaultFullPath = "/this/is/not/the/default/full/path"
 	const nondefaultPerHostDir = "/this/is/not/the/default/certs.d"


### PR DESCRIPTION
Mark localhost as insecure to enable communicating with a registry
running on localhost without requiring TLS or explicitly marking it as
insecure in the registries.conf.  This behaviour aligns with Docker.

Notice, that localhost can still be marked to not skip TLS verification
either by setting it via the SystemContext or by configuring it
explicitly in the registries.conf.  A registry is considered to be
running on localhost if it either starts with "localhost:" or with
"127.0.0.1".

Fixes: #544
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>