### PR TITLE
update openshift API paths to groupified path

### DIFF
--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -136,7 +136,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 // getImage loads the specified image object.
 func (c *openshiftClient) getImage(ctx context.Context, imageStreamImageName string) (*image, error) {
 	// FIXME: validate components per validation.IsValidPathSegmentName?
-	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreamimages/%s@%s", c.ref.namespace, c.ref.stream, imageStreamImageName)
+	path := fmt.Sprintf("/apis/image.openshift.io/v1/namespaces/%s/imagestreamimages/%s@%s", c.ref.namespace, c.ref.stream, imageStreamImageName)
 	body, err := c.doRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -265,7 +265,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 	}
 
 	// FIXME: validate components per validation.IsValidPathSegmentName?
-	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreams/%s", s.client.ref.namespace, s.client.ref.stream)
+	path := fmt.Sprintf("/apis/image.openshift.io/v1/namespaces/%s/imagestreams/%s", s.client.ref.namespace, s.client.ref.stream)
 	body, err := s.client.doRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return err
@@ -476,7 +476,7 @@ sigExists:
 			Content:    newSig,
 		}
 		body, err := json.Marshal(sig)
-		_, err = d.client.doRequest(ctx, "POST", "/oapi/v1/imagesignatures", body)
+		_, err = d.client.doRequest(ctx, "POST", "/apis/image.openshift.io/v1/imagesignatures", body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In 3.7, openshift moved to use groupified kubernetes APIs.  This pull updates the containers/image project to use these new APIs.  The old-style `oapi` endpoint is being removed in openshift v4.