### PR TITLE
Add AuthEnableKeyring to SystemContext

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -37,8 +37,6 @@ var (
 	dockerHomePath          = filepath.FromSlash(".docker/config.json")
 	dockerLegacyHomePath    = ".dockercfg"
 
-	enableKeyring = false
-
 	// ErrNotLoggedIn is returned for users not logged into a registry
 	// that they are trying to logout of
 	ErrNotLoggedIn = errors.New("not logged in")
@@ -57,7 +55,7 @@ func SetAuthentication(sys *types.SystemContext, registry, username, password st
 		// The keyring might not work in all environments (e.g., missing capability) and isn't supported on all platforms.
 		// Hence, we want to fall-back to using the authfile in case the keyring failed.
 		// However, if the enableKeyring is false, we want adhere to the user specification and not use the keyring.
-		if enableKeyring {
+		if sys != nil && sys.AuthEnableKeyring {
 			err := setAuthToKernelKeyring(registry, username, password)
 			if err == nil {
 				logrus.Debugf("credentials for (%s, %s) were stored in the kernel keyring\n", registry, username)
@@ -81,7 +79,7 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		return sys.DockerAuthConfig.Username, sys.DockerAuthConfig.Password, nil
 	}
 
-	if enableKeyring {
+	if sys != nil && sys.AuthEnableKeyring {
 		username, password, err := getAuthFromKernelKeyring(registry)
 		if err == nil {
 			logrus.Debug("returning credentials from kernel keyring")
@@ -127,7 +125,7 @@ func RemoveAuthentication(sys *types.SystemContext, registry string) error {
 		}
 
 		// Next if keyring is enabled try kernel keyring
-		if enableKeyring {
+		if sys != nil && sys.AuthEnableKeyring {
 			err := deleteAuthFromKernelKeyring(registry)
 			if err == nil {
 				logrus.Debugf("credentials for %s were deleted from the kernel keyring", registry)
@@ -150,7 +148,7 @@ func RemoveAuthentication(sys *types.SystemContext, registry string) error {
 // RemoveAllAuthentication deletes all the credentials stored in auth.json and kernel keyring
 func RemoveAllAuthentication(sys *types.SystemContext) error {
 	return modifyJSON(sys, func(auths *dockerConfigFile) (bool, error) {
-		if enableKeyring {
+		if sys != nil && sys.AuthEnableKeyring {
 			err := removeAllAuthFromKernelKeyring()
 			if err == nil {
 				logrus.Debugf("removing all credentials from kernel keyring")

--- a/types/types.go
+++ b/types/types.go
@@ -506,6 +506,8 @@ type SystemContext struct {
 	// this field is ignored if `AuthFilePath` is set (we favor the newer format);
 	// only reading of this data is supported;
 	LegacyFormatAuthFilePath string
+	// If true, credentials are stored in kernel user keyring
+	AuthEnableKeyring bool
 	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.


### PR DESCRIPTION
Add boolean AuthEnableKeyring to SystemContex to enable podman set auth to keyring.

Signed-off-by: Qi Wang <qiwan@redhat.com>