### PR TITLE
Add documentation about rewriting docker.io registries

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -109,6 +109,26 @@ internet without having to change `Dockerfile`s, or to add redundancy).
 *Note*: Redirection and mirrors are currently processed only when reading images, not when pushing
 to a registry; that may change in the future.
 
+#### Normalization of docker.io references
+
+The Docker Hub `docker.io` is handled in a special way: every push and pull
+operation gets internally normalized with `/library` if no other specific
+namespace is defined (for example on `docker.io/namespace/image`).
+
+(Note that the above-described normalization happens to match the behavior of
+Docker.)
+
+This means that a pull of `docker.io/alpine` will be internally translated to
+`docker.io/library/alpine`. A pull of `docker.io/user/alpine` will not be
+rewritten because this is already the correct remote path.
+
+Therefore, to remap or mirror the `docker.io` images in the (implied) `/library`
+namespace (or that whole namespace), the prefix and location fields in this
+configuration file must explicitly include that `/library` namespace. For
+example `prefix = "docker.io/library/alpine"` and not `prefix =
+"docker.io/alpine"`. The latter would match the `docker.io/alpine/*`
+repositories but not the `docker.io/[library/]alpine` image).
+
 ### EXAMPLE
 
 ```

--- a/docs/containers-registries.d.5.md
+++ b/docs/containers-registries.d.5.md
@@ -24,7 +24,7 @@ don’t matter.
 The contents of these files are merged together; to have a well-defined and easy to understand
 behavior, there can be only one configuration section describing a single namespace within a registry
 (in particular there can be at most one one `default-docker` section across all files,
-and there can be at most one instance of any key under the the `docker` section;
+and there can be at most one instance of any key under the `docker` section;
 these sections are documented later).
 
 Thus, it is forbidden to have two conflicting configurations for a single registry or scope,
@@ -98,7 +98,7 @@ docker:
 For developers in `example.com`:
 
 - Consume most container images using the public servers also used by clients.
-- Use a separate sigure storage for an container images in a namespace corresponding to the developers' department, with a staging storage used before publishing signatures.
+- Use a separate signature storage for an container images in a namespace corresponding to the developers' department, with a staging storage used before publishing signatures.
 - Craft an individual exception for a single branch a specific developer is working on locally.
 
 ```yaml


### PR DESCRIPTION
We now document the already existing internal `/library` suffix for
docker.io mirrors and provide an example how to deal with them.

I also fixed two typos in `containers-registries.d.5.md`.

Closes https://github.com/containers/image/issues/775