### PR TITLE
tests: use corresponding skopeo repo for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script: >
   sudo docker run --privileged -ti --rm --user $(id -u):$(id -g)
   -e TRAVIS=$TRAVIS -e TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
   -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
+  -e TRAVIS_PULL_REQUEST_SLUG=$TRAVIS_PULL_REQUEST_SLUG -e TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
   -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e TRAVIS_COMMIT=$TRAVIS_COMMIT
   -e GOPATH=/gopath -e TRASH_CACHE=/gopath/.trashcache -e HOME=/gopath
   -v /etc/passwd:/etc/passwd -v /etc/sudoers:/etc/sudoers -v /etc/sudoers.d:/etc/sudoers.d

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,11 @@ PRs that fix issues should include a reference like `Closes #XXXX` in the
 commit message so that github will automatically close the referenced issue
 when the PR is merged.
 
+For testing purposes PRs modifying dependencies require a branch of `skopeo` with the
+same name as the branch of the PR in the same group where the PR can be found.
+E.g. if requesting a pull of branch `mybranch` from `mygroup/image`, then a repository
+`mygroup/skopeo` with `mybranch` is needed.
+
 <!--
 All PRs require at least two LGTMs (Looks Good To Me) from maintainers.
 -->

--- a/hack/test-skopeo.sh
+++ b/hack/test-skopeo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+export GOPATH=$(mktemp -d)
+skopeo_path=${GOPATH}/src/github.com/containers/skopeo
+
+trap "rm -rf ${GOPATH}" EXIT
+
+if [ -z ${TRAVIS_PULL_REQUEST_SLUG} ] ; then
+    git clone -b master https://github.com/containers/skopeo ${skopeo_path}
+else
+    if ! git clone -b "${TRAVIS_BRANCH}" \
+            https://:@github.com/"${TRAVIS_PULL_REQUEST_SLUG/image/skopeo}" \
+            ${skopeo_path} ; then
+        git clone -b master https://github.com/containers/skopeo ${skopeo_path}
+    fi
+fi
+
+vendor_path=${skopeo_path}/vendor/github.com/containers/image
+rm -rf ${vendor_path} && cp -r . ${vendor_path} && rm -rf ${vendor_path}/vendor
+cd ${skopeo_path}
+make BUILDTAGS="${BUILDTAGS}" binary-local test-all-local
+${SUDO} make BUILDTAGS="${BUILDTAGS}" check


### PR DESCRIPTION
Per default, use the master branch of containers/skopeo for testing.

But if there is a fork of skopeo in the same group as the
containers/image repository being tested and with the same branch,
then use it for testing. This enables testing containers/image PRs
modifying dependencies.

For example, for a request to pull branch `mybranch` of
`mygroup/image` (a fork of `containers/image`), a branch `mybranch` of
`mygroup/skopeo` (a fork of `containers/skopeo`) is needed. Of course,
if new dependencies are being added, an additional request will be
needed to pull branch `mybranch` of repository `mygroup/skopeo` to
branch `master` of repo `containers/skopeo`.

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>

This is the first commit of PR #546!

Closes #552 