### PR TITLE
Provide additional OverrideManifestMIMETypeList option for copy.Image

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -42,7 +42,8 @@ func (os *orderedSet) append(s string) {
 // Note that the conversion will only happen later, through ic.src.UpdatedImage
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
-func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (string, []string, error) {
+func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string,
+	forceManifestMIMEType string, overrideManifestMIMETypeList []string, requiresOciEncryption bool) (string, []string, error) {
 	_, srcType, err := ic.src.Manifest(ctx)
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
@@ -55,6 +56,8 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 
 	if forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}
+	} else if len(overrideManifestMIMETypeList) > 0 {
+		destSupportedManifestMIMETypes = overrideManifestMIMETypeList
 	}
 
 	if len(destSupportedManifestMIMETypes) == 0 && (!requiresOciEncryption || manifest.MIMETypeSupportsEncryption(srcType)) {


### PR DESCRIPTION
While the existing ForceManifestMIMEType option forces a single, specific
MIME type for the destination image, OverrideManifestMIMETypeList allows
for a list of one or more MIME types. Passing in a list with a single
mime type is equivalent to setting ForceManifestMIMEType, but this allows
for narrowing the set of MIME types used while not requiring conversion
for images which use MIME types in the list. For example, this would allow
for copying images with forced conversion of V2Schema1 images while allowing
both OCI and V2Schema2 images to be preserved as-is.

The particular use case of immediate concern is to support copying images
to a v2.7.1 Docker registry with Schema1 disabled. Without overriding
MIME types, schema1 images fail with a 500 error from the registry.

To copy an image to a v2.7.1 docker registry which only converts schema1 images,
leaving all other images unchanged, the following would be added to copy.Options:

	OverrideManifestMIMETypeList: []string{
		imgspecv1.MediaTypeImageManifest,
		manifest.DockerV2Schema2MediaType,
		imgspecv1.MediaTypeImageIndex,
		manifest.DockerV2ListMediaType,
	},

Signed-off-by: Scott Seago <sseago@redhat.com>