### PR TITLE
Make restTLSClientConfig in restConfig a public field

### DIFF
--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -65,7 +65,7 @@ type restConfig struct {
 	BearerToken string
 
 	// TLSClientConfig contains settings to enable transport layer security
-	restTLSClientConfig
+	TLSClientConfig restTLSClientConfig
 
 	// Server should be accessed without verifying the TLS
 	// certificate. For testing only.
@@ -238,8 +238,8 @@ func getServerIdentificationPartialConfig(configAuthInfo clientcmdAuthInfo, conf
 
 	// configClusterInfo holds the information identify the server provided by .kubeconfig
 	configClientConfig := &restConfig{}
-	configClientConfig.CAFile = configClusterInfo.CertificateAuthority
-	configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
+	configClientConfig.TLSClientConfig.CAFile = configClusterInfo.CertificateAuthority
+	configClientConfig.TLSClientConfig.CAData = configClusterInfo.CertificateAuthorityData
 	configClientConfig.Insecure = configClusterInfo.InsecureSkipTLSVerify
 	if err := mergo.MergeWithOverwrite(mergedConfig, configClientConfig); err != nil {
 		return nil, err
@@ -264,10 +264,10 @@ func getUserIdentificationPartialConfig(configAuthInfo clientcmdAuthInfo) (*rest
 		mergedConfig.BearerToken = configAuthInfo.Token
 	}
 	if len(configAuthInfo.ClientCertificate) > 0 || len(configAuthInfo.ClientCertificateData) > 0 {
-		mergedConfig.CertFile = configAuthInfo.ClientCertificate
-		mergedConfig.CertData = configAuthInfo.ClientCertificateData
-		mergedConfig.KeyFile = configAuthInfo.ClientKey
-		mergedConfig.KeyData = configAuthInfo.ClientKeyData
+		mergedConfig.TLSClientConfig.CertFile = configAuthInfo.ClientCertificate
+		mergedConfig.TLSClientConfig.CertData = configAuthInfo.ClientCertificateData
+		mergedConfig.TLSClientConfig.KeyFile = configAuthInfo.ClientKey
+		mergedConfig.TLSClientConfig.KeyData = configAuthInfo.ClientKeyData
 	}
 	if len(configAuthInfo.Username) > 0 || len(configAuthInfo.Password) > 0 {
 		mergedConfig.Username = configAuthInfo.Username
@@ -806,8 +806,8 @@ func defaultServerURL(host string, defaultTLS bool) (*url.URL, error) {
 func defaultServerURLFor(config *restConfig) (*url.URL, error) {
 	// TODO: move the default to secure when the apiserver supports TLS by default
 	// config.Insecure is taken to mean "I want HTTPS but don't bother checking the certs against a CA."
-	hasCA := len(config.CAFile) != 0 || len(config.CAData) != 0
-	hasCert := len(config.CertFile) != 0 || len(config.CertData) != 0
+	hasCA := len(config.TLSClientConfig.CAFile) != 0 || len(config.TLSClientConfig.CAData) != 0
+	hasCert := len(config.TLSClientConfig.CertFile) != 0 || len(config.TLSClientConfig.CertData) != 0
 	defaultTLS := hasCA || hasCert || config.Insecure
 	host := config.Host
 	if host == "" {
@@ -968,11 +968,11 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 	}
 
 	if c.HasCA() {
-		tlsConfig.RootCAs = rootCertPool(c.CAData)
+		tlsConfig.RootCAs = rootCertPool(c.TLSClientConfig.CAData)
 	}
 
 	if c.HasCertAuth() {
-		cert, err := tls.X509KeyPair(c.CertData, c.KeyData)
+		cert, err := tls.X509KeyPair(c.TLSClientConfig.CertData, c.TLSClientConfig.KeyData)
 		if err != nil {
 			return nil, err
 		}
@@ -988,17 +988,17 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 // either populated or were empty to start.
 func loadTLSFiles(c *restConfig) error {
 	var err error
-	c.CAData, err = dataFromSliceOrFile(c.CAData, c.CAFile)
+	c.TLSClientConfig.CAData, err = dataFromSliceOrFile(c.TLSClientConfig.CAData, c.TLSClientConfig.CAFile)
 	if err != nil {
 		return err
 	}
 
-	c.CertData, err = dataFromSliceOrFile(c.CertData, c.CertFile)
+	c.TLSClientConfig.CertData, err = dataFromSliceOrFile(c.TLSClientConfig.CertData, c.TLSClientConfig.CertFile)
 	if err != nil {
 		return err
 	}
 
-	c.KeyData, err = dataFromSliceOrFile(c.KeyData, c.KeyFile)
+	c.TLSClientConfig.KeyData, err = dataFromSliceOrFile(c.TLSClientConfig.KeyData, c.TLSClientConfig.KeyFile)
 	if err != nil {
 		return err
 	}
@@ -1042,13 +1042,13 @@ func rootCertPool(caData []byte) *x509.CertPool {
 // HasCA is a modified copy of k8s.io/kubernetes/pkg/client/transport.Config.HasCA.
 // HasCA returns whether the configuration has a certificate authority or not.
 func (c *restConfig) HasCA() bool {
-	return len(c.CAData) > 0 || len(c.CAFile) > 0
+	return len(c.TLSClientConfig.CAData) > 0 || len(c.TLSClientConfig.CAFile) > 0
 }
 
 // HasCertAuth is a modified copy of k8s.io/kubernetes/pkg/client/transport.Config.HasCertAuth.
 // HasCertAuth returns whether the configuration has certificate authentication or not.
 func (c *restConfig) HasCertAuth() bool {
-	return len(c.CertData) != 0 || len(c.CertFile) != 0
+	return len(c.TLSClientConfig.CertData) != 0 || len(c.TLSClientConfig.CertFile) != 0
 }
 
 // clientcmdConfig is a modified copy of k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api.Config.

--- a/openshift/openshift-copies_test.go
+++ b/openshift/openshift-copies_test.go
@@ -78,7 +78,7 @@ func TestDirectClientConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &restConfig{
 		Host: "https://172.17.0.2:8443",
-		restTLSClientConfig: restTLSClientConfig{
+		TLSClientConfig: restTLSClientConfig{
 			CertData: []byte("Client cert"),
 			KeyData:  []byte("Client key"),
 			CAData:   []byte("Cluster CA"),
@@ -96,7 +96,7 @@ func TestDeferredLoadingClientConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &restConfig{
 		Host: "https://172.17.0.2:8443",
-		restTLSClientConfig: restTLSClientConfig{
+		TLSClientConfig: restTLSClientConfig{
 			CertData: []byte("Client cert"),
 			KeyData:  []byte("Client key"),
 			CAData:   []byte("Cluster CA"),
@@ -113,7 +113,7 @@ func TestDefaultClientConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &restConfig{
 		Host: "https://172.17.0.2:8443",
-		restTLSClientConfig: restTLSClientConfig{
+		TLSClientConfig: restTLSClientConfig{
 			CertData: []byte("Client cert"),
 			KeyData:  []byte("Client key"),
 			CAData:   []byte("Cluster CA"),


### PR DESCRIPTION
imdario/mergo, despite its official documentation, does not merge public fields inside private fields as of v.0.3.9: https://github.com/imdario/mergo/issues/139

Fixing that seems non-trivial.

Instead, make the `restTLSClientConfig` a public field of `restConfig`.

The `restConfig` type itself remains private, so this does not make anything actually public outside the subpackage. This way, the calls to mergo work as expected with both 0.3.8 and 0.3.9.