### PR TITLE
pkg/blobinfocache: fixup unit tests for euid 0

### DIFF
--- a/pkg/blobinfocache/default_test.go
+++ b/pkg/blobinfocache/default_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/pkg/blobinfocache/memory"
 	"github.com/containers/image/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/gocapability/capability"
 )
 
 func TestBlobInfoCacheDir(t *testing.T) {
@@ -147,6 +148,12 @@ func TestDefaultCache(t *testing.T) {
 	}()
 	os.Unsetenv("HOME")
 	os.Unsetenv("XDG_DATA_HOME")
+	os.Setenv("_CONTAINERS_ROOTLESS_UID", "-1")
+	cap, err := capability.NewPid(0)
+	require.NoError(t, err)
+	cap.Unset(capability.EFFECTIVE|capability.PERMITTED|capability.INHERITABLE|capability.BOUNDING|capability.AMBIENT, capability.CAP_DAC_OVERRIDE)
+	err = cap.Apply(capability.EFFECTIVE | capability.PERMITTED | capability.INHERITABLE | capability.BOUNDING | capability.AMBIENT)
+	require.NoError(t, err)
 	c = DefaultCache(nil)
 	assert.IsType(t, memory.New(), c)
 


### PR DESCRIPTION
When testing, force our rootless ID to -1 to avoid using the hard-coded default location when the tests are being run by a privileged user.  Turn off CAP_DAC_OVERRIDE in the test so that when we expect to be denied the ability to create a subdirectory under a directory to which DAC says we can't write, that's what will actually happen, even for root.
I don't think we run tests as root in CI, so this may not be worth merging.  If so, I'm fine with that.