### PR TITLE
pkg/docker/config/config_test: Stabilize "normalize registry" test

### DIFF
--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -151,10 +151,10 @@ func TestGetAuth(t *testing.T) {
 			},
 			{
 				name:             "normalize registry",
-				hostname:         "https://docker.io/v1",
+				hostname:         "https://example.org/v1",
 				path:             filepath.Join("testdata", "full.json"),
-				expectedUsername: "docker",
-				expectedPassword: "io",
+				expectedUsername: "example",
+				expectedPassword: "org",
 			},
 			{
 				name:             "match localhost",


### PR DESCRIPTION
In 1c0fb51d9b (#593), I changed the test data for this test from:

```go
makeTestAuthConfig(testAuthConfigDataMap{
  "docker.io":      testAuthConfigData{"user", "pw"},
  "localhost:5000": testAuthConfigData{"joe", "pass"},
})
```

to the `full.json` fixture which includes:

```json
{
  "auths": {
    "example.org": {
      "auth": "ZXhhbXBsZTpvcmc="
    },
    "index.docker.io": {
      "auth": "aW5kZXg6ZG9ja2VyLmlv"
    },
    "docker.io": {
      "auth": "ZG9ja2VyOmlv"
    },
    ...
  }
}
```

That lead ordering instability matching the normalized `docker.io`, with it occasionally matching the expected `docker.io` entry, and occasionally matching the `index.docker.io` entry.  With this commit, I'm adjusting the hostname to be based on `example.org` to avoid such ambiguity in target matching while still excercising all the normalization logic that was being excercised before 1c0fb51d9b.