### PR TITLE
progress bar: use spinners for -1 blob sizes

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -46,6 +46,6 @@ github.com/etcd-io/bbolt v1.3.2
 github.com/klauspost/pgzip v1.2.1
 github.com/klauspost/compress v1.4.1
 github.com/klauspost/cpuid v1.2.0
-github.com/vbauerster/mpb v3.3.4
+github.com/vbauerster/mpb v3.4.0
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1


### PR DESCRIPTION
Schema1 manifests don't include blob sizes causing the BlobInfo sizes to
be -1 and ultimately preventing the progress bars from displaying
meaningful data.  Use a spinner for such cases.  The spinner renders a
sequence of dots (".", "..", "...", "....", "").

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>