### PR TITLE
Add registry mirror support to docker client

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -25,7 +25,7 @@ type Image struct {
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
 func newImage(ctx context.Context, sys *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
-	s, err := newImageSource(sys, ref)
+	s, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
+	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
@@ -28,17 +29,89 @@ type dockerImageSource struct {
 	cachedManifestMIMEType string // Only valid if cachedManifest != nil
 }
 
-// newImageSource creates a new ImageSource for the specified image reference.
-// The caller must call .Close() on the returned ImageSource.
-func newImageSource(sys *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
-	c, err := newDockerClientFromRef(sys, ref, false, "pull")
+// newImageSource creates a new `ImageSource` for the specified image reference
+// `ref`.
+//
+// The following steps will be done during the instance creation:
+//
+// - Lookup the registry within the configured location in
+//   `sys.SystemRegistriesConfPath`. If there is no configured registry available,
+//   we fallback to the provided docker reference `ref`.
+//
+// - References which contain a configured prefix will be automatically rewritten
+//   to the correct target reference. For example, if the configured
+//   `prefix = "example.com/foo"`, `location = "example.com"` and the image will be
+//   pulled from the ref `example.com/foo/image`, then the resulting pull will
+//   effectively point to `example.com/image`.
+//
+// - If the rewritten reference succeeds, it will be used as the `dockerRef`
+//   in the client. If the rewrite fails, the function immediately returns an error.
+//
+// - Each mirror will be used (in the configured order) to test the
+//   availability of the image manifest on the remote location. For example,
+//   if the manifest is not reachable due to connectivity issues, then the next
+//   mirror will be tested instead. If no mirror is configured or contains the
+//   target manifest, then the initial `ref` will be tested as fallback. The
+//   creation of the new `dockerImageSource` only succeeds if a remote
+//   location with the available manifest was found.
+//
+// A cleanup call to `.Close()` is needed if the caller is done using the returned
+// `ImageSource`.
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
+	registry, err := sysregistriesv2.FindRegistry(sys, ref.ref.Name())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error loading registries configuration")
 	}
-	return &dockerImageSource{
-		ref: ref,
-		c:   c,
-	}, nil
+
+	if registry == nil {
+		// No configuration was found for the provided reference, so we create
+		// a fallback registry by hand to make the client creation below work
+		// as intended.
+		registry = &sysregistriesv2.Registry{
+			Endpoint: sysregistriesv2.Endpoint{
+				Location: ref.ref.String(),
+			},
+		}
+	}
+
+	// Found the registry within the sysregistriesv2 configuration. Now we test
+	// all endpoints for the manifest availability. If a working image source
+	// was found, it will be used for all future pull actions.
+	var (
+		imageSource     *dockerImageSource
+		manifestLoadErr error
+	)
+	for _, endpoint := range append(registry.Mirrors, registry.Endpoint) {
+		logrus.Debugf("Trying to pull %q from endpoint %q", ref.ref, endpoint.Location)
+
+		newRef, err := endpoint.RewriteReference(ref.ref, registry.Prefix)
+		if err != nil {
+			return nil, err
+		}
+		dockerRef, err := newReference(newRef)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := newDockerClientFromRef(sys, dockerRef, false, "pull")
+		if err != nil {
+			return nil, err
+		}
+		client.tlsClientConfig.InsecureSkipVerify = endpoint.Insecure
+
+		testImageSource := &dockerImageSource{
+			ref: dockerRef,
+			c:   client,
+		}
+
+		manifestLoadErr = testImageSource.ensureManifestIsLoaded(ctx)
+		if manifestLoadErr == nil {
+			imageSource = testImageSource
+			break
+		}
+	}
+
+	return imageSource, manifestLoadErr
 }
 
 // Reference returns the reference used to set up this source, _as specified by the user_
@@ -274,7 +347,7 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 			return nil, false, err
 		}
 		req = req.WithContext(ctx)
-		res, err := s.c.client.Do(req)
+		res, err := s.c.doHTTP(req)
 		if err != nil {
 			return nil, false, err
 		}

--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -7,14 +7,68 @@ containers-registries.conf - Syntax of System Registry Configuration File
 
 # DESCRIPTION
 The CONTAINERS-REGISTRIES configuration file is a system-wide configuration
-file for container image registries. The file format is TOML. The valid
-categories are: 'registries.search', 'registries.insecure', and
-'registries.block'.
+file for container image registries. The file format is TOML.
 
 By default, the configuration file is located at `/etc/containers/registries.conf`.
 
-# FORMAT
-The TOML_format is used to build a simple list format for registries under three
+# FORMATS
+
+## VERSION 2
+VERSION 2 is the latest format of the `registries.conf` and is currently in
+beta. This means in general VERSION 1 should be used in production environments
+for now.
+
+Every registry can have its own mirrors configured.  The mirrors will be tested
+in order for the availability of the remote manifest.  This happens currently
+only during an image pull.  If the manifest is not reachable due to connectivity
+issues or the unavailability of the remote manifest, then the next mirror will
+be tested instead.  If no mirror is configured or contains the manifest to be
+pulled, then the initially provided reference will be used as fallback.  It is
+possible to set the `insecure` option per mirror, too.
+
+Furthermore it is possible to specify a `prefix` for a registry.  The `prefix`
+is used to find the relevant target registry from where the image has to be
+pulled.  During the test for the availability of the image, the prefixed
+location will be rewritten to the correct remote location.  This applies to
+mirrors as well as the fallback `location`.  If no prefix is specified, it
+defaults to the specified `location`.  For example, if
+`prefix = "example.com/foo"`, `location = "example.com"` and the image will be
+pulled from `example.com/foo/image`, then the resulting pull will be effectively
+point to `example.com/image`.
+
+By default container runtimes use TLS when retrieving images from a registry.
+If the registry is not setup with TLS, then the container runtime will fail to
+pull images from the registry. If you set `insecure = true` for a registry or a
+mirror you overwrite the `insecure` flag for that specific entry.  This means
+that the container runtime will attempt use unencrypted HTTP to pull the image.
+It also allows you to pull from a registry with self-signed certificates.
+
+If you set the `unqualified-search = true` for the registry, then it is possible
+to omit the registry hostname when pulling images.  This feature does not work
+together with a specified `prefix`.
+
+If `blocked = true` then it is not allowed to pull images from that registry.
+
+### EXAMPLE
+
+```
+[[registry]]
+location = "example.com"
+insecure = false
+prefix = "example.com/foo"
+unqualified-search = false
+blocked = false
+mirror = [
+    { location = "example-mirror-0.local", insecure = false },
+    { location = "example-mirror-1.local", insecure = true }
+]
+```
+
+## VERSION 1
+VERSION 1 can be used as alternative to the VERSION 2, but it is not capable in
+using registry mirrors or a prefix.
+
+The TOML_format is used to build a simple list for registries under three
 categories: `registries.search`, `registries.insecure`, and `registries.block`.
 You can list multiple registries using a comma separated list.
 
@@ -22,18 +76,13 @@ Search registries are used when the caller of a container runtime does not fully
 container image that they want to execute.  These registries are prepended onto the front
 of the specified container image until the named image is found at a registry.
 
-Insecure Registries.  By default container runtimes use TLS when retrieving images
-from a registry.  If the registry is not setup with TLS, then the container runtime
-will fail to pull images from the registry. If you add the registry to the list of
-insecure registries then the container runtime will attempt use standard web protocols to
-pull the image.  It also allows you to pull from a registry with self-signed certificates.
 Note insecure registries can be used for any registry, not just the registries listed
 under search.
 
-Block Registries.  The registries in this category are are not pulled from when
-retrieving images.
+The fields `registries.insecure` and `registries.block` work as like as the
+`insecure` and `blocked` from VERSION 2.
 
-# EXAMPLE
+### EXAMPLE
 The following example configuration defines two searchable registries, one
 insecure registry, and two blocked registries.
 
@@ -49,6 +98,8 @@ registries = ['registry.untrusted.com', 'registry.unsafe.com']
 ```
 
 # HISTORY
+Mar 2019, Added additional configuration format by Sascha Grunert <sgrunert@suse.com>
+
 Aug 2018, Renamed to containers-registries.conf(5) by Valentin Rothberg <vrothberg@suse.com>
 
 Jun 2018, Updated by Tom Sweeney <tsweeney@redhat.com>

--- a/registries.conf
+++ b/registries.conf
@@ -1,5 +1,11 @@
 # For more information on this configuration file, see containers-registries.conf(5).
 #
+# There are multiple versions of the configuration syntax available, where the
+# second iteration is backwards compatible to the first one. Mixing up both
+# formats will result in an runtime error.
+#
+# The initial configuration format looks like this:
+#
 # Registries to search for images that are not fully-qualified.
 # i.e. foobar.com/my_image:latest vs my_image:latest
 [registries.search]
@@ -19,3 +25,41 @@ registries = []
 # The atomic CLI `atomic trust` can be used to easily configure the policy.json file.
 [registries.block]
 registries = []
+
+# The second version of the configuration format allows to specify registry
+# mirrors:
+#
+# [[registry]]
+# # The main location of the registry
+# location = "example.com"
+#
+# # If true, certs verification will be skipped and HTTP (non-TLS) connections
+# # will be allowed.
+# insecure = false
+#
+# # Prefix is used for matching images, and to translate one namespace to
+# # another.  If `prefix = "example.com/foo"`, `location = "example.com"` and
+# # we pull from "example.com/foo/myimage:latest", the image will effectively be
+# # pulled from "example.com/myimage:latest".  If no Prefix is specified,
+# # it defaults to the specified `location`. When a prefix is used, then a pull
+# # without specifying the prefix is not possible any more.
+# prefix = "example.com/foo"
+#
+# # If true, the registry can be used when pulling an unqualified image. If a
+# # prefix is specified, unqualified pull is not possible any more.
+# unqualified-search = false
+#
+# # If true, pulling from the registry will be blocked.
+# blocked = false
+#
+# # All available mirrors of the registry.  The mirrors will be evaluated in
+# # order during an image pull.  Furthermore it is possible to specify the
+# # `insecure` flag per registry mirror, too.
+# mirror = [
+#     { location = "example-mirror-0.local", insecure = false },
+#     { location = "example-mirror-1.local", insecure = true },
+#     # It is also possible to specify an additional path within the `location`.
+#     # A pull to `example.com/foo/image:latest` will then result in
+#     # `example-mirror-2.local/path/image:latest`.
+#     { location = "example-mirror-2.local/path" },
+# ]


### PR DESCRIPTION
This change relates to #559 and enables registry mirror support for the docker client.

### Major changes
* The first working mirror will be used for the pull
* The main registry will be the fallback if no mirror works
* The `Insecure` flags will be used from system context and now from the corresponding registry / mirror as fallback too
* Configuring a prefix will be considered (see test cases)

## Test cases:

The following test cases has been verified by manual testing via cri-o:

<details><summary><strong>It should succeed to pull an image from a working registry mirror</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull gcr.local/google-containers/hyperkube:v1.13.2
```
*Then*
```fish
exit 0
```
</p></details>

<details><summary><strong>It should succeed to pull an image unqualified from a working registry mirror</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
unqualified-search = true
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull google-containers/hyperkube:v1.13.2
```
*Then*
```fish
exit 0
```
</p></details>

<details><summary><strong>It should succeed to pull an image from a working registry mirror if unqualified search is enabled but not used</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
unqualified-search = true
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull gcr.local/google-containers/hyperkube:v1.13.2
```
*Then*
```fish
exit 0
```
</p></details>

<details><summary><strong>It should succeed to pull an image from a working registry mirror with  prefix</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
prefix = "gcr.local/foo/bar"
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull gcr.local/foo/bar/google-containers/hyperkube:v1.13.2
```
*Then*
```fish
exit 0
```
</p></details>

<details><summary><strong>It should fail to pull an image if prefix is specified but not used</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
prefix = "gcr.local/foo/bar"
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull gcr.local/google-containers/hyperkube:v1.13.2
```
*Then*
```fish
FATA[0000] pulling image failed ...
exit 1
```
</p></details>

<details><summary><strong>It should fail to pull an image unqualified if prefix is specified</strong></summary>
<p>

*Given*
`/etc/containers/registry.conf`
```toml
[[registry]]
url = "gcr.local"
prefix = "gcr.local/foo/bar"
unqualified-search = true
mirror = [
    { url = "wrong.local" },
    { url = "gcr.io" },
]
```
*When*
```fish
> sudo crictl pull google-containers/hyperkube:v1.13.2
```
*Then*
```fish
FATA[0000] pulling image failed ...
exit 1
```
</p></details>
