### PR TITLE
Simplify MIME type updates

### DIFF
--- a/manifest/common.go
+++ b/manifest/common.go
@@ -1,5 +1,12 @@
 package manifest
 
+import (
+	"fmt"
+
+	"github.com/containers/image/v5/pkg/compression"
+	"github.com/pkg/errors"
+)
+
 // dupStringSlice returns a deep copy of a slice of strings, or nil if the
 // source slice is empty.
 func dupStringSlice(list []string) []string {
@@ -32,4 +39,49 @@ func layerInfosToStrings(infos []LayerInfo) []string {
 		layers[i] = info.Digest.String()
 	}
 	return layers
+}
+
+// compressionMIMETypeSet describes a set of MIME type “variants” that represent differently-compressed
+// versions of “the same kind of content”.
+// The map key is the return value of compression.Algorithm.Name(), or mtsUncompressed;
+// the map value is a MIME type, or mtsUnsupportedMIMEType to mean "recognized but unsupported".
+type compressionMIMETypeSet map[string]string
+
+const mtsUncompressed = ""        // A key in compressionMIMETypeSet for the uncompressed variant
+const mtsUnsupportedMIMEType = "" // A value in compressionMIMETypeSet that means “recognized but unsupported”
+
+// compressionVariantMIMEType returns a variant of mimeType for the specified algorithm (which may be nil
+// to mean "no compression"), based on variantTable.
+func compressionVariantMIMEType(variantTable []compressionMIMETypeSet, mimeType string, algorithm *compression.Algorithm) (string, error) {
+	if mimeType == mtsUnsupportedMIMEType { // Prevent matching against the {algo:mtsUnsupportedMIMEType} entries
+		return "", fmt.Errorf("cannot update unknown MIME type")
+	}
+	for _, variants := range variantTable {
+		for _, mt := range variants {
+			if mt == mimeType { // Found the variant
+				name := mtsUncompressed
+				if algorithm != nil {
+					name = algorithm.Name()
+				}
+				if res, ok := variants[name]; ok {
+					if res != mtsUnsupportedMIMEType {
+						return res, nil
+					}
+					if name != mtsUncompressed {
+						return "", fmt.Errorf("%s compression is not supported", name)
+					}
+					return "", errors.New("uncompressed variant is not supported")
+				}
+				if name != mtsUncompressed {
+					return "", fmt.Errorf("unknown compression algorithm %s", name)
+				}
+				// We can't very well say “the idea of no compression is unknown”
+				return "", errors.New("uncompressed variant is not supported")
+			}
+		}
+	}
+	if algorithm != nil {
+		return "", fmt.Errorf("unsupported MIME type for compression: %s", mimeType)
+	}
+	return "", fmt.Errorf("unsupported MIME type for decompression: %s", mimeType)
 }

--- a/manifest/common.go
+++ b/manifest/common.go
@@ -1,0 +1,35 @@
+package manifest
+
+// dupStringSlice returns a deep copy of a slice of strings, or nil if the
+// source slice is empty.
+func dupStringSlice(list []string) []string {
+	if len(list) == 0 {
+		return nil
+	}
+	dup := make([]string, len(list))
+	copy(dup, list)
+	return dup
+}
+
+// dupStringStringMap returns a deep copy of a map[string]string, or nil if the
+// passed-in map is nil or has no keys.
+func dupStringStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// layerInfosToStrings converts a list of layer infos, presumably obtained from a Manifest.LayerInfos()
+// method call, into a format suitable for inclusion in a types.ImageInspectInfo structure.
+func layerInfosToStrings(infos []LayerInfo) []string {
+	layers := make([]string, len(infos))
+	for i, info := range infos {
+		layers[i] = info.Digest.String()
+	}
+	return layers
+}

--- a/manifest/common_test.go
+++ b/manifest/common_test.go
@@ -1,0 +1,54 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/containers/image/v5/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLayerInfosToStrings(t *testing.T) {
+	strings := layerInfosToStrings([]LayerInfo{})
+	assert.Equal(t, []string{}, strings)
+
+	strings = layerInfosToStrings([]LayerInfo{
+		{
+			BlobInfo: types.BlobInfo{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Digest:    "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+				Size:      32,
+			},
+			EmptyLayer: true,
+		},
+		{
+			BlobInfo: types.BlobInfo{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+				Size:      8841833,
+			},
+			EmptyLayer: false,
+		},
+		{
+			BlobInfo: types.BlobInfo{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
+				Size:      291,
+			},
+			EmptyLayer: false,
+		},
+		{
+			BlobInfo: types.BlobInfo{
+				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+				Digest:    "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+				Size:      32,
+			},
+			EmptyLayer: true,
+		},
+	})
+	assert.Equal(t, []string{
+		"sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+		"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+		"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
+		"sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+	}, strings)
+}

--- a/manifest/common_test.go
+++ b/manifest/common_test.go
@@ -3,8 +3,10 @@ package manifest
 import (
 	"testing"
 
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLayerInfosToStrings(t *testing.T) {
@@ -51,4 +53,37 @@ func TestLayerInfosToStrings(t *testing.T) {
 		"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
 		"sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
 	}, strings)
+}
+
+func TestCompressionVariantMIMEType(t *testing.T) {
+	sets := []compressionMIMETypeSet{
+		{mtsUncompressed: "AU", compression.Gzip.Name(): "AG" /* No zstd variant */},
+		{mtsUncompressed: "BU", compression.Gzip.Name(): "BG", compression.Zstd.Name(): mtsUnsupportedMIMEType},
+		{ /* No uncompressed variant */ compression.Gzip.Name(): "CG", compression.Zstd.Name(): "CZ"},
+		{mtsUncompressed: "", compression.Gzip.Name(): "DG"},
+	}
+
+	for _, c := range []struct {
+		input    string
+		algo     *compression.Algorithm
+		expected string
+	}{
+		{"AU", nil, "AU"}, {"AU", &compression.Gzip, "AG"}, {"AU", &compression.Zstd, ""},
+		{"AG", nil, "AU"}, {"AG", &compression.Gzip, "AG"}, {"AG", &compression.Zstd, ""},
+		{"BU", &compression.Zstd, ""},
+		{"BG", &compression.Zstd, ""},
+		{"CG", nil, ""}, {"CG", &compression.Zstd, "CZ"},
+		{"CZ", nil, ""}, {"CZ", &compression.Gzip, "CG"},
+		{"DG", nil, ""},
+		{"unknown", nil, ""}, {"unknown", &compression.Gzip, ""},
+		{"", nil, ""}, {"", &compression.Gzip, ""},
+	} {
+		res, err := compressionVariantMIMEType(sets, c.input, c.algo)
+		if c.expected == "" {
+			assert.Error(t, err, c.input)
+		} else {
+			require.NoError(t, err, c.input)
+			assert.Equal(t, c.expected, res, c.input)
+		}
+	}
 }

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -213,26 +213,17 @@ func (m *Schema2) LayerInfos() []LayerInfo {
 	return blobs
 }
 
-// isSchema2ForeignLayer is a convenience wrapper to check if a given mime type
-// is a compressed or decompressed schema 2 foreign layer.
-func isSchema2ForeignLayer(mimeType string) bool {
-	switch mimeType {
-	case DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip:
-		return true
-	default:
-		return false
-	}
-}
-
-// isSchema2Layer is a convenience wrapper to check if a given mime type is a
-// compressed or decompressed schema 2 layer.
-func isSchema2Layer(mimeType string) bool {
-	switch mimeType {
-	case DockerV2SchemaLayerMediaTypeUncompressed, DockerV2Schema2LayerMediaType:
-		return true
-	default:
-		return false
-	}
+var schema2CompressionMIMETypeSets = []compressionMIMETypeSet{
+	{
+		mtsUncompressed:         DockerV2Schema2ForeignLayerMediaType,
+		compression.Gzip.Name(): DockerV2Schema2ForeignLayerMediaTypeGzip,
+		compression.Zstd.Name(): mtsUnsupportedMIMEType,
+	},
+	{
+		mtsUncompressed:         DockerV2SchemaLayerMediaTypeUncompressed,
+		compression.Gzip.Name(): DockerV2Schema2LayerMediaType,
+		compression.Zstd.Name(): mtsUnsupportedMIMEType,
+	},
 }
 
 // updatedSchema2MIMEType returns the result of applying edits in updated (MediaType, CompressionOperation) to
@@ -246,48 +237,23 @@ func updatedSchema2MIMEType(mimeType string, updated types.BlobInfo) (string, er
 	// Note that manifests in containers-storage might be reporting the
 	// wrong media type since the original manifests are stored while layers
 	// are decompressed in storage.  Hence, we need to consider the case
-	// that an already {de}compressed layer should be {de}compressed, which
-	// is being addressed in `isSchema2{Foreign}Layer`.
+	// that an already {de}compressed layer should be {de}compressed;
+	// compressionVariantMIMEType does that by not caring whether the original is
+	// {de}compressed.
 	switch updated.CompressionOperation {
 	case types.PreserveOriginal:
 		// Keep the original media type.
 		return mimeType, nil
 
 	case types.Decompress:
-		// Decompress the original media type and check if it was
-		// non-distributable one or not.
-		switch {
-		case isSchema2ForeignLayer(mimeType):
-			return DockerV2Schema2ForeignLayerMediaType, nil
-		case isSchema2Layer(mimeType):
-			return DockerV2SchemaLayerMediaTypeUncompressed, nil
-		default:
-			return "", fmt.Errorf("unsupported media type for decompression: %q", mimeType)
-		}
+		return compressionVariantMIMEType(schema2CompressionMIMETypeSets, mimeType, nil)
 
 	case types.Compress:
 		if updated.CompressionAlgorithm == nil {
 			logrus.Debugf("Preparing updated manifest: blob %q was compressed but does not specify by which algorithm: falling back to use the original blob", updated.Digest)
 			return mimeType, nil
 		}
-		// Compress the original media type and set the new one based on
-		// that type (distributable or not) and the specified compression
-		// algorithm. Throw an error if the algorithm is not supported.
-		switch updated.CompressionAlgorithm.Name() {
-		case compression.Gzip.Name():
-			switch {
-			case isSchema2ForeignLayer(mimeType):
-				return DockerV2Schema2ForeignLayerMediaTypeGzip, nil
-			case isSchema2Layer(mimeType):
-				return DockerV2Schema2LayerMediaType, nil
-			default:
-				return "", fmt.Errorf("unsupported media type for compression: %q", mimeType)
-			}
-		case compression.Zstd.Name():
-			return "", fmt.Errorf("zstd compression is not supported for docker images")
-		default:
-			return "", fmt.Errorf("unknown compression algorithm %q", updated.CompressionAlgorithm.Name())
-		}
+		return compressionVariantMIMEType(schema2CompressionMIMETypeSets, mimeType, updated.CompressionAlgorithm)
 
 	default:
 		return "", fmt.Errorf("unknown compression operation (%d)", updated.CompressionOperation)

--- a/manifest/list.go
+++ b/manifest/list.go
@@ -59,30 +59,6 @@ type ListUpdate struct {
 	MediaType string
 }
 
-// dupStringSlice returns a deep copy of a slice of strings, or nil if the
-// source slice is empty.
-func dupStringSlice(list []string) []string {
-	if len(list) == 0 {
-		return nil
-	}
-	dup := make([]string, len(list))
-	copy(dup, list)
-	return dup
-}
-
-// dupStringStringMap returns a deep copy of a map[string]string, or nil if the
-// passed-in map is nil or has no keys.
-func dupStringStringMap(m map[string]string) map[string]string {
-	if len(m) == 0 {
-		return nil
-	}
-	result := make(map[string]string)
-	for k, v := range m {
-		result[k] = v
-	}
-	return result
-}
-
 // ListFromBlob parses a list of manifests.
 func ListFromBlob(manifest []byte, manifestMIMEType string) (List, error) {
 	normalized := NormalizedMIMEType(manifestMIMEType)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -256,13 +256,3 @@ func FromBlob(manblob []byte, mt string) (Manifest, error) {
 	// Note that this may not be reachable, NormalizedMIMEType has a default for unknown values.
 	return nil, fmt.Errorf("Unimplemented manifest MIME type %s (normalized as %s)", mt, nmt)
 }
-
-// layerInfosToStrings converts a list of layer infos, presumably obtained from a Manifest.LayerInfos()
-// method call, into a format suitable for inclusion in a types.ImageInspectInfo structure.
-func layerInfosToStrings(infos []LayerInfo) []string {
-	layers := make([]string, len(infos))
-	for i, info := range infos {
-		layers[i] = info.Digest.String()
-	}
-	return layers
-}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containers/image/v5/types"
 	"github.com/containers/libtrust"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -162,50 +161,4 @@ func TestNormalizedMIMEType(t *testing.T) {
 		res := NormalizedMIMEType(c)
 		assert.Equal(t, DockerV2Schema1SignedMediaType, res, c)
 	}
-}
-
-func TestLayerInfosToStrings(t *testing.T) {
-	strings := layerInfosToStrings([]LayerInfo{})
-	assert.Equal(t, []string{}, strings)
-
-	strings = layerInfosToStrings([]LayerInfo{
-		{
-			BlobInfo: types.BlobInfo{
-				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-				Digest:    "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
-				Size:      32,
-			},
-			EmptyLayer: true,
-		},
-		{
-			BlobInfo: types.BlobInfo{
-				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-				Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
-				Size:      8841833,
-			},
-			EmptyLayer: false,
-		},
-		{
-			BlobInfo: types.BlobInfo{
-				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-				Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
-				Size:      291,
-			},
-			EmptyLayer: false,
-		},
-		{
-			BlobInfo: types.BlobInfo{
-				MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
-				Digest:    "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
-				Size:      32,
-			},
-			EmptyLayer: true,
-		},
-	})
-	assert.Equal(t, []string{
-		"sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
-		"sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
-		"sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
-		"sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
-	}, strings)
 }

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -107,12 +107,6 @@ var oci1CompressionMIMETypeSets = []compressionMIMETypeSet{
 	},
 }
 
-// updatedOCI1MIMEType returns the result of applying edits in updated (MediaType, CompressionOperation) to
-// mimeType. It may use updated.Digest for error messages.
-func updatedOCI1MIMEType(mimeType string, updated types.BlobInfo) (string, error) {
-	return updatedMIMEType(oci1CompressionMIMETypeSets, mimeType, updated)
-}
-
 // UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls+mediatype), in order (the root layer first, and then successive layered layers)
 func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.Layers) != len(layerInfos) {
@@ -129,7 +123,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 			}
 			mimeType = decMimeType
 		}
-		mimeType, err := updatedOCI1MIMEType(mimeType, info)
+		mimeType, err := updatedMIMEType(oci1CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
 			return errors.Wrapf(err, "Error preparing updated manifest, layer %q", info.Digest)
 		}

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -139,7 +139,7 @@ func updatedOCI1MIMEType(mimeType string, updated types.BlobInfo) (string, error
 		case isOCI1Layer(mimeType):
 			return imgspecv1.MediaTypeImageLayer, nil
 		default:
-			return "", fmt.Errorf("Error preparing updated manifest: unsupported media type for decompression: %q", mimeType)
+			return "", fmt.Errorf("unsupported media type for decompression: %q", mimeType)
 		}
 
 	case types.Compress:
@@ -158,7 +158,7 @@ func updatedOCI1MIMEType(mimeType string, updated types.BlobInfo) (string, error
 			case isOCI1Layer(mimeType):
 				return imgspecv1.MediaTypeImageLayerGzip, nil
 			default:
-				return "", fmt.Errorf("Error preparing updated manifest: unsupported media type for compression: %q", mimeType)
+				return "", fmt.Errorf("unsupported media type for compression: %q", mimeType)
 			}
 
 		case compression.Zstd.Name():
@@ -168,15 +168,15 @@ func updatedOCI1MIMEType(mimeType string, updated types.BlobInfo) (string, error
 			case isOCI1Layer(mimeType):
 				return imgspecv1.MediaTypeImageLayerZstd, nil
 			default:
-				return "", fmt.Errorf("Error preparing updated manifest: unsupported media type for compression: %q", mimeType)
+				return "", fmt.Errorf("unsupported media type for compression: %q", mimeType)
 			}
 
 		default:
-			return "", fmt.Errorf("Error preparing updated manifest: unknown compression algorithm %q for layer %q", updated.CompressionAlgorithm.Name(), updated.Digest)
+			return "", fmt.Errorf("unknown compression algorithm %q", updated.CompressionAlgorithm.Name())
 		}
 
 	default:
-		return "", fmt.Errorf("Error preparing updated manifest: unknown compression operation (%d) for layer %q", updated.CompressionOperation, updated.Digest)
+		return "", fmt.Errorf("unknown compression operation (%d)", updated.CompressionOperation)
 	}
 }
 
@@ -198,7 +198,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedOCI1MIMEType(mimeType, info)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Error preparing updated manifest, layer %q", info.Digest)
 		}
 		if info.CryptoOperation == types.Encrypt {
 			encMediaType, err := getEncryptedMediaType(mimeType)


### PR DESCRIPTION
In preparation to fixing #733, this simplifies MIME type updates in manifests by factoring out the code common to all cases, and by making the mapping itself table-driven instead of a large set of manually written switch statements.

Should not change behavior, apart from some error strings.

See the individual commit messages for details.