### PR TITLE
copy: relax platform checks

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -709,7 +709,7 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 			wantedOS = sys.OSChoice
 		}
 		if wantedOS != c.OS {
-			return fmt.Errorf("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedOS)
+			logrus.Infof("Image operating system mismatch: image uses %q, expecting %q", c.OS, wantedOS)
 		}
 
 		wantedArch := runtime.GOARCH
@@ -717,7 +717,7 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 			wantedArch = sys.ArchitectureChoice
 		}
 		if wantedArch != c.Architecture {
-			return fmt.Errorf("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedArch)
+			logrus.Infof("Image architecture mismatch: image uses %q, expecting %q", c.Architecture, wantedArch)
 		}
 	}
 	return nil

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/containerd/containerd v1.2.10/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtM
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8 h1:ZZOFPzvZO3N0f4LIQvZi68F2XDAMl/gqBfFMVjY6B3Y=
 github.com/containerd/continuity v0.0.0-20180216233310-d8fb8589b0e8/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc h1:TP+534wVlf61smEIq1nwLLAjQVEK2EADoW3CX9AuT+8=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=


### PR DESCRIPTION
Relax the platform checks of the source images architecture and OS when
copying.  Some images do not set these attributes correctly in their
config which unexpectedly broke previously running deployments.

Instead of returning an error, just info-log about the mismatch.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>