### PR TITLE
Untested: Enforce runtime architecture

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -663,7 +663,7 @@ func checkImageDestinationForCurrentRuntimeOS(ctx context.Context, sys *types.Sy
 			wantedOS = sys.OSChoice
 		}
 		if (wantedOS == "windows" && c.OS == "linux") || (wantedOS != "windows" && c.OS == "windows") {
-			return fmt.Errorf("image operating system %q cannot be used on %q", c.OS, wantedOS)
+			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedOS)
 		}
 	}
 	return nil

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -662,7 +662,7 @@ func checkImageDestinationForCurrentRuntimeOS(ctx context.Context, sys *types.Sy
 		if sys != nil && sys.OSChoice != "" {
 			wantedOS = sys.OSChoice
 		}
-		if (wantedOS == "windows" && c.OS == "linux") || (wantedOS != "windows" && c.OS == "windows") {
+		if wantedOS != c.OS {
 			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedOS)
 		}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -653,19 +653,17 @@ func (c *copier) Printf(format string, a ...interface{}) {
 
 func checkImageDestinationForCurrentRuntimeOS(ctx context.Context, sys *types.SystemContext, src types.Image, dest types.ImageDestination) error {
 	if dest.MustMatchRuntimeOS() {
-		wantedOS := runtime.GOOS
-		if sys != nil && sys.OSChoice != "" {
-			wantedOS = sys.OSChoice
-		}
 		c, err := src.OCIConfig(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "Error parsing image configuration")
 		}
-		osErr := fmt.Errorf("image operating system %q cannot be used on %q", c.OS, wantedOS)
-		if wantedOS == "windows" && c.OS == "linux" {
-			return osErr
-		} else if wantedOS != "windows" && c.OS == "windows" {
-			return osErr
+
+		wantedOS := runtime.GOOS
+		if sys != nil && sys.OSChoice != "" {
+			wantedOS = sys.OSChoice
+		}
+		if (wantedOS == "windows" && c.OS == "linux") || (wantedOS != "windows" && c.OS == "windows") {
+			return fmt.Errorf("image operating system %q cannot be used on %q", c.OS, wantedOS)
 		}
 	}
 	return nil

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -112,7 +112,7 @@ func (d *dirImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *dirImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -90,7 +90,7 @@ func (d *daemonImageDestination) DesiredLayerCompression() types.LayerCompressio
 	return types.PreserveOriginal
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *daemonImageDestination) MustMatchRuntimeOS() bool {
 	return d.mustMatchRuntimeOS
 }

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -94,7 +94,7 @@ func (d *dockerImageDestination) AcceptsForeignLayerURLs() bool {
 	return true
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *dockerImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -78,7 +78,7 @@ func (d *Destination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *Destination) MustMatchRuntimeOS() bool {
 	return false
 }

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -66,7 +66,7 @@ func (d *ociArchiveImageDestination) AcceptsForeignLayerURLs() bool {
 	return d.unpackedDest.AcceptsForeignLayerURLs()
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise
 func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
 	return d.unpackedDest.MustMatchRuntimeOS()
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -97,7 +97,7 @@ func (d *ociImageDestination) AcceptsForeignLayerURLs() bool {
 	return true
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -378,7 +378,7 @@ func (d *openshiftImageDestination) AcceptsForeignLayerURLs() bool {
 	return true
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 	return false
 }

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -120,7 +120,7 @@ func (d *ostreeImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -930,7 +930,7 @@ func (s *storageImageDestination) AcceptsForeignLayerURLs() bool {
 	return false
 }
 
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 func (s *storageImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }

--- a/types/types.go
+++ b/types/types.go
@@ -264,7 +264,7 @@ type ImageDestination interface {
 	// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 	// uploaded to the image destination, true otherwise.
 	AcceptsForeignLayerURLs() bool
-	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
+	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
 	MustMatchRuntimeOS() bool
 	// IgnoresEmbeddedDockerReference() returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
 	// and would prefer to receive an unmodified manifest instead of one modified for the destination.


### PR DESCRIPTION
When pulling images for consumption by the current runtime, reject images that target a different architecture: https://bugzilla.redhat.com/show_bug.cgi?id=1753019 .

WIP:
- Absolutely untested, beyond that it compiles.
- I have no idea how this interacts with manifest lists yet.
- We might want to look for images that would be broken by this (is it possible to run i386 images on x86_64?)
- This should ideally be tested directly in CRI-O to ensure it behaves reasonably, and the error is propagated all the way up to the pod status.
- I’d really love to hear opinions on the semantics change of `MustMatchRuntimeOS`.