### PR TITLE
Mirror documentation changes

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -29,44 +29,16 @@ type dockerImageSource struct {
 	cachedManifestMIMEType string // Only valid if cachedManifest != nil
 }
 
-// newImageSource creates a new `ImageSource` for the specified image reference
-// `ref`.
-//
-// The following steps will be done during the instance creation:
-//
-// - Lookup the registry within the configured location in
-//   `sys.SystemRegistriesConfPath`. If there is no configured registry available,
-//   we fallback to the provided docker reference `ref`.
-//
-// - References which contain a configured prefix will be automatically rewritten
-//   to the correct target reference. For example, if the configured
-//   `prefix = "example.com/foo"`, `location = "example.com"` and the image will be
-//   pulled from the ref `example.com/foo/image`, then the resulting pull will
-//   effectively point to `example.com/image`.
-//
-// - If the rewritten reference succeeds, it will be used as the `dockerRef`
-//   in the client. If the rewrite fails, the function immediately returns an error.
-//
-// - Each mirror will be used (in the configured order) to test the
-//   availability of the image manifest on the remote location. For example,
-//   if the manifest is not reachable due to connectivity issues, then the next
-//   mirror will be tested instead. If no mirror is configured or contains the
-//   target manifest, then the initial `ref` will be tested as fallback. The
-//   creation of the new `dockerImageSource` only succeeds if a remote
-//   location with the available manifest was found.
-//
-// A cleanup call to `.Close()` is needed if the caller is done using the returned
-// `ImageSource`.
+// newImageSource creates a new ImageSource for the specified image reference.
+// The caller must call .Close() on the returned ImageSource.
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
 	registry, err := sysregistriesv2.FindRegistry(sys, ref.ref.Name())
 	if err != nil {
 		return nil, errors.Wrapf(err, "error loading registries configuration")
 	}
-
 	if registry == nil {
-		// No configuration was found for the provided reference, so we create
-		// a fallback registry by hand to make the client creation below work
-		// as intended.
+		// No configuration was found for the provided reference, so use the
+		// equivalent of a default configuration.
 		registry = &sysregistriesv2.Registry{
 			Endpoint: sysregistriesv2.Endpoint{
 				Location: ref.ref.String(),
@@ -76,9 +48,11 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 
 	primaryDomain := reference.Domain(ref.ref)
-	// Found the registry within the sysregistriesv2 configuration. Now we test
-	// all endpoints for the manifest availability. If a working image source
-	// was found, it will be used for all future pull actions.
+	// Check all endpoints for the manifest availability. If we find one that does
+	// contain the image, it will be used for all future pull actions.  Always try the
+	// non-mirror original location last; this both transparently handles the case
+	// of no mirrors configured, and ensures we return the error encountered when
+	// acessing the upstream location if all endpoints fail.
 	manifestLoadErr := errors.New("Internal error: newImageSource returned without trying any endpoint")
 	pullSources, err := registry.PullSourcesFromReference(ref.ref)
 	if err != nil {

--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -18,68 +18,127 @@ VERSION 2 is the latest format of the `registries.conf` and is currently in
 beta. This means in general VERSION 1 should be used in production environments
 for now.
 
-Every registry can have its own mirrors configured.  The mirrors will be tested
-in order for the availability of the remote manifest.  This happens currently
-only during an image pull.  If the manifest is not reachable due to connectivity
-issues or the unavailability of the remote manifest, then the next mirror will
-be tested instead.  If no mirror is configured or contains the manifest to be
-pulled, then the initially provided reference will be used as fallback.  It is
-possible to set the `insecure` option per mirror, too.
+### GLOBAL SETTINGS
 
-Furthermore it is possible to specify a `prefix` for a registry.  The `prefix`
-is used to find the relevant target registry from where the image has to be
-pulled.  During the test for the availability of the image, the prefixed
-location will be rewritten to the correct remote location.  This applies to
-mirrors as well as the fallback `location`.  If no prefix is specified, it
-defaults to the specified `location`.  For example, if
-`prefix = "example.com/foo"`, `location = "example.com"` and the image will be
-pulled from `example.com/foo/image`, then the resulting pull will be effectively
-point to `example.com/image`.
+`unqualified-search-registries`
+: An array of _host_[`:`_port_] registries to try when pulling an unqualified image, in order.
 
-By default container runtimes use TLS when retrieving images from a registry.
-If the registry is not setup with TLS, then the container runtime will fail to
-pull images from the registry. If you set `insecure = true` for a registry or a
-mirror you overwrite the `insecure` flag for that specific entry.  This means
-that the container runtime will attempt use unencrypted HTTP to pull the image.
-It also allows you to pull from a registry with self-signed certificates.
+### NAMESPACED `[[registry]]` SETTINGS
 
-If `blocked = true` then it is not allowed to pull images from that registry.
+The bulk of the configuration is represented as an array of `[[registry]]`
+TOML tables; the settings may therefore differ among different registries
+as well as among different namespaces/repositories within a registry.
 
-If `mirror-by-digest-only = true`, mirrors will only be used during pulling if
-the image is referred to by digest.  Referencing an image by digest enforces to
-always return the same image, independent if it is being pulled from the main
-registry or a mirror.  Pulling an image referenced by tag could yield different
-results, depending on which mirror or registry it is being pulled from.  Setting
-this attribute makes sure to avoid such a situation but requires the primary
-registry to always be available if references by tag are used.
+#### Choosing a `[[registry]]` TOML table
 
-In addition, at the top level, an `unqualified-search-registries` array can be
-specified; this is a list of host[:port] (not more general prefix!) entries to
-use when pulling an unqualified image, in order.
+Given an image name, a single `[[registry]]` TOML table is chosen based on its `prefix` field.
+
+`prefix`
+: A prefix of the user-specified image name, i.e. using one of the following formats:
+    - _host_[`:`_port_]
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_(`:`_tag|`@`_digest_)
+
+    The user-specified image name must start with the specified `prefix` (and continue
+    with the appropriate separator) for a particular `[[registry]]` TOML table to be
+    considered; (only) the TOML table with the longest match is used.
+
+    As a special case, the `prefix` field can be missing; if so, it defaults to the value
+    of the `location` field (described below).
+
+#### Per-namespace settings
+
+`insecure`
+: `true` or `false`.
+    By default, container runtimes require TLS when retrieving images from a registry.
+    If `insecure` is set to `true`, unencrypted HTTP as well as TLS connections with untrusted
+    certificates are allowed.
+
+`blocked`
+: `true` or `false`.
+    If `true`, pulling images with matching names is forbidden.
+
+#### Remapping and mirroring registries
+
+The user-specified image reference is, primarily, a "logical" image name, always used for naming
+the image.  By default, the image reference also directly specifies the registry and repository
+to use, but the following options can be used to redirect the underlying accesses
+to different registry servers or locations (e.g. to support configurations with no access to the
+internet without having to change `Dockerfile`s, or to add redundancy).
+
+`location`
+: Accepts the same format as the `prefix` field, and specifies the physical location
+    of the `prefix`-rooted namespace.
+
+    By default, this equal to `prefix` (in which case `prefix` can be omitted and the
+    `[[registry]]` TOML table can only specify `location`).
+
+    Example: Given
+    ```
+    prefix = "example.com/foo"
+    location = "internal-registry-for-example.net/bar"
+    ```
+    requests for the image `example.com/foo/myimage:latest` will actually work with the
+    `internal-registry-for-example.net/bar/myimage:latest` image.
+
+`mirror`
+: An array of TOML tables specifiying (possibly-partial) mirrors for the
+    `prefix`-rooted namespace.
+
+    The mirrors are attempted in the specified order; the first one that can be
+    contacted and contains the image will be used (and if none of the mirrors contains the image,
+    the primary location specified by the `registry.location` field, or using the unmodified
+    user-specified reference, is tried last).
+
+    Each TOML table in the `mirror` array can contain the following fields, with the same semantics
+    as if specified in the `[[registry]]` TOML table directly:
+    - `location`
+    - `insecure`
+
+`mirror-by-digest-only`
+: `true` or `false`.
+    If `true`, mirrors will only be used during pulling if the image reference includes a digest.
+    Referencing an image by digest ensures that the same is always used
+    (whereas referencing an image by a tag may cause different registries to return
+    different images if the tag mapping is out of sync).
+
+    Note that if this is `true`, images referenced by a tag will only use the primary
+    registry, failing if that registry is not accessible.
+
+*Note*: Redirection and mirrors are currently processed only when reading images, not when pushing
+to a registry; that may change in the future.
 
 ### EXAMPLE
 
 ```
+unqualified-search-registries = ["example.com"]
+
 [[registry]]
-location = "example.com"
-insecure = false
 prefix = "example.com/foo"
-unqualified-search = false
+insecure = false
 blocked = false
+location = "internal-registry-for-example.com/bar"
 
 [[registry.mirror]]
-location = "example-mirror-0.local"
+location = "example-mirror-0.local/mirror-for-foo"
 
 [[registry.mirror]]
-location = "example-mirror-1.local"
+location = "example-mirror-1.local/mirrors/foo"
 insecure = true
 ```
+Given the above, a pull of `example.com/foo/image:latest` will try:
+    1. `example-mirror-0.local/mirror-for-foo/image:latest`
+    2. `example-mirror-1.local/mirrors/foo/image:latest`
+    3. `internal-registry-for-example.net/bar/myimage:latest`
+
+in order, and use the first one that exists.
 
 ## VERSION 1
-VERSION 1 can be used as alternative to the VERSION 2, but it is not capable in
-using registry mirrors or a prefix.
+VERSION 1 can be used as alternative to the VERSION 2, but it does not support
+using registry mirrors, longest-prefix matches, or location rewriting.
 
-The TOML_format is used to build a simple list for registries under three
+The TOML format is used to build a simple list of registries under three
 categories: `registries.search`, `registries.insecure`, and `registries.block`.
 You can list multiple registries using a comma separated list.
 
@@ -87,11 +146,11 @@ Search registries are used when the caller of a container runtime does not fully
 container image that they want to execute.  These registries are prepended onto the front
 of the specified container image until the named image is found at a registry.
 
-Note insecure registries can be used for any registry, not just the registries listed
+Note that insecure registries can be used for any registry, not just the registries listed
 under search.
 
-The fields `registries.insecure` and `registries.block` work as like as the
-`insecure` and `blocked` from VERSION 2.
+The `registries.insecure` and `registries.block` lists have the same meaning as the
+`insecure` and `blocked` fields in VERSION 2.
 
 ### EXAMPLE
 The following example configuration defines two searchable registries, one

--- a/registries.conf
+++ b/registries.conf
@@ -29,36 +29,54 @@ registries = []
 # The second version of the configuration format allows to specify registry
 # mirrors:
 #
-# # A list of host[:port] (not more general prefix!) entries to use when pulling an unqualified image, in order.
+# # An array of host[:port] registries to try when pulling an unqualified image, in order.
 # unqualified-search-registries = ["example.com"]
 #
 # [[registry]]
-# # The main location of the registry
-# location = "example.com"
-#
-# # If true, certs verification will be skipped and HTTP (non-TLS) connections
-# # will be allowed.
-# insecure = false
-#
-# # Prefix is used for matching images, and to translate one namespace to
-# # another.  If `prefix = "example.com/foo"`, `location = "example.com"` and
-# # we pull from "example.com/foo/myimage:latest", the image will effectively be
-# # pulled from "example.com/myimage:latest".  If no Prefix is specified,
-# # it defaults to the specified `location`. When a prefix is used, then a pull
-# # without specifying the prefix is not possible any more.
+# # The "prefix" field is used to choose the relevant [[registry]] TOML table;
+# # (only) the TOML table with the longest match for the input image name
+# # (taking into account namespace/repo/tag/digest separators) is used.
+# #
+# # If the prefix field is missing, it defaults to be the same as the "location" field.
 # prefix = "example.com/foo"
 #
-# # If true, pulling from the registry will be blocked.
+# # If true, unencrypted HTTP as well as TLS connections with untrusted
+# # certificates are allowed.
+# insecure = false
+#
+# # If true, pulling images with matching names is forbidden.
 # blocked = false
 #
-# # All available mirrors of the registry.  The mirrors will be evaluated in
-# # order during an image pull.  Furthermore it is possible to specify the
-# # `insecure` flag per registry mirror, too.
-# mirror = [
-#     { location = "example-mirror-0.local", insecure = false },
-#     { location = "example-mirror-1.local", insecure = true },
-#     # It is also possible to specify an additional path within the `location`.
-#     # A pull to `example.com/foo/image:latest` will then result in
-#     # `example-mirror-2.local/path/image:latest`.
-#     { location = "example-mirror-2.local/path" },
-# ]
+# # The physical location of the "prefix"-rooted namespace.
+# #
+# # By default, this equal to "prefix" (in which case "prefix" can be omitted
+# # and the [[registry]] TOML table can only specify "location").
+# #
+# # Example: Given
+# #   prefix = "example.com/foo"
+# #   location = "internal-registry-for-example.net/bar"
+# # requests for the image example.com/foo/myimage:latest will actually work with the
+# # internal-registry-for-example.net/bar/myimage:latest image.
+# location = internal-registry-for-example.com/bar"
+#
+# # (Possibly-partial) mirrors for the "prefix"-rooted namespace.
+# #
+# # The mirrors are attempted in the specified order; the first one that can be
+# # contacted and contains the image will be used (and if none of the mirrors contains the image,
+# # the primary location specified by the "registry.location" field, or using the unmodified
+# # user-specified reference, is tried last).
+# #
+# # Each TOML table in the "mirror" array can contain the following fields, with the same semantics
+# # as if specified in the [[registry]] TOML table directly:
+# # - location
+# # - insecure
+# [[registry.mirror]]
+# location = "example-mirror-0.local/mirror-for-foo"
+# [[registry.mirror]]
+# location = "example-mirror-1.local/mirrors/foo"
+# insecure = true
+# # Given the above, a pull of example.com/foo/image:latest will try:
+# # 1. example-mirror-0.local/mirror-for-foo/image:latest
+# # 2. example-mirror-1.local/mirrors/foo/image:latest
+# # 3. internal-registry-for-example.net/bar/myimage:latest
+# # in order, and use the first one that exists.


### PR DESCRIPTION
This follows up on #564 ; see the individual commit messages for details, I can drop any part you don’t like.

Notable parts:
- This drops most of the big comment before `newImageSource`. @vrothberg you asked for that documentation, or more documentation; is this OK with you?
- The documentation has been rewritten to hopefully make more sense to a first-time reader (notably it starts with the “prefix” value and how it is used to find the relevant entry), but I’m still not really happy with how it turned out. Maybe we should use a bulleted/definition list. Or maybe it’s because I’m not all that familiar with TOML and I struggle with the terminology. Either way, comments and suggestions (including “drop that, the original was better”) are very welcome.

Cc: @vrothberg @saschagrunert 