### PR TITLE
[DO NOT MERGE] ostree: make selinux optional

### DIFF
--- a/ostree/mandatoryaccesscontrol_stub.go
+++ b/ostree/mandatoryaccesscontrol_stub.go
@@ -1,0 +1,11 @@
+package ostree
+
+import "os"
+
+type macStub struct{}
+
+func (m macStub) Close() {}
+
+func (m macStub) ChangeLabels(root string, fullpath string, fileMode os.FileMode) error {
+	return nil
+}

--- a/ostree/ostree_noselinux.go
+++ b/ostree/ostree_noselinux.go
@@ -1,0 +1,14 @@
+// +build !containers_image_ostree_stub,mac_stub
+
+package ostree
+
+import "os"
+
+type mandatoryAccessControl interface {
+	Close()
+	ChangeLabels(root string, fullpath string, fileMode os.FileMode) error
+}
+
+func createMac() (mandatoryAccessControl, error) {
+	return &macStub{}, nil
+}

--- a/ostree/ostree_selinux.go
+++ b/ostree/ostree_selinux.go
@@ -1,0 +1,78 @@
+// +build !containers_image_ostree_stub,!mac_stub
+
+package ostree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/pkg/errors"
+)
+
+// #cgo pkg-config: glib-2.0 libselinux
+// #include <glib.h>
+// #include <stdlib.h>
+// #include <selinux/selinux.h>
+// #include <selinux/label.h>
+import "C"
+
+type mandatoryAccessControl interface {
+	Close()
+	ChangeLabels(root string, fullpath string, fileMode os.FileMode) error
+}
+
+type macSelinux struct {
+	handler *C.struct_selabel_handle
+}
+
+func createMac() (mandatoryAccessControl, error) {
+	if os.Getuid() == 0 && selinux.GetEnabled() {
+		selinuxHnd, err := C.selabel_open(C.SELABEL_CTX_FILE, nil, 0)
+		if selinuxHnd == nil {
+			return nil, errors.Wrapf(err, "cannot open the SELinux DB")
+		}
+		return &macSelinux{selinuxHnd}, nil
+	}
+
+	return &macStub{}, nil
+}
+
+func (m macSelinux) Close() {
+	C.selabel_close(m.handler)
+}
+
+func (m macSelinux) ChangeLabels(root string, fullpath string, fileMode os.FileMode) error {
+	relPath, err := filepath.Rel(root, fullpath)
+	if err != nil {
+		return err
+	}
+	// Handle /exports/hostfs as a special case.  Files under this directory are copied to the host,
+	// thus we benefit from maintaining the same SELinux label they would have on the host as we could
+	// use hard links instead of copying the files.
+	relPath = fmt.Sprintf("/%s", strings.TrimPrefix(relPath, "exports/hostfs/"))
+
+	relPathC := C.CString(relPath)
+	defer C.free(unsafe.Pointer(relPathC))
+	var context *C.char
+
+	res, err := C.selabel_lookup_raw(m.handler, &context, relPathC, C.int(fileMode&os.ModePerm))
+	if int(res) < 0 && err != syscall.ENOENT {
+		return errors.Wrapf(err, "cannot selabel_lookup_raw %s", relPath)
+	}
+	if int(res) == 0 {
+		defer C.freecon(context)
+		fullpathC := C.CString(fullpath)
+		defer C.free(unsafe.Pointer(fullpathC))
+		res, err = C.lsetfilecon_raw(fullpathC, context)
+		if int(res) < 0 {
+			return errors.Wrapf(err, "cannot setfilecon_raw %s", fullpath)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Enable building with or without SELinux support via the go build tag
'selinux'.

Building with the build tag 'selinux' requires the presence of
'libselinux' to run, no matter if SELinux is enabled or not.

Building without the build tag 'selinux' eliminates the requirement of
having 'libselinux'.

This PR implements the initial intention of #546.

Closes #432.

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>