### PR TITLE
add http response to log

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -533,6 +533,8 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 	defer res.Body.Close()
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
+		err := client.HandleErrorResponse(res)
+		logrus.Debugf("Server response when trying to obtain an access token: \n%q", err.Error())
 		return nil, ErrUnauthorizedForCredentials
 	case http.StatusOK:
 		break


### PR DESCRIPTION
fix https://github.com/containers/libpod/issues/3884
Add http response message log to show server-side error message.

Signed-off-by: Qi Wang <qiwan@redhat.com>