### PR TITLE
getCPUVariantWindows uses arch provided to getCPUVariant

### DIFF
--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -62,11 +62,11 @@ func getCPUInfo(pattern string) (info string, err error) {
 	return "", fmt.Errorf("getCPUInfo for pattern: %s not found", pattern)
 }
 
-func getCPUVariantWindows() string {
+func getCPUVariantWindows(arch string) string {
 	// Windows only supports v7 for ARM32 and v8 for ARM64 and so we can use
 	// runtime.GOARCH to determine the variants
 	var variant string
-	switch runtime.GOARCH {
+	switch arch {
 	case "arm64":
 		variant = "v8"
 	case "arm":
@@ -107,7 +107,7 @@ func getCPUVariantArm() string {
 
 func getCPUVariant(os string, arch string) string {
 	if os == "windows" {
-		return getCPUVariantWindows()
+		return getCPUVariantWindows(arch)
 	}
 	if arch == "arm" || arch == "arm64" {
 		return getCPUVariantArm()


### PR DESCRIPTION
Fixes: #875