### PR TITLE
Allow for disabling schema1 MIME types for docker destinations

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -58,14 +58,16 @@ func (d *dockerImageDestination) Close() error {
 }
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
+	mimeTypes := []string{
 		imgspecv1.MediaTypeImageManifest,
 		manifest.DockerV2Schema2MediaType,
 		imgspecv1.MediaTypeImageIndex,
 		manifest.DockerV2ListMediaType,
-		manifest.DockerV2Schema1SignedMediaType,
-		manifest.DockerV2Schema1MediaType,
 	}
+	if d.c.sys == nil || !d.c.sys.DockerDisableDestSchema1MIMETypes {
+		mimeTypes = append(mimeTypes, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema1MediaType)
+	}
+	return mimeTypes
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.

--- a/types/types.go
+++ b/types/types.go
@@ -547,6 +547,8 @@ type SystemContext struct {
 	// Note that this field is used mainly to integrate containers/image into projectatomic/docker
 	// in order to not break any existing docker's integration tests.
 	DockerDisableV1Ping bool
+	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
+	DockerDisableDestSchema1MIMETypes bool
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
 


### PR DESCRIPTION
This commit adds DockerDisableDestSchema1MIMETypes to types.Context
which, if set to true, will omit DockerV2Schema1SignedMediaType and
DockerV2Schema1MediaType from
dockerImageDestination.SupportedManifestMIMETypes.

Signed-off-by: Scott Seago <sseago@redhat.com>