### PR TITLE
ostree: default is no OStree support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,10 @@ SKOPEO_BRANCH = master
 SUDO =
 
 # when cross compiling _for_ a Darwin or windows host, then we must use openpgp
-BUILD_TAGS_WINDOWS_CROSS = containers_image_ostree_stub containers_image_openpgp
-BUILD_TAGS_DARWIN_CROSS = containers_image_ostree_stub containers_image_openpgp
-# when compiling _on_ a Darwin host, then we can link against gpgme
-BUILD_TAGS_DARWIN_NATIVE = containers_image_ostree_stub
+BUILD_TAGS_WINDOWS_CROSS = containers_image_openpgp
+BUILD_TAGS_DARWIN_CROSS = containers_image_openpgp
 
-ifeq ($(shell uname),Darwin)
-PLATFORM_BUILD_TAG = $(BUILD_TAGS_DARWIN_NATIVE)
-endif
-
-
-BUILDTAGS = btrfs_noversion libdm_no_deferred_remove $(PLATFORM_BUILD_TAG)
+BUILDTAGS = btrfs_noversion libdm_no_deferred_remove
 BUILDFLAGS := -tags "$(BUILDTAGS)"
 
 PACKAGES := $(shell go list $(BUILDFLAGS) ./... | grep -v github.com/containers/image/vendor)

--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ or use the build tags described below to avoid the dependencies (e.g. using `go 
 
 - `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
 the primary downside is that creating new signatures with the Golang-only implementation is not supported.
-- `containers_image_ostree`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports` to download images from an OStree repository.
-This builds the library requiring the `libostree` development libraries.
-Otherwise a stub which reports that the transport is not supported gets used.
-The `github.com/containers/image/ostree` package is completely disabled and impossible to import when this build tag is not in use.
+- `containers_image_ostree`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports`. This builds the library requiring the `libostree` development libraries. Otherwise a stub which reports that the transport is not supported gets used. The `github.com/containers/image/ostree` package is completely disabled
+and impossible to import when this build tag is not in use.
 
 ## [Contributing](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ or use the build tags described below to avoid the dependencies (e.g. using `go 
 
 - `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
 the primary downside is that creating new signatures with the Golang-only implementation is not supported.
-- `ostree_repos`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports` to download images from an OStree repository.
+- `containers_image_ostree`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports` to download images from an OStree repository.
 This builds the library requiring the `libostree` development libraries.
 Otherwise a stub which reports that the transport is not supported gets used.
 The `github.com/containers/image/ostree` package is completely disabled and impossible to import when this build tag is not in use.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ or use the build tags described below to avoid the dependencies (e.g. using `go 
 
 - `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
 the primary downside is that creating new signatures with the Golang-only implementation is not supported.
-- `containers_image_ostree_stub`: Instead of importing `ostree:` transport in `github.com/containers/image/transports/alltransports`, use a stub which reports that the transport is not supported. This allows building the library without requiring the `libostree` development libraries. The `github.com/containers/image/ostree` package is completely disabled
-and impossible to import when this build tag is in use.
+- `ostree_repos`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports` to download images from an OStree repository.
+This builds the library requiring the `libostree` development libraries.
+Otherwise a stub which reports that the transport is not supported gets used.
+The `github.com/containers/image/ostree` package is completely disabled and impossible to import when this build tag is not in use.
 
 ## [Contributing](CONTRIBUTING.md)
 

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build ostree_repos
 
 package ostree
 

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -1,4 +1,4 @@
-// +build ostree_repos
+// +build containers_image_ostree
 
 package ostree
 

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build ostree_repos
 
 package ostree
 

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -1,4 +1,4 @@
-// +build ostree_repos
+// +build containers_image_ostree
 
 package ostree
 

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build ostree_repos
 
 package ostree
 

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -1,4 +1,4 @@
-// +build ostree_repos
+// +build containers_image_ostree
 
 package ostree
 

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build ostree_repos
 
 package ostree
 

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -1,4 +1,4 @@
-// +build ostree_repos
+// +build containers_image_ostree
 
 package ostree
 

--- a/transports/alltransports/ostree.go
+++ b/transports/alltransports/ostree.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub,linux
+// +build ostree_repos,linux
 
 package alltransports
 

--- a/transports/alltransports/ostree.go
+++ b/transports/alltransports/ostree.go
@@ -1,4 +1,4 @@
-// +build ostree_repos,linux
+// +build containers_image_ostree,linux
 
 package alltransports
 

--- a/transports/alltransports/ostree_stub.go
+++ b/transports/alltransports/ostree_stub.go
@@ -1,4 +1,4 @@
-// +build containers_image_ostree_stub !linux
+// +build !ostree_repos !linux
 
 package alltransports
 

--- a/transports/alltransports/ostree_stub.go
+++ b/transports/alltransports/ostree_stub.go
@@ -1,4 +1,4 @@
-// +build !ostree_repos !linux
+// +build !containers_image_ostree !linux
 
 package alltransports
 


### PR DESCRIPTION
Since only Skopeo uses the OStree transport for fetching images from
OStree repositories, making default no support for OStree. It
simplifies building on other components like libpod and buildah.

This PR is completely different approach to address #432 motivated by [this](https://github.com/containers/image/pull/562#issuecomment-458071484) and [this](https://github.com/containers/image/pull/562#issuecomment-458177678) comments of @giuseppe 

It will require changes in Skopeo, Buildah, CRI-O and libpod to have support for the c/image OStree backend only for Skopeo.

Closes #432.

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>