### PR TITLE
Fix destination stream overwrite on progress

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1154,13 +1154,14 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 
 	// === Report progress using the c.progress channel, if required.
 	if c.progress != nil && c.progressInterval > 0 {
-		destStream := newProgressReader(
+		progressReader := newProgressReader(
 			destStream,
 			c.progress,
 			c.progressInterval,
 			srcInfo,
 		)
-		defer destStream.reportDone()
+		defer progressReader.reportDone()
+		destStream = progressReader
 	}
 
 	// === Finally, send the layer stream to dest.


### PR DESCRIPTION
The new-initialization of the `io.Reader` `destStream` caused to break
the progress reader calling `Read` at all, which is now fixed.
