### PR TITLE
Add not about policy.json file in homedir

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -10,8 +10,7 @@ containers-policy.json - syntax for the signature verification policy file
 Signature verification policy files are used to specify policy, e.g. trusted keys,
 applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
 
-The default policy is stored (unless overridden at compile-time) at `/etc/containers/policy.json`;
-applications performing verification may allow using a different policy instead.
+The default policy is stored (unless overridden at compile-time) at `/etc/containers/policy.json`;  applications performing verification may allow using a different policy instead. Rootless applications may also read default policy from `$HOME/.config/containers/policy.json` if it exist.
 
 ## FORMAT
 


### PR DESCRIPTION
We are now reading ~/.config/containers/policy.json if it exists
in the users homedir, when running rootless.  We should document
in the man page that this file is also used.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>