### PR TITLE
WantedPlatforms: OSChoice used to determine variant

### DIFF
--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -106,7 +106,7 @@ func getCPUVariantArm() string {
 }
 
 func getCPUVariant(os string, arch string) string {
-	if os == "windows" {
+	if os == "windows" || runtime.GOOS == "windows" {
 		return getCPUVariantWindows(arch)
 	}
 	if arch == "arm" || arch == "arm64" {

--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -124,6 +124,11 @@ var compatibility = map[string][]string{
 // the most compatible platform is first.
 // If some option (arch, os, variant) is not present, a value from current platform is detected.
 func WantedPlatforms(ctx *types.SystemContext) ([]imgspecv1.Platform, error) {
+	wantedOS := runtime.GOOS
+	if ctx != nil && ctx.OSChoice != "" {
+		wantedOS = ctx.OSChoice
+	}
+
 	wantedArch := runtime.GOARCH
 	wantedVariant := ""
 	if ctx != nil && ctx.ArchitectureChoice != "" {
@@ -134,15 +139,10 @@ func WantedPlatforms(ctx *types.SystemContext) ([]imgspecv1.Platform, error) {
 		// ctx.ArchitectureChoice == runtime.GOARCH, because we have no idea whether the runtime.GOARCH
 		// value is relevant to the use case, and if we do autodetect a variant,
 		// ctx.VariantChoice can't be used to override it back to "".
-		wantedVariant = getCPUVariant(runtime.GOOS, runtime.GOARCH)
+		wantedVariant = getCPUVariant(wantedOS, runtime.GOARCH)
 	}
 	if ctx != nil && ctx.VariantChoice != "" {
 		wantedVariant = ctx.VariantChoice
-	}
-
-	wantedOS := runtime.GOOS
-	if ctx != nil && ctx.OSChoice != "" {
-		wantedOS = ctx.OSChoice
 	}
 
 	var wantedPlatforms []imgspecv1.Platform


### PR DESCRIPTION
If a OSChoice is specified, but the architecture/variant
is left to be determined, we determine the variant taking
into account the OSChoice, and the detection of architecture.

mentioned in #876. 