### PR TITLE
Remove manifest interface SupportsEncryption

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -527,15 +527,6 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		return nil, "", "", errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(c.rawSource.Reference()))
 	}
 
-	// TODO: Remove src.SupportsEncryption call and interface once copyUpdatedConfigAndManifest does not depend on source Image manifest type
-	// Currently, the way copyUpdatedConfigAndManifest updates the manifest is to apply updates to the source manifest and call PutManifest
-	// of the modified source manifest. The implication is that schemas like docker2 cannot be encrypted even though the destination
-	// supports encryption because docker2 struct does not have annotations, which are required.
-	// Reference to issue: https://github.com/containers/image/issues/746
-	if options.OciEncryptLayers != nil && !src.SupportsEncryption(ctx) {
-		return nil, "", "", errors.Errorf("Encryption request but not supported by source transport %s", src.Reference().Transport().Name())
-	}
-
 	// If the destination is a digested reference, make a note of that, determine what digest value we're
 	// expecting, and check that the source manifest matches it.  If the source manifest doesn't, but it's
 	// one item from a manifest list that matches it, accept that as a match.

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -46,6 +46,10 @@ type genericManifest interface {
 	// This does not change the state of the original Image object.
 	UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error)
 	// SupportsEncryption returns if encryption is supported for the manifest type
+	//
+	// Deprecated: Initially used to determine if a manifest can be copied from a source manifest type since
+	// the process of updating a manifest between different manifest types was to update then convert.
+	// This resulted in some fields in the update being lost. This has been fixed by: https://github.com/containers/image/pull/836
 	SupportsEncryption(ctx context.Context) bool
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -399,6 +399,10 @@ type Image interface {
 	// This does not change the state of the original Image object.
 	UpdatedImage(ctx context.Context, options ManifestUpdateOptions) (Image, error)
 	// SupportsEncryption returns an indicator that the image supports encryption
+	//
+	// Deprecated: Initially used to determine if a manifest can be copied from a source manifest type since
+	// the process of updating a manifest between different manifest types was to update then convert.
+	// This resulted in some fields in the update being lost. This has been fixed by: https://github.com/containers/image/pull/836
 	SupportsEncryption(ctx context.Context) bool
 	// Size returns an approximation of the amount of disk space which is consumed by the image in its current
 	// location.  If the size is not known, -1 will be returned.


### PR DESCRIPTION
The additional interface "SupportsEncryption" was required temporarily due to https://github.com/containers/image/issues/746 

Quote from the TODO in code:

>Remove src.SupportsEncryption call and interface once copyUpdatedConfigAndManifest does not depend on source Image manifest type. Currently, the way copyUpdatedConfigAndManifest updates the manifest is to apply updates to the source manifest and call PutManifest of the modified source manifest. The implication is that schemas like docker2 cannot be encrypted even though the destination supports encryption because docker2 struct does not have annotations, which are required.

Reference to issue: https://github.com/containers/image/issues/746

Signed-off-by: Brandon Lum <lumjjb@gmail.com>