### PR TITLE
Support IdentityToken in registry authn

### DIFF
--- a/pkg/docker/config/testdata/example_identitytoken.json
+++ b/pkg/docker/config/testdata/example_identitytoken.json
@@ -1,0 +1,8 @@
+{
+    "auths": {
+        "example.org": {
+            "auth": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOg==",
+            "identitytoken": "some very long identity token"
+        }
+    }
+}

--- a/types/types.go
+++ b/types/types.go
@@ -450,6 +450,11 @@ type ImageInspectInfo struct {
 type DockerAuthConfig struct {
 	Username string
 	Password string
+	// IdentityToken can be used as an refresh_token in place of username and
+	// password to obtain the bearer/access token in oauth2 flow. If identity
+	// token is set, password should not be set.
+	// Ref: https://docs.docker.com/registry/spec/auth/oauth/
+	IdentityToken string
 }
 
 // OptionalBool is a boolean with an additional undefined value, which is meant


### PR DESCRIPTION
Adding the support for using identitytoken in the .docker/config.json
files. It's part of oauth2 and Azure Container Registry is one of the case that uses this.

Since containers/image implemented it's own docker registry client, we want to make it working with oauth2. The identitytoken can be used to get an access/bear token in place of password. Instead of setting basicAuth in the request, we follow the oauth2 definition to send a post request with grant_type.

Reference:
1. Docker registry oauth2 documentation: https://docs.docker.com/registry/spec/auth/oauth/
2. Azure Container Registry oauth2 documentation: https://github.com/Azure/acr/blob/7eddc1c5866ce5cc80e95df37d9d119e70d8c15e/docs/AAD-OAuth.md

Test: Tested with podman and logging into azure container registry, which uses identitytoken.

Concern: This patch changed the `config.GetAuthentication` interface, which is used by podman directly. Not sure if this is intended behaviour for podman to access GetAuthentication directly.

close #748  
This is the base to fix these: containers/skopeo#533 and containers/libpod#4357.

Signed-off-by: yihuaf <fang.yihua.eric@gmail.com>