### PR TITLE
registries.conf.d: add stances for the registries.conf

### DIFF
--- a/docs/containers-registries.conf.d.5.md
+++ b/docs/containers-registries.conf.d.5.md
@@ -1,0 +1,33 @@
+% CONTAINERS-REGISTRIES.CONF.D(5)
+% Valentin Rothberg
+% Mar 2020
+
+# NAME
+containers-registries.conf.d - directory for drop-in registries.conf files
+
+# DESCRIPTION
+CONTAINERS-REGISTRIES.CONF.D is a systemd-wide directory for drop-in
+configuration files in the `containers-registries.conf(5)` format.
+
+By default, the directory is located at `/etc/containers/registries.conf.d`.
+
+# CONFIGURATION PRECEDENCE
+
+Once the main configuration at `/etc/containers/registries.conf` is loaded, the
+files in `/etc/containers/registries.conf.d` are loaded in alpha-numerical order.
+Specified fields in a config will overwrite any previous setting.
+
+For instance, setting the `unqualified-search-registries` in
+`/etc/containers/registries.conf.d/myregistries.conf` will overwrite previous
+settings in `/etc/containers/registries.conf`.
+
+Note that all files must be specified in the same version of the
+`containers-registries.conf(5)` format.  The entire `[[registry]]` table will
+always be overridden if set.
+
+# SEE ALSO
+`containers-registries.conf(5)`
+
+# HISTORY
+
+Mar 2020, Originally compiled by Valentin Rothberg <rothberg@redhat.com>

--- a/go.mod
+++ b/go.mod
@@ -39,10 +39,10 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20190816131739-be0936907f66
 	go.etcd.io/bbolt v1.3.3 // indirect
-	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
+	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2
+	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	k8s.io/client-go v0.0.0-20170217214107-bcde30fb7eae
 )

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -463,3 +463,18 @@ func TestTryUpdatingCache(t *testing.T) {
 	assert.Nil(t, registries)
 	assert.Equal(t, 1, len(configCache))
 }
+
+func TestRegistriesConfDirectory(t *testing.T) {
+	ctx := &types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/base-for-registries.d.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
+	}
+	configCache = make(map[string]*V2RegistriesConf)
+	registries, err := TryUpdatingCache(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, registries)
+
+	assert.Equal(t, registries.UnqualifiedSearchRegistries, []string{"example-overwrite.com"})
+	assert.Equal(t, len(registries.Registries), 1)
+	assert.Equal(t, registries.Registries[0].Location, "2.com")
+}

--- a/pkg/sysregistriesv2/testdata/base-for-registries.d.conf
+++ b/pkg/sysregistriesv2/testdata/base-for-registries.d.conf
@@ -1,0 +1,5 @@
+unqualified-search-registries = ["example.com"]
+
+[[registry]]
+location = "base.com"
+insecure = true

--- a/pkg/sysregistriesv2/testdata/registries.conf.d/config-1.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d/config-1.conf
@@ -1,0 +1,4 @@
+unqualified-search-registries = ["example-overwrite.com"]
+
+[[registry]]
+location = "1.com"

--- a/pkg/sysregistriesv2/testdata/registries.conf.d/config-2.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d/config-2.conf
@@ -1,0 +1,2 @@
+[[registry]]
+location = "2.com"

--- a/types/types.go
+++ b/types/types.go
@@ -497,6 +497,8 @@ type SystemContext struct {
 	RegistriesDirPath string
 	// Path to the system-wide registries configuration file
 	SystemRegistriesConfPath string
+	// Path to the system-wide registries configuration directory
+	SystemRegistriesConfDirPath string
 	// If not "", overrides the default path for the authentication file, but only new format files
 	AuthFilePath string
 	// if not "", overrides the default path for the authentication file, but with the legacy format;


### PR DESCRIPTION
When loading the registries.conf, allow for loading additional files
from `/etc/containers/registries.conf.d`.  The files are loaded in
alpha-numerical order and specified fields will overwrite the previous
config.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>