### PR TITLE
Add $HOME/.config/containers/registries.conf to config path

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -9,7 +9,7 @@ containers-registries.conf - Syntax of System Registry Configuration File
 The CONTAINERS-REGISTRIES configuration file is a system-wide configuration
 file for container image registries. The file format is TOML.
 
-By default, the configuration file is located at `/etc/containers/registries.conf`.
+Container engines will use the `$HOME/.config/containers/registries.conf` if it exists, otherwise they will use `/etc/containers/registries.conf`
 
 # FORMATS
 


### PR DESCRIPTION
provide per-user configuration of registries.conf under $HOME/.config/containers/registries.conf for other tools.

Signed-off-by: Qi Wang <qiwan@redhat.com>