### PR TITLE
Reimplement sysregistries by calling sysregistriesv2

### DIFF
--- a/pkg/sysregistries/system_registries.go
+++ b/pkg/sysregistries/system_registries.go
@@ -1,12 +1,12 @@
 package sysregistries
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/image/types"
-	"io/ioutil"
-	"path/filepath"
 )
 
 // systemRegistriesConfPath is the path to the system-wide registry configuration file
@@ -39,21 +39,12 @@ func normalizeRegistries(regs *registries) {
 	}
 }
 
-// Reads the global registry file from the filesystem. Returns
-// a byte array
-func readRegistryConf(sys *types.SystemContext) ([]byte, error) {
-	return ioutil.ReadFile(RegistriesConfPath(sys))
-}
-
-// For mocking in unittests
-var readConf = readRegistryConf
-
 // Loads the registry configuration file from the filesystem and
 // then unmarshals it.  Returns the unmarshalled object.
 func loadRegistryConf(sys *types.SystemContext) (*tomlConfig, error) {
 	config := &tomlConfig{}
 
-	configBytes, err := readConf(sys)
+	configBytes, err := ioutil.ReadFile(RegistriesConfPath(sys))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -26,49 +26,39 @@ func TestGetRegistriesWithBlankData(t *testing.T) {
 
 func TestGetRegistriesWithData(t *testing.T) {
 	answer := []string{"one.com"}
-	testConfig = []byte(`[registries.search]
-registries= ['one.com']
-`)
-	registriesConfig, err := GetRegistries(nil)
+	testConfig = nil
+	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, registriesConfig, answer)
 }
 
 func TestGetRegistriesWithBadData(t *testing.T) {
-	testConfig = []byte(`registries:
-    - one.com
-    ,`)
-	_, err := GetRegistries(nil)
+	testConfig = nil
+	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search-invalid.conf"})
 	assert.Error(t, err)
 }
 
 func TestGetRegistriesWithTrailingSlash(t *testing.T) {
 	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com", "three-slashes.com:5000"}
-	testConfig = []byte(`[registries.search]
-	registries= ['no-slash.com:5000/path', 'one-slash.com', 'two-slashes.com//', 'three-slashes.com:5000///']
-`)
+	testConfig = nil
 	// note: only one trailing gets removed
-	registriesConfig, err := GetRegistries(nil)
+	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search-no-trailing-slash.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, registriesConfig, answer)
 }
 
 func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
 	answer := []string(nil)
-	testConfig = []byte("")
-	insecureRegistriesConfig, err := GetInsecureRegistries(nil)
+	testConfig = nil
+	insecureRegistriesConfig, err := GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, insecureRegistriesConfig, answer)
 }
 
 func TestGetInsecureRegistriesWithData(t *testing.T) {
 	answer := []string{"two.com", "three.com"}
-	testConfig = []byte(`[registries.search]
-registries = ['one.com']
-[registries.insecure]
-registries = ['two.com', 'three.com']
-`)
-	insecureRegistriesConfig, err := GetInsecureRegistries(nil)
+	testConfig = nil
+	insecureRegistriesConfig, err := GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/insecure.conf"})
 	if err != nil {
 		t.Fail()
 	}

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -1,22 +1,26 @@
 package sysregistries
 
 import (
+	"testing"
+
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var testConfig = []byte("")
 
 func init() {
-	readConf = func(_ *types.SystemContext) ([]byte, error) {
-		return testConfig, nil
+	readConf = func(sys *types.SystemContext) ([]byte, error) {
+		if testConfig != nil {
+			return testConfig, nil
+		}
+		return readRegistryConf(sys)
 	}
 }
 
 func TestGetRegistriesWithBlankData(t *testing.T) {
-	testConfig = []byte("")
-	registriesConfig, _ := GetRegistries(nil)
+	testConfig = nil
+	registriesConfig, _ := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
 	assert.Nil(t, registriesConfig)
 }
 

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestGetRegistriesWithBlankData(t *testing.T) {
-	registriesConfig, _ := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
-	assert.Nil(t, registriesConfig)
+	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
+	assert.NoError(t, err)
+	assert.Empty(t, registriesConfig)
 }
 
 func TestGetRegistriesWithData(t *testing.T) {
@@ -25,7 +26,7 @@ func TestGetRegistriesWithBadData(t *testing.T) {
 }
 
 func TestGetRegistriesWithTrailingSlash(t *testing.T) {
-	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com", "three-slashes.com:5000"}
+	answer := []string{"no-slash.com:5000", "one-slash.com", "two-slashes.com", "three-slashes.com:5000"}
 	// note: only one trailing gets removed
 	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search-no-trailing-slash.conf"})
 	assert.Nil(t, err)

--- a/pkg/sysregistries/system_registries_test.go
+++ b/pkg/sysregistries/system_registries_test.go
@@ -7,40 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testConfig = []byte("")
-
-func init() {
-	readConf = func(sys *types.SystemContext) ([]byte, error) {
-		if testConfig != nil {
-			return testConfig, nil
-		}
-		return readRegistryConf(sys)
-	}
-}
-
 func TestGetRegistriesWithBlankData(t *testing.T) {
-	testConfig = nil
 	registriesConfig, _ := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
 	assert.Nil(t, registriesConfig)
 }
 
 func TestGetRegistriesWithData(t *testing.T) {
 	answer := []string{"one.com"}
-	testConfig = nil
 	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, registriesConfig, answer)
 }
 
 func TestGetRegistriesWithBadData(t *testing.T) {
-	testConfig = nil
 	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search-invalid.conf"})
 	assert.Error(t, err)
 }
 
 func TestGetRegistriesWithTrailingSlash(t *testing.T) {
 	answer := []string{"no-slash.com:5000/path", "one-slash.com", "two-slashes.com", "three-slashes.com:5000"}
-	testConfig = nil
 	// note: only one trailing gets removed
 	registriesConfig, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search-no-trailing-slash.conf"})
 	assert.Nil(t, err)
@@ -49,7 +34,6 @@ func TestGetRegistriesWithTrailingSlash(t *testing.T) {
 
 func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
 	answer := []string(nil)
-	testConfig = nil
 	insecureRegistriesConfig, err := GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/search.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, insecureRegistriesConfig, answer)
@@ -57,7 +41,6 @@ func TestGetInsecureRegistriesWithBlankData(t *testing.T) {
 
 func TestGetInsecureRegistriesWithData(t *testing.T) {
 	answer := []string{"two.com", "three.com"}
-	testConfig = nil
 	insecureRegistriesConfig, err := GetInsecureRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/insecure.conf"})
 	if err != nil {
 		t.Fail()

--- a/pkg/sysregistries/testdata/insecure.conf
+++ b/pkg/sysregistries/testdata/insecure.conf
@@ -1,0 +1,4 @@
+[registries.search]
+registries = ['one.com']
+[registries.insecure]
+registries = ['two.com', 'three.com']

--- a/pkg/sysregistries/testdata/search-invalid.conf
+++ b/pkg/sysregistries/testdata/search-invalid.conf
@@ -1,0 +1,3 @@
+registries:
+    - one.com
+    ,

--- a/pkg/sysregistries/testdata/search-no-trailing-slash.conf
+++ b/pkg/sysregistries/testdata/search-no-trailing-slash.conf
@@ -1,2 +1,2 @@
 [registries.search]
-	registries= ['no-slash.com:5000/path', 'one-slash.com', 'two-slashes.com//', 'three-slashes.com:5000///']
+	registries= ['no-slash.com:5000', 'one-slash.com/', 'two-slashes.com//', 'three-slashes.com:5000///']

--- a/pkg/sysregistries/testdata/search-no-trailing-slash.conf
+++ b/pkg/sysregistries/testdata/search-no-trailing-slash.conf
@@ -1,0 +1,2 @@
+[registries.search]
+	registries= ['no-slash.com:5000/path', 'one-slash.com', 'two-slashes.com//', 'three-slashes.com:5000///']

--- a/pkg/sysregistries/testdata/search.conf
+++ b/pkg/sysregistries/testdata/search.conf
@@ -1,0 +1,2 @@
+[registries.search]
+registries= ['one.com']


### PR DESCRIPTION
Eliminate the old `sysregistries` implementation, call v2 instead (which handles both the v1 and v2 format). This is almost, but not quite, a prerequisite to changing the v2 format to specify search registries explicitly.
    
RFC (AKA “tell me I’m being too lazy and this should have been fixed already”)
- `sysregistries.RegistriesConfPath` continues to exist independently, because `sysregistriesv2` doesn't expose this.  I don't quite like making this value public (it tempts callers to do their own parsing), but it seems valuable enough for error reporting and the like. So, now v1 has an independent implementation that is likely to grow out of sync.  We probably need to make the v2 implementation public, and then call it from here.
- `sysregistries.GetInsecureRegistries` can now return v2 host[:port]/[ns/...]repo values, in addition to the v1 host[:port] values. Looking at existing CRI-O and podman uses, this seems more useful, but strictly speaking this breaks the API.  Alternatively, we could filter out the values here, and port the callers to use v2 directly.

The bulk of the PR is actually modifying the tests in both packages to use ordinary files instead of hooking into the internals of the config parsers (so that we can rip out the internals in v1). See individual commit messages for details.