### PR TITLE
zstd: support docker v2s2 

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -861,7 +861,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		// re-compressed using the desired format.
 		logrus.Debugf("Blob will be converted")
 
-		compressionOperation = types.PreserveOriginal
+		compressionOperation = types.Compress
 		s, err := decompressor(destStream)
 		if err != nil {
 			return types.BlobInfo{}, err

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -213,10 +213,14 @@ func (m *manifestSchema2) convertToManifestOCI1(ctx context.Context) (types.Imag
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributable
 		case manifest.DockerV2Schema2ForeignLayerMediaTypeGzip:
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributableGzip
+		case manifest.DockerV2Schema2ForeignLayerMediaTypeZstd:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerNonDistributableZstd
 		case manifest.DockerV2SchemaLayerMediaTypeUncompressed:
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayer
 		case manifest.DockerV2Schema2LayerMediaType:
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerGzip
+		case manifest.DockerV2Schema2LayerMediaTypeZstd:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerZstd
 		default:
 			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", m.m.LayersDescriptors[idx].MediaType)
 		}

--- a/image/fixtures/oci1-all-media-types-to-schema2.json
+++ b/image/fixtures/oci1-all-media-types-to-schema2.json
@@ -33,7 +33,7 @@
             "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
         },
         {
-            "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+            "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar.zstd",
             "size": 291,
             "digest": "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa"
         }

--- a/image/fixtures/oci1-all-media-types.json
+++ b/image/fixtures/oci1-all-media-types.json
@@ -32,7 +32,7 @@
             "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
         },
         {
-            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
             "size": 291,
             "digest": "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa"
         }

--- a/image/fixtures/schema2-all-media-types-to-oci1.json
+++ b/image/fixtures/schema2-all-media-types-to-oci1.json
@@ -17,6 +17,11 @@
             "digest": "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c"
         },
         {
+            "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
+            "size": 152,
+            "digest": "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c"
+        },
+        {
             "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar",
             "size": 11739507,
             "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
@@ -27,7 +32,7 @@
             "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
         },
         {
-            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
             "size": 291,
             "digest": "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa"
         }

--- a/image/fixtures/schema2-all-media-types.json
+++ b/image/fixtures/schema2-all-media-types.json
@@ -18,6 +18,11 @@
             "digest": "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c"
         },
         {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.zstd",
+            "size": 152,
+            "digest": "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c"
+        },
+        {
             "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar",
             "size": 11739507,
             "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
@@ -28,7 +33,7 @@
             "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
         },
         {
-            "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+            "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar.zstd",
             "size": 291,
             "digest": "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa"
         }

--- a/image/fixtures/schema2-invalid-media-type.json
+++ b/image/fixtures/schema2-invalid-media-type.json
@@ -23,7 +23,7 @@
           "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
        },
        {
-          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.invalid",
           "size": 8841833,
           "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
        },

--- a/image/oci.go
+++ b/image/oci.go
@@ -194,13 +194,13 @@ func (m *manifestOCI1) convertToManifestSchema2() (types.Image, error) {
 		case imgspecv1.MediaTypeImageLayerNonDistributableGzip:
 			layers[idx].MediaType = manifest.DockerV2Schema2ForeignLayerMediaTypeGzip
 		case imgspecv1.MediaTypeImageLayerNonDistributableZstd:
-			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+			layers[idx].MediaType = manifest.DockerV2Schema2ForeignLayerMediaTypeZstd
 		case imgspecv1.MediaTypeImageLayer:
 			layers[idx].MediaType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
 		case imgspecv1.MediaTypeImageLayerGzip:
 			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaType
 		case imgspecv1.MediaTypeImageLayerZstd:
-			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaTypeZstd
 		default:
 			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", layers[idx].MediaType)
 		}

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -414,10 +414,23 @@ func TestConvertToManifestSchema2(t *testing.T) {
 func TestConvertToManifestSchema2AllMediaTypes(t *testing.T) {
 	originalSrc := newOCI1ImageSource(t, "httpd-copy:latest")
 	original := manifestOCI1FromFixture(t, originalSrc, "oci1-all-media-types.json")
-	_, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+	res, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
 	})
-	require.Error(t, err) // zstd compression is not supported for docker images
+	require.NoError(t, err)
+
+	convertedJSON, mt, err := res.Manifest(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, manifest.DockerV2Schema2MediaType, mt)
+
+	byHandJSON, err := ioutil.ReadFile("fixtures/oci1-all-media-types-to-schema2.json")
+	require.NoError(t, err)
+	var converted, byHand map[string]interface{}
+	err = json.Unmarshal(byHandJSON, &byHand)
+	require.NoError(t, err)
+	err = json.Unmarshal(convertedJSON, &converted)
+	require.NoError(t, err)
+	assert.Equal(t, byHand, converted)
 }
 
 func TestConvertToV2S2WithInvalidMIMEType(t *testing.T) {

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -256,15 +256,22 @@ func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 			switch info.CompressionAlgorithm.Name() {
 			case compression.Gzip.Name():
 				switch original[i].MediaType {
-				case DockerV2Schema2ForeignLayerMediaType:
+				case DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeZstd:
 					m.LayersDescriptors[i].MediaType = DockerV2Schema2ForeignLayerMediaTypeGzip
-				case DockerV2SchemaLayerMediaTypeUncompressed:
+				case DockerV2SchemaLayerMediaTypeUncompressed, DockerV2Schema2LayerMediaTypeZstd:
 					m.LayersDescriptors[i].MediaType = DockerV2Schema2LayerMediaType
 				default:
 					return fmt.Errorf("Error preparing updated manifest: unsupported media type for compression: %q", original[i].MediaType)
 				}
 			case compression.Zstd.Name():
-				return fmt.Errorf("Error preparing updated manifest: zstd compression is not supported for docker images")
+				switch original[i].MediaType {
+				case DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip:
+					m.LayersDescriptors[i].MediaType = DockerV2Schema2ForeignLayerMediaTypeZstd
+				case DockerV2SchemaLayerMediaTypeUncompressed, DockerV2Schema2LayerMediaType:
+					m.LayersDescriptors[i].MediaType = DockerV2Schema2LayerMediaTypeZstd
+				default:
+					return fmt.Errorf("Error preparing updated manifest: unsupported media type for compression: %q", original[i].MediaType)
+				}
 			default:
 				return fmt.Errorf("Error preparing updated manifest: unknown compression algorithm %q for layer %q", info.CompressionAlgorithm.Name(), info.Digest)
 			}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -24,6 +24,8 @@ const (
 	DockerV2Schema2ConfigMediaType = "application/vnd.docker.container.image.v1+json"
 	// DockerV2Schema2LayerMediaType is the MIME type used for schema 2 layers.
 	DockerV2Schema2LayerMediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// DockerV2Schema2LayerMediaTypeZstd is the MIME type used for zstd compressed schema 2 layers. Note that this type is only meant for conversion into an OCI format.
+	DockerV2Schema2LayerMediaTypeZstd = "application/vnd.docker.image.rootfs.diff.tar.zstd"
 	// DockerV2SchemaLayerMediaTypeUncompressed is the mediaType used for uncompressed layers.
 	DockerV2SchemaLayerMediaTypeUncompressed = "application/vnd.docker.image.rootfs.diff.tar"
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list
@@ -32,12 +34,14 @@ const (
 	DockerV2Schema2ForeignLayerMediaType = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for gzippped schema 2 foreign layers.
 	DockerV2Schema2ForeignLayerMediaTypeGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for zstd compressed schema 2 foreign layers. Note that this type is only meant for conversion into an OCI format.
+	DockerV2Schema2ForeignLayerMediaTypeZstd = "application/vnd.docker.image.rootfs.foreign.diff.tar.zstd"
 )
 
 // SupportedSchema2MediaType checks if the specified string is a supported Docker v2s2 media type.
 func SupportedSchema2MediaType(m string) error {
 	switch m {
-	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed:
+	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeZstd, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed, DockerV2Schema2LayerMediaTypeZstd:
 		return nil
 	default:
 		return fmt.Errorf("unsupported docker v2s2 media type: %q", m)


### PR DESCRIPTION
Support zstd for docker v2s2 images.  That's required to copy and
convert a v2s2 image into an OCI images, for instance, via

   `skopeo copy --dest-compress --dest-compress-format=zstd docker://...  oci:...`

When compressing or decompressing a layer, we first update the current
manifest and later convert it.  Hence, supporting v2s2 is currently
required to support compressing and converting in one call.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>