### PR TITLE
feat(docker): support docker registry token

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -108,6 +108,7 @@ func newImageSourceAttempt(ctx context.Context, sys *types.SystemContext, pullSo
 	if endpointSys != nil && endpointSys.DockerAuthConfig != nil && reference.Domain(ref.ref) != primaryDomain {
 		copy := *endpointSys
 		copy.DockerAuthConfig = nil
+		copy.DockerBearerRegistryToken = ""
 		endpointSys = &copy
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -542,7 +542,10 @@ type SystemContext struct {
 	// Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	DockerInsecureSkipTLSVerify OptionalBool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
+	// Ignored if DockerBearerRegistryToken is non-empty.
 	DockerAuthConfig *DockerAuthConfig
+	// if not "", the library uses this registry token to authenticate to the registry
+	DockerBearerRegistryToken string
 	// if not "", an User-Agent header is added to each request when contacting a registry.
 	DockerRegistryUserAgent string
 	// if true, a V1 ping attempt isn't done to give users a better error. Default is false.


### PR DESCRIPTION
Close https://github.com/containers/image/issues/689

I tried not to break backward compatibility, so I didn't change `config.GetAuthentication`. If I can do it, I'd like to make `config.GetAuthentication` return `registryToken` as well, but I'll follow your thought anyway.

Also, are there any tests against private images?  I looked for the test with `sys.DockerAuthConfig` because I wanted to add tests for `sys.DockerRegistryToken` to it, but I couldn't find it. Although I've added only the failing test, I should add happy path as well. Would you tell me how to achieve it?