### PR TITLE
Make DefaultPolicyPath a public interface

### DIFF
--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -48,11 +48,11 @@ func (err InvalidPolicyFormatError) Error() string {
 // NOTE: When this function returns an error, report it to the user and abort.
 // DO NOT hard-code fallback policies in your application.
 func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
-	return NewPolicyFromFile(defaultPolicyPath(sys))
+	return NewPolicyFromFile(DefaultPolicyPath(sys))
 }
 
-// defaultPolicyPath returns a path to the default policy of the system.
-func defaultPolicyPath(sys *types.SystemContext) string {
+// DefaultPolicyPath returns a path to the default policy of the system.
+func DefaultPolicyPath(sys *types.SystemContext) string {
 	if sys != nil {
 		if sys.SignaturePolicyPath != "" {
 			return sys.SignaturePolicyPath

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -119,7 +119,7 @@ func TestDefaultPolicyPath(t *testing.T) {
 		// No environment expansion happens in the overridden paths
 		{&types.SystemContext{SignaturePolicyPath: variableReference}, variableReference},
 	} {
-		path := defaultPolicyPath(c.sys)
+		path := DefaultPolicyPath(c.sys)
 		assert.Equal(t, c.expected, path)
 	}
 }


### PR DESCRIPTION
We want to tell users to install or edit /etc/config/policy.path
so we need to expose the interface from containers/image.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>