### PR TITLE
restrict sizes of inmem processed blobs

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/pkg/docker/config"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/pkg/tlsclientconfig"
@@ -591,7 +591,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge, 
 	default:
 		return nil, errors.Errorf("unexpected http code: %d (%s), URL: %s", res.StatusCode, http.StatusText(res.StatusCode), authReq.URL)
 	}
-	tokenBlob, err := ioutil.ReadAll(res.Body)
+	tokenBlob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxAuthTokenBodySize)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +684,7 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 		return nil, errors.Wrapf(clientLib.HandleErrorResponse(res), "Error downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureListBodySize)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/types"
@@ -622,7 +623,7 @@ sigExists:
 		}
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusCreated {
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxErrorBodySize)
 			if err == nil {
 				logrus.Debugf("Error body %s", string(body))
 			}

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -7,10 +7,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/types"
@@ -102,7 +102,7 @@ func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/image/oci.go
+++ b/image/oci.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/types"
@@ -67,7 +67,7 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/iolimits/iolimits.go
+++ b/internal/iolimits/iolimits.go
@@ -1,0 +1,57 @@
+package iolimits
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// All constants below are intended to be used as limits for `ReadAtMost`. The
+// immediate use-case for limiting the size of in-memory copied data is to
+// protect against OOM DOS attacks as described inCVE-2020-1702. Instead of
+// copying data until running out of memory, we error out after hitting the
+// specified limit.
+const (
+	// megaByte denotes one megabyte and is intended to be used as a limit in
+	// `ReadAtMost`.
+	megaByte = 1 << 20
+	// MaxManifestBodySize is the maximum allowed size of a manifest. The limit
+	// of 4 MB aligns with the one of a Docker registry:
+	// https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/handlers/manifests.go#L30
+	MaxManifestBodySize = 4 * megaByte
+	// MaxAuthTokenBodySize is the maximum allowed size of an auth token.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxAuthTokenBodySize = megaByte
+	// MaxSignatureListBodySize is the maximum allowed size of a signature list.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureListBodySize = 4 * megaByte
+	// MaxSignatureBodySize is the maximum allowed size of a signature.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureBodySize = 4 * megaByte
+	// MaxErrorBodySize is the maximum allowed size of an error-response body.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxErrorBodySize = megaByte
+	// MaxConfigBodySize is the maximum allowed size of a config blob.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxConfigBodySize = 4 * megaByte
+	// MaxOpenShiftStatusBody is the maximum allowed size of an OpenShift status body.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxOpenShiftStatusBody = 4 * megaByte
+)
+
+// ReadAtMost reads from reader and errors out if the specified limit (in bytes) is exceeded.
+func ReadAtMost(reader io.Reader, limit int) ([]byte, error) {
+	limitedReader := io.LimitReader(reader, int64(limit+1))
+
+	res, err := ioutil.ReadAll(limitedReader)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	if len(res) > limit {
+		return nil, errors.Errorf("exceeded maximum allowed size of %d bytes", limit)
+	}
+
+	return res, nil
+}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/image/v5/version"
@@ -102,7 +102,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		return nil, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxOpenShiftStatusBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Restrict the sizes of blobs which are copied into memory such as the
manifest, the config, signatures, etc.  This will protect consumers of
c/image from rogue or hijacked registries that return too big blobs in
hope to cause an OOM DOS attack.

Note that error messages should be improved in a future change to make
sure that it's clear in which code path we hit a limit.

Fixes: CVE-2020-1702
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1792796
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>