### PR TITLE
Release 2.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -4,14 +4,14 @@ import "fmt"
 
 const (
 	// VersionMajor is for an API incompatible changes
-	VersionMajor = 1
+	VersionMajor = 2
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 7
+	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This is a major version bump because the API changes; while we will try to minimize API changes in the future, past experience shows that it is still extremely likely that they will be very frequent, unless the API is significantly restructured and/or large parts of it hidden or declared out of bounds.  Expect the major number to increase several times before this can settle.