### PR TITLE
docker/docker_client: Drop redundant Domain(ref.ref) call

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -197,7 +197,7 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 // “write” specifies whether the client will be used for "write" access (in particular passed to lookaside.go:toplevelFromSection)
 func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write bool, actions string) (*dockerClient, error) {
 	registry := reference.Domain(ref.ref)
-	username, password, err := config.GetAuthentication(sys, reference.Domain(ref.ref))
+	username, password, err := config.GetAuthentication(sys, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}


### PR DESCRIPTION
There have been redundant calls here since two `ref.ref.Hostname()` calls were added in aaedc642 (#52).  At that point the two calls were separated by a `dockerHostname` check which could have been shifted by two lines to avoid the doubled function calls.  But in f28367e1 (#333) the `dockerHostname` check moved to a separate function entirely (`newDockerClientWithDetails`) while the `Domain()` calls remained together in `newDockerClientFromRef`.  So now there is no longer any reason for the second call, and this pull request drops it.