### PR TITLE
Use the same HTTP client for contacting the bearer token server and the registry

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -526,11 +526,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 		authReq.SetBasicAuth(c.username, c.password)
 	}
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.String())
-	tr := tlsclientconfig.NewTransport()
-	// TODO(runcom): insecure for now to contact the external token service
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	client := &http.Client{Transport: tr}
-	res, err := client.Do(authReq)
+	res, err := c.client.Do(authReq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #654.

Alternative to #655.