### PR TITLE
OCI: Don't crash if OCI1Index.Manifests[].Platform is nil

### DIFF
--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -79,6 +79,9 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range index.Manifests {
+			if d.Platform == nil {
+				continue
+			}
 			imagePlatform := imgspecv1.Platform{
 				Architecture: d.Platform.Architecture,
 				OS:           d.Platform.OS,


### PR DESCRIPTION
This field is optional per the spec "SHOULD be present if its target
is platform-specific", and as noted in
https://github.com/containers/skopeo/issues/901 this happened in
practice.

Signed-off-by: Alexander Larsson <alexl@redhat.com>