### PR TITLE
Add User-Agent to docker oauth requests

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -613,6 +613,9 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	params.Add("client_id", "containers/image")
 
 	authReq.Body = ioutil.NopCloser(bytes.NewBufferString(params.Encode()))
+	if c.sys != nil && c.sys.DockerRegistryUserAgent != "" {
+		authReq.Header.Add("User-Agent", c.sys.DockerRegistryUserAgent)
+	}
 	authReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.String())
 	res, err := c.client.Do(authReq)
@@ -664,6 +667,9 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 
 	if c.auth.Username != "" && c.auth.Password != "" {
 		authReq.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	if c.sys != nil && c.sys.DockerRegistryUserAgent != "" {
+		authReq.Header.Add("User-Agent", c.sys.DockerRegistryUserAgent)
 	}
 
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.String())


### PR DESCRIPTION
Per https://github.com/containers/image/issues/843
https://github.com/metallkopf provided a patch which is now needed in 2 paces
copy from makeRequestToResolvedURLOnce()