### PR TITLE
Release v2.0.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
The main motivation is to propagate the latest progress-bar fixes (i.e., using spinners for unknown blob sizes) and to ultimately close https://bugzilla.redhat.com/show_bug.cgi?id=1695236 once it's in Fedora.

@mtrmac @rhatdan PTAL