### PR TITLE
Fix panic on terminated blob uploads

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -170,7 +170,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 		defer uploadReader.Terminate(errors.New("Reading data from an already terminated upload"))
 		res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, uploadReader, inputInfo.Size, v2Auth, nil)
 		if err != nil {
-			logrus.Debugf("Error uploading layer chunked, response %#v", res)
+			logrus.Debugf("Error uploading layer chunked %v", err)
 			return nil, err
 		}
 		defer res.Body.Close()

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -174,6 +174,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 			return nil, err
 		}
 		defer res.Body.Close()
+		if !successStatus(res.StatusCode) {
+			return nil, errors.Wrapf(client.HandleErrorResponse(res), "Error uploading layer chunked")
+		}
 		uploadLocation, err := res.Location()
 		if err != nil {
 			return nil, errors.Wrap(err, "Error determining upload URL")

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/internal/uploadreader"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/types"
@@ -162,19 +163,27 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 
 	digester := digest.Canonical.Digester()
 	sizeCounter := &sizeCounter{}
-	tee := io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter))
-	res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, tee, inputInfo.Size, v2Auth, nil)
+	uploadLocation, err = func() (*url.URL, error) { // A scope for defer
+		uploadReader := uploadreader.NewUploadReader(io.TeeReader(stream, io.MultiWriter(digester.Hash(), sizeCounter)))
+		// This error text should never be user-visible, we terminate only after makeRequestToResolvedURL
+		// returns, so there isn’t a way for the error text to be provided to any of our callers.
+		defer uploadReader.Terminate(errors.New("Reading data from an already terminated upload"))
+		res, err = d.c.makeRequestToResolvedURL(ctx, "PATCH", uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, uploadReader, inputInfo.Size, v2Auth, nil)
+		if err != nil {
+			logrus.Debugf("Error uploading layer chunked, response %#v", res)
+			return nil, err
+		}
+		defer res.Body.Close()
+		uploadLocation, err := res.Location()
+		if err != nil {
+			return nil, errors.Wrap(err, "Error determining upload URL")
+		}
+		return uploadLocation, nil
+	}()
 	if err != nil {
-		logrus.Debugf("Error uploading layer chunked, response %#v", res)
 		return types.BlobInfo{}, err
 	}
-	defer res.Body.Close()
 	computedDigest := digester.Digest()
-
-	uploadLocation, err = res.Location()
-	if err != nil {
-		return types.BlobInfo{}, errors.Wrap(err, "Error determining upload URL")
-	}
 
 	// FIXME: DELETE uploadLocation on failure (does not really work in docker/distribution servers, which incorrectly require the "delete" action in the token's scope)
 

--- a/internal/uploadreader/upload_reader.go
+++ b/internal/uploadreader/upload_reader.go
@@ -1,0 +1,61 @@
+package uploadreader
+
+import (
+	"io"
+	"sync"
+)
+
+// UploadReader is a pass-through reader for use in sending non-trivial data using the net/http
+// package (http.NewRequest, http.Post and the like).
+//
+// The net/http package uses a separate goroutine to upload data to a HTTP connection,
+// and it is possible for the server to return a response (typically an error) before consuming
+// the full body of the request. In that case http.Client.Do can return with an error while
+// the body is still being read — regardless of of the cancellation, if any, of http.Request.Context().
+//
+// As a result, any data used/updated by the io.Reader() provided as the request body may be
+// used/updated even after http.Client.Do returns, causing races.
+//
+// To fix this, UploadReader provides a synchronized Terminate() method, which can block for
+// a not-completely-negligible time (for a duration of the underlying Read()), but guarantees that
+// after Terminate() returns, the underlying reader is never used any more (unlike calling
+// the cancellation callback of context.WithCancel, which returns before any recipients may have
+// reacted to the cancellation).
+type UploadReader struct {
+	mutex sync.Mutex
+	// The following members can only be used with mutex held
+	reader           io.Reader
+	terminationError error // nil if not terminated yet
+}
+
+// NewUploadReader returns an UploadReader for an "underlying" reader.
+func NewUploadReader(underlying io.Reader) *UploadReader {
+	return &UploadReader{
+		reader:           underlying,
+		terminationError: nil,
+	}
+}
+
+// Read returns the error set by Terminate, if any, or calls the underlying reader.
+// It is safe to call this from a different goroutine than Terminate.
+func (ur *UploadReader) Read(p []byte) (int, error) {
+	ur.mutex.Lock()
+	defer ur.mutex.Unlock()
+
+	if ur.terminationError != nil {
+		return 0, ur.terminationError
+	}
+	return ur.reader.Read(p)
+}
+
+// Terminate waits for in-progress Read calls, if any, to finish, and ensures that after
+// this function returns, any Read calls will fail with the provided error, and the underlying
+// reader will never be used any more.
+//
+// It is safe to call this from a different goroutine than Read.
+func (ur *UploadReader) Terminate(err error) {
+	ur.mutex.Lock() // May block for some time if ur.reader.Read() is in progress
+	defer ur.mutex.Unlock()
+
+	ur.terminationError = err
+}

--- a/internal/uploadreader/upload_reader_test.go
+++ b/internal/uploadreader/upload_reader_test.go
@@ -1,0 +1,35 @@
+package uploadreader
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadReader(t *testing.T) {
+	// This is a smoke test in a single goroutine, without really testing the locking.
+
+	data := bytes.Repeat([]byte{0x01}, 65535)
+	// No termination
+	ur := NewUploadReader(bytes.NewReader(data))
+	read, err := ioutil.ReadAll(ur)
+	require.NoError(t, err)
+	assert.Equal(t, data, read)
+
+	// Terminated
+	ur = NewUploadReader(bytes.NewReader(data))
+	readLen := len(data) / 2
+	read, err = ioutil.ReadAll(io.LimitReader(ur, int64(readLen)))
+	require.NoError(t, err)
+	assert.Equal(t, data[:readLen], read)
+	terminationErr := errors.New("Terminated")
+	ur.Terminate(terminationErr)
+	read, err = ioutil.ReadAll(ur)
+	assert.Equal(t, terminationErr, err)
+	assert.Len(t, read, 0)
+}


### PR DESCRIPTION
This should
fix #750 , fix #756 .

primarily by preventing the net/http layer from using the input stream after it returns a response to the request.

See the individual commit messages for details.

So far I don’t know of a reliable way to add a test for this (after all, it is a race); a reliable way to trigger the race with the original code is https://github.com/containers/image/issues/750#issuecomment-619107393 , but that violates the rules of the used API.