### PR TITLE
Added possibility to overwrite default tmp dir for big files

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -36,7 +36,7 @@ func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.
 		return nil, errors.New("docker-archive doesn't support modifying existing images")
 	}
 
-	tarDest := tarfile.NewDestination(fh, ref.destinationRef)
+	tarDest := tarfile.NewDestinationWithContext(sys, fh, ref.destinationRef)
 	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
 		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
 	}

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+
 	"github.com/containers/image/v5/docker/tarfile"
 	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
@@ -14,11 +15,11 @@ type archiveImageSource struct {
 
 // newImageSource returns a types.ImageSource for the specified image reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx context.Context, ref archiveReference) (types.ImageSource, error) {
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveReference) (types.ImageSource, error) {
 	if ref.destinationRef != nil {
 		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
 	}
-	src, err := tarfile.NewSourceFromFile(ref.path)
+	src, err := tarfile.NewSourceFromFileWithContext(sys, ref.path)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -134,7 +134,7 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (ref archiveReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, ref)
+	src, err := newImageSource(ctx, sys, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (ref archiveReference) NewImage(ctx context.Context, sys *types.SystemConte
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref archiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, ref)
+	return newImageSource(ctx, sys, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -54,7 +54,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 	return &daemonImageDestination{
 		ref:                ref,
 		mustMatchRuntimeOS: mustMatchRuntimeOS,
-		Destination:        tarfile.NewDestination(writer, namedTaggedRef),
+		Destination:        tarfile.NewDestinationWithContext(sys, writer, namedTaggedRef),
 		goroutineCancel:    goroutineCancel,
 		statusChannel:      statusChannel,
 		writer:             writer,

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -40,7 +40,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 	}
 	defer inputStream.Close()
 
-	src, err := tarfile.NewSourceFromStream(inputStream)
+	src, err := tarfile.NewSourceFromStreamWithSystemContext(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -29,6 +29,7 @@ type Destination struct {
 	// Other state.
 	blobs  map[digest.Digest]types.BlobInfo // list of already-sent blobs
 	config []byte
+	sysCtx *types.SystemContext
 }
 
 // NewDestination returns a tarfile.Destination for the specified io.Writer.
@@ -94,12 +95,14 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+// Deprecated: Please use PutBlobWithSystemContext which will allows you to configure temp directory
+// for big files through SystemContext.BigFilesTemporaryDir
 func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed datas.
 	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
 		logrus.Debugf("docker tarfile: input with unknown size, streaming to disk first ...")
-		streamCopy, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-tarfile-blob")
+		streamCopy, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(d.sysCtx), "docker-tarfile-blob")
 		if err != nil {
 			return types.BlobInfo{}, err
 		}

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -46,7 +46,14 @@ type layerInfo struct {
 // 	To do for both the NewSourceFromFile and NewSourceFromStream functions
 
 // NewSourceFromFile returns a tarfile.Source for the specified path.
+// Deprecated: Please use NewSourceFromFileWithContext which will allows you to configure temp directory
+// for big files through SystemContext.BigFilesTemporaryDir
 func NewSourceFromFile(path string) (*Source, error) {
+	return NewSourceFromFileWithContext(nil, path)
+}
+
+// NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
+func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error opening file %q", path)
@@ -65,16 +72,25 @@ func NewSourceFromFile(path string) (*Source, error) {
 			tarPath: path,
 		}, nil
 	}
-	return NewSourceFromStream(stream)
+	return NewSourceFromStreamWithSystemContext(sys, stream)
 }
 
 // NewSourceFromStream returns a tarfile.Source for the specified inputStream,
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
+// Deprecated: Please use NewSourceFromStreamWithSystemContext which will allows you to configure
+// temp directory for big files through SystemContext.BigFilesTemporaryDir
 func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
+	return NewSourceFromStreamWithSystemContext(nil, inputStream)
+}
+
+// NewSourceFromStreamWithSystemContext returns a tarfile.Source for the specified inputStream,
+// which can be either compressed or uncompressed. The caller can close the
+// inputStream immediately after NewSourceFromFile returns.
+func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
 	// FIXME: use SystemContext here.
 	// Save inputStream to a temporary file
-	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-tar")
+	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temporary file")
 	}

--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -3,6 +3,8 @@ package tmpdir
 import (
 	"os"
 	"runtime"
+
+	"github.com/containers/image/v5/types"
 )
 
 // unixTempDirForBigFiles is the directory path to store big files on non Windows systems.
@@ -18,7 +20,10 @@ const builtinUnixTempDirForBigFiles = "/var/tmp"
 // TemporaryDirectoryForBigFiles returns a directory for temporary (big) files.
 // On non Windows systems it avoids the use of os.TempDir(), because the default temporary directory usually falls under /tmp
 // which on systemd based systems could be the unsuitable tmpfs filesystem.
-func TemporaryDirectoryForBigFiles() string {
+func TemporaryDirectoryForBigFiles(sys *types.SystemContext) string {
+	if sys != nil && sys.BigFilesTemporaryDir != "" {
+		return sys.BigFilesTemporaryDir
+	}
 	var temporaryDirectoryForBigFiles string
 	if runtime.GOOS == "windows" {
 		temporaryDirectoryForBigFiles = os.TempDir()

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -19,7 +19,7 @@ type ociArchiveImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
-	tempDirRef, err := createOCIRef(ref.image)
+	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating oci reference")
 	}

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -20,7 +20,7 @@ type ociArchiveImageSource struct {
 // newImageSource returns an ImageSource for reading from an existing directory.
 // newImageSource untars the file and saves it in a temp directory
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
-	tempDirRef, err := createUntarTempDir(ref)
+	tempDirRef, err := createUntarTempDir(sys, ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp directory")
 	}
@@ -43,7 +43,7 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 	if !ok {
 		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociArchiveReference")
 	}
-	tempDirRef, err := createUntarTempDir(ociArchRef)
+	tempDirRef, err := createUntarTempDir(nil, ociArchRef)
 	if err != nil {
 		return imgspecv1.Descriptor{}, errors.Wrap(err, "error creating temp directory")
 	}

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -38,12 +38,18 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiv
 }
 
 // LoadManifestDescriptor loads the manifest
+// Deprecated: use LoadManifestDescriptorWithContext instead
 func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
+	return LoadManifestDescriptorWithContext(nil, imgRef)
+}
+
+// LoadManifestDescriptorWithContext loads the manifest
+func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociArchRef, ok := imgRef.(ociArchiveReference)
 	if !ok {
 		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociArchiveReference")
 	}
-	tempDirRef, err := createUntarTempDir(nil, ociArchRef)
+	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {
 		return imgspecv1.Descriptor{}, errors.Wrap(err, "error creating temp directory")
 	}

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -159,8 +159,9 @@ func (t *tempDirOCIRef) deleteTempDir() error {
 }
 
 // createOCIRef creates the oci reference of the image
-func createOCIRef(image string) (tempDirOCIRef, error) {
-	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(), "oci")
+// If SystemContext.BigFilesTemporaryDir not "", overrides the temporary directory to use for storing big files
+func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error) {
+	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
 	if err != nil {
 		return tempDirOCIRef{}, errors.Wrapf(err, "error creating temp directory")
 	}
@@ -174,8 +175,8 @@ func createOCIRef(image string) (tempDirOCIRef, error) {
 }
 
 // creates the temporary directory and copies the tarred content to it
-func createUntarTempDir(ref ociArchiveReference) (tempDirOCIRef, error) {
-	tempDirRef, err := createOCIRef(ref.image)
+func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (tempDirOCIRef, error) {
+	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
 		return tempDirOCIRef{}, errors.Wrap(err, "error creating oci reference")
 	}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -341,8 +341,8 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
 // it's time to Commit() the image
-func newImageDestination(imageRef storageReference) (*storageImageDestination, error) {
-	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(), "storage")
+func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*storageImageDestination, error) {
+	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "storage")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
 	}

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -295,5 +295,5 @@ func (s storageReference) NewImageSource(ctx context.Context, sys *types.SystemC
 }
 
 func (s storageReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(s)
+	return newImageDestination(sys, s)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -490,9 +490,10 @@ type SystemContext struct {
 	OSChoice string
 	// If not "", overrides the system's default directory containing a blob info cache.
 	BlobInfoCacheDir string
-
 	// Additional tags when creating or copying a docker-archive.
 	DockerArchiveAdditionalTags []reference.NamedTagged
+	// If not "", overrides the temporary directory to use for storing big files
+	BigFilesTemporaryDir string
 
 	// === OCI.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
Fixed #495 
Added possibility to overwrite default tmp dir for big files.
The problem in this PR is in that fact that not in all usage places it is possible to use SystemContext.
Signed-off-by: bpopovschi <zyqsempai@mail.ru>