### PR TITLE
Bubbling up errors returned by copyBlobFromStream

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1006,7 +1006,7 @@ func (c *copier) copyConfig(ctx context.Context, src types.Image) error {
 			return destInfo, nil
 		}()
 		if err != nil {
-			return nil
+			return err
 		}
 		if destInfo.Digest != srcInfo.Digest {
 			return errors.Errorf("Internal error: copying uncompressed config blob %s changed digest to %s", srcInfo.Digest, destInfo.Digest)


### PR DESCRIPTION
While debuging skopeo copy feature I ran into an issue where the remote image registry was reporting an absent blob error during a Manifest upload.

The error, from skopeo's point of view was:

FATA[0015] Error writing manifest: Error uploading manifest latest to registry/repo/image: manifest blob unknown: blob unknown to registry

By further reading image registry logs I noticed that skopeo never did upload the missing blob, I also noticed that we were ignoring an error during config's upload and decided to add a debug there. With my debug I discovered that the error being returned by the registry was:

received unexpected HTTP status: 503 Service Unavailable

The problem is indeed on the image registry(most likely in a load balancer) but we should never ignore errors, hence this patch.