### PR TITLE
Retry logic cleanups

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -417,10 +417,10 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 	const numIterations = 5
 	const maxDelay = 60
 
-	parseRetryAfter := func(r *http.Response, delay int64) int64 {
+	parseRetryAfter := func(r *http.Response, fallbackDelay int64) int64 {
 		after := res.Header.Get("Retry-After")
 		if after == "" {
-			return delay
+			return fallbackDelay
 		}
 		logrus.Debugf("detected 'Retry-After' header %q", after)
 		// First check if we have a numerical value.
@@ -435,13 +435,13 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 			if delta > 0 {
 				return delta
 			}
-			logrus.Debugf("negative date: falling back to using %d seconds", delay)
-			return delay
+			logrus.Debugf("negative date: falling back to using %d seconds", fallbackDelay)
+			return fallbackDelay
 		}
 		// If the header contains bogus, fall back to using the default
 		// exponential back off.
-		logrus.Debugf("invalid format: falling back to using %d seconds", delay)
-		return delay
+		logrus.Debugf("invalid format: falling back to using %d seconds", fallbackDelay)
+		return fallbackDelay
 	}
 
 	for i := 0; i < numIterations; i++ {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -277,7 +277,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 	}
 	defer resp.Body.Close()
 
-	return httpResponseToError(resp)
+	return httpResponseToError(resp, "")
 }
 
 // SearchResult holds the information of each matching image
@@ -351,7 +351,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, httpResponseToError(resp))
+				logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, httpResponseToError(resp, ""))
 			} else {
 				if err := json.NewDecoder(resp.Body).Decode(v1Res); err != nil {
 					return nil, err
@@ -368,7 +368,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	} else {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			logrus.Errorf("error getting search results from v2 endpoint %q: %v", registry, httpResponseToError(resp))
+			logrus.Errorf("error getting search results from v2 endpoint %q: %v", registry, httpResponseToError(resp, ""))
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(v2Res); err != nil {
 				return nil, err
@@ -627,7 +627,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		defer resp.Body.Close()
 		logrus.Debugf("Ping %s status %d", url, resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-			return httpResponseToError(resp)
+			return httpResponseToError(resp, "")
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -446,7 +446,8 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 
 	for i := 0; i < numIterations; i++ {
 		res, err = c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)
-		if stream != nil || res == nil || res.StatusCode != http.StatusTooManyRequests {
+		if res == nil || res.StatusCode != http.StatusTooManyRequests || // Only retry on StatusTooManyRequests, success or other failure is returned to caller immediately
+			stream != nil { // We can't retry with a body (which is not restartable in the general case)
 			break
 		}
 		if i < numIterations-1 {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -408,8 +408,8 @@ func (c *dockerClient) makeRequest(ctx context.Context, method, path string, hea
 // If the stream is non-nil, no back off will be performed.
 // TODO(runcom): too many arguments here, use a struct
 func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url string, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
-	var delay int64 = 2
 	const numIterations = 5
+	const initialDelay = 2
 	const maxDelay = 60
 
 	parseRetryAfter := func(res *http.Response, fallbackDelay int64) int64 {
@@ -439,6 +439,7 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 		return fallbackDelay
 	}
 
+	var delay int64 = initialDelay
 	attempts := 0
 	for {
 		res, err := c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -457,7 +457,12 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 			delay = backoffMaxDelay
 		}
 		logrus.Debugf("too many request to %s: sleeping for %f seconds before next attempt", url, delay.Seconds())
-		time.Sleep(delay)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+			// Nothing
+		}
 		delay = delay * 2 // exponential back off
 	}
 }

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -448,7 +448,6 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 		res, err = c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)
 		if stream == nil && res != nil && res.StatusCode == http.StatusTooManyRequests {
 			if i < numIterations-1 {
-				logrus.Errorf("HEADER %v", res.Header)
 				delay = parseRetryAfter(res, delay)
 				if delay > maxDelay {
 					delay = maxDelay

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -70,7 +70,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if err := httpResponseToError(res); err != nil {
+		if err := httpResponseToError(res, "Error fetching tags list"); err != nil {
 			return nil, err
 		}
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -239,7 +239,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := httpResponseToError(res); err != nil {
+	if err := httpResponseToError(res, "Error fetching blob"); err != nil {
 		return nil, 0, err
 	}
 	cache.RecordKnownLocation(s.ref.Transport(), bicTransportScope(s.ref), info.Digest, newBICLocationReference(s.ref))

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -26,9 +26,9 @@ func (e ErrUnauthorizedForCredentials) Error() string {
 	return fmt.Sprintf("unable to retrieve auth token: invalid username/password: %s", e.Err.Error())
 }
 
-// httpResponseToError translates the https.Response into an error. It returns
+// httpResponseToError translates the https.Response into an error, possibly prefixing it with the supplied context. It returns
 // nil if the response is not considered an error.
-func httpResponseToError(res *http.Response) error {
+func httpResponseToError(res *http.Response, context string) error {
 	switch res.StatusCode {
 	case http.StatusOK:
 		return nil
@@ -38,6 +38,9 @@ func httpResponseToError(res *http.Response) error {
 		err := client.HandleErrorResponse(res)
 		return ErrUnauthorizedForCredentials{Err: err}
 	default:
-		return perrors.Errorf("invalid status code from registry %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+		if context != "" {
+			context = context + ": "
+		}
+		return perrors.Errorf("%sinvalid status code from registry %d (%s)", context, res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -14,7 +14,7 @@ var (
 	// docker V1 registry.
 	ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
 	// ErrTooManyRequests is returned when the status code returned is 429
-	ErrTooManyRequests = errors.New("too many request to registry")
+	ErrTooManyRequests = errors.New("too many requests to registry")
 )
 
 // ErrUnauthorizedForCredentials is returned when the status code returned is 401


### PR DESCRIPTION
@vrothberg RFC.

This is a set of small updates to #703 .  The support for `context.Context` timeouts is the only really important part; other than that, there are a few adjustments to user-visible output, and other than that mostly user-invisible tinkering, and I’d be perfectly happy to drop or change any of them.

See the individual commit messages for details.