### PR TITLE
docker client: error if registry is blocked

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -254,6 +254,9 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		return nil, errors.Wrapf(err, "error loading registries")
 	}
 	if reg != nil {
+		if reg.Blocked {
+			return nil, fmt.Errorf("registry %s is blocked in %s", reg.Prefix, sysregistriesv2.ConfigPath(sys))
+		}
 		skipVerify = reg.Insecure
 	}
 	tlsClientConfig.InsecureSkipVerify = skipVerify

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -303,9 +303,8 @@ func (config *V2RegistriesConf) postProcess() error {
 	return nil
 }
 
-// getConfigPath returns the system-registries config path if specified.
-// Otherwise, systemRegistriesConfPath is returned.
-func getConfigPath(ctx *types.SystemContext) string {
+// ConfigPath returns the path to the system-wide registry configuration file.
+func ConfigPath(ctx *types.SystemContext) string {
 	confPath := systemRegistriesConfPath
 	if ctx != nil {
 		if ctx.SystemRegistriesConfPath != "" {
@@ -336,7 +335,7 @@ func InvalidateCache() {
 
 // getConfig returns the config object corresponding to ctx, loading it if it is not yet cached.
 func getConfig(ctx *types.SystemContext) (*V2RegistriesConf, error) {
-	configPath := getConfigPath(ctx)
+	configPath := ConfigPath(ctx)
 
 	configMutex.Lock()
 	defer configMutex.Unlock()

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -115,7 +115,7 @@ func TestRefMatchesPrefix(t *testing.T) {
 	}
 }
 
-func TestGetConfigPath(t *testing.T) {
+func TestConfigPath(t *testing.T) {
 	const nondefaultPath = "/this/is/not/the/default/registries.conf"
 	const variableReference = "$HOME"
 	const rootPrefix = "/root/prefix"
@@ -146,7 +146,7 @@ func TestGetConfigPath(t *testing.T) {
 		// No environment expansion happens in the overridden paths
 		{&types.SystemContext{SystemRegistriesConfPath: variableReference}, variableReference},
 	} {
-		path := getConfigPath(c.sys)
+		path := ConfigPath(c.sys)
 		assert.Equal(t, c.expected, path)
 	}
 }


### PR DESCRIPTION
Return an error whenever we attempt to create a docker client when the
underlying registry is configured to be blocked in the registries.conf.
Until now, users of the c/image library implemented this behaviour but
it has not been enforced.

Now, it's time to pull the trigger and enforce the configuration.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

---

Entirely untested. Just want to throw it at Skopeo and continue working on it later.