### PR TITLE
add support for default credential store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clean:
 	rm -rf tools.timestamp $(MANPAGES)
 
 test:
-	@PATH="$(PATH):$(shell pwd)/pkg/docker/config/testdata" $(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
+	@$(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
 
 # This is not run as part of (make all), but Travis CI does run this.
 # Demonstrating a working version of skopeo (possibly with modified SKOPEO_REPO/SKOPEO_BRANCH, e.g.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clean:
 	rm -rf tools.timestamp $(MANPAGES)
 
 test:
-	@$(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
+	@PATH="$(PATH):$(shell pwd)/pkg/docker/config/testdata" $(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
 
 # This is not run as part of (make all), but Travis CI does run this.
 # Demonstrating a working version of skopeo (possibly with modified SKOPEO_REPO/SKOPEO_BRANCH, e.g.

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -24,6 +24,7 @@ type dockerAuthConfig struct {
 type dockerConfigFile struct {
 	AuthConfigs map[string]dockerAuthConfig `json:"auths"`
 	CredHelpers map[string]string           `json:"credHelpers,omitempty"`
+	CredStore   string                      `json:"credsStore,omitempty"`
 }
 
 type authPath struct {
@@ -303,6 +304,11 @@ func findAuthentication(registry, path string, legacyFormat bool) (string, strin
 	// First try cred helpers. They should always be normalized.
 	if ch, exists := auths.CredHelpers[registry]; exists {
 		return getAuthFromCredHelper(ch, registry)
+	}
+
+	// Second try default credential store
+	if cs := auths.CredStore; cs != "" {
+		return getAuthFromCredHelper(cs, registry)
 	}
 
 	// I'm feeling lucky

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -82,6 +82,12 @@ func TestGetAuth(t *testing.T) {
 		os.Setenv("XDG_RUNTIME_DIR", origXDG)
 	}()
 
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join("testdata"), origPath))
+	defer func() {
+		os.Setenv("PATH", origPath)
+	}()
+
 	origHomeDir := homedir.Get()
 	tmpDir2, err := ioutil.TempDir("", "test_docker_client_get_auth")
 	if err != nil {
@@ -181,6 +187,13 @@ func TestGetAuth(t *testing.T) {
 				expectedPassword: "host-5000",
 			},
 			{
+				name:             "use external helper",
+				hostname:         "foobar.example.org",
+				path:             filepath.Join("testdata", "helper.json"),
+				expectedUsername: "foo",
+				expectedPassword: "bar",
+			},
+			{
 				name:             "use system context",
 				hostname:         "example.org",
 				path:             filepath.Join("testdata", "example.json"),
@@ -223,73 +236,6 @@ func TestGetAuth(t *testing.T) {
 			})
 		}
 	}
-}
-
-func TestGetHelperAuth(t *testing.T) {
-	origXDG := os.Getenv("XDG_RUNTIME_DIR")
-	tmpDir1, err := ioutil.TempDir("", "test_docker_client_get_auth")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("using temporary XDG_RUNTIME_DIR directory: %q", tmpDir1)
-	// override XDG_RUNTIME_DIR
-	os.Setenv("XDG_RUNTIME_DIR", tmpDir1)
-	defer func() {
-		err := os.RemoveAll(tmpDir1)
-		if err != nil {
-			t.Logf("failed to cleanup temporary home directory %q: %v", tmpDir1, err)
-		}
-		os.Setenv("XDG_RUNTIME_DIR", origXDG)
-	}()
-
-	origHomeDir := homedir.Get()
-	tmpDir2, err := ioutil.TempDir("", "test_docker_client_get_auth")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("using temporary home directory: %q", tmpDir2)
-	//override homedir
-	os.Setenv(homedir.Key(), tmpDir2)
-	defer func() {
-		err := os.RemoveAll(tmpDir2)
-		if err != nil {
-			t.Logf("failed to cleanup temporary home directory %q: %v", tmpDir2, err)
-		}
-		os.Setenv(homedir.Key(), origHomeDir)
-	}()
-
-	configDir1 := filepath.Join(tmpDir1, "containers")
-	if err := os.MkdirAll(configDir1, 0700); err != nil {
-		t.Fatal(err)
-	}
-	configDir2 := filepath.Join(tmpDir2, ".docker")
-	if err := os.MkdirAll(configDir2, 0700); err != nil {
-		t.Fatal(err)
-	}
-	configPath := filepath.Join(configDir2, "config.json")
-
-	if err := os.RemoveAll(configPath); err != nil {
-		t.Fatal(err)
-	}
-
-	helperPath := filepath.Join("testdata", "helper.json")
-
-	helperContents, err := ioutil.ReadFile(helperPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("test auth helper", func(t *testing.T) {
-		if err := ioutil.WriteFile(configPath, helperContents, 0640); err != nil {
-			t.Fatal(err)
-		}
-		var sys *types.SystemContext
-		username, password, err := GetAuthentication(sys, "foobar.example.org")
-		assert.Equal(t, nil, err)
-		assert.Equal(t, "foo", username)
-		assert.Equal(t, "bar", password)
-	})
-
 }
 
 func TestGetAuthFromLegacyFile(t *testing.T) {

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -207,11 +207,14 @@ func TestGetAuth(t *testing.T) {
 				},
 			},
 		} {
-			if tc.path == "" {
-				if err := os.RemoveAll(configPath); err != nil {
-					t.Fatal(err)
-				}
+			for _, cPath := range configPaths {
+				os.RemoveAll(cPath)
 			}
+			// if tc.path == "" {
+			// 	if err := os.RemoveAll(configPath); err != nil {
+			// 		t.Fatal(err)
+			// 	}
+			// }
 
 			t.Run(tc.name, func(t *testing.T) {
 				if tc.path != "" {

--- a/pkg/docker/config/testdata/docker-credential-imagetest
+++ b/pkg/docker/config/testdata/docker-credential-imagetest
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ACTION="${1}"
+shift
+
+case "${ACTION}" in
+get)
+    read DOCKER_REGISTRY
+    echo "{\"ServerURL\":\"${DOCKER_REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}"
+    exit 0
+    ;;
+*)
+    echo "not implemented"
+    exit 1
+    ;;
+esac

--- a/pkg/docker/config/testdata/helper.json
+++ b/pkg/docker/config/testdata/helper.json
@@ -1,0 +1,6 @@
+{
+    "auths": {
+        "foobar.example.org": {}
+    },
+    "credsStore": "imagetest"
+}


### PR DESCRIPTION
#### What change does this introduce?

Added a check for `credsStore` in the `${HOME}/.docker/config.json` file, at least on OSX the `auths` list is just URIs and there isn't a `credHelpers` list.

#### Why make this change?

To implement authentication when using applications that import this library on OSX and possibly other BSD/*nix OS

#### What approach will be taken?

Implement the check for a default credentials store past the registry specific `credHelpers` list.