### PR TITLE
Add $HOME/.config/containers/certs.d to perHostCertDirPath

### DIFF
--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -18,7 +18,7 @@ func TestDockerCertDir(t *testing.T) {
 	const rootPrefix = "/root/prefix"
 	const registryHostPort = "thishostdefinitelydoesnotexist:5000"
 
-	systemPerHostResult := filepath.Join(systemPerHostCertDirPaths[len(systemPerHostCertDirPaths)-1], registryHostPort)
+	systemPerHostResult := filepath.Join(perHostCertDirs[len(perHostCertDirs)-1].path, registryHostPort)
 	for _, c := range []struct {
 		sys      *types.SystemContext
 		expected string

--- a/docs/containers-certs.d.5.md
+++ b/docs/containers-certs.d.5.md
@@ -4,7 +4,7 @@
 containers-certs.d - Directory for storing custom container-registry TLS configurations
 
 # DESCRIPTION
-A custom TLS configuration for a container registry can be configured by creating a directory under `/etc/containers/certs.d`.
+A custom TLS configuration for a container registry can be configured by creating a directory under `$HOME/.config/containers/certs.d` or `/etc/containers/certs.d`.
 The name of the directory must correspond to the `host:port` of the registry (e.g., `my-registry.com:5000`).
 
 ## Directory Structure

--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -207,6 +207,9 @@ the destination registry is unambiguous. Pulling by digest
 (i.e., quay.io/repository/name@digest) further eliminates the ambiguity of
 tags.
 
+# SEE ALSO
+  containers-certs.d(5)
+
 # HISTORY
 Dec 2019, Warning added for unqualified image names by Tom Sweeney <tsweeney@redhat.com>
 


### PR DESCRIPTION
We want to allow users to store certs in their homedir when running in rootless mode.
We want rootless podman and rootless buildah to add $HOME/.config/containers/certs.d
to the search path for certificates by default.

Currently there is no way for a non privileged user to get certs without being root on
the system or specify the certs dir on ever call.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
