### PR TITLE
docker-image-src/getExternalBlob: handle nil resp

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -147,10 +147,10 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 			break
 		}
 	}
-	if resp.Body != nil && err == nil {
-		return resp.Body, getBlobSize(resp), nil
+	if err != nil {
+		return nil, 0, err
 	}
-	return nil, 0, err
+	return resp.Body, getBlobSize(resp), nil
 }
 
 func getBlobSize(resp *http.Response) int64 {


### PR DESCRIPTION
makeRequestToResolvedURL() can return {nil, err} for all
given urls. In that case, resp.Body can cause SIGSEGV
because resp is nil.

Signed-off-by: Arjun Sreedharan <arjun024@gmail.com>