### PR TITLE
Improve error reporting on mirror failures

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -64,7 +64,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	attempts := []attempt{}
 	for _, pullSource := range pullSources {
-		logrus.Debugf("Trying to pull %q", pullSource.Reference)
+		logrus.Debugf("Trying to access %q", pullSource.Reference)
 		s, err := newImageSourceAttempt(ctx, sys, pullSource, primaryDomain)
 		if err == nil {
 			return s, nil

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -69,6 +69,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 		if err == nil {
 			return s, nil
 		}
+		logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
 		attempts = append(attempts, attempt{
 			ref: pullSource.Reference,
 			err: err,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.11
 require (
 	github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 // indirect
 	github.com/BurntSushi/toml v0.3.1
-	github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8 // indirect
 	github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b
 	github.com/containers/ocicrypt v0.0.0-20190930154801-b87a4a69c741
 	github.com/containers/storage v1.15.5
@@ -16,7 +15,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/etcd-io/bbolt v1.3.3
 	github.com/ghodss/yaml v0.0.0-20161207003320-04f313413ffd
-	github.com/gogo/protobuf v0.0.0-20170815085658-fcdc5011193f // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v0.0.0-20170217192616-94e7d24fd285 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect


### PR DESCRIPTION
Primarily, ensure that errors reported by `docker.newImageSource` (i.e. most errors trying to access registries) also contain failures when accessing _all_ mirrors, not just the last error = the error accessing the primary endpoint.

The resulting error is extremely ugly (see below) but hopefully informative, and we can tinker with that later after this is not as urgent (in two ways: by dropping some context and shortening the error in common failure cases, and by by heuristically prioritizing some of the errors vs. others, e.g. a TLS / user authentication failure for a mirror is more likely to be relevant than a DNS not found for the primary).

In addition:
- Some errors (notably an endpoint being configured as blocked) are now not immediately fatal, the other endpoints continue to be attempted.
- The debug logs, in addition to starting each attempt with `Trying to pull…` (now `Trying to access…`), also contain the failure for each endpoint as soon as that endpoint fails.

See individual commit messages for details.

Fixes #674.