### PR TITLE
Extended SystemContext to include VariantChoice.

### DIFF
--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -100,13 +100,17 @@ func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest
 	if ctx != nil && ctx.OSChoice != "" {
 		wantedOS = ctx.OSChoice
 	}
+	wantedVariant := ""
+	if ctx != nil && ctx.VariantChoice != "" {
+		wantedVariant = ctx.VariantChoice
+	}
 
 	for _, d := range list.Manifests {
-		if d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS {
+		if d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS && (d.Platform.Variant == wantedVariant || wantedVariant == "") {
 			return d.Digest, nil
 		}
 	}
-	return "", fmt.Errorf("no image found in manifest list for architecture %s, OS %s", wantedArch, wantedOS)
+	return "", fmt.Errorf("no image found in manifest list for architecture %s(variant \"%s\"), OS %s", wantedArch, wantedVariant, wantedOS)
 }
 
 // Serialize returns the list in a blob format.

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -100,10 +100,14 @@ func TestChooseInstance(t *testing.T) {
 		require.NoError(t, err)
 		// Match found
 		for arch, expected := range manifestList.matchedInstances {
-			digest, err := list.ChooseInstance(&types.SystemContext{
+			ctx := &types.SystemContext{
 				ArchitectureChoice: arch,
 				OSChoice:           "linux",
-			})
+			}
+			if arch == "arm" {
+				ctx.VariantChoice = "v5"
+			}
+			digest, err := list.ChooseInstance(ctx)
 			require.NoError(t, err, arch)
 			assert.Equal(t, expected, digest)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -486,6 +486,8 @@ type SystemContext struct {
 	LegacyFormatAuthFilePath string
 	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
 	ArchitectureChoice string
+	// If not "", overrides the use of Architecture variant when choosing an image or verifying architecture match.
+	VariantChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
 	// If not "", overrides the system's default directory containing a blob info cache.


### PR DESCRIPTION
Like ArchitectureChoice and OSChoice, the user has a choice of architecture variant that can be used.