### PR TITLE
Add NewReference to a few transports, + storage.GetStoreIfSet

### DIFF
--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -41,10 +41,10 @@ func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 
 // archiveReference is an ImageReference for Docker images.
 type archiveReference struct {
-	// only used for destinations
+	path string
+	// only used for destinations,
 	// archiveReference.destinationRef is optional and can be nil for destinations as well.
 	destinationRef reference.NamedTagged
-	path           string
 }
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -64,11 +64,6 @@ func ParseReference(refString string) (types.ImageReference, error) {
 			return nil, errors.Wrapf(err, "docker-archive parsing reference")
 		}
 		ref = reference.TagNameOnly(ref)
-
-		if _, isDigest := ref.(reference.Canonical); isDigest {
-			return nil, errors.Errorf("docker-archive doesn't support digest references: %s", refString)
-		}
-
 		refTagged, isTagged := ref.(reference.NamedTagged)
 		if !isTagged {
 			// Really shouldn't be hit...
@@ -77,9 +72,20 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		destinationRef = refTagged
 	}
 
+	return NewReference(path, destinationRef)
+}
+
+// NewReference rethrns a Docker archive reference for a path and an optional destination reference.
+func NewReference(path string, destinationRef reference.NamedTagged) (types.ImageReference, error) {
+	if strings.Contains(path, ":") {
+		return nil, errors.Errorf("Invalid docker-archive: reference: colon in path %q is not supported", path)
+	}
+	if _, isDigest := destinationRef.(reference.Canonical); isDigest {
+		return nil, errors.Errorf("docker-archive doesn't support digest references: %s", destinationRef.String())
+	}
 	return archiveReference{
-		destinationRef: destinationRef,
 		path:           path,
+		destinationRef: destinationRef,
 	}, nil
 }
 

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -30,6 +30,14 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 	if named == nil && id == "" {
 		return nil, ErrInvalidReference
 	}
+	if named != nil && reference.IsNameOnly(named) {
+		return nil, errors.Wrapf(ErrInvalidReference, "reference %s has neither a tag nor a digest", named.String())
+	}
+	if id != "" {
+		if err := validateImageID(id); err != nil {
+			return nil, errors.Wrapf(ErrInvalidReference, "invalid ID value %q: %v", id, err)
+		}
+	}
 	// We take a copy of the transport, which contains a pointer to the
 	// store that it used for resolving this reference, so that the
 	// transport that we'll return from Transport() won't be affected by

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,12 @@ func TestNewReference(t *testing.T) {
 	require.True(t, ok)
 	// Success is tested throughout; test only the failure
 	_, err := newReference(*st, nil, "")
+	assert.Error(t, err)
+	_, err = newReference(*st, nil, "ab")
+	assert.Error(t, err)
+	ref, err := reference.ParseNormalizedNamed("busybox")
+	require.NoError(t, err)
+	_, err = newReference(*st, ref, "")
 	assert.Error(t, err)
 }
 

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -136,7 +136,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		// If it looks like a digest, leave it alone for now.
 		if _, err := digest.Parse(possibleID); err != nil {
 			// Otherwise…
-			if idSum, err := digest.Parse("sha256:" + possibleID); err == nil && idSum.Validate() == nil {
+			if _, err := digest.Parse("sha256:" + possibleID); err == nil {
 				id = possibleID // … it is a full ID
 			} else if img, err := store.Image(possibleID); err == nil && img != nil && len(possibleID) >= minimumTruncatedIDLength && strings.HasPrefix(img.ID, possibleID) {
 				// … it is a truncated version of the ID of an image that's present in local storage,

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -43,6 +43,8 @@ type StoreTransport interface {
 	types.ImageTransport
 	// SetStore sets the default store for this transport.
 	SetStore(storage.Store)
+	// GetStoreIfSet returns the default store for this transport, or nil if not set/determined yet.
+	GetStoreIfSet() storage.Store
 	// GetImage retrieves the image from the transport's store that's named
 	// by the reference.
 	GetImage(types.ImageReference) (*storage.Image, error)
@@ -80,6 +82,11 @@ func (s *storageTransport) Name() string {
 // SetStore does not affect previously parsed references.
 func (s *storageTransport) SetStore(store storage.Store) {
 	s.store = store
+}
+
+// GetStoreIfSet returns the default store for this transport, as set using SetStore() or initialized by default, or nil if not set/determined yet.
+func (s *storageTransport) GetStoreIfSet() storage.Store {
+	return s.store
 }
 
 // SetDefaultUIDMap sets the default UID map to use when opening stores.

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -54,6 +54,9 @@ type StoreTransport interface {
 	// ParseStoreReference parses a reference, overriding any store
 	// specification that it may contain.
 	ParseStoreReference(store storage.Store, reference string) (*storageReference, error)
+	// NewStoreReference creates a reference for (named@ID) in store.
+	// either of name or ID can be unset; named must not be a reference.IsNameOnly.
+	NewStoreReference(store storage.Store, named reference.Named, id string) (*storageReference, error)
 	// SetDefaultUIDMap sets the default UID map to use when opening stores.
 	SetDefaultUIDMap(idmap []idtools.IDMap)
 	// SetDefaultGIDMap sets the default GID map to use when opening stores.
@@ -174,12 +177,18 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		named = reference.TagNameOnly(named)
 	}
 
-	result, err := newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, named, id)
+	result, err := s.NewStoreReference(store, named, id)
 	if err != nil {
 		return nil, err
 	}
 	logrus.Debugf("parsed reference into %q", result.StringWithinTransport())
 	return result, nil
+}
+
+// NewStoreReference creates a reference for (named@ID) in store.
+// either of name or ID can be unset; named must not be a reference.IsNameOnly.
+func (s *storageTransport) NewStoreReference(store storage.Store, named reference.Named, id string) (*storageReference, error) {
+	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, named, id)
 }
 
 func (s *storageTransport) GetStore() (storage.Store, error) {

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -20,6 +20,16 @@ func TestTransportName(t *testing.T) {
 	assert.Equal(t, "containers-storage", Transport.Name())
 }
 
+func TestTransportSetGetStore(t *testing.T) {
+	Transport.SetStore(nil)
+	res := Transport.GetStoreIfSet()
+	assert.Nil(t, res)
+	store := newStore(t) // Calls SetStore
+	res = Transport.GetStoreIfSet()
+	assert.Equal(t, store, res)
+	Transport.SetStore(nil)
+}
+
 func TestTransportParseStoreReference(t *testing.T) {
 	const digest3 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 

--- a/tarball/tarball_reference.go
+++ b/tarball/tarball_reference.go
@@ -22,7 +22,6 @@ type ConfigUpdater interface {
 }
 
 type tarballReference struct {
-	transport   types.ImageTransport
 	config      imgspecv1.Image
 	annotations map[string]string
 	filenames   []string
@@ -43,7 +42,7 @@ func (r *tarballReference) ConfigUpdate(config imgspecv1.Image, annotations map[
 }
 
 func (r *tarballReference) Transport() types.ImageTransport {
-	return r.transport
+	return Transport
 }
 
 func (r *tarballReference) StringWithinTransport() string {

--- a/tarball/tarball_transport.go
+++ b/tarball/tarball_transport.go
@@ -48,11 +48,21 @@ func (t *tarballTransport) ParseReference(reference string) (types.ImageReferenc
 		}
 		f.Close()
 	}
-	ref := &tarballReference{
-		filenames: filenames,
-		stdin:     stdin,
+	return NewReference(filenames, stdin)
+}
+
+// NewReference creates a new "tarball:" reference for the listed fileNames.
+// If any of the fileNames is "-", the contents of stdin are used instead.
+func NewReference(fileNames []string, stdin []byte) (types.ImageReference, error) {
+	for _, path := range fileNames {
+		if strings.Contains(path, separator) {
+			return nil, fmt.Errorf("Invalid path %q: paths including the separator %q are not supported", path, separator)
+		}
 	}
-	return ref, nil
+	return &tarballReference{
+		filenames: fileNames,
+		stdin:     stdin,
+	}, nil
 }
 
 func (t *tarballTransport) ValidatePolicyConfigurationScope(scope string) error {

--- a/tarball/tarball_transport.go
+++ b/tarball/tarball_transport.go
@@ -49,7 +49,6 @@ func (t *tarballTransport) ParseReference(reference string) (types.ImageReferenc
 		f.Close()
 	}
 	ref := &tarballReference{
-		transport: t,
 		filenames: filenames,
 		stdin:     stdin,
 	}


### PR DESCRIPTION
`New*Reference` allows creating references from well-typed data without string formatting and parsing; this adds it to a few transports that were missing the functionality.

Also adds `storage.Transport.GetStoreIfSet` (naming?) to allow checking that the default store is not set to two different values in a single application.

See individual commit messages for details.