### PR TITLE
internal/testing/explicitfilepath-tmpdir: handle unset TMPDIR

### DIFF
--- a/internal/testing/explicitfilepath-tmpdir/tmpdir.go
+++ b/internal/testing/explicitfilepath-tmpdir/tmpdir.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	tmpDir := os.Getenv("TMPDIR")
+	tmpDir := os.TempDir()
 	explicitTmpDir, err := filepath.EvalSymlinks(tmpDir)
 	if err == nil {
 		os.Setenv("TMPDIR", explicitTmpDir)


### PR DESCRIPTION
Handle cases where $TMPDIR isn't set by reading it by calling `os.TempDir()` instead of reading the environment variable directly.  This allows tests to pass for `directory` when $TMPDIR is not set.