### PR TITLE
Remove an unnecessary pipe in ostreeImageSource.GetBlob

### DIFF
--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -17,7 +17,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/klauspost/pgzip"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	glib "github.com/ostreedev/ostree-go/pkg/glibobject"
 	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/tar/asm"
@@ -323,13 +323,7 @@ func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 
 	ots := asm.NewOutputTarStream(getter, metaUnpacker)
 
-	pipeReader, pipeWriter := io.Pipe()
-	go func() {
-		io.Copy(pipeWriter, ots)
-		pipeWriter.Close()
-	}()
-
-	rc := ioutils.NewReadCloserWrapper(pipeReader, func() error {
+	rc := ioutils.NewReadCloserWrapper(ots, func() error {
 		getter.Close()
 		mfz.Close()
 		return ots.Close()


### PR DESCRIPTION
The pipe was used before commit c809f3dc87c2a04086d766b72e9f8d15cd10b181 to integrate a `gzip.NewWriter`; now it is not necessary, so drop it.