### PR TITLE
.travis.Dockerfile: use ubuntu:18.04

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:18.04
 
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev


### PR DESCRIPTION
Use the latest stable version of Ubuntu, since Ubuntu 17.10 (i.e.,
ArtfulAardvark) hit EOL.

Fixes: https://github.com/containers/skopeo/issues/648
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>