### PR TITLE
README: Drop '**' from "Contributing" header

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the primary downside is that creating new signatures with the Golang-only implem
 - `containers_image_ostree_stub`: Instead of importing `ostree:` transport in `github.com/containers/image/transports/alltransports`, use a stub which reports that the transport is not supported. This allows building the library without requiring the `libostree` development libraries. The `github.com/containers/image/ostree` package is completely disabled
 and impossible to import when this build tag is in use.
 
-## [Contributing](CONTRIBUTING.md)**
+## [Contributing](CONTRIBUTING.md)
 
 Information about contributing to this project.
 


### PR DESCRIPTION
These are from f4d6188f (#474).  I dunno if they were intentional or not, but I thought they might be footnote markers so I scrolled down to the bottom of the README looking for a footnote.  Remove them to save other people from that same confusion ;).