### PR TITLE
switch to openshift image api group instead from deprecated oapi

### DIFF
--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/image/version"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -136,7 +135,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 // getImage loads the specified image object.
 func (c *openshiftClient) getImage(ctx context.Context, imageStreamImageName string) (*image, error) {
 	// FIXME: validate components per validation.IsValidPathSegmentName?
-	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreamimages/%s@%s", c.ref.namespace, c.ref.stream, imageStreamImageName)
+	path := fmt.Sprintf("/apis/image.openshift.io/v1/namespaces/%s/imagestreamimages/%s@%s", c.ref.namespace, c.ref.stream, imageStreamImageName)
 	body, err := c.doRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -265,7 +264,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 	}
 
 	// FIXME: validate components per validation.IsValidPathSegmentName?
-	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreams/%s", s.client.ref.namespace, s.client.ref.stream)
+	path := fmt.Sprintf("/apis/image.openshift.io/v1/namespaces/%s/imagestreams/%s", s.client.ref.namespace, s.client.ref.stream)
 	body, err := s.client.doRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
@mtrmac @rhatdan the `/oapi` is going to be removed in 4.0, we need to switch this to use the proper openshift api group.