### PR TITLE
Clean up docker/tarfile a bit

### DIFF
--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -15,24 +15,24 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/types"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
 // Source is a partial implementation of types.ImageSource for reading from tarPath.
 type Source struct {
 	tarPath              string
-	removeTarPathOnClose bool      // Remove temp file on close if true
-	cacheDataLock        sync.Once // Atomic way to ensure that ensureCachedDataIsPresent is only invoked once
+	removeTarPathOnClose bool // Remove temp file on close if true
 	// The following data is only available after ensureCachedDataIsPresent() succeeds
-	cacheDataResult   error         // The return value of ensureCachedDataIsPresent, since it should be as safe to cache as the side effects
 	tarManifest       *ManifestItem // nil if not available yet.
 	configBytes       []byte
 	configDigest      digest.Digest
 	orderedDiffIDList []digest.Digest
 	knownLayers       map[digest.Digest]*layerInfo
 	// Other state
-	generatedManifest []byte // Private cache for GetManifest(), nil if not set yet.
+	generatedManifest []byte    // Private cache for GetManifest(), nil if not set yet.
+	cacheDataLock     sync.Once // Private state for ensureCachedDataIsPresent to make it concurrency-safe
+	cacheDataResult   error     // Private state for ensureCachedDataIsPresent
 }
 
 type layerInfo struct {


### PR DESCRIPTION
- Move single-method members into the right section
- Use a separate helper which returns err as usual, to centralize the `cacheDataResult` usage and make sure future updates don’t have to deal with less unusual error reporting mechanism.

The second commit is RFC — I do think centralizing the `cacheDataResult` use is worth it, but I’m less certain about making the inner function public, even with a `…Private` name. It could instead be created as a variable inside `ensureCachedDataIsPresent` (`actualImplementation := func() error { … }` or so).