### PR TITLE
Improve handling of Variant: ""

### DIFF
--- a/image/fixtures/schema2list-variants.json
+++ b/image/fixtures/schema2list-variants.json
@@ -1,0 +1,44 @@
+{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39",
+         "platform": {
+            "architecture": "arm",
+            "variant": "v6",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:bcf9771c0b505e68c65440474179592ffdfa98790eb54ffbf129969c5e429990",
+         "platform": {
+            "architecture": "arm",
+            "variant": "unrecognized-present",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 527,
+         "digest": "sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux"
+         }
+      }
+   ]
+}

--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -119,7 +119,7 @@ func getCPUVariant(os string, arch string) string {
 // order from most capable (most restrictive) to least capable (most compatible).
 // Architectures that don’t have variants should not have an entry here.
 var compatibility = map[string][]string{
-	"arm":   {"v7", "v6", "v5"},
+	"arm":   {"v8", "v7", "v6", "v5"},
 	"arm64": {"v8"},
 }
 

--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -191,17 +191,10 @@ func WantedPlatforms(ctx *types.SystemContext) ([]imgspecv1.Platform, error) {
 	return res, nil
 }
 
+// MatchesPlatform returns true if a platform descriptor from a multi-arch image matches
+// an item from the return value of WantedPlatforms.
 func MatchesPlatform(image imgspecv1.Platform, wanted imgspecv1.Platform) bool {
-	if image.Architecture != wanted.Architecture {
-		return false
-	}
-	if image.OS != wanted.OS {
-		return false
-	}
-
-	if image.Variant == wanted.Variant {
-		return true
-	}
-
-	return false
+	return image.Architecture == wanted.Architecture &&
+		image.OS == wanted.OS &&
+		image.Variant == wanted.Variant
 }

--- a/internal/pkg/platform/platform_matcher_test.go
+++ b/internal/pkg/platform/platform_matcher_test.go
@@ -14,17 +14,32 @@ func TestWantedPlatforms(t *testing.T) {
 		ctx      types.SystemContext
 		expected []imgspecv1.Platform
 	}{
+		{ // X86_64 does not have variants
+			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "amd64", Variant: ""},
+			},
+		},
 		{ // ARM
 			types.SystemContext{ArchitectureChoice: "arm", OSChoice: "linux", VariantChoice: "v6"},
 			[]imgspecv1.Platform{
 				{OS: "linux", Architecture: "arm", Variant: "v6"},
 				{OS: "linux", Architecture: "arm", Variant: "v5"},
+				{OS: "linux", Architecture: "arm", Variant: ""},
+			},
+		},
+		{ // ARM64 has a base variant
+			types.SystemContext{ArchitectureChoice: "arm64", OSChoice: "linux"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "arm64", Variant: ""},
+				{OS: "linux", Architecture: "arm64", Variant: "v8"},
 			},
 		},
 		{ // Custom (completely unrecognized data)
 			types.SystemContext{ArchitectureChoice: "armel", OSChoice: "freeBSD", VariantChoice: "custom"},
 			[]imgspecv1.Platform{
 				{OS: "freeBSD", Architecture: "armel", Variant: "custom"},
+				{OS: "freeBSD", Architecture: "armel", Variant: ""},
 			},
 		},
 	} {

--- a/internal/pkg/platform/platform_matcher_test.go
+++ b/internal/pkg/platform/platform_matcher_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/containers/image/v5/types"
@@ -8,29 +9,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWantedPlatformsCompatibility(t *testing.T) {
-	ctx := &types.SystemContext{
-		ArchitectureChoice: "arm",
-		OSChoice:           "linux",
-		VariantChoice:      "v6",
+func TestWantedPlatforms(t *testing.T) {
+	for _, c := range []struct {
+		ctx      types.SystemContext
+		expected []imgspecv1.Platform
+	}{
+		{ // ARM
+			types.SystemContext{ArchitectureChoice: "arm", OSChoice: "linux", VariantChoice: "v6"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "arm", Variant: "v6"},
+				{OS: "linux", Architecture: "arm", Variant: "v5"},
+			},
+		},
+		{ // Custom (completely unrecognized data)
+			types.SystemContext{ArchitectureChoice: "armel", OSChoice: "freeBSD", VariantChoice: "custom"},
+			[]imgspecv1.Platform{
+				{OS: "freeBSD", Architecture: "armel", Variant: "custom"},
+			},
+		},
+	} {
+		testName := fmt.Sprintf("%q/%q/%q", c.ctx.ArchitectureChoice, c.ctx.OSChoice, c.ctx.VariantChoice)
+		platforms, err := WantedPlatforms(&c.ctx)
+		assert.Nil(t, err, testName)
+		assert.Equal(t, c.expected, platforms, testName)
 	}
-	platforms, err := WantedPlatforms(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, []imgspecv1.Platform{
-		{OS: ctx.OSChoice, Architecture: ctx.ArchitectureChoice, Variant: "v6"},
-		{OS: ctx.OSChoice, Architecture: ctx.ArchitectureChoice, Variant: "v5"},
-	}, platforms)
-}
-
-func TestWantedPlatformsCustom(t *testing.T) {
-	ctx := &types.SystemContext{
-		ArchitectureChoice: "armel",
-		OSChoice:           "freeBSD",
-		VariantChoice:      "custom",
-	}
-	platforms, err := WantedPlatforms(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, []imgspecv1.Platform{
-		{OS: ctx.OSChoice, Architecture: ctx.ArchitectureChoice, Variant: ctx.VariantChoice},
-	}, platforms)
 }

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -87,6 +87,21 @@ func TestChooseInstance(t *testing.T) {
 				"unmatched",
 			},
 		},
+		{ // Focus on ARM variant field testing
+			listFile: "schema2list-variants.json",
+			matchedInstances: []expectedMatch{
+				{"amd64", "", "sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610"},
+				{"arm", "v7", "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39"},
+				{"arm", "v6", "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39"},
+				{"arm", "v5", "sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53"},
+				{"arm", "", "sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53"},
+				{"arm", "unrecognized-present", "sha256:bcf9771c0b505e68c65440474179592ffdfa98790eb54ffbf129969c5e429990"},
+				{"arm", "unrecognized-not-present", "sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53"},
+			},
+			unmatchedInstances: []string{
+				"unmatched",
+			},
+		},
 		{
 			listFile: "oci1index.json",
 			matchedInstances: []expectedMatch{


### PR DESCRIPTION
- When a variant is autodetected (or specified), always try a `Variant: ""` image as well – and only as the last attempt. This is necessary for images like `docker://k8s.gcr.io/pause:3.1` .

  NOTE: This includes the case of `VariantChoice` with a completely unrecognized variant, even in that case we try `Variant: ""`.

- When a variant is not specified with `OverrideArch`, or perhaps not autodetected, try an image with a "base variant" as well. This is necessary for images like `docker://busybox:1.27.2` . If the available images contain _both_ a `Variant: ""` and a `Variant: baseVariant` image, the two are equivalent in priority and the outcome is ambiguous; in that case, prefer the `Variant: ""` image to more closely match the `VariantChoice` made; the caller can always explicitly use `VariantChoice: baseVariant` to get the other one (which would not be the case if we preferred `Variant: baseVariant`).

Fixes #898.