### PR TITLE
docker: handle http 429 status codes

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -71,9 +70,8 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if res.StatusCode != http.StatusOK {
-			// print url also
-			return nil, errors.Errorf("Invalid status code returned when fetching tags list %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+		if err := httpResponseToError(res); err != nil {
+			return nil, err
 		}
 
 		var tagsHolder struct {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containers/image/v4/pkg/blobinfocache/none"
 	"github.com/containers/image/v4/types"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -232,9 +232,8 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 	if err != nil {
 		return nil, 0, err
 	}
-	if res.StatusCode != http.StatusOK {
-		// print url also
-		return nil, 0, errors.Errorf("Invalid status code returned when fetching blob %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+	if err := httpResponseToError(res); err != nil {
+		return nil, 0, err
 	}
 	cache.RecordKnownLocation(s.ref.Transport(), bicTransportScope(s.ref), info.Digest, newBICLocationReference(s.ref))
 	return res.Body, getBlobSize(res), nil

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -1,0 +1,33 @@
+package docker
+
+import (
+	"errors"
+	"net/http"
+
+	perrors "github.com/pkg/errors"
+)
+
+var (
+	// ErrV1NotSupported is returned when we're trying to talk to a
+	// docker V1 registry.
+	ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
+	// ErrUnauthorizedForCredentials is returned when the status code returned is 401
+	ErrUnauthorizedForCredentials = errors.New("unable to retrieve auth token: invalid username/password")
+	// ErrTooManyRequests is returned when the status code returned is 429
+	ErrTooManyRequests = errors.New("too many request to registry")
+)
+
+// httpResponseToError translates the https.Response into an error. It returns
+// nil if the response is not considered an error.
+func httpResponseToError(res *http.Response) error {
+	switch res.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusTooManyRequests:
+		return ErrTooManyRequests
+	case http.StatusUnauthorized:
+		return ErrUnauthorizedForCredentials
+	default:
+		return perrors.Errorf("invalid status code from registry %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+	}
+}


### PR DESCRIPTION
Consolidate checking the http-status codes to allow for a more uniform
error handling.  Also treat code 429 (too many requests) as a known
error instead of an invalid status code.

When hitting 429, perform an exponential back off starting a 2 seconds
for at most 5 iterations.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>