### PR TITLE
pkg/docker/config: correct defaultPerUIDPathFormat

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -32,7 +32,7 @@ type authPath struct {
 }
 
 var (
-	defaultPerUIDPathFormat = filepath.FromSlash("/run/containers/%d/auth.json")
+	defaultPerUIDPathFormat = filepath.FromSlash("/run/user/%d/containers/auth.json")
 	xdgRuntimeDirPath       = filepath.FromSlash("containers/auth.json")
 	dockerHomePath          = filepath.FromSlash(".docker/config.json")
 	dockerLegacyHomePath    = ".dockercfg"

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -39,12 +39,12 @@ func TestGetPathToAuth(t *testing.T) {
 		legacyFormat bool
 	}{
 		// Default paths
-		{&types.SystemContext{}, "", "/run/containers/" + uid + "/auth.json", false},
-		{nil, "", "/run/containers/" + uid + "/auth.json", false},
+		{&types.SystemContext{}, "", "/run/user/" + uid + "/containers/auth.json", false},
+		{nil, "", "/run/user/" + uid + "/containers/auth.json", false},
 		// SystemContext overrides
 		{&types.SystemContext{AuthFilePath: "/absolute/path"}, "", "/absolute/path", false},
 		{&types.SystemContext{LegacyFormatAuthFilePath: "/absolute/path"}, "", "/absolute/path", true},
-		{&types.SystemContext{RootForImplicitAbsolutePaths: "/prefix"}, "", "/prefix/run/containers/" + uid + "/auth.json", false},
+		{&types.SystemContext{RootForImplicitAbsolutePaths: "/prefix"}, "", "/prefix/run/user/" + uid + "/containers/auth.json", false},
 		// XDG_RUNTIME_DIR defined
 		{nil, tmpDir, tmpDir + "/containers/auth.json", false},
 		{nil, tmpDir + "/thisdoesnotexist", "", false},


### PR DESCRIPTION
If I'm reading https://github.com/containers/libpod/issues/4227 right, we should make `defaultPerUIDPathFormat` correspond to the value that we'd compute by combining the default value of `${XDG_RUNTIME_DIR}` (typically `/run/user/$(id -u)`) and `xdgRuntimeDirPath`.