### PR TITLE
oci manifest: do not require whitelist of layer types

### DIFF
--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -427,5 +427,5 @@ func TestConvertToV2S2WithInvalidMIMEType(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = manifestOCI1FromManifest(originalSrc, manifest)
-	require.Error(t, err)
+	require.NoError(t, err)
 }

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -81,9 +81,6 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 		if updates[i].MediaType == "" {
 			return errors.Errorf("update %d of %d passed to Schema2List.UpdateInstances had no media type (was %q)", i+1, len(updates), list.Manifests[i].MediaType)
 		}
-		if err := SupportedSchema2MediaType(updates[i].MediaType); err != nil && SupportedOCI1MediaType(updates[i].MediaType) != nil {
-			return errors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances had an unsupported media type (was %q): %q", i+1, len(updates), list.Manifests[i].MediaType, updates[i].MediaType)
-		}
 		list.Manifests[i].MediaType = updates[i].MediaType
 	}
 	return nil

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -64,9 +64,6 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 		if updates[i].MediaType == "" {
 			return errors.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had no media type (was %q)", i+1, len(updates), index.Manifests[i].MediaType)
 		}
-		if err := SupportedOCI1MediaType(updates[i].MediaType); err != nil && SupportedSchema2MediaType(updates[i].MediaType) != nil && updates[i].MediaType != imgspecv1.MediaTypeImageIndex {
-			return errors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances had an unsupported media type (was %q): %q", i+1, len(updates), index.Manifests[i].MediaType, updates[i].MediaType)
-		}
 		index.Manifests[i].MediaType = updates[i].MediaType
 	}
 	return nil

--- a/manifest/oci_test.go
+++ b/manifest/oci_test.go
@@ -71,14 +71,6 @@ func TestSupportedOCI1MediaType(t *testing.T) {
 	}
 }
 
-func TestInvalidOCI1MediaType(t *testing.T) {
-	bytes, err := ioutil.ReadFile("fixtures/ociv1.invalid.mediatype.manifest.json")
-	assert.Nil(t, err)
-
-	_, err = OCI1FromManifest(bytes)
-	assert.NotNil(t, err)
-}
-
 func TestUpdateLayerInfosOCIGzipToZstd(t *testing.T) {
 	bytes, err := ioutil.ReadFile("fixtures/ociv1.manifest.json")
 	assert.Nil(t, err)


### PR DESCRIPTION
69aa1e85460f ("media type checks") introduced a whitelist of required mime
types for individual layers.

However, this actually violates the OCI spec,
https://github.com/opencontainers/image-spec/blob/master/manifest.md which
says:

"An encountered mediaType that is unknown to the implementation MUST be ignored."

Indeed, we have code that uses manifest types not defined in this
whitelist, so it breaks our code.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>