### PR TITLE
progress bars: use github.com/vbauerster/mpb

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,6 @@ golang.org/x/crypto 453249f01cfeb54c3d549ddb75ff152ca243f9d8
 golang.org/x/net 6b27048ae5e6ad1ef927e72e437531493de612fe
 golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 golang.org/x/sys 43e60d72a8e2bd92ee98319ba9a384a0e9837c08
-gopkg.in/cheggaaa/pb.v1 v1.0.27
 gopkg.in/yaml.v2 a3f3340b5840cee44f372bddb5880fcbc419b46a
 k8s.io/client-go bcde30fb7eaed76fd98a36b4120321b94995ffb6
 github.com/xeipuuv/gojsonschema master
@@ -48,3 +47,6 @@ github.com/boltdb/bolt master
 github.com/klauspost/pgzip v1.2.1
 github.com/klauspost/compress v1.4.1
 github.com/klauspost/cpuid v1.2.0
+github.com/vbauerster/mpb v3.3.4
+github.com/mattn/go-isatty v0.0.4
+github.com/VividCortex/ewma v1.1.1


### PR DESCRIPTION
Use the github.com/vbauerster/mpb library for displaying the progress
bars.  It is actively maintained, is designed for multi-bar usage and
just gets the job done.

This will fix issues with single bars being displayed multiple times.
Note that updating the bar's prefix does not work anymore.  We're now
logging those entries, for instance, when we skip a blob as it's
already present.

The output now looks as follows (e.g., when pulling jboss/wildfly):

```
Getting image source signatures
Copying blob aeb7866da422 [======================================] 71.2 MiB / 71.2 MiB
Copying blob 157601a0b538 [======================================] 10.3 MiB / 10.3 MiB
Copying blob 642f4164f381 [======================================] 1.9 KiB / 1.9 KiB
Copying blob bda512e97517 [======================================] 74.6 MiB / 74.6 MiB
Copying blob 4cccaafdae21 [======================================] 170.9 MiB / 170.9 MiB
Copying config 2602b48525 [======================================] 6.5KiB / 6.5KiB
Writing manifest to image destination
Storing signatures
```

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>