### PR TITLE
Add TransportFromImageName procedure

### DIFF
--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -22,6 +22,7 @@ import (
 
 // ParseImageName converts a URL-like image name to a types.ImageReference.
 func ParseImageName(imgName string) (types.ImageReference, error) {
+	// Keep this in sync with TransportFromImageName!
 	parts := strings.SplitN(imgName, ":", 2)
 	if len(parts) != 2 {
 		return nil, errors.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
@@ -31,4 +32,15 @@ func ParseImageName(imgName string) (types.ImageReference, error) {
 		return nil, errors.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
 	}
 	return transport.ParseReference(parts[1])
+}
+
+// TransportFromImageName converts an URL-like name to a types.ImageTransport or nil when
+// the transport is unknown or when the input is invalid.
+func TransportFromImageName(imageName string) types.ImageTransport {
+	// Keep this in sync with ParseImageName!
+	parts := strings.SplitN(imageName, ":", 2)
+	if len(parts) == 2 {
+		return transports.Get(parts[0])
+	}
+	return nil
 }

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -3,6 +3,7 @@ package alltransports
 import (
 	"testing"
 
+	"github.com/containers/image/directory"
 	"github.com/containers/image/transports"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,13 @@ func TestImageNameHandling(t *testing.T) {
 		transport := transports.Get(c)
 		assert.NotNil(t, transport, c)
 	}
+}
+
+func TestTransportFromImageName(t *testing.T) {
+	dirTransport := TransportFromImageName("dir:/tmp/test")
+	assert.Equal(t, dirTransport.Name(), directory.Transport.Name())
+	unknownTransport := TransportFromImageName("unknown:ref:test")
+	assert.Equal(t, unknownTransport, nil)
+	invalidName := TransportFromImageName("unknown")
+	assert.Equal(t, invalidName, nil)
 }


### PR DESCRIPTION
This change adds a new transports.TransportFromImageName procedure
to get the transport's name of an image without parsing the store
reference.