### PR TITLE
Adds the possibility to choose the image by the variant field in a manifest

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -705,16 +705,21 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 		}
 		wantedPlatforms, err := platform.WantedPlatforms(sys)
 		if err != nil {
-			return errors.Wrapf(err, "error getting platform information %#v", sys)
+			return errors.Wrapf(err, "error getting current platform information %#v", sys)
 		}
-		wantedPlatform := wantedPlatforms[0] // TODO fixme
-		if wantedPlatform.OS != c.OS {
-			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedPlatform.OS)
+		for _, wantedPlatform := range wantedPlatforms {
+			if wantedPlatform.OS != c.OS {
+				return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedPlatform.OS)
+			}
+			if wantedPlatform.Architecture != c.Architecture {
+				return fmt.Errorf("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedPlatform.Architecture)
+			}
+			/*
+				// TODO Waiting for https://github.com/opencontainers/image-spec/pull/777
+				if wantedPlatform.Variant != "" && c.Variant != "" && wantedPlatform.Variant != c.Variant {
+					return fmt.Errorf("Image variant mismatch: image uses %q, expecting %q", c.Variant, wantedPlatform.Variant)
+				}*/
 		}
-		if wantedPlatform.Architecture != c.Architecture {
-			return fmt.Errorf("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedPlatform.Architecture)
-		}
-		// TODO also check for variant
 	}
 	return nil
 }

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -702,10 +702,11 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 		if err != nil {
 			return errors.Wrapf(err, "Error parsing image configuration")
 		}
-		wantedPlatform, err := manifest.WantedPlatform(sys)
+		wantedPlatforms, err := manifest.WantedPlatforms(sys)
 		if err != nil {
 			return errors.Wrapf(err, "error getting platform information %#v", sys)
 		}
+		wantedPlatform := wantedPlatforms[0] // TODO fixme
 		if wantedPlatform.OS != c.OS {
 			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedPlatform.OS)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -703,22 +702,17 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 		if err != nil {
 			return errors.Wrapf(err, "Error parsing image configuration")
 		}
-
-		wantedOS := runtime.GOOS
-		if sys != nil && sys.OSChoice != "" {
-			wantedOS = sys.OSChoice
+		wantedPlatform, err := manifest.WantedPlatform(sys)
+		if err != nil {
+			return errors.Wrapf(err, "error getting platform information %#v", sys)
 		}
-		if wantedOS != c.OS {
-			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedOS)
+		if wantedPlatform.OS != c.OS {
+			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedPlatform.OS)
 		}
-
-		wantedArch := runtime.GOARCH
-		if sys != nil && sys.ArchitectureChoice != "" {
-			wantedArch = sys.ArchitectureChoice
+		if wantedPlatform.Architecture != c.Architecture {
+			return fmt.Errorf("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedPlatform.Architecture)
 		}
-		if wantedArch != c.Architecture {
-			return fmt.Errorf("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedArch)
-		}
+		// TODO also check for variant
 	}
 	return nil
 }

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/image"
+	platform "github.com/containers/image/v5/internal/pkg/platform"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
@@ -702,7 +703,7 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 		if err != nil {
 			return errors.Wrapf(err, "Error parsing image configuration")
 		}
-		wantedPlatforms, err := manifest.WantedPlatforms(sys)
+		wantedPlatforms, err := platform.WantedPlatforms(sys)
 		if err != nil {
 			return errors.Wrapf(err, "error getting platform information %#v", sys)
 		}

--- a/image/fixtures/schema2list.json
+++ b/image/fixtures/schema2list.json
@@ -34,16 +34,6 @@
       {
          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
          "size": 527,
-         "digest": "sha256:a8fe0549cac196f439de3bf2b57af14f7cd4e59915ccd524428f588628a4ef31",
-         "platform": {
-            "architecture": "arm",
-            "os": "linux",
-            "variant": "v7"
-         }
-      },
-      {
-         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "size": 527,
          "digest": "sha256:dc472a59fb006797aa2a6bfb54cc9c57959bb0a6d11fadaa608df8c16dea39cf",
          "platform": {
             "architecture": "arm64",

--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -144,7 +144,7 @@ func WantedPlatforms(ctx *types.SystemContext) ([]imgspecv1.Platform, error) {
 	return wantedPlatforms, nil
 }
 
-func MatchesPlatform(image Schema2PlatformSpec, wanted imgspecv1.Platform) bool {
+func MatchesPlatform(image imgspecv1.Platform, wanted imgspecv1.Platform) bool {
 	if image.Architecture != wanted.Architecture {
 		return false
 	}

--- a/internal/pkg/platform/platform_matcher_test.go
+++ b/internal/pkg/platform/platform_matcher_test.go
@@ -1,0 +1,46 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/containers/image/v5/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWantedPlatformsCompatibility(t *testing.T) {
+	ctx := &types.SystemContext{
+		ArchitectureChoice: "arm",
+		OSChoice:           "linux",
+		VariantChoice:      "v6",
+	}
+	platforms, err := WantedPlatforms(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, len(platforms), 2)
+	assert.Equal(t, platforms[0], imgspecv1.Platform{
+		OS:           ctx.OSChoice,
+		Architecture: ctx.ArchitectureChoice,
+		Variant:      "v6",
+	})
+	assert.Equal(t, platforms[1], imgspecv1.Platform{
+		OS:           ctx.OSChoice,
+		Architecture: ctx.ArchitectureChoice,
+		Variant:      "v5",
+	})
+}
+
+func TestWantedPlatformsCustom(t *testing.T) {
+	ctx := &types.SystemContext{
+		ArchitectureChoice: "armel",
+		OSChoice:           "freeBSD",
+		VariantChoice:      "custom",
+	}
+	platforms, err := WantedPlatforms(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, len(platforms), 1)
+	assert.Equal(t, platforms[0], imgspecv1.Platform{
+		OS:           ctx.OSChoice,
+		Architecture: ctx.ArchitectureChoice,
+		Variant:      ctx.VariantChoice,
+	})
+}

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -91,19 +91,18 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 // ChooseInstance parses blob as a schema2 manifest list, and returns the digest
 // of the image which is appropriate for the current environment.
 func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
-	wantedPlatform, err := WantedPlatform(ctx)
+	wantedPlatforms, err := WantedPlatforms(ctx)
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting platform information %#v", ctx)
 	}
-
-	for _, d := range list.Manifests {
-		// TODO some variants might work on different demanded variants (https://github.com/containerd/containerd/blob/master/platforms/compare.go#L29)
-		if d.Platform.Architecture == wantedPlatform.Architecture && d.Platform.OS == wantedPlatform.OS && (wantedPlatform.Variant == "" || d.Platform.Variant == wantedPlatform.Variant) {
-			return d.Digest, nil
+	for _, wantedPlatform := range wantedPlatforms {
+		for _, d := range list.Manifests {
+			if MatchesPlatform(d.Platform, wantedPlatform) {
+				return d.Digest, nil
+			}
 		}
 	}
-
-	return "", fmt.Errorf("no image found in image index for architecture %s, OS %s, Variant %s", wantedPlatform.Architecture, wantedPlatform.OS, wantedPlatform.Variant)
+	return "", fmt.Errorf("no image found in image index for architecture %s, OS %s, Variant %s", wantedPlatforms[0].Architecture, wantedPlatforms[0].OS, wantedPlatforms[0].Variant)
 }
 
 // Serialize returns the list in a blob format.

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -110,7 +110,7 @@ func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest
 			}
 		}
 	}
-	return "", fmt.Errorf("no image found in image index for architecture %s, OS %s, Variant %s", wantedPlatforms[0].Architecture, wantedPlatforms[0].OS, wantedPlatforms[0].Variant)
+	return "", fmt.Errorf("no image found in manifest list for architecture %s, variant %s, OS %s", wantedPlatforms[0].Architecture, wantedPlatforms[0].Variant, wantedPlatforms[0].OS)
 }
 
 // Serialize returns the list in a blob format.

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -99,11 +99,14 @@ func TestChooseInstance(t *testing.T) {
 		require.NoError(t, err)
 		// Match found
 		for arch, expected := range manifestList.matchedInstances {
-			digest, err := list.ChooseInstance(&types.SystemContext{
+			ctx := &types.SystemContext{
 				ArchitectureChoice: arch,
 				OSChoice:           "linux",
-				VariantChoice:      "v6",
-			})
+			}
+			if arch == "arm" {
+				ctx.VariantChoice = "v6"
+			}
+			digest, err := list.ChooseInstance(ctx)
 			require.NoError(t, err, arch)
 			assert.Equal(t, expected, digest)
 		}
@@ -112,7 +115,6 @@ func TestChooseInstance(t *testing.T) {
 			_, err := list.ChooseInstance(&types.SystemContext{
 				ArchitectureChoice: arch,
 				OSChoice:           "linux",
-				VariantChoice:      "v6",
 			})
 			assert.Error(t, err)
 		}

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -75,9 +75,7 @@ func TestChooseInstance(t *testing.T) {
 			matchedInstances: map[string]digest.Digest{
 				"amd64": "sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af",
 				"s390x": "sha256:e5aa1b0a24620228b75382997a0977f609b3ca3a95533dafdef84c74cc8df642",
-				// There are several "arm" images with different variants;
-				// the current code returns the first match. NOTE: This is NOT an API promise.
-				"arm": "sha256:9142d97ef280a7953cf1a85716de49a24cc1dd62776352afad67e635331ff77a",
+				"arm":   "sha256:b5dbad4bdb4444d919294afe49a095c23e86782f98cdf0aa286198ddb814b50b",
 			},
 			unmatchedInstances: []string{
 				"unmatched",
@@ -104,6 +102,7 @@ func TestChooseInstance(t *testing.T) {
 			digest, err := list.ChooseInstance(&types.SystemContext{
 				ArchitectureChoice: arch,
 				OSChoice:           "linux",
+				VariantChoice:      "v6",
 			})
 			require.NoError(t, err, arch)
 			assert.Equal(t, expected, digest)
@@ -113,6 +112,7 @@ func TestChooseInstance(t *testing.T) {
 			_, err := list.ChooseInstance(&types.SystemContext{
 				ArchitectureChoice: arch,
 				OSChoice:           "linux",
+				VariantChoice:      "v6",
 			})
 			assert.Error(t, err)
 		}

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -76,6 +76,7 @@ func TestChooseInstance(t *testing.T) {
 				"amd64": "sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af",
 				"s390x": "sha256:e5aa1b0a24620228b75382997a0977f609b3ca3a95533dafdef84c74cc8df642",
 				"arm":   "sha256:b5dbad4bdb4444d919294afe49a095c23e86782f98cdf0aa286198ddb814b50b",
+				"arm64": "sha256:dc472a59fb006797aa2a6bfb54cc9c57959bb0a6d11fadaa608df8c16dea39cf",
 			},
 			unmatchedInstances: []string{
 				"unmatched",
@@ -104,7 +105,7 @@ func TestChooseInstance(t *testing.T) {
 				OSChoice:           "linux",
 			}
 			if arch == "arm" {
-				ctx.VariantChoice = "v6"
+				ctx.VariantChoice = "v7"
 			}
 			digest, err := list.ChooseInstance(ctx)
 			require.NoError(t, err, arch)

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -84,11 +84,23 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 		wantedOS = ctx.OSChoice
 	}
 
+	var fallback digest.Digest
+
 	for _, d := range index.Manifests {
 		if d.Platform != nil && d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS {
-			return d.Digest, nil
+			// TODO It should be possible to somehow use runtime.GOARM to construct a default VariantChoice
+			if ctx != nil && (ctx.VariantChoice == "" || d.Platform.Variant == ctx.VariantChoice) {
+				return d.Digest, nil
+			}
+			if fallback == "" {
+				fallback = d.Digest
+			}
 		}
 	}
+	if fallback != "" {
+		return fallback, nil
+	}
+
 	for _, d := range index.Manifests {
 		if d.Platform == nil {
 			return d.Digest, nil

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 
+	platform "github.com/containers/image/v5/internal/pkg/platform"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
@@ -75,20 +76,20 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 // ChooseInstance parses blob as an oci v1 manifest index, and returns the digest
 // of the image which is appropriate for the current environment.
 func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
-	wantedPlatforms, err := WantedPlatforms(ctx)
+	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
 		return "", errors.Wrapf(err, "error getting platform information %#v", ctx)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range index.Manifests {
-			imagePlatform := Schema2PlatformSpec{
+			imagePlatform := imgspecv1.Platform{
 				Architecture: d.Platform.Architecture,
 				OS:           d.Platform.OS,
 				OSVersion:    d.Platform.OSVersion,
 				OSFeatures:   dupStringSlice(d.Platform.OSFeatures),
 				Variant:      d.Platform.Variant,
 			}
-			if MatchesPlatform(imagePlatform, wantedPlatform) {
+			if platform.MatchesPlatform(imagePlatform, wantedPlatform) {
 				return d.Digest, nil
 			}
 		}

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -100,7 +100,7 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 			return d.Digest, nil
 		}
 	}
-	return "", fmt.Errorf("no image found in image index for architecture %s, OS %s, Variant %s", wantedPlatforms[0].Architecture, wantedPlatforms[0].OS, wantedPlatforms[0].Variant)
+	return "", fmt.Errorf("no image found in manifest list for architecture %s, variant %s, OS %s", wantedPlatforms[0].Architecture, wantedPlatforms[0].Variant, wantedPlatforms[0].OS)
 }
 
 // Serialize returns the index in a blob format.

--- a/manifest/platform_matcher.go
+++ b/manifest/platform_matcher.go
@@ -1,0 +1,120 @@
+package manifest
+
+// Largely based on
+// https://github.com/moby/moby/blob/bc846d2e8fe5538220e0c31e9d0e8446f6fbc022/distribution/cpuinfo_unix.go
+// https://github.com/containerd/containerd/blob/726dcaea50883e51b2ec6db13caff0e7936b711d/platforms/cpuinfo.go
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/containers/image/v5/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// For Linux, the kernel has already detected the ABI, ISA and Features.
+// So we don't need to access the ARM registers to detect platform information
+// by ourselves. We can just parse these information from /proc/cpuinfo
+func getCPUInfo(pattern string) (info string, err error) {
+	if runtime.GOOS != "linux" {
+		return "", fmt.Errorf("getCPUInfo for OS %s not implemented", runtime.GOOS)
+	}
+
+	cpuinfo, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return "", err
+	}
+	defer cpuinfo.Close()
+
+	// Start to Parse the Cpuinfo line by line. For SMP SoC, we parse
+	// the first core is enough.
+	scanner := bufio.NewScanner(cpuinfo)
+	for scanner.Scan() {
+		newline := scanner.Text()
+		list := strings.Split(newline, ":")
+
+		if len(list) > 1 && strings.EqualFold(strings.TrimSpace(list[0]), pattern) {
+			return strings.TrimSpace(list[1]), nil
+		}
+	}
+
+	// Check whether the scanner encountered errors
+	err = scanner.Err()
+	if err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("getCPUInfo for pattern: %s not found", pattern)
+}
+
+func getCPUVariant() string {
+	if runtime.GOOS == "windows" {
+		// Windows only supports v7 for ARM32 and v8 for ARM64 and so we can use
+		// runtime.GOARCH to determine the variants
+		var variant string
+		switch runtime.GOARCH {
+		case "arm64":
+			variant = "v8"
+		case "arm":
+			variant = "v7"
+		default:
+			variant = "unknown"
+		}
+
+		return variant
+	}
+
+	variant, err := getCPUInfo("Cpu architecture")
+	if err != nil {
+		return ""
+	}
+	// TODO handle RPi Zero mismatch (https://github.com/moby/moby/pull/36121#issuecomment-398328286)
+
+	switch strings.ToLower(variant) {
+	case "8", "aarch64":
+		variant = "v8"
+	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
+		variant = "v7"
+	case "6", "6tej":
+		variant = "v6"
+	case "5", "5t", "5te", "5tej":
+		variant = "v5"
+	case "4", "4t":
+		variant = "v4"
+	case "3":
+		variant = "v3"
+	default:
+		variant = "unknown"
+	}
+
+	return variant
+}
+
+func WantedPlatform(ctx *types.SystemContext) (imgspecv1.Platform, error) {
+	wantedArch := runtime.GOARCH
+	if ctx != nil && ctx.ArchitectureChoice != "" {
+		wantedArch = ctx.ArchitectureChoice
+	}
+	wantedOS := runtime.GOOS
+	if ctx != nil && ctx.OSChoice != "" {
+		wantedOS = ctx.OSChoice
+	}
+
+	wantedPlatform := imgspecv1.Platform{
+		OS:           wantedOS,
+		Architecture: wantedArch,
+	}
+
+	if ctx != nil && ctx.VariantChoice != "" {
+		if wantedArch == "arm" || wantedArch == "arm64" {
+			wantedPlatform.Variant = ctx.VariantChoice
+		} else {
+			wantedPlatform.Variant = getCPUVariant()
+			// TODO handle Variant == 'unknown'
+		}
+	}
+	return wantedPlatform, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -510,6 +510,8 @@ type SystemContext struct {
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
+	// If not "", overrides the use of detected ARM platform variant when choosing an image or verifying variant match.
+	VariantChoice string
 	// If not "", overrides the system's default directory containing a blob info cache.
 	BlobInfoCacheDir string
 	// Additional tags when creating or copying a docker-archive.


### PR DESCRIPTION
This is part of an https://github.com/containers/skopeo/issues/790 and improves the `ChooseImage` method so that it respects the `variant` field which is used on ARM architecture. It also exposes the `VariantChoice` to the outside world, so it can be passed as a command line argument.

I'm not a Golang person, so it might be a little rusty. I intentionally kept the original behaviour that when there is no match for Variant, the first record matching the platform and architecture is returned. It might be more transparent to fail in that case though.