### PR TITLE
Add "Env" to ImageInspectInfo

### DIFF
--- a/image/docker_schema1_test.go
+++ b/image/docker_schema1_test.go
@@ -278,6 +278,14 @@ func TestManifestSchema1Inspect(t *testing.T) {
 				"sha256:62e48e39dc5b30b75a97f05bccc66efbae6058b860ee20a5c9a184b9d5e25788",
 				"sha256:e623934bca8d1a74f51014256445937714481e49343a31bda2bc5f534748184d",
 			},
+			Env: []string{
+				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"container=oci",
+				"KOLLA_BASE_DISTRO=rhel",
+				"KOLLA_INSTALL_TYPE=binary",
+				"KOLLA_INSTALL_METATYPE=rhos",
+				"PS1=$(tput bold)($(printenv KOLLA_SERVICE_NAME))$(tput sgr0)[$(id -un)@$(hostname -s) $(pwd)]$ ",
+			},
 		}, *ii)
 	}
 }

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -288,6 +288,14 @@ func TestManifestSchema2Inspect(t *testing.T) {
 			"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
 			"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
 		},
+		Env: []string{
+			"PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"HTTPD_PREFIX=/usr/local/apache2",
+			"HTTPD_VERSION=2.4.23",
+			"HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+			"HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-2.4.23.tar.bz2",
+			"HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc",
+		},
 	}, *ii)
 
 	// nil configBlob will trigger an error in m.ConfigBlob()

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -268,6 +268,14 @@ func TestManifestOCI1Inspect(t *testing.T) {
 			"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
 			"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
 		},
+		Env: []string{
+			"PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"HTTPD_PREFIX=/usr/local/apache2",
+			"HTTPD_VERSION=2.4.23",
+			"HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+			"HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-2.4.23.tar.bz2",
+			"HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc",
+		},
 	}, *ii)
 
 	// nil configBlob will trigger an error in m.ConfigBlob()

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -226,6 +226,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 	}
 	if s1.Config != nil {
 		i.Labels = s1.Config.Labels
+		i.Env = s1.Config.Env
 	}
 	return i, nil
 }

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -241,6 +241,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 	}
 	if s2.Config != nil {
 		i.Labels = s2.Config.Labels
+		i.Env = s2.Config.Env
 	}
 	return i, nil
 }

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -116,6 +116,7 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 		Architecture:  v1.Architecture,
 		Os:            v1.OS,
 		Layers:        layerInfosToStrings(m.LayerInfos()),
+		Env:           d1.Config.Env,
 	}
 	return i, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -398,6 +398,7 @@ type ImageInspectInfo struct {
 	Architecture  string
 	Os            string
 	Layers        []string
+	Env           []string
 }
 
 // DockerAuthConfig contains authorization information for connecting to a registry.


### PR DESCRIPTION
Adds the "Env" field in the image schema. Allow the library user
gets the "Env" value available in the image JSON data. Close #248

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>