### PR TITLE
additional authentication files

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -453,6 +453,11 @@ type SystemContext struct {
 	SystemRegistriesConfPath string
 	// If not "", overrides the default path for the authentication file
 	AuthFilePath string
+	// Allows to specify additional authentication files that can be used
+	// during credential lookup.  Note that the additional authentication
+	// files are only used for reading.  Only the AuthFilePath can be used
+	// for storing and removing credentials.
+	AdditionalAuthFiles []string
 	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.


### PR DESCRIPTION
Allow specifying additional authentication files passed through
`types.SystemContext`.  Those additional files are only used for reading
credentials.  The `AuthFilePath` remains the center of auth management
and is the only authentication file used for storing new and removing
old credentials.

Having the ability to specify additional authentication files can come
in handy to unify multiple entities that have dedicated auth files, for
instance, the K8s kubelet.  See the below bug for additional details.

Also add debug logs to `findAuthentication()` to ease debugging
potential future regressions.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1686556
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>