### PR TITLE
Fallback to v2s2 if OCI manifest upload fails on ECR

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -390,14 +390,23 @@ func isManifestInvalidError(err error) bool {
 	if !ok || len(errors) == 0 {
 		return false
 	}
-	ec, ok := errors[0].(errcode.ErrorCoder)
+	err = errors[0]
+	ec, ok := err.(errcode.ErrorCoder)
 	if !ok {
 		return false
 	}
+
+	switch ec.ErrorCode() {
 	// ErrorCodeManifestInvalid is returned by OpenShift with acceptschema2=false.
+	case v2.ErrorCodeManifestInvalid:
+		return true
 	// ErrorCodeTagInvalid is returned by docker/distribution (at least as of commit ec87e9b6971d831f0eff752ddb54fb64693e51cd)
 	// when uploading to a tag (because it can’t find a matching tag inside the manifest)
-	return ec.ErrorCode() == v2.ErrorCodeManifestInvalid || ec.ErrorCode() == v2.ErrorCodeTagInvalid
+	case v2.ErrorCodeTagInvalid:
+		return true
+	default:
+		return false
+	}
 }
 
 func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
@@ -404,6 +405,12 @@ func isManifestInvalidError(err error) bool {
 	// when uploading to a tag (because it can’t find a matching tag inside the manifest)
 	case v2.ErrorCodeTagInvalid:
 		return true
+	// ErrorCodeUnsupported with 'Invalid JSON syntax' is returned by AWS ECR when
+	// uploading an OCI manifest that is (correctly, according to the spec) missing
+	// a top-level media type. See libpod issue #1719
+	// FIXME: remove this case when ECR behavior is fixed
+	case errcode.ErrorCodeUnsupported:
+		return strings.Contains(err.Error(), "Invalid JSON syntax")
 	default:
 		return false
 	}


### PR DESCRIPTION
Uploading a spec-compliant OCI manifest which contains no top-level media type fails on AWS ECR with an Unsupported error code and  an 'Invalid JSON syntax' error message.

As suggested in containers/libpod#1719 catch this case as an invalid manifest error so that we automatically fallback to other accepted media types in copyOneImage().
