### PR TITLE
Vendor in latest containers/storage

### DIFF
--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -180,7 +181,10 @@ func (s *storageTransport) GetStore() (storage.Store, error) {
 	// Return the transport's previously-set store.  If we don't have one
 	// of those, initialize one now.
 	if s.store == nil {
-		options := storage.DefaultStoreOptions
+		options, err := storage.DefaultStoreOptions(os.Getuid() != 0, os.Getuid())
+		if err != nil {
+			return nil, err
+		}
 		options.UIDMap = s.defaultUIDMap
 		options.GIDMap = s.defaultGIDMap
 		store, err := storage.GetStore(options)

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/containers/image
 
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/storage master
+github.com/containers/storage v1.12.1
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716


### PR DESCRIPTION
DefaultStorageOptions now is a function and takes a rootless argument
and the UID of root within the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>