### PR TITLE
Add API function `TryUpdatingCache`

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -338,11 +338,24 @@ func getConfig(ctx *types.SystemContext) (*V2RegistriesConf, error) {
 	configPath := ConfigPath(ctx)
 
 	configMutex.Lock()
-	defer configMutex.Unlock()
 	// if the config has already been loaded, return the cached registries
 	if config, inCache := configCache[configPath]; inCache {
+		configMutex.Unlock()
 		return config, nil
 	}
+	configMutex.Unlock()
+
+	return TryUpdatingCache(ctx)
+}
+
+// TryUpdatingCache loads the configuration from the provided `SystemContext`
+// without using the internal cache. On success, the loaded configuration will
+// be added into the internal registry cache.
+func TryUpdatingCache(ctx *types.SystemContext) (*V2RegistriesConf, error) {
+	configPath := ConfigPath(ctx)
+
+	configMutex.Lock()
+	defer configMutex.Unlock()
 
 	// load the config
 	config, err := loadRegistryConf(configPath)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -445,3 +445,22 @@ func TestPullSourcesFromReference(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(pullSources))
 }
+
+func TestTryUpdatingCache(t *testing.T) {
+	ctx := &types.SystemContext{
+		SystemRegistriesConfPath: "testdata/try-update-cache-valid.conf",
+	}
+	configCache = make(map[string]*V2RegistriesConf)
+	registries, err := TryUpdatingCache(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(registries.Registries))
+	assert.Equal(t, 1, len(configCache))
+
+	ctxInvalid := &types.SystemContext{
+		SystemRegistriesConfPath: "testdata/try-update-cache-invalid.conf",
+	}
+	registries, err = TryUpdatingCache(ctxInvalid)
+	assert.NotNil(t, err)
+	assert.Nil(t, registries)
+	assert.Equal(t, 1, len(configCache))
+}

--- a/pkg/sysregistriesv2/testdata/try-update-cache-invalid.conf
+++ b/pkg/sysregistriesv2/testdata/try-update-cache-invalid.conf
@@ -1,0 +1,1 @@
+invalid

--- a/pkg/sysregistriesv2/testdata/try-update-cache-valid.conf
+++ b/pkg/sysregistriesv2/testdata/try-update-cache-valid.conf
@@ -1,0 +1,2 @@
+[[registry]]
+location = "registry.com"


### PR DESCRIPTION
The function can be used to reload the registries without harming the
cache on failure. On success, the cache will be updated as intended.
This function can be reused by the current `GetRegistries` API.