### PR TITLE
Add exported ValidatePrefix function

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -84,6 +84,13 @@ func (e *InvalidRegistries) Error() string {
 	return e.s
 }
 
+// ValidatePrefix calls parseURL but discards the normalized registry value returned
+// It just checks that the registry value given as an input is valid
+func ValidatePrefix(input string) error {
+	_, err := parseURL(input)
+	return err
+}
+
 // parseURL parses the input string, performs some sanity checks and returns
 // the sanitized input string.  An error is returned if the input string is
 // empty or if contains an "http{s,}://" prefix.


### PR DESCRIPTION
This function calls parseURL to validate the registry input
but discards the normalized registry value. Mainly to be used
by the CRD and controller to validate registry values given
by the user in the container runtime config.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>