### PR TITLE
fix Bug 1688041 - podman image save removes existing image

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -27,15 +27,6 @@ func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.
 		return nil, errors.Wrapf(err, "error opening file %q", ref.path)
 	}
 
-	fhStat, err := fh.Stat()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error statting file %q", ref.path)
-	}
-
-	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {
-		return nil, errors.New("docker-archive doesn't support modifying existing images")
-	}
-
 	tarDest := tarfile.NewDestination(fh, ref.destinationRef)
 	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
 		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)


### PR DESCRIPTION
fix [Bug 1688041 - podman image save removes existing image ](https://bugzilla.redhat.com/show_bug.cgi?id=1688041)

docker doesn't return error `docker-archive:img1: docker-archive doesn't support modifying existing images`
`docker save` can replace the existing file.
`podman save` should overwrite the existing file.
Signed-off-by: Qi Wang <qiwan@redhat.com>