### PR TITLE
WIP: Allow image specified by both tag and digest.

### DIFF
--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -69,17 +69,6 @@ func newReference(ref reference.Named) (dockerReference, error) {
 	if reference.IsNameOnly(ref) {
 		return dockerReference{}, errors.Errorf("Docker reference %s has neither a tag nor a digest", reference.FamiliarString(ref))
 	}
-	// A github.com/distribution/reference value can have a tag and a digest at the same time!
-	// The docker/distribution API does not really support that (we can’t ask for an image with a specific
-	// tag and digest), so fail.  This MAY be accepted in the future.
-	// (Even if it were supported, the semantics of policy namespaces are unclear - should we drop
-	// the tag or the digest first?)
-	_, isTagged := ref.(reference.NamedTagged)
-	_, isDigested := ref.(reference.Canonical)
-	if isTagged && isDigested {
-		return dockerReference{}, errors.Errorf("Docker references with both a tag and digest are currently not supported")
-	}
-
 	return dockerReference{
 		ref: ref,
 	}, nil

--- a/docker/policyconfiguration/naming.go
+++ b/docker/policyconfiguration/naming.go
@@ -15,14 +15,12 @@ func DockerReferenceIdentity(ref reference.Named) (string, error) {
 	tagged, isTagged := ref.(reference.NamedTagged)
 	digested, isDigested := ref.(reference.Canonical)
 	switch {
-	case isTagged && isDigested: // Note that this CAN actually happen.
-		return "", errors.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
 	case !isTagged && !isDigested: // This should not happen, the caller is expected to ensure !reference.IsNameOnly()
 		return "", errors.Errorf("Internal inconsistency: Docker reference %s with neither a tag nor a digest", reference.FamiliarString(ref))
+	case isDigested: // Note that (isTagged && isDigested) CAN actually happen as well while the digest should be used in this case.
+		res = res + "@" + digested.Digest().String()
 	case isTagged:
 		res = res + ":" + tagged.Tag()
-	case isDigested:
-		res = res + "@" + digested.Digest().String()
 	default: // Coverage: The above was supposed to be exhaustive.
 		return "", errors.New("Internal inconsistency, unexpected default branch")
 	}

--- a/docker/policyconfiguration/naming_test.go
+++ b/docker/policyconfiguration/naming_test.go
@@ -32,8 +32,9 @@ func TestDockerReference(t *testing.T) {
 		"repo":                   {"docker.io/library/repo", "docker.io/library", "docker.io"},
 	} {
 		for inputSuffix, mappedSuffix := range map[string]string{
-			":tag":       ":tag",
-			sha256Digest: sha256Digest,
+			":tag":                ":tag",
+			sha256Digest:          sha256Digest,
+			":tag" + sha256Digest: sha256Digest, // tag with digest should be treated as digest
 		} {
 			fullInput := inputName + inputSuffix
 			ref, err := reference.ParseNormalizedNamed(fullInput)
@@ -74,6 +75,6 @@ func TestDockerReferenceIdentity(t *testing.T) {
 	_, ok = parsed.(reference.NamedTagged)
 	require.True(t, ok)
 	id, err = DockerReferenceIdentity(parsed)
-	assert.Equal(t, "", id)
-	assert.Error(t, err)
+	assert.Equal(t, "docker.io/library/busybox@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", id)
+	assert.NoError(t, err)
 }

--- a/transports/alltransports/alltransports_test.go
+++ b/transports/alltransports/alltransports_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const sha256digest = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
 func TestParseImageName(t *testing.T) {
 	// This primarily tests error handling, TestImageNameHandling is a table-driven
 	// test for the expected values.
@@ -30,6 +32,8 @@ func TestImageNameHandling(t *testing.T) {
 		{"dir", "/etc", "/etc"},
 		{"docker", "//busybox", "//busybox:latest"},
 		{"docker", "//busybox:notlatest", "//busybox:notlatest"}, // This also tests handling of multiple ":" characters
+		{"docker", "//busybox" + sha256digest, "//busybox" + sha256digest},
+		{"docker", "//busybox:v1-dirty" + sha256digest, "//busybox:v1-dirty" + sha256digest},
 		{"docker-archive", "/var/lib/oci/busybox.tar:busybox:latest", "/var/lib/oci/busybox.tar:docker.io/library/busybox:latest"},
 		{"docker-archive", "busybox.tar:busybox:latest", "busybox.tar:docker.io/library/busybox:latest"},
 		{"oci", "/etc:someimage", "/etc:someimage"},


### PR DESCRIPTION
Refers to #783.

Changes:
- Moved the code that returns an error when both tag and digest are
  present from `newReference` to `reference.newImageDestination` in
  order to allow pulls but no pushes.
- If present use digest instead of tag as `DockerReferenceIdentity`
  or rather for policy matching.
- Adjusted tests.

Signed-off-by: Max Goltzsche <max.goltzsche@gmail.com>

Question remains how well this works with the other tools in the chain - needs to be tested first which  is why this is still WIP.