### PR TITLE
Make: split out installing tools

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+container:
+  image: golang:1.13
+
+env:
+  GOPROXY: https://proxy.golang.org
+
+validate_task:
+  validate_script:
+    - apt-get update -qq
+    - apt-get install -qq -y libgpgme-dev libdevmapper-dev btrfs-tools libbtrfs-dev
+    - make tools
+    - make .gitvalidation
+    - make validate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script: >
   -e GOCACHE=/tmp/gocache
   -v /etc/passwd:/etc/passwd -v /etc/sudoers:/etc/sudoers -v /etc/sudoers.d:/etc/sudoers.d
   -v /var/run:/var/run:z -v $HOME/gopath:/gopath:Z
-  -w /gopath/src/github.com/containers/image image-test bash -c "PATH=$PATH:/gopath/bin make cross tools .gitvalidation validate test test-skopeo SUDO=sudo BUILDTAGS=\"$BUILDTAGS\""
+  -w /gopath/src/github.com/containers/image image-test bash -c "PATH=$PATH:/gopath/bin make cross tools test test-skopeo SUDO=sudo BUILDTAGS=\"$BUILDTAGS\""

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-skopeo:
 		cd $${skopeo_path} && \
 		GO111MODULE="on" go mod edit -replace $${project_module}=$${project_path} && \
 		make vendor && \
-		make BUILDTAGS="$(BUILDTAGS)" binary-local test-all-local && \
+		make BUILDTAGS="$(BUILDTAGS)" binary-local test-unit-local && \
 		$(SUDO) make BUILDTAGS="$(BUILDTAGS)" check && \
 		rm -rf $${skopeo_path}
 

--- a/internal/pkg/keyctl/keyring.go
+++ b/internal/pkg/keyctl/keyring.go
@@ -5,9 +5,6 @@
 // +build linux
 
 // Package keyctl is a Go interface to linux kernel keyrings (keyctl interface)
-//
-// Deprecated: Most callers should use either golang.org/x/sys/unix directly,
-// or the original (and more extensive) github.com/jsipprell/keyctl .
 package keyctl
 
 import (

--- a/internal/pkg/keyctl/keyring_test.go
+++ b/internal/pkg/keyctl/keyring_test.go
@@ -11,7 +11,10 @@ import (
 func TestSessionKeyring(t *testing.T) {
 
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testname"
 	keyring, err := SessionKeyring()
@@ -41,7 +44,10 @@ func TestSessionKeyring(t *testing.T) {
 
 func TestUserKeyring(t *testing.T) {
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testuser"
 
@@ -71,7 +77,10 @@ func TestUserKeyring(t *testing.T) {
 
 func TestLink(t *testing.T) {
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testlink"
 
@@ -121,7 +130,10 @@ func TestLink(t *testing.T) {
 
 func TestUnlink(t *testing.T) {
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testunlink"
 	keyring, err := SessionKeyring()
@@ -147,7 +159,10 @@ func TestUnlink(t *testing.T) {
 
 func TestReadKeyring(t *testing.T) {
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testuser"
 
@@ -176,7 +191,10 @@ func TestReadKeyring(t *testing.T) {
 
 func TestDescribe(t *testing.T) {
 	token := make([]byte, 20)
-	rand.Read(token)
+	_, err := rand.Read(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	testname := "testuser"
 


### PR DESCRIPTION
Split the installation of required tools into dedicated .install.$tool 
targets and only install them if they're absent.  Remove the sudo call 
when installing golangci-lint by properly setting GOBIN.               

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>