### PR TITLE
Beautify registries.conf TOML

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -30,10 +30,10 @@ const builtinRegistriesConfPath = "/etc/containers/registries.conf"
 // Endpoint describes a remote location of a registry.
 type Endpoint struct {
 	// The endpoint's remote location.
-	Location string `toml:"location"`
+	Location string `toml:"location,omitempty"`
 	// If true, certs verification will be skipped and HTTP (non-TLS)
 	// connections will be allowed.
-	Insecure bool `toml:"insecure"`
+	Insecure bool `toml:"insecure,omitempty"`
 }
 
 // rewriteReference will substitute the provided reference `prefix` to the
@@ -59,13 +59,13 @@ type Registry struct {
 	// A registry is an Endpoint too
 	Endpoint
 	// The registry's mirrors.
-	Mirrors []Endpoint `toml:"mirror"`
+	Mirrors []Endpoint `toml:"mirror,omitempty"`
 	// If true, pulling from the registry will be blocked.
-	Blocked bool `toml:"blocked"`
+	Blocked bool `toml:"blocked,omitempty"`
 	// If true, mirrors will only be used for digest pulls. Pulling images by
 	// tag can potentially yield different images, depending on which endpoint
 	// we pull from.  Forcing digest-pulls for mirrors avoids that issue.
-	MirrorByDigestOnly bool `toml:"mirror-by-digest-only"`
+	MirrorByDigestOnly bool `toml:"mirror-by-digest-only,omitempty"`
 	// Prefix is used for matching images, and to translate one namespace to
 	// another.  If `Prefix="example.com/bar"`, `location="example.com/foo/bar"`
 	// and we pull from "example.com/bar/myimage:latest", the image will

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -56,6 +56,12 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 
 // Registry represents a registry.
 type Registry struct {
+	// Prefix is used for matching images, and to translate one namespace to
+	// another.  If `Prefix="example.com/bar"`, `location="example.com/foo/bar"`
+	// and we pull from "example.com/bar/myimage:latest", the image will
+	// effectively be pulled from "example.com/foo/bar/myimage:latest".
+	// If no Prefix is specified, it defaults to the specified location.
+	Prefix string `toml:"prefix"`
 	// A registry is an Endpoint too
 	Endpoint
 	// The registry's mirrors.
@@ -66,12 +72,6 @@ type Registry struct {
 	// tag can potentially yield different images, depending on which endpoint
 	// we pull from.  Forcing digest-pulls for mirrors avoids that issue.
 	MirrorByDigestOnly bool `toml:"mirror-by-digest-only,omitempty"`
-	// Prefix is used for matching images, and to translate one namespace to
-	// another.  If `Prefix="example.com/bar"`, `location="example.com/foo/bar"`
-	// and we pull from "example.com/bar/myimage:latest", the image will
-	// effectively be pulled from "example.com/foo/bar/myimage:latest".
-	// If no Prefix is specified, it defaults to the specified location.
-	Prefix string `toml:"prefix"`
 }
 
 // PullSource consists of an Endpoint and a Reference. Note that the reference is


### PR DESCRIPTION
This tidies up the TOML generated by marshaling a `sysregistriesv2.V2RegistriesConf`:
- by skipping fields with the default value
- by making sure that the lookup key (`prefix`/`location`) is the first entry in a `registry`