### PR TITLE
ci: change `$GOCACHE` to a writeable path

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:18.04
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev
 
-ADD https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz /tmp
+ADD https://storage.googleapis.com/golang/go1.11.12.linux-amd64.tar.gz /tmp
 
-RUN tar -C /usr/local -xzf /tmp/go1.11.1.linux-amd64.tar.gz && \
-    rm /tmp/go1.11.1.linux-amd64.tar.gz && \
+RUN tar -C /usr/local -xzf /tmp/go1.11.12.linux-amd64.tar.gz && \
+    rm /tmp/go1.11.12.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/* /usr/local/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script: >
   -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
   -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e TRAVIS_COMMIT=$TRAVIS_COMMIT
   -e GOPATH=/gopath -e TRASH_CACHE=/gopath/.trashcache
+  -e GOCACHE=/tmp/gocache
   -v /etc/passwd:/etc/passwd -v /etc/sudoers:/etc/sudoers -v /etc/sudoers.d:/etc/sudoers.d
   -v /var/run:/var/run:z -v $HOME/gopath:/gopath:Z
   -w /gopath/src/github.com/containers/image image-test bash -c "PATH=$PATH:/gopath/bin make cross tools .gitvalidation validate test test-skopeo SUDO=sudo BUILDTAGS=\"$BUILDTAGS\""


### PR DESCRIPTION
The `$GOCACHE` seems not writeable by the user executing the tests
inside the docker container. This PR should fix this and unblock the CI
pipeline. To make skopeo build with go modules we have to rely on the
latest dot release of go 1.11.