### PR TITLE
set client_id

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -610,6 +610,7 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	}
 	params.Add("grant_type", "refresh_token")
 	params.Add("refresh_token", c.auth.IdentityToken)
+	params.Add("client_id", "containers/image")
 
 	authReq.Body = ioutil.NopCloser(bytes.NewBufferString(params.Encode()))
 	authReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
could be elaborated to include release however this fixes a problem with missing the *required* `client_id` form field  

per https://tools.ietf.org/html/rfc6749#section-4.1.3