### PR TITLE
copy.Image(): select the CopySystemImage image using the source context

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -269,7 +269,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error parsing primary manifest as list for %s", transports.ImageName(srcRef))
 		}
-		instanceDigest, err := manifestList.ChooseInstance(options.DestinationCtx) // try to pick one that matches options.DestinationCtx
+		instanceDigest, err := manifestList.ChooseInstance(options.SourceCtx) // try to pick one that matches options.SourceCtx
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error choosing an image from manifest list %s", transports.ImageName(srcRef))
 		}


### PR DESCRIPTION
Go back to selecting which image instance we copy in CopySystemImage mode using the source context rather than the destination context, as we did before #400.  Using the destination context made more sense to me, but it's probably worth breaking that out that as a separate decision.