### PR TITLE
*: Fix policy.json.md -> containers-policy.json.5.md references

### DIFF
--- a/docs/containers-signature.5.md
+++ b/docs/containers-signature.5.md
@@ -48,7 +48,7 @@ newly added cryptographic signature formats, if necessary.)
 
 Consumers of container signatures SHOULD verify the cryptographic signature
 against one or more trusted public keys
-(e.g. defined in a [policy.json signature verification policy file](policy.json.md))
+(e.g. defined in a [policy.json signature verification policy file](containers-policy.json.5.md))
 before parsing or processing the JSON payload in _any_ way,
 in particular they SHOULD stop processing the container signature
 if the cryptographic signature verification fails, without even starting to process the JSON payload.
@@ -193,10 +193,10 @@ However, depending on the specific application, users or system administrators m
 (e.g. ignoring the tag value in the signature when pulling the `:latest` tag or when referencing an image by digest),
 or they may require `critical.identity.docker-reference` values with a completely different namespace to the reference used to refer to/download the image
 (e.g. requiring a `critical.identity.docker-reference` value which identifies the image as coming from a supplier when fetching it from a company-internal mirror of approved images).
-The software performing this verification SHOULD allow the users to define such a policy using the [policy.json signature verification policy file format](policy.json.md).
+The software performing this verification SHOULD allow the users to define such a policy using the [policy.json signature verification policy file format](containers-policy.json.5.md).
 
 The `critical.identity.docker-reference` value SHOULD contain either a tag or digest;
-in most cases, it SHOULD use a tag rather than a digest.  (See also the default [`matchRepoDigestOrExact` matching semantics in `policy.json`](policy.json.md#signedby).)
+in most cases, it SHOULD use a tag rather than a digest.  (See also the default [`matchRepoDigestOrExact` matching semantics in `policy.json`](containers-policy.json.5.md#signedby).)
 
 ### `optional`
 

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -6,7 +6,7 @@
 
 package signature
 
-// NOTE: Keep this in sync with docs/policy.json.md!
+// NOTE: Keep this in sync with docs/containers-policy.json.5.md!
 
 // Policy defines requirements for considering a signature, or an image, valid.
 type Policy struct {

--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	// register all known transports
-	// NOTE: Make sure docs/policy.json.md is updated when adding or updating
+	// NOTE: Make sure docs/containers-policy.json.5.md is updated when adding or updating
 	// a transport.
 	_ "github.com/containers/image/directory"
 	_ "github.com/containers/image/docker"


### PR DESCRIPTION
Catching up with be91505 (docs: rename manpages to *.5.md, 2019-03-01, #594).

Generated with:

  $ sed -i 's/policy.json.md/containers-policy.json.5.md/g' $(git grep -l policy.json.md)

Looking to carry this over the finish line for Wking.

Replaces: https://github.com/containers/image/pull/638
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>