### PR TITLE
Don’t drag in compression implementations into c/image/types

### DIFF
--- a/pkg/compression/internal/types.go
+++ b/pkg/compression/internal/types.go
@@ -1,0 +1,57 @@
+package internal
+
+import "io"
+
+// CompressorFunc writes the compressed stream to the given writer using the specified compression level.
+// The caller must call Close() on the stream (even if the input stream does not need closing!).
+type CompressorFunc func(io.Writer, *int) (io.WriteCloser, error)
+
+// DecompressorFunc returns the decompressed stream, given a compressed stream.
+// The caller must call Close() on the decompressed stream (even if the compressed input stream does not need closing!).
+type DecompressorFunc func(io.Reader) (io.ReadCloser, error)
+
+// Algorithm is a compression algorithm that can be used for CompressStream.
+type Algorithm struct {
+	name         string
+	prefix       []byte
+	decompressor DecompressorFunc
+	compressor   CompressorFunc
+}
+
+// NewAlgorithm creates an Algorithm instance.
+// This function exists so that Algorithm instances can only be created by code that
+// is allowed to import this internal subpackage.
+func NewAlgorithm(name string, prefix []byte, decompressor DecompressorFunc, compressor CompressorFunc) Algorithm {
+	return Algorithm{
+		name:         name,
+		prefix:       prefix,
+		decompressor: decompressor,
+		compressor:   compressor,
+	}
+}
+
+// Name returns the name for the compression algorithm.
+func (c Algorithm) Name() string {
+	return c.name
+}
+
+// AlgorithmCompressor returns the compressor field of algo.
+// This is a function instead of a public method so that it is only callable from by code
+// that is allowed to import this internal subpackage.
+func AlgorithmCompressor(algo Algorithm) CompressorFunc {
+	return algo.compressor
+}
+
+// AlgorithmDecompressor returns the decompressor field of algo.
+// This is a function instead of a public method so that it is only callable from by code
+// that is allowed to import this internal subpackage.
+func AlgorithmDecompressor(algo Algorithm) DecompressorFunc {
+	return algo.decompressor
+}
+
+// AlgorithmPrefix returns the prefix field of algo.
+// This is a function instead of a public method so that it is only callable from by code
+// that is allowed to import this internal subpackage.
+func AlgorithmPrefix(algo Algorithm) []byte {
+	return algo.prefix
+}

--- a/pkg/compression/types/types.go
+++ b/pkg/compression/types/types.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"github.com/containers/image/pkg/compression/internal"
+)
+
+// DecompressorFunc returns the decompressed stream, given a compressed stream.
+// The caller must call Close() on the decompressed stream (even if the compressed input stream does not need closing!).
+type DecompressorFunc = internal.DecompressorFunc
+
+// Algorithm is a compression algorithm provided and supported by pkg/compression.
+// It can’t be supplied from the outside.
+type Algorithm = internal.Algorithm

--- a/types/types.go
+++ b/types/types.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/containers/image/docker/reference"
-	"github.com/containers/image/pkg/compression"
-	"github.com/opencontainers/go-digest"
+	compression "github.com/containers/image/pkg/compression/types"
+	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 


### PR DESCRIPTION
<s>**Don’t merge:** Includes all of #714.</s>

Fixes #659, see the commit message as for how.

@vrothberg @giuseppe RFC. This is a bit baroque, but it is a local thing that does not require any discussion about how to redesign the interfaces in some other way; AFAICT all existing public indentifiers continue to work with the existing semantics.

We can redesign pkg/compression in some other way in some future major version, if there is ever a good enough reason, and we obviously can completely tear down what this PR does at that time.