### PR TITLE
Trivial c/image/docker cleanups

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -381,8 +381,6 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 
-	// When retrieving the digest from a registry >= 2.3 use the following header:
-	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
 	headers := make(map[string][]string)
 	headers["Accept"] = manifest.DefaultRequestedManifestMIMETypes
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -138,8 +138,9 @@ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *dig
 
 func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest string) ([]byte, string, error) {
 	path := fmt.Sprintf(manifestPath, reference.Path(s.ref.ref), tagOrDigest)
-	headers := make(map[string][]string)
-	headers["Accept"] = manifest.DefaultRequestedManifestMIMETypes
+	headers := map[string][]string{
+		"Accept": manifest.DefaultRequestedManifestMIMETypes,
+	}
 	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil, v2Auth, nil)
 	if err != nil {
 		return nil, "", err
@@ -381,9 +382,9 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 
-	headers := make(map[string][]string)
-	headers["Accept"] = manifest.DefaultRequestedManifestMIMETypes
-
+	headers := map[string][]string{
+		"Accept": manifest.DefaultRequestedManifestMIMETypes,
+	}
 	refTail, err := ref.tagOrDigest()
 	if err != nil {
 		return err


### PR DESCRIPTION
Primarily removes a no-longer-accurate comment; also uses a literal to hopefully be a bit more readable.