### PR TITLE
copy: fix options.DestinationCtx nil check

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -194,7 +194,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	} else {
 		c.compressionFormat = *options.DestinationCtx.CompressionFormat
 	}
-	if options.DestinationCtx == nil {
+	if options.DestinationCtx != nil {
 		// Note that the compressionLevel can be nil.
 		c.compressionLevel = options.DestinationCtx.CompressionLevel
 	}


### PR DESCRIPTION
Fix the nil check for options.DestinationCtx which
has been inverted mistakenly.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>