### PR TITLE
Registries v2 explicit search

### DIFF
--- a/docker/reference/README.md
+++ b/docker/reference/README.md
@@ -1,2 +1,2 @@
-This is a copy of github.com/docker/distribution/reference as of commit fb0bebc4b64e3881cc52a2478d749845ed76d2a8,
+This is a copy of github.com/docker/distribution/reference as of commit 3226863cbcba6dbc2f6c83a37b28126c934af3f8,
 except that ParseAnyReferenceWithSet has been removed to drop the dependency on github.com/docker/distribution/digestset.

--- a/docker/reference/normalize.go
+++ b/docker/reference/normalize.go
@@ -55,6 +55,35 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	return named, nil
 }
 
+// ParseDockerRef normalizes the image reference following the docker convention. This is added
+// mainly for backward compatibility.
+// The reference returned can only be either tagged or digested. For reference contains both tag
+// and digest, the function returns digested reference, e.g. docker.io/library/busybox:latest@
+// sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa will be returned as
+// docker.io/library/busybox@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa.
+func ParseDockerRef(ref string) (Named, error) {
+	named, err := ParseNormalizedNamed(ref)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := named.(NamedTagged); ok {
+		if canonical, ok := named.(Canonical); ok {
+			// The reference is both tagged and digested, only
+			// return digested.
+			newNamed, err := WithName(canonical.Name())
+			if err != nil {
+				return nil, err
+			}
+			newCanonical, err := WithDigest(newNamed, canonical.Digest())
+			if err != nil {
+				return nil, err
+			}
+			return newCanonical, nil
+		}
+	}
+	return TagNameOnly(named), nil
+}
+
 // splitDockerDomain splits a repository name to domain and remotename string.
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.

--- a/docker/reference/normalize_test.go
+++ b/docker/reference/normalize_test.go
@@ -571,3 +571,83 @@ func TestMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDockerRef(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "nothing",
+			input:    "busybox",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "tag only",
+			input:    "busybox:latest",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "digest only",
+			input:    "busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			expected: "docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		},
+		{
+			name:     "path only",
+			input:    "library/busybox",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "hostname only",
+			input:    "docker.io/busybox",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "no tag",
+			input:    "docker.io/library/busybox",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "no path",
+			input:    "docker.io/busybox:latest",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "no hostname",
+			input:    "library/busybox:latest",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "full reference with tag",
+			input:    "docker.io/library/busybox:latest",
+			expected: "docker.io/library/busybox:latest",
+		},
+		{
+			name:     "gcr reference without tag",
+			input:    "gcr.io/library/busybox",
+			expected: "gcr.io/library/busybox:latest",
+		},
+		{
+			name:     "both tag and digest",
+			input:    "gcr.io/library/busybox:latest@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			expected: "gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			normalized, err := ParseDockerRef(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			output := normalized.String()
+			if output != test.expected {
+				t.Fatalf("expected %q to be parsed as %v, got %v", test.input, test.expected, output)
+			}
+			_, err = Parse(output)
+			if err != nil {
+				t.Fatalf("%q should be a valid reference, but got an error: %v", output, err)
+			}
+		})
+	}
+}

--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -15,7 +15,7 @@
 //	tag                             := /[\w][\w.-]{0,127}/
 //
 //	digest                          := digest-algorithm ":" digest-hex
-//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
 //	digest-algorithm-separator      := /[+.-_]/
 //	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
 //	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
@@ -205,7 +205,7 @@ func Parse(s string) (Reference, error) {
 	var repo repository
 
 	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
-	if nameMatch != nil && len(nameMatch) == 3 {
+	if len(nameMatch) == 3 {
 		repo.domain = nameMatch[1]
 		repo.path = nameMatch[2]
 	} else {

--- a/docker/reference/regexp.go
+++ b/docker/reference/regexp.go
@@ -20,15 +20,15 @@ var (
 		optional(repeated(separatorRegexp, alphaNumericRegexp)))
 
 	// domainComponentRegexp restricts the registry domain component of a
-	// repository name to start with a component as defined by domainRegexp
+	// repository name to start with a component as defined by DomainRegexp
 	// and followed by an optional port.
 	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
-	// domainRegexp defines the structure of potential domain components
+	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names.
-	domainRegexp = expression(
+	DomainRegexp = expression(
 		domainComponentRegexp,
 		optional(repeated(literal(`.`), domainComponentRegexp)),
 		optional(literal(`:`), match(`[0-9]+`)))
@@ -51,14 +51,14 @@ var (
 	// regexp has capturing groups for the domain and name part omitting
 	// the separating forward slash from either.
 	NameRegexp = expression(
-		optional(domainRegexp, literal(`/`)),
+		optional(DomainRegexp, literal(`/`)),
 		nameComponentRegexp,
 		optional(repeated(literal(`/`), nameComponentRegexp)))
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
 	anchoredNameRegexp = anchored(
-		optional(capture(domainRegexp), literal(`/`)),
+		optional(capture(DomainRegexp), literal(`/`)),
 		capture(nameComponentRegexp,
 			optional(repeated(literal(`/`), nameComponentRegexp))))
 

--- a/docker/reference/regexp_test.go
+++ b/docker/reference/regexp_test.go
@@ -116,7 +116,7 @@ func TestDomainRegexp(t *testing.T) {
 			match: true,
 		},
 	}
-	r := regexp.MustCompile(`^` + domainRegexp.String() + `$`)
+	r := regexp.MustCompile(`^` + DomainRegexp.String() + `$`)
 	for i := range hostcases {
 		checkRegexp(t, r, hostcases[i])
 	}

--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -43,10 +43,6 @@ mirror you overwrite the `insecure` flag for that specific entry.  This means
 that the container runtime will attempt use unencrypted HTTP to pull the image.
 It also allows you to pull from a registry with self-signed certificates.
 
-If you set the `unqualified-search = true` for the registry, then it is possible
-to omit the registry hostname when pulling images.  This feature does not work
-together with a specified `prefix`.
-
 If `blocked = true` then it is not allowed to pull images from that registry.
 
 If `mirror-by-digest-only = true`, mirrors will only be used during pulling if
@@ -56,6 +52,10 @@ registry or a mirror.  Pulling an image referenced by tag could yield different
 results, depending on which mirror or registry it is being pulled from.  Setting
 this attribute makes sure to avoid such a situation but requires the primary
 registry to always be available if references by tag are used.
+
+In addition, at the top level, an `unqualified-search-registries` array can be
+specified; this is a list of host[:port] (not more general prefix!) entries to
+use when pulling an unqualified image, in order.
 
 ### EXAMPLE
 

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -308,7 +308,7 @@ var configMutex = sync.Mutex{}
 // configCache caches already loaded configs with config paths as keys and is
 // used to avoid redudantly parsing configs. Concurrent accesses to the cache
 // are synchronized via configMutex.
-var configCache = make(map[string][]Registry)
+var configCache = make(map[string]*V2RegistriesConf)
 
 // InvalidateCache invalidates the registry cache.  This function is meant to be
 // used for long-running processes that need to reload potential changes made to
@@ -316,7 +316,7 @@ var configCache = make(map[string][]Registry)
 func InvalidateCache() {
 	configMutex.Lock()
 	defer configMutex.Unlock()
-	configCache = make(map[string][]Registry)
+	configCache = make(map[string]*V2RegistriesConf)
 }
 
 // GetRegistries loads and returns the registries specified in the config.
@@ -328,8 +328,8 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	configMutex.Lock()
 	defer configMutex.Unlock()
 	// if the config has already been loaded, return the cached registries
-	if registries, inCache := configCache[configPath]; inCache {
-		return registries, nil
+	if config, inCache := configCache[configPath]; inCache {
+		return config.Registries, nil
 	}
 
 	// load the config
@@ -365,7 +365,7 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	}
 
 	// populate the cache
-	configCache[configPath] = registries
+	configCache[configPath] = &V2RegistriesConf{Registries: registries}
 
 	return registries, err
 }

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -384,18 +384,18 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	return config.Registries, nil
 }
 
-// FindUnqualifiedSearchRegistries returns all registries that are configured
-// for unqualified image search (i.e., with Registry.Search == true).
-func FindUnqualifiedSearchRegistries(ctx *types.SystemContext) ([]Registry, error) {
+// UnqualifiedSearchRegistries returns a list of host[:port] entries to try
+// for unqualified image search, in the returned order)
+func UnqualifiedSearchRegistries(ctx *types.SystemContext) ([]string, error) {
 	config, err := getConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	unqualified := []Registry{}
+	unqualified := []string{}
 	for _, reg := range config.Registries {
 		if reg.Search {
-			unqualified = append(unqualified, reg)
+			unqualified = append(unqualified, reg.Prefix)
 		}
 	}
 	return unqualified, nil

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -122,11 +122,20 @@ type V1TOMLConfig struct {
 	Block    V1TOMLregistries `toml:"block"`
 }
 
+// V1RegistriesConf is the sysregistries v1 configuration format.
+type V1RegistriesConf struct {
+	V1TOMLConfig `toml:"registries"`
+}
+
+// V2RegistriesConf is the sysregistries v2 configuration format.
+type V2RegistriesConf struct {
+	Registries []Registry `toml:"registry"`
+}
+
 // tomlConfig is the data type used to unmarshal the toml config.
 type tomlConfig struct {
-	Registries []Registry `toml:"registry"`
-	// backwards compatability to sysregistries v1
-	V1TOMLConfig `toml:"registries"`
+	V2RegistriesConf
+	V1RegistriesConf // for backwards compatibility with sysregistries v1
 }
 
 // InvalidRegistries represents an invalid registry configurations.  An example

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -266,7 +266,7 @@ insecure = true`), 0600)
 
 	ctx := &types.SystemContext{SystemRegistriesConfPath: configFile.Name()}
 
-	configCache = make(map[string][]Registry)
+	configCache = make(map[string]*V2RegistriesConf)
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -283,7 +283,7 @@ insecure = true`), 0600)
 func TestInvalidateCache(t *testing.T) {
 	ctx := &types.SystemContext{SystemRegistriesConfPath: "testdata/invalidate-cache.conf"}
 
-	configCache = make(map[string][]Registry)
+	configCache = make(map[string]*V2RegistriesConf)
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -360,7 +360,6 @@ func TestRewriteReferenceFailedDuringParseNamed(t *testing.T) {
 
 func TestPullSourcesFromReference(t *testing.T) {
 	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/pull-sources-from-reference.conf"}
-	configCache = make(map[string][]Registry)
 	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(registries))

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -184,6 +184,9 @@ func TestFindUnqualifiedSearchRegistries(t *testing.T) {
 	unqRegs, err := UnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
+
+	_, err = UnqualifiedSearchRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/invalid-search.conf"})
+	assert.Error(t, err)
 }
 
 func TestInsecureConflicts(t *testing.T) {

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -165,7 +165,7 @@ func TestFindRegistry(t *testing.T) {
 	assert.Equal(t, "empty-prefix.com", reg.Location)
 }
 
-func assertSearchRegistryLocationsEqual(t *testing.T, expected []string, regs []Registry) {
+func assertRegistryLocationsEqual(t *testing.T, expected []string, regs []Registry) {
 	// verify the expected registries and their order
 	names := []string{}
 	for _, r := range regs {
@@ -181,9 +181,9 @@ func TestFindUnqualifiedSearchRegistries(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 
-	unqRegs, err := FindUnqualifiedSearchRegistries(sys)
+	unqRegs, err := UnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
-	assertSearchRegistryLocationsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
+	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 }
 
 func TestInsecureConflicts(t *testing.T) {
@@ -213,9 +213,9 @@ func TestV1BackwardsCompatibility(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(registries))
 
-	unqRegs, err := FindUnqualifiedSearchRegistries(sys)
+	unqRegs, err := UnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
-	assertSearchRegistryLocationsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
+	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 
 	// check if merging works
 	reg, err := FindRegistry(sys, "registry-a.com/bar/foo/barfoo:latest")
@@ -287,7 +287,7 @@ func TestInvalidateCache(t *testing.T) {
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
-	assertSearchRegistryLocationsEqual(t, []string{"registry.com", "blocked.registry.com", "insecure.registry.com", "untrusted.registry.com"}, registries)
+	assertRegistryLocationsEqual(t, []string{"registry.com", "blocked.registry.com", "insecure.registry.com", "untrusted.registry.com"}, registries)
 
 	// invalidate the cache, make sure it's empty and reload
 	InvalidateCache()
@@ -296,7 +296,7 @@ func TestInvalidateCache(t *testing.T) {
 	registries, err = GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
-	assertSearchRegistryLocationsEqual(t, []string{"registry.com", "blocked.registry.com", "insecure.registry.com", "untrusted.registry.com"}, registries)
+	assertRegistryLocationsEqual(t, []string{"registry.com", "blocked.registry.com", "insecure.registry.com", "untrusted.registry.com"}, registries)
 }
 
 func toNamedRef(t *testing.T, ref string) reference.Named {

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -48,6 +48,14 @@ func TestEmptyConfig(t *testing.T) {
 	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(registries))
+
+	// When SystemRegistriesConfPath is not explicitly specified (but RootForImplicitAbsolutePaths might be), missing file is treated
+	// the same as an empty one, without reporting an error.
+	nonexistentRoot, err := filepath.Abs("testdata/this-does-not-exist")
+	require.NoError(t, err)
+	registries, err = GetRegistries(&types.SystemContext{RootForImplicitAbsolutePaths: nonexistentRoot})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(registries))
 }
 
 func TestMirrors(t *testing.T) {
@@ -221,6 +229,7 @@ func TestInvalidV2Configs(t *testing.T) {
 		{"testdata/missing-registry-location.conf", "invalid location"},
 		{"testdata/missing-mirror-location.conf", "invalid location"},
 		{"testdata/invalid-prefix.conf", "invalid location"},
+		{"testdata/this-does-not-exist.conf", "no such file or directory"},
 	} {
 		_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: c.path})
 		assert.Error(t, err, c.path)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -183,6 +183,7 @@ func TestInvalidV2Configs(t *testing.T) {
 		{"testdata/blocked-conflicts.conf", "registry 'registry.com' is defined multiple times with conflicting 'blocked' setting"},
 		{"testdata/missing-registry-location.conf", "invalid location"},
 		{"testdata/missing-mirror-location.conf", "invalid location"},
+		{"testdata/invalid-prefix.conf", "invalid location"},
 	} {
 		_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: c.path})
 		assert.Error(t, err, c.path)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -196,6 +196,9 @@ func TestFindRegistry(t *testing.T) {
 	assert.NotNil(t, reg)
 	assert.Equal(t, "empty-prefix.com", reg.Prefix)
 	assert.Equal(t, "empty-prefix.com", reg.Location)
+
+	_, err = FindRegistry(&types.SystemContext{SystemRegistriesConfPath: "testdata/this-does-not-exist.conf"}, "example.com")
+	assert.Error(t, err)
 }
 
 func assertRegistryLocationsEqual(t *testing.T, expected []string, regs []Registry) {

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -226,6 +226,11 @@ func TestV1BackwardsCompatibility(t *testing.T) {
 	assert.NotNil(t, reg)
 	assert.True(t, reg.Insecure)
 	assert.True(t, reg.Blocked)
+
+	for _, c := range []string{"testdata/v1-invalid-block.conf", "testdata/v1-invalid-insecure.conf", "testdata/v1-invalid-search.conf"} {
+		_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: c})
+		assert.Error(t, err, c)
+	}
 }
 
 func TestMixingV1andV2(t *testing.T) {

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -211,19 +211,18 @@ func TestV1BackwardsCompatibility(t *testing.T) {
 
 	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
-	assert.Equal(t, 5, len(registries))
+	assert.Equal(t, 4, len(registries))
 
 	unqRegs, err := UnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 
 	// check if merging works
-	reg, err := FindRegistry(sys, "registry-a.com/bar/foo/barfoo:latest")
+	reg, err := FindRegistry(sys, "registry-b.com/bar/foo/barfoo:latest")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
-	assert.True(t, reg.Search)
 	assert.True(t, reg.Insecure)
-	assert.False(t, reg.Blocked)
+	assert.True(t, reg.Blocked)
 }
 
 func TestMixingV1andV2(t *testing.T) {

--- a/pkg/sysregistriesv2/testdata/invalid-prefix.conf
+++ b/pkg/sysregistriesv2/testdata/invalid-prefix.conf
@@ -1,0 +1,18 @@
+[[registry]]
+location = "registry.com:5000"
+prefix = "http://schema-is-invalid.com"
+
+[[registry]]
+location = "another-registry.com:5000"
+prefix = "complex-prefix.com:4000/with/path"
+
+[[registry]]
+location = "registry.com:5000"
+prefix = "another-registry.com"
+
+[[registry]]
+location = "no-prefix.com"
+
+[[registry]]
+location = "empty-prefix.com"
+prefix = ""

--- a/pkg/sysregistriesv2/testdata/invalid-search.conf
+++ b/pkg/sysregistriesv2/testdata/invalid-search.conf
@@ -1,0 +1,1 @@
+unqualified-search-registries = ["registry-a.com/namespace-is-forbidden"]

--- a/pkg/sysregistriesv2/testdata/missing-mirror-location.conf
+++ b/pkg/sysregistriesv2/testdata/missing-mirror-location.conf
@@ -1,6 +1,7 @@
+unqualified-search-registries = ["registry-a.com"]
+
 [[registry]]
 location = "registry-a.com"
-unqualified-search = true
 
 [[registry]]
 location = "registry-b.com"

--- a/pkg/sysregistriesv2/testdata/missing-registry-location.conf
+++ b/pkg/sysregistriesv2/testdata/missing-registry-location.conf
@@ -1,9 +1,9 @@
+unqualified-search-registries = ["registry-a.com"]
+
 [[registry]]
 location = "registry-a.com"
-unqualified-search = true
 
 [[registry]]
 location = "registry-b.com"
 
 [[registry]]
-unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/mixing-v1-v2.conf
+++ b/pkg/sysregistriesv2/testdata/mixing-v1-v2.conf
@@ -1,3 +1,5 @@
+unqualified-search-registries = ["registry-a.com", "registry-c.com"]
+
 [registries.search]
 registries = ["registry-a.com", "registry-c.com"]
 
@@ -9,11 +11,9 @@ registries = ["registry-d.com", "registry-e.com", "registry-a.com"]
 
 [[registry]]
 location = "registry-a.com"
-unqualified-search = true
 
 [[registry]]
 location = "registry-b.com"
 
 [[registry]]
 location = "registry-c.com"
-unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/unqualified-search.conf
+++ b/pkg/sysregistriesv2/testdata/unqualified-search.conf
@@ -1,14 +1,13 @@
+unqualified-search-registries = ["registry-a.com", "registry-c.com", "registry-d.com"]
+
 [[registry]]
 location = "registry-a.com"
-unqualified-search = true
 
 [[registry]]
 location = "registry-b.com"
 
 [[registry]]
 location = "registry-c.com"
-unqualified-search = true
 
 [[registry]]
 location = "registry-d.com"
-unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/v1-compatibility.conf
+++ b/pkg/sysregistriesv2/testdata/v1-compatibility.conf
@@ -5,4 +5,4 @@ registries = ["registry-a.com////", "registry-c.com", "registry-d.com"]
 registries = ["registry-b.com"]
 
 [registries.insecure]
-registries = ["registry-d.com", "registry-e.com", "registry-a.com"]
+registries = ["registry-b.com////", "registry-d.com", "registry-e.com", "registry-a.com"]

--- a/pkg/sysregistriesv2/testdata/v1-invalid-block.conf
+++ b/pkg/sysregistriesv2/testdata/v1-invalid-block.conf
@@ -1,0 +1,8 @@
+[registries.search]
+registries = ["registry-a.com////", "registry-c.com", "registry-d.com", "http://schema-is-invalid.com"]
+
+[registries.block]
+registries = ["registry-b.com", "http://schema-is-invalid.com"]
+
+[registries.insecure]
+registries = ["registry-b.com////", "registry-d.com", "registry-e.com", "registry-a.com"]

--- a/pkg/sysregistriesv2/testdata/v1-invalid-insecure.conf
+++ b/pkg/sysregistriesv2/testdata/v1-invalid-insecure.conf
@@ -1,0 +1,8 @@
+[registries.search]
+registries = ["registry-a.com////", "registry-c.com", "registry-d.com"]
+
+[registries.block]
+registries = ["registry-b.com"]
+
+[registries.insecure]
+registries = ["registry-b.com////", "registry-d.com", "registry-e.com", "registry-a.com", "http://schema-is-invalid.com"]

--- a/pkg/sysregistriesv2/testdata/v1-invalid-search.conf
+++ b/pkg/sysregistriesv2/testdata/v1-invalid-search.conf
@@ -1,0 +1,8 @@
+[registries.search]
+registries = ["registry-a.com////", "registry-c.com", "registry-d.com", "http://schema-is-invalid.com"]
+
+[registries.block]
+registries = ["registry-b.com"]
+
+[registries.insecure]
+registries = ["registry-b.com////", "registry-d.com", "registry-e.com", "registry-a.com"]

--- a/registries.conf
+++ b/registries.conf
@@ -29,6 +29,9 @@ registries = []
 # The second version of the configuration format allows to specify registry
 # mirrors:
 #
+# # A list of host[:port] (not more general prefix!) entries to use when pulling an unqualified image, in order.
+# unqualified-search-registries = ["example.com"]
+#
 # [[registry]]
 # # The main location of the registry
 # location = "example.com"
@@ -44,10 +47,6 @@ registries = []
 # # it defaults to the specified `location`. When a prefix is used, then a pull
 # # without specifying the prefix is not possible any more.
 # prefix = "example.com/foo"
-#
-# # If true, the registry can be used when pulling an unqualified image. If a
-# # prefix is specified, unqualified pull is not possible any more.
-# unqualified-search = false
 #
 # # If true, pulling from the registry will be blocked.
 # blocked = false


### PR DESCRIPTION
This primarily modifies the v2 format to use a top-level `unqualified-search-registries` array instead of an `unqualified-search` boolean in each of the per-prefix (which is not per-registry) entry.

In addition:
- `V1RegistriesConf` and `V2RegistriesConf` are now explicitly public types, with a `Nonempty` method
- There is a public `V1RegistriesConf.ConvertToV2`, to allow callers to _persistently_ upgrade a v1 config (e.g. to add a v2-only property to it, notably the mirror configuration).

<s>Do not merge as is: This currently includes #636.</s>