### PR TITLE
Sysregistriesv2 test fixtures

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -393,21 +393,12 @@ func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
 	return nil, nil
 }
 
-// Reads the global registry file from the filesystem. Returns a byte array.
-func readRegistryConf(configPath string) ([]byte, error) {
-	configBytes, err := ioutil.ReadFile(configPath)
-	return configBytes, err
-}
-
-// Used in unittests to parse custom configs without a types.SystemContext.
-var readConf = readRegistryConf
-
 // Loads the registry configuration file from the filesystem and then unmarshals
 // it.  Returns the unmarshalled object.
 func loadRegistryConf(configPath string) (*tomlConfig, error) {
 	config := &tomlConfig{}
 
-	configBytes, err := readConf(configPath)
+	configBytes, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -13,17 +13,6 @@ import (
 	"github.com/containers/image/docker/reference"
 )
 
-var testConfig = []byte("")
-
-func init() {
-	readConf = func(configPath string) ([]byte, error) {
-		if testConfig == nil {
-			return readRegistryConf(configPath)
-		}
-		return testConfig, nil
-	}
-}
-
 func TestParseLocation(t *testing.T) {
 	var err error
 	var location string
@@ -55,14 +44,12 @@ func TestParseLocation(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
-	testConfig = nil
 	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(registries))
 }
 
 func TestMirrors(t *testing.T) {
-	testConfig = nil
 	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/mirrors.conf"}
 
 	registries, err := GetRegistries(sys)
@@ -80,14 +67,12 @@ func TestMirrors(t *testing.T) {
 }
 
 func TestMissingRegistryLocation(t *testing.T) {
-	testConfig = nil
 	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/missing-registry-location.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid location")
 }
 
 func TestMissingMirrorLocation(t *testing.T) {
-	testConfig = nil
 	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/missing-mirror-location.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid location")
@@ -134,7 +119,6 @@ func TestRefMatchesPrefix(t *testing.T) {
 }
 
 func TestFindRegistry(t *testing.T) {
-	testConfig = nil
 	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/find-registry.conf"}
 
 	registries, err := GetRegistries(sys)
@@ -191,7 +175,6 @@ func assertSearchRegistryLocationsEqual(t *testing.T, expected []string, regs []
 }
 
 func TestFindUnqualifiedSearchRegistries(t *testing.T) {
-	testConfig = nil
 	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/unqualified-search.conf"}
 
 	registries, err := GetRegistries(sys)
@@ -204,7 +187,6 @@ func TestFindUnqualifiedSearchRegistries(t *testing.T) {
 }
 
 func TestInsecureConflicts(t *testing.T) {
-	testConfig = nil
 	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/insecure-conflicts.conf"})
 	assert.NotNil(t, err)
 	assert.Nil(t, registries)
@@ -212,7 +194,6 @@ func TestInsecureConflicts(t *testing.T) {
 }
 
 func TestBlockConflicts(t *testing.T) {
-	testConfig = nil
 	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/blocked-conflicts.conf"})
 	assert.NotNil(t, err)
 	assert.Nil(t, registries)
@@ -220,14 +201,12 @@ func TestBlockConflicts(t *testing.T) {
 }
 
 func TestUnmarshalConfig(t *testing.T) {
-	testConfig = nil
 	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/unmarshal.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 }
 
 func TestV1BackwardsCompatibility(t *testing.T) {
-	testConfig = nil
 	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/v1-compatibility.conf"}
 
 	registries, err := GetRegistries(sys)
@@ -248,15 +227,12 @@ func TestV1BackwardsCompatibility(t *testing.T) {
 }
 
 func TestMixingV1andV2(t *testing.T) {
-	testConfig = nil
 	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/mixing-v1-v2.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "mixing sysregistry v1/v2 is not supported")
 }
 
 func TestConfigCache(t *testing.T) {
-	testConfig = nil
-
 	configFile, err := ioutil.TempFile("", "sysregistriesv2-test")
 	require.NoError(t, err)
 	defer os.Remove(configFile.Name())
@@ -305,7 +281,6 @@ insecure = true`), 0600)
 }
 
 func TestInvalidateCache(t *testing.T) {
-	testConfig = nil
 	ctx := &types.SystemContext{SystemRegistriesConfPath: "testdata/invalidate-cache.conf"}
 
 	configCache = make(map[string][]Registry)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -14,7 +14,10 @@ import (
 var testConfig = []byte("")
 
 func init() {
-	readConf = func(_ string) ([]byte, error) {
+	readConf = func(configPath string) ([]byte, error) {
+		if testConfig == nil {
+			return readRegistryConf(configPath)
+		}
 		return testConfig, nil
 	}
 }
@@ -50,10 +53,8 @@ func TestParseLocation(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
-	testConfig = []byte(``)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	testConfig = nil
+	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/empty.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(registries))
 }

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -2,6 +2,8 @@ package sysregistriesv2
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/containers/image/types"
@@ -60,27 +62,14 @@ func TestEmptyConfig(t *testing.T) {
 }
 
 func TestMirrors(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com"
+	testConfig = nil
+	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/mirrors.conf"}
 
-[[registry.mirror]]
-location = "mirror-1.registry.com"
-
-[[registry.mirror]]
-location = "mirror-2.registry.com"
-insecure = true
-
-[[registry]]
-location = "blocked.registry.com"
-blocked = true`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(registries))
 
-	reg, err := FindRegistry(nil, "registry.com/image:tag")
+	reg, err := FindRegistry(sys, "registry.com/image:tag")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, 2, len(reg.Mirrors))
@@ -91,36 +80,15 @@ blocked = true`)
 }
 
 func TestMissingRegistryLocation(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry-a.com"
-unqualified-search = true
-
-[[registry]]
-location = "registry-b.com"
-
-[[registry]]
-unqualified-search = true`)
-	configCache = make(map[string][]Registry)
-	_, err := GetRegistries(nil)
+	testConfig = nil
+	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/missing-registry-location.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid location")
 }
 
 func TestMissingMirrorLocation(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry-a.com"
-unqualified-search = true
-
-[[registry]]
-location = "registry-b.com"
-[[registry.mirror]]
-location = "mirror-b.com"
-[[registry.mirror]]
-`)
-	configCache = make(map[string][]Registry)
-	_, err := GetRegistries(nil)
+	testConfig = nil
+	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/missing-mirror-location.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid location")
 }
@@ -166,65 +134,47 @@ func TestRefMatchesPrefix(t *testing.T) {
 }
 
 func TestFindRegistry(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com:5000"
-prefix = "simple-prefix.com"
+	testConfig = nil
+	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/find-registry.conf"}
 
-[[registry]]
-location = "another-registry.com:5000"
-prefix = "complex-prefix.com:4000/with/path"
-
-[[registry]]
-location = "registry.com:5000"
-prefix = "another-registry.com"
-
-[[registry]]
-location = "no-prefix.com"
-
-[[registry]]
-location = "empty-prefix.com"
-prefix = ""`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(registries))
 
-	reg, err := FindRegistry(nil, "simple-prefix.com/foo/bar:latest")
+	reg, err := FindRegistry(sys, "simple-prefix.com/foo/bar:latest")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "simple-prefix.com", reg.Prefix)
 	assert.Equal(t, reg.Location, "registry.com:5000")
 
 	// path match
-	reg, err = FindRegistry(nil, "simple-prefix.com/")
+	reg, err = FindRegistry(sys, "simple-prefix.com/")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 
 	// hostname match
-	reg, err = FindRegistry(nil, "simple-prefix.com")
+	reg, err = FindRegistry(sys, "simple-prefix.com")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 
 	// invalid match
-	reg, err = FindRegistry(nil, "simple-prefix.comx")
+	reg, err = FindRegistry(sys, "simple-prefix.comx")
 	assert.Nil(t, err)
 	assert.Nil(t, reg)
 
-	reg, err = FindRegistry(nil, "complex-prefix.com:4000/with/path/and/beyond:tag")
+	reg, err = FindRegistry(sys, "complex-prefix.com:4000/with/path/and/beyond:tag")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "complex-prefix.com:4000/with/path", reg.Prefix)
 	assert.Equal(t, "another-registry.com:5000", reg.Location)
 
-	reg, err = FindRegistry(nil, "no-prefix.com/foo:tag")
+	reg, err = FindRegistry(sys, "no-prefix.com/foo:tag")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "no-prefix.com", reg.Prefix)
 	assert.Equal(t, "no-prefix.com", reg.Location)
 
-	reg, err = FindRegistry(nil, "empty-prefix.com/foo:tag")
+	reg, err = FindRegistry(sys, "empty-prefix.com/foo:tag")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.Equal(t, "empty-prefix.com", reg.Prefix)
@@ -241,135 +191,55 @@ func assertSearchRegistryLocationsEqual(t *testing.T, expected []string, regs []
 }
 
 func TestFindUnqualifiedSearchRegistries(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry-a.com"
-unqualified-search = true
+	testConfig = nil
+	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/unqualified-search.conf"}
 
-[[registry]]
-location = "registry-b.com"
-
-[[registry]]
-location = "registry-c.com"
-unqualified-search = true
-
-[[registry]]
-location = "registry-d.com"
-unqualified-search = true
-`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 
-	unqRegs, err := FindUnqualifiedSearchRegistries(nil)
+	unqRegs, err := FindUnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
 	assertSearchRegistryLocationsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 }
 
-func TestInsecureConfligs(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com"
-
-[[registry.mirror]]
-location = "mirror-1.registry.com"
-
-[[registry.mirror]]
-location = "mirror-2.registry.com"
-
-
-[[registry]]
-location = "registry.com"
-insecure = true
-`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+func TestInsecureConflicts(t *testing.T) {
+	testConfig = nil
+	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/insecure-conflicts.conf"})
 	assert.NotNil(t, err)
 	assert.Nil(t, registries)
 	assert.Contains(t, err.Error(), "registry 'registry.com' is defined multiple times with conflicting 'insecure' setting")
 }
 
-func TestBlockConfligs(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com"
-
-[[registry.mirror]]
-location = "mirror-1.registry.com"
-
-[[registry.mirror]]
-location = "mirror-2.registry.com"
-
-
-[[registry]]
-location = "registry.com"
-blocked = true
-`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+func TestBlockConflicts(t *testing.T) {
+	testConfig = nil
+	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/blocked-conflicts.conf"})
 	assert.NotNil(t, err)
 	assert.Nil(t, registries)
 	assert.Contains(t, err.Error(), "registry 'registry.com' is defined multiple times with conflicting 'blocked' setting")
 }
 
 func TestUnmarshalConfig(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com"
-
-[[registry.mirror]]
-location = "mirror-1.registry.com"
-
-[[registry.mirror]]
-location = "mirror-2.registry.com"
-
-
-[[registry]]
-location = "blocked.registry.com"
-blocked = true
-
-
-[[registry]]
-location = "insecure.registry.com"
-insecure = true
-
-
-[[registry]]
-location = "untrusted.registry.com"
-insecure = true`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	testConfig = nil
+	registries, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/unmarshal.conf"})
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 }
 
 func TestV1BackwardsCompatibility(t *testing.T) {
-	testConfig = []byte(`
-[registries.search]
-registries = ["registry-a.com////", "registry-c.com", "registry-d.com"]
+	testConfig = nil
+	sys := &types.SystemContext{SystemRegistriesConfPath: "testdata/v1-compatibility.conf"}
 
-[registries.block]
-registries = ["registry-b.com"]
-
-[registries.insecure]
-registries = ["registry-d.com", "registry-e.com", "registry-a.com"]`)
-
-	configCache = make(map[string][]Registry)
-	registries, err := GetRegistries(nil)
+	registries, err := GetRegistries(sys)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(registries))
 
-	unqRegs, err := FindUnqualifiedSearchRegistries(nil)
+	unqRegs, err := FindUnqualifiedSearchRegistries(sys)
 	assert.Nil(t, err)
 	assertSearchRegistryLocationsEqual(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, unqRegs)
 
 	// check if merging works
-	reg, err := FindRegistry(nil, "registry-a.com/bar/foo/barfoo:latest")
+	reg, err := FindRegistry(sys, "registry-a.com/bar/foo/barfoo:latest")
 	assert.Nil(t, err)
 	assert.NotNil(t, reg)
 	assert.True(t, reg.Search)
@@ -378,35 +248,21 @@ registries = ["registry-d.com", "registry-e.com", "registry-a.com"]`)
 }
 
 func TestMixingV1andV2(t *testing.T) {
-	testConfig = []byte(`
-[registries.search]
-registries = ["registry-a.com", "registry-c.com"]
-
-[registries.block]
-registries = ["registry-b.com"]
-
-[registries.insecure]
-registries = ["registry-d.com", "registry-e.com", "registry-a.com"]
-
-[[registry]]
-location = "registry-a.com"
-unqualified-search = true
-
-[[registry]]
-location = "registry-b.com"
-
-[[registry]]
-location = "registry-c.com"
-unqualified-search = true `)
-
-	configCache = make(map[string][]Registry)
-	_, err := GetRegistries(nil)
+	testConfig = nil
+	_, err := GetRegistries(&types.SystemContext{SystemRegistriesConfPath: "testdata/mixing-v1-v2.conf"})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "mixing sysregistry v1/v2 is not supported")
 }
 
 func TestConfigCache(t *testing.T) {
-	testConfig = []byte(`
+	testConfig = nil
+
+	configFile, err := ioutil.TempFile("", "sysregistriesv2-test")
+	require.NoError(t, err)
+	defer os.Remove(configFile.Name())
+	defer configFile.Close()
+
+	err = ioutil.WriteFile(configFile.Name(), []byte(`
 [[registry]]
 location = "registry.com"
 
@@ -429,9 +285,10 @@ insecure = true
 
 [[registry]]
 location = "untrusted.registry.com"
-insecure = true`)
+insecure = true`), 0600)
+	require.NoError(t, err)
 
-	ctx := &types.SystemContext{SystemRegistriesConfPath: "foo"}
+	ctx := &types.SystemContext{SystemRegistriesConfPath: configFile.Name()}
 
 	configCache = make(map[string][]Registry)
 	registries, err := GetRegistries(ctx)
@@ -440,39 +297,16 @@ insecure = true`)
 
 	// empty the config, but use the same SystemContext to show that the
 	// previously specified registries are in the cache
-	testConfig = []byte("")
+	err = ioutil.WriteFile(configFile.Name(), []byte{}, 0600)
+	require.NoError(t, err)
 	registries, err = GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
 }
 
 func TestInvalidateCache(t *testing.T) {
-	testConfig = []byte(`
-[[registry]]
-location = "registry.com"
-
-[[registry.mirror]]
-location = "mirror-1.registry.com"
-
-[[registry.mirror]]
-location = "mirror-2.registry.com"
-
-
-[[registry]]
-location = "blocked.registry.com"
-blocked = true
-
-
-[[registry]]
-location = "insecure.registry.com"
-insecure = true
-
-
-[[registry]]
-location = "untrusted.registry.com"
-insecure = true`)
-
-	ctx := &types.SystemContext{}
+	testConfig = nil
+	ctx := &types.SystemContext{SystemRegistriesConfPath: "testdata/invalidate-cache.conf"}
 
 	configCache = make(map[string][]Registry)
 	registries, err := GetRegistries(ctx)

--- a/pkg/sysregistriesv2/testdata/blocked-conflicts.conf
+++ b/pkg/sysregistriesv2/testdata/blocked-conflicts.conf
@@ -1,0 +1,13 @@
+[[registry]]
+location = "registry.com"
+
+[[registry.mirror]]
+location = "mirror-1.registry.com"
+
+[[registry.mirror]]
+location = "mirror-2.registry.com"
+
+
+[[registry]]
+location = "registry.com"
+blocked = true

--- a/pkg/sysregistriesv2/testdata/find-registry.conf
+++ b/pkg/sysregistriesv2/testdata/find-registry.conf
@@ -1,0 +1,18 @@
+[[registry]]
+location = "registry.com:5000"
+prefix = "simple-prefix.com"
+
+[[registry]]
+location = "another-registry.com:5000"
+prefix = "complex-prefix.com:4000/with/path"
+
+[[registry]]
+location = "registry.com:5000"
+prefix = "another-registry.com"
+
+[[registry]]
+location = "no-prefix.com"
+
+[[registry]]
+location = "empty-prefix.com"
+prefix = ""

--- a/pkg/sysregistriesv2/testdata/insecure-conflicts.conf
+++ b/pkg/sysregistriesv2/testdata/insecure-conflicts.conf
@@ -1,0 +1,13 @@
+[[registry]]
+location = "registry.com"
+
+[[registry.mirror]]
+location = "mirror-1.registry.com"
+
+[[registry.mirror]]
+location = "mirror-2.registry.com"
+
+
+[[registry]]
+location = "registry.com"
+insecure = true

--- a/pkg/sysregistriesv2/testdata/invalidate-cache.conf
+++ b/pkg/sysregistriesv2/testdata/invalidate-cache.conf
@@ -1,0 +1,23 @@
+[[registry]]
+location = "registry.com"
+
+[[registry.mirror]]
+location = "mirror-1.registry.com"
+
+[[registry.mirror]]
+location = "mirror-2.registry.com"
+
+
+[[registry]]
+location = "blocked.registry.com"
+blocked = true
+
+
+[[registry]]
+location = "insecure.registry.com"
+insecure = true
+
+
+[[registry]]
+location = "untrusted.registry.com"
+insecure = true

--- a/pkg/sysregistriesv2/testdata/mirrors.conf
+++ b/pkg/sysregistriesv2/testdata/mirrors.conf
@@ -1,0 +1,13 @@
+[[registry]]
+location = "registry.com"
+
+[[registry.mirror]]
+location = "mirror-1.registry.com"
+
+[[registry.mirror]]
+location = "mirror-2.registry.com"
+insecure = true
+
+[[registry]]
+location = "blocked.registry.com"
+blocked = true

--- a/pkg/sysregistriesv2/testdata/missing-mirror-location.conf
+++ b/pkg/sysregistriesv2/testdata/missing-mirror-location.conf
@@ -1,0 +1,9 @@
+[[registry]]
+location = "registry-a.com"
+unqualified-search = true
+
+[[registry]]
+location = "registry-b.com"
+[[registry.mirror]]
+location = "mirror-b.com"
+[[registry.mirror]]

--- a/pkg/sysregistriesv2/testdata/missing-registry-location.conf
+++ b/pkg/sysregistriesv2/testdata/missing-registry-location.conf
@@ -1,0 +1,9 @@
+[[registry]]
+location = "registry-a.com"
+unqualified-search = true
+
+[[registry]]
+location = "registry-b.com"
+
+[[registry]]
+unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/mixing-v1-v2.conf
+++ b/pkg/sysregistriesv2/testdata/mixing-v1-v2.conf
@@ -1,0 +1,19 @@
+[registries.search]
+registries = ["registry-a.com", "registry-c.com"]
+
+[registries.block]
+registries = ["registry-b.com"]
+
+[registries.insecure]
+registries = ["registry-d.com", "registry-e.com", "registry-a.com"]
+
+[[registry]]
+location = "registry-a.com"
+unqualified-search = true
+
+[[registry]]
+location = "registry-b.com"
+
+[[registry]]
+location = "registry-c.com"
+unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/unmarshal.conf
+++ b/pkg/sysregistriesv2/testdata/unmarshal.conf
@@ -1,0 +1,23 @@
+[[registry]]
+location = "registry.com"
+
+[[registry.mirror]]
+location = "mirror-1.registry.com"
+
+[[registry.mirror]]
+location = "mirror-2.registry.com"
+
+
+[[registry]]
+location = "blocked.registry.com"
+blocked = true
+
+
+[[registry]]
+location = "insecure.registry.com"
+insecure = true
+
+
+[[registry]]
+location = "untrusted.registry.com"
+insecure = true

--- a/pkg/sysregistriesv2/testdata/unqualified-search.conf
+++ b/pkg/sysregistriesv2/testdata/unqualified-search.conf
@@ -1,0 +1,14 @@
+[[registry]]
+location = "registry-a.com"
+unqualified-search = true
+
+[[registry]]
+location = "registry-b.com"
+
+[[registry]]
+location = "registry-c.com"
+unqualified-search = true
+
+[[registry]]
+location = "registry-d.com"
+unqualified-search = true

--- a/pkg/sysregistriesv2/testdata/v1-compatibility.conf
+++ b/pkg/sysregistriesv2/testdata/v1-compatibility.conf
@@ -1,0 +1,8 @@
+[registries.search]
+registries = ["registry-a.com////", "registry-c.com", "registry-d.com"]
+
+[registries.block]
+registries = ["registry-b.com"]
+
+[registries.insecure]
+registries = ["registry-d.com", "registry-e.com", "registry-a.com"]


### PR DESCRIPTION
This is a hopefully-noncontroversial subset of #633: Modify `sysregistriesv2` tests to use ordinary files instead of hooking into the internals of the config parsers.

See individual commit messages for details.