### PR TITLE
Always use SigningMechanism implementations by reference

### DIFF
--- a/signature/mechanism_gpgme.go
+++ b/signature/mechanism_gpgme.go
@@ -139,7 +139,7 @@ func (m *gpgmeSigningMechanism) Sign(input []byte, keyIdentity string) ([]byte, 
 }
 
 // Verify parses unverifiedSignature and returns the content and the signer's identity
-func (m gpgmeSigningMechanism) Verify(unverifiedSignature []byte) (contents []byte, keyIdentity string, err error) {
+func (m *gpgmeSigningMechanism) Verify(unverifiedSignature []byte) (contents []byte, keyIdentity string, err error) {
 	signedBuffer := bytes.Buffer{}
 	signedData, err := gpgme.NewDataWriter(&signedBuffer)
 	if err != nil {
@@ -170,6 +170,6 @@ func (m gpgmeSigningMechanism) Verify(unverifiedSignature []byte) (contents []by
 // WARNING: The short key identifier (which correponds to "Key ID" for OpenPGP keys)
 // is NOT the same as a "key identity" used in other calls ot this interface, and
 // the values may have no recognizable relationship if the public key is not available.
-func (m gpgmeSigningMechanism) UntrustedSignatureContents(untrustedSignature []byte) (untrustedContents []byte, shortKeyIdentifier string, err error) {
+func (m *gpgmeSigningMechanism) UntrustedSignatureContents(untrustedSignature []byte) (untrustedContents []byte, shortKeyIdentifier string, err error) {
 	return gpgUntrustedSignatureContents(untrustedSignature)
 }

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -154,6 +154,6 @@ func (m *openpgpSigningMechanism) Verify(unverifiedSignature []byte) (contents [
 // WARNING: The short key identifier (which correponds to "Key ID" for OpenPGP keys)
 // is NOT the same as a "key identity" used in other calls ot this interface, and
 // the values may have no recognizable relationship if the public key is not available.
-func (m openpgpSigningMechanism) UntrustedSignatureContents(untrustedSignature []byte) (untrustedContents []byte, shortKeyIdentifier string, err error) {
+func (m *openpgpSigningMechanism) UntrustedSignatureContents(untrustedSignature []byte) (untrustedContents []byte, shortKeyIdentifier string, err error) {
 	return gpgUntrustedSignatureContents(untrustedSignature)
 }


### PR DESCRIPTION
… instead of by value.

AFAICS this did not have any actual undesirable impact (the mechanism object is either not used at all, or used only to read another object reference), but it was not intentional and passing the data by value could lead to surprises later.