### PR TITLE
dockerImageDestination: HasThreadSafePutBlob -> false

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -113,7 +113,7 @@ func (c *sizeCounter) Write(p []byte) (n int, err error) {
 
 // HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
 func (d *dockerImageDestination) HasThreadSafePutBlob() bool {
-	return true
+	return false
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).


### PR DESCRIPTION
Mark dockerImageDestination to not be thread safe as there is a race
condition in dockerClient.extraScope causing copy.Copy() to error out
with `[...]dockerClient.extraScope was set before TryReusingBlob`,
which must be addressed in future changes.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>