### PR TITLE
pkg/docker/config: Deprecate GetUserLoggedIn

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -85,21 +85,6 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 	return "", "", nil
 }
 
-// GetUserLoggedIn returns the username logged in to registry from either
-// auth.json or XDG_RUNTIME_DIR
-// Used to tell the user if someone is logged in to the registry when logging in
-func GetUserLoggedIn(sys *types.SystemContext, registry string) (string, error) {
-	path, err := getPathToAuth(sys)
-	if err != nil {
-		return "", err
-	}
-	username, _, _ := findAuthentication(registry, path, false)
-	if username != "" {
-		return username, nil
-	}
-	return "", nil
-}
-
 // RemoveAuthentication deletes the credentials stored in auth.json
 func RemoveAuthentication(sys *types.SystemContext, registry string) error {
 	return modifyJSON(sys, func(auths *dockerConfigFile) (bool, error) {


### PR DESCRIPTION
And refactor it to use `GetAuthentication`, which is just as convenient for callers.  This also removes the lookup differences between lookup logic between the two functions (e.g. `GetUserLoggedIn` used to ignore `DockerAuthConfig`).

Spun off from #588 [here][1] and #596.

[1]: https://github.com/containers/image/commit/480020500db2b2ca5ab850c6657a5df4d0b98904#diff-45d77e7dc3a84219aeb2aaad81b6bf96R298