### PR TITLE
Add debug line to get Content-Type from manifests

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -190,6 +190,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	if err != nil {
 		return nil, "", err
 	}
+	logrus.Debugf("Content-Type from manifest GET is %q", res.Header.Get("Content-Type"))
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return nil, "", errors.Wrapf(client.HandleErrorResponse(res), "Error reading manifest %s in %s", tagOrDigest, s.physicalRef.ref.Name())


### PR DESCRIPTION
Often, manifests fail to pull because of a MIME type mismatch and have
to be debugged manually to figure out what the server/proxy is sending
the client.  This is much easier to see when it's just printed for you.

Signed-off-by: Robb Manes <rmanes@redhat.com>