### PR TITLE
ostreeImageSource.GetBlob(): close mfz when we're done with it

### DIFF
--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -313,11 +313,11 @@ func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 	if err != nil {
 		return nil, 0, err
 	}
-	defer mfz.Close()
 	metaUnpacker := storage.NewJSONUnpacker(mfz)
 
 	getter, err := newOSTreePathFileGetter(s.repo, branch)
 	if err != nil {
+		mfz.Close()
 		return nil, 0, err
 	}
 
@@ -331,6 +331,7 @@ func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 
 	rc := ioutils.NewReadCloserWrapper(pipeReader, func() error {
 		getter.Close()
+		mfz.Close()
 		return ots.Close()
 	})
 	return rc, layerSize, nil


### PR DESCRIPTION
The `bytes.Reader` that we use to read the decompressed copy of the tar split data in `ostreeImageSource.GetBlob()` was being closed when we returned using `defer`, at which time the goroutine that was feeding the `io.ReadCloser` that we returned could still be running.  Move its `Close()` call so that it's closed along with the `io.ReadCloser` that we return.