### PR TITLE
copy: add nil checks

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -182,11 +182,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
-		blobInfoCache:    blobinfocache.DefaultCache(options.DestinationCtx),
-		compressionLevel: options.DestinationCtx.CompressionLevel,
+		blobInfoCache: blobinfocache.DefaultCache(options.DestinationCtx),
 	}
 	// Default to using gzip compression unless specified otherwise.
-	if options.DestinationCtx.CompressionFormat == nil {
+	if options.DestinationCtx == nil || options.DestinationCtx.CompressionFormat == nil {
 		algo, err := compression.AlgorithmByName("gzip")
 		if err != nil {
 			return nil, err
@@ -194,6 +193,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		c.compressionFormat = algo
 	} else {
 		c.compressionFormat = *options.DestinationCtx.CompressionFormat
+	}
+	if options.DestinationCtx == nil {
+		// Note that the compressionLevel can be nil.
+		c.compressionLevel = options.DestinationCtx.CompressionLevel
 	}
 
 	unparsedToplevel := image.UnparsedInstance(rawSource, nil)


### PR DESCRIPTION
`DestinationCtx` can conventionally be nil, so add some checks around
references to avoid potential nil dereferences.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>