### PR TITLE
Use docker client TLS config for getting bearer token

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -524,8 +524,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 	}
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.String())
 	tr := tlsclientconfig.NewTransport()
-	// TODO(runcom): insecure for now to contact the external token service
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	tr.TLSClientConfig = c.tlsClientConfig
 	client := &http.Client{Transport: tr}
 	res, err := client.Do(authReq)
 	if err != nil {


### PR DESCRIPTION
Fixes #654 

I also removed the `TODO` as we use the parameters value now which is set on the `dockerClient`s TLS config.
I don't know what runcom means or if this was forced to true, so I would be thankful for some explanations if I missed something there.
The fix is quite trivial as it is already done like this a few lines below:
https://github.com/containers/image/blob/master/docker/docker_client.go#L560
By looking at the blame it seems like this was just forgotten as the old line was 3 years old.

I tested logging in with podman, logging out and reusing an existing login from `docker`:
```
 vincent@vincent-pc  libpod   master ●  bin/podman logout docker-reg --log-level debug
INFO[0000] running as rootless                          
DEBU[0000] Looking for TLS certificates and private keys in /etc/containers/certs.d/docker-reg 
DEBU[0000]  crt: /etc/containers/certs.d/docker-reg/ca.crt 
DEBU[0000]  cert: /etc/containers/certs.d/docker-reg/client.cert 
DEBU[0000]  key: /etc/containers/certs.d/docker-reg/client.key 
DEBU[0000] GET https://docker-reg/v2/           
DEBU[0000] Ping https://docker-reg/v2/ status 401 
DEBU[0000] GET https://docker-reg/artifactory/api/docker/null/v2/token?service=docker-reg 
Not logged into docker-reg
 vincent@vincent-pc  libpod   master ●  bin/podman login docker-reg --log-level debug
INFO[0000] running as rootless                          
Username: uid
Password: 
DEBU[0004] Looking for TLS certificates and private keys in /etc/containers/certs.d/docker-reg 
DEBU[0004]  crt: /etc/containers/certs.d/docker-reg/ca.crt 
DEBU[0004]  cert: /etc/containers/certs.d/docker-reg/client.cert 
DEBU[0004]  key: /etc/containers/certs.d/docker-reg/client.key 
DEBU[0004] GET https://docker-reg/v2/           
DEBU[0004] Ping https://docker-reg/v2/ status 401 
DEBU[0004] GET https://docker-reg/artifactory/api/docker/null/v2/token?account=uid&service=docker-reg 
DEBU[0004] GET https://docker-reg/v2/           
Login Succeeded!
 vincent@vincent-pc  libpod   master ●  bin/podman logout docker-reg --log-level debug
INFO[0000] running as rootless                          
Removed login credentials for docker-reg
 vincent@vincent-pc  libpod   master ●  docker login docker-reg                  
Username: uid
Password: 
Error response from daemon: Get https://docker-reg/v2/: remote error: tls: handshake failure
 ✘ vincent@vincent-pc  libpod   master ●  docker login docker-reg
Username: uid
Password: 
WARNING! Your password will be stored unencrypted in /home/vincent/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
 vincent@vincent-pc  libpod   master ●  bin/podman login docker-reg --log-level debug 
INFO[0000] running as rootless                          
Authenticating with existing credentials...
DEBU[0000] Looking for TLS certificates and private keys in /etc/containers/certs.d/docker-reg 
DEBU[0000]  crt: /etc/containers/certs.d/docker-reg/ca.crt 
DEBU[0000]  cert: /etc/containers/certs.d/docker-reg/client.cert 
DEBU[0000]  key: /etc/containers/certs.d/docker-reg/client.key 
DEBU[0000] GET https://docker-reg/v2/           
DEBU[0000] Ping https://docker-reg/v2/ status 401 
DEBU[0000] GET https://docker-reg/artifactory/api/docker/null/v2/token?account=uid&service=docker-reg 
DEBU[0000] GET https://docker-reg/v2/           
Existing credentials are valid. Already logged in to docker-reg
```