### PR TITLE
sysregistriesv2: only print debug message if ref was rewritten

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -62,7 +62,7 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 	if err != nil {
 		return nil, errors.Wrapf(err, "error rewriting reference")
 	}
-	logrus.Debugf("reference rewritten from '%v' to '%v'", refString, newParsedRef.String())
+
 	return newParsedRef, nil
 }
 


### PR DESCRIPTION
Only print the debug message in `(*Endpoint).rewriteReference()` if the
reference has actually been rewritten.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>