### PR TITLE
Fix progress bar cleanup, and other small cleanups

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/klauspost/pgzip"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbauerster/mpb"
@@ -621,7 +621,7 @@ func (c *copier) copyConfig(ctx context.Context, src types.Image) error {
 			return err
 		}
 		if bar != nil {
-			bar.SetTotal(0, true)
+			bar.SetTotal(int64(len(configBlob)), true)
 		}
 		if destInfo.Digest != srcInfo.Digest {
 			return errors.Errorf("Internal error: copying uncompressed config blob %s changed digest to %s", srcInfo.Digest, destInfo.Digest)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -503,12 +503,11 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		go copyLayerHelper(i, srcLayer, progressBars[i])
 	}
 
-	destInfos := make([]types.BlobInfo, numLayers)
-	diffIDs := make([]digest.Digest, numLayers)
-
 	// Wait for all layers to be copied
 	copyGroup.Wait()
 
+	destInfos := make([]types.BlobInfo, numLayers)
+	diffIDs := make([]digest.Digest, numLayers)
 	for i, cld := range data {
 		if cld.err != nil {
 			return cld.err

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -486,9 +486,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 			cld.destInfo, cld.diffID, cld.err = ic.copyLayer(ctx, srcLayer, bar)
 		}
 		data[index] = cld
-		if bar != nil {
-			bar.SetTotal(srcLayer.Size, true)
-		}
+		bar.SetTotal(srcLayer.Size, true)
 	}
 
 	progressPool := ic.c.newProgressPool()
@@ -626,9 +624,7 @@ func (c *copier) copyConfig(ctx context.Context, src types.Image) error {
 		if err != nil {
 			return err
 		}
-		if bar != nil {
-			bar.SetTotal(int64(len(configBlob)), true)
-		}
+		bar.SetTotal(int64(len(configBlob)), true)
 		progressPool.Wait()
 		if destInfo.Digest != srcInfo.Digest {
 			return errors.Errorf("Internal error: copying uncompressed config blob %s changed digest to %s", srcInfo.Digest, destInfo.Digest)


### PR DESCRIPTION
Primarily, this fixes the `.Wait` call in `copyUpdatedConfigAndManifest`, terminating the pool before all its possible uses, by using several shorter-lived pools.  Also ensures that the pools are always cleaned up, and other small cleanups.

See the individual commit descriptions for details.

@vrothberg PTAL.