### PR TITLE
GuessMIMEType: recognize OCI images with no layers

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -127,12 +127,11 @@ func GuessMIMEType(manifest []byte) string {
 			Config struct {
 				MediaType string `json:"mediaType"`
 			} `json:"config"`
-			Layers []imgspecv1.Descriptor `json:"layers"`
 		}{}
 		if err := json.Unmarshal(manifest, &ociMan); err != nil {
 			return ""
 		}
-		if ociMan.Config.MediaType == imgspecv1.MediaTypeImageConfig && len(ociMan.Layers) != 0 {
+		if ociMan.Config.MediaType == imgspecv1.MediaTypeImageConfig {
 			return imgspecv1.MediaTypeImageManifest
 		}
 		ociIndex := struct {


### PR DESCRIPTION
Don't require OCI image manifests to have layers in order for us to be able to recognize that we're looking at an OCI image manifest.

This should help with https://github.com/containers/libpod/pull/4165.