### PR TITLE
Makefile: don't assume that GOBIN in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,15 @@ tools.timestamp: Makefile
 	@touch tools.timestamp
 
 vendor: tools.timestamp vendor.conf
-	@trash
+	@if which trash > /dev/null ; then \
+		trash ; \
+	else \
+		if [ "$(GOBIN)" ] ; then \
+			$(GOBIN)/trash ; \
+		else \
+			$(GOPATH)/bin/trash ; \
+		fi ; \
+	fi
 	@touch vendor
 
 clean:


### PR DESCRIPTION
The execution of 'trash' in the 'vendor' target of the 'Makefile'
assumes that GOBIN is part of PATH and therefore 'trash' can be called
directly. This commit enables executing 'trash' if neither GOBIN nor
GOPATH/bin are in PATH.

Closes #620

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>