### PR TITLE
storage_test.go: check storage interfaces

### DIFF
--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -35,7 +35,11 @@ import (
 )
 
 var (
-	topwd = ""
+	topwd                             = ""
+	_imgd      types.ImageDestination = &storageImageDestination{} //nolint
+	_imgs      types.ImageSource      = &storageImageSource{}      //nolint
+	_ref       types.ImageReference   = &storageReference{}        //nolint
+	_transport types.ImageTransport   = &storageTransport{}        //nolint
 )
 
 const (


### PR DESCRIPTION
Revert a previous change that removed the checks for storage interfaces
as golangci-lint complained about them.  Those checks are still desired
to catch errors early in case storage doesn't implement those
interfaces.  Silence golangci-lint by explicitly ingoring any lint
report for these specific lines.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>