### PR TITLE
Explicitly replace docker/libtrust with containers/libtrust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,13 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8 // indirect
+	github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b
 	github.com/containers/storage v1.13.4
 	github.com/docker/distribution v0.0.0-20170817175659-5f6282db7d65
 	github.com/docker/docker v0.0.0-20180522102801-da99009bbb11
 	github.com/docker/docker-credential-helpers v0.6.0
 	github.com/docker/go-connections v0.0.0-20180212134524-7beb39f0b969
-	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/etcd-io/bbolt v1.3.3
 	github.com/ghodss/yaml v0.0.0-20161207003320-04f313413ffd
 	github.com/gogo/protobuf v0.0.0-20170815085658-fcdc5011193f // indirect
@@ -47,5 +48,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	k8s.io/client-go v0.0.0-20170217214107-bcde30fb7eae
 )
-
-replace github.com/docker/libtrust => github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8 h1:ZZOFPzvZO
 github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
-github.com/containers/storage v1.13.2 h1:UXZ0Ckmk6+6+4vj2M2ywruVtH97pnRoAhTG8ctd+yQI=
-github.com/containers/storage v1.13.2/go.mod h1:6D8nK2sU9V7nEmAraINRs88ZEscM5C5DK+8Npp27GeA=
 github.com/containers/storage v1.13.4 h1:j0bBaJDKbUHtAW1MXPFnwXJtqcH+foWeuXK1YaBV5GA=
 github.com/containers/storage v1.13.4/go.mod h1:6D8nK2sU9V7nEmAraINRs88ZEscM5C5DK+8Npp27GeA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/containers/image/types"
-	"github.com/docker/libtrust"
-	"github.com/opencontainers/go-digest"
+	"github.com/containers/libtrust"
+	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/containers/image/types"
-	"github.com/docker/libtrust"
-	"github.com/opencontainers/go-digest"
+	"github.com/containers/libtrust"
+	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
<s>**Do not merge:** Includes unmerged #714.</s>

... instead of using the `replace` directive in `go.mod`, which changes absolutely nothing for consumers of this library.

Cleans up after #701.

(`docker/libtrust` remains listed in `go.mod` because it is a dependency of the `docker/distribution` _module_; it’s not used by the `docker/distribution` _subpackages_ we call. See https://github.com/golang/go/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod .)