### PR TITLE
Add defaults for using the rootless policy path

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -10,8 +10,7 @@ containers-policy.json - syntax for the signature verification policy file
 Signature verification policy files are used to specify policy, e.g. trusted keys,
 applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
 
-The default policy is stored (unless overridden at compile-time) at `/etc/containers/policy.json`;
-applications performing verification may allow using a different policy instead.
+By default, the policy is read from `$HOME/.config/containers/policy.json`, if it exists, otherwise from `/etc/containers/policy.json`;  applications performing verification may allow using a different policy instead.
 
 ## FORMAT
 


### PR DESCRIPTION
Add support for default rootless policy path of $HOME/.config/containers/policy.json

Signed-off-by: Qi Wang <qiwan@redhat.com>