### PR TITLE
Switch to github.com/etcd-io/bbolt

### DIFF
--- a/pkg/blobinfocache/boltdb/boltdb.go
+++ b/pkg/blobinfocache/boltdb/boltdb.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/containers/image/pkg/blobinfocache/internal/prioritize"
 	"github.com/containers/image/types"
+	bolt "github.com/etcd-io/bbolt"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 )

--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,6 @@ github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
 github.com/gorilla/mux 94e7d24fd285520f3d12ae998f7fdd6b5393d453
 github.com/imdario/mergo 50d4dbd4eb0e84778abe37cefef140271d96fade
-github.com/mattn/go-runewidth 14207d285c6c197daabb5c9793d63e7af9ab2d50
 github.com/mistifyio/go-zfs c0224de804d438efd11ea6e52ada8014537d6062
 github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
@@ -43,7 +42,7 @@ github.com/syndtr/gocapability master
 github.com/Microsoft/go-winio ab35fc04b6365e8fcb18e6e9e41ea4a02b10b175
 github.com/Microsoft/hcsshim eca7177590cdcbd25bbc5df27e3b693a54b53a6a
 github.com/ulikunitz/xz v0.5.4
-github.com/boltdb/bolt master
+github.com/etcd-io/bbolt v1.3.2
 github.com/klauspost/pgzip v1.2.1
 github.com/klauspost/compress v1.4.1
 github.com/klauspost/cpuid v1.2.0


### PR DESCRIPTION
github.com/boltdb/bolt is no longer maintained.

Fixes: #560
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>