### PR TITLE
registries.conf: remove references on v1

### DIFF
--- a/registries.conf
+++ b/registries.conf
@@ -1,57 +1,22 @@
 # For more information on this configuration file, see containers-registries.conf(5).
 #
-# There are multiple versions of the configuration syntax available, where the
-# second iteration is backwards compatible to the first one. Mixing up both
-# formats will result in an runtime error.
-#
-# The initial configuration format looks like this:
-#
-# Registries to search for images that are not fully-qualified.
-# i.e. foobar.com/my_image:latest vs my_image:latest
-#
 # NOTE: RISK OF USING UNQUALIFIED IMAGE NAMES
 # We recommend always using fully qualified image names including the registry
 # server (full dns name), namespace, image name, and tag
-# (e.g., registry.redhat.io/ubi8/ubi:latest). When using short names, there is
-# always an inherent risk that the image being pulled could be spoofed. For
-# example, a user wants to pull an image named `foobar` from a registry and
-# expects it to come from myregistry.com. If myregistry.com is not first in the
-# search list, an attacker could place a different `foobar` image at a registry
-# earlier in the search list. The user would accidentally pull and run the
-# attacker's image and code rather than the intended content. We recommend only
-# adding registries which are completely trusted, i.e. registries which don't
-# allow unknown or anonymous users to create accounts with arbitrary names. This
-# will prevent an image from being spoofed, squatted or otherwise made insecure.
-# If it is necessary to use one of these registries, it should be added at the
-# end of the list.
+# (e.g., registry.redhat.io/ubi8/ubi:latest). Pulling by digest (i.e.,
+# quay.io/repository/name@digest) further eliminates the ambiguity of tags.
+# When using short names, there is always an inherent risk that the image being
+# pulled could be spoofed. For example, a user wants to pull an image named
+# `foobar` from a registry and expects it to come from myregistry.com. If
+# myregistry.com is not first in the search list, an attacker could place a
+# different `foobar` image at a registry earlier in the search list. The user
+# would accidentally pull and run the attacker's image and code rather than the
+# intended content. We recommend only adding registries which are completely
+# trusted (i.e., registries which don't allow unknown or anonymous users to
+# create accounts with arbitrary names). This will prevent an image from being
+# spoofed, squatted or otherwise made insecure.  If it is necessary to use one
+# of these registries, it should be added at the end of the list.
 #
-# It is recommended to use fully-qualified images for pulling as the
-# destination registry is unambiguous. Pulling by digest
-# (i.e., quay.io/repository/name@digest) further eliminates the ambiguity of
-# tags.
-
-[registries.search]
-registries = []
-
-# Registries that do not use TLS when pulling images or uses self-signed
-# certificates.
-[registries.insecure]
-registries = []
-
-# Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
-# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
-# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
-# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
-# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
-# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
-# The atomic CLI `atomic trust` can be used to easily configure the policy.json file.
-[registries.block]
-registries = []
-
-# The second version of the configuration format allows to specify registry
-# mirrors:
-#
-# NOTE: Please read the note about the risk of unqualified images identified above.
 # # An array of host[:port] registries to try when pulling an unqualified image, in order.
 # unqualified-search-registries = ["example.com"]
 #


### PR DESCRIPTION
Version 2 of the registries.conf has been used long enough in the wild
to consider it stable.  Hence, remove the references in the
registries.conf file to the previous version in hope to increase v2
adoption.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>