### PR TITLE
add AuthEnableKeyring  to disable/enable keyring

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -46,11 +46,11 @@ func SetAuthentication(sys *types.SystemContext, registry, username, password st
 			return false, setAuthToCredHelper(ch, registry, username, password)
 		}
 
-		// Set the credentials to kernel keyring if sys.AuthFile is not specified.
+		// Set the credentials to kernel keyring if sys.AuthEnableKeyring is set to true.
 		// The keyring might not work in all environments (e.g., missing capability) and isn't supported on all platforms.
 		// Hence, we want to fall-back to using the authfile in case the keyring failed.
-		// However, if the sys.AuthFilePath is set, we want adhere to the user specification and not use the keyring.
-		if sys.AuthFilePath == "" {
+		// However, if the sys.AuthEnableKeyring is false, we want adhere to the user specification and not use the keyring.
+		if sys.AuthEnableKeyring {
 			err := setAuthToKernelKeyring(registry, username, password)
 			if err == nil {
 				logrus.Debugf("credentials for (%s, %s) were stored in the kernel keyring\n", registry, username)
@@ -74,10 +74,14 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		return sys.DockerAuthConfig.Username, sys.DockerAuthConfig.Password, nil
 	}
 
-	username, password, err := getAuthFromKernelKeyring(registry)
-	if err == nil {
-		logrus.Debug("returning credentials from kernel keyring")
-		return username, password, nil
+	// if sys.AuthEnableKeyring is true, returns credentials from kernel keyring
+	// if theres no credentials in the kernel keyring, fall back on the authfile
+	if sys.AuthEnableKeyring {
+		username, password, err := getAuthFromKernelKeyring(registry)
+		if err == nil {
+			logrus.Debug("returning credentials from kernel keyring")
+			return username, password, nil
+		}
 	}
 
 	dockerLegacyPath := filepath.Join(homedir.Get(), dockerLegacyHomePath)
@@ -118,12 +122,14 @@ func RemoveAuthentication(sys *types.SystemContext, registry string) error {
 		}
 
 		// Next try kernel keyring
-		err := deleteAuthFromKernelKeyring(registry)
-		if err == nil {
-			logrus.Debugf("credentials for %s were deleted from the kernel keyring", registry)
-			return false, nil
+		if sys.AuthEnableKeyring {
+			err := deleteAuthFromKernelKeyring(registry)
+			if err == nil {
+				logrus.Debugf("credentials for %s were deleted from the kernel keyring", registry)
+				return false, nil
+			}
+			logrus.Debugf("failed to delete credentials from the kernel keyring, falling back to authfiles")
 		}
-		logrus.Debugf("failed to delete credentials from the kernel keyring, falling back to authfiles")
 
 		if _, ok := auths.AuthConfigs[registry]; ok {
 			delete(auths.AuthConfigs, registry)

--- a/types/types.go
+++ b/types/types.go
@@ -453,6 +453,8 @@ type SystemContext struct {
 	RegistriesDirPath string
 	// Path to the system-wide registries configuration file
 	SystemRegistriesConfPath string
+	// If true, stores the user credentials to kernel keyring. Otherwise the credentials will be in the authentication file
+	AuthEnableKeyring bool
 	// If not "", overrides the default path for the authentication file
 	AuthFilePath string
 	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.


### PR DESCRIPTION
Add AuthEnableKeyring field to SystemContext and set/get credentials to/from kernel keyring only if AuthEnableKeyring is true

Signed-off-by: Qi Wang <qiwan@redhat.com>