### PR TITLE
Add comment DockerAuthConfig

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -401,6 +401,7 @@ type ImageInspectInfo struct {
 }
 
 // DockerAuthConfig contains authorization information for connecting to a registry.
+// the value of Username and Password can be empty for accessing the registry anonymously
 type DockerAuthConfig struct {
 	Username string
 	Password string


### PR DESCRIPTION
Add comment for DockerAuthConfig. In SystemContext, the fileds value of DockerAuthConfig can be empty.

Related PR [#646](https://github.com/containers/skopeo/pull/646)

Signed-off-by: Qi Wang <qiwan@redhat.com>