### PR TITLE
Support credsStore config

### DIFF
--- a/docs/containers-auth.json.5.md
+++ b/docs/containers-auth.json.5.md
@@ -36,8 +36,26 @@ their accounts on quay.io and docker.io:
 An entry can be removed by using a `logout` command from a container
 tool such as `podman logout` or `buildah logout`.
 
+In addition, credential store and credential helpers can be configured and the credentials-helper
+software can be used to manage the credentials in a more secure way than depending on the base64 encoded authentication
+provided by `login`. If the credential helpers are configured for specific registries, the `credsStore` will not be used
+for operations concerning credentials of the specified registries.
+
+When the credential store is in use on a Linux platform, the auth.json file would contain:
+
+```
+    "auths": {
+        "localhost:5001": {}
+    },
+    "credsStore": "secretservice"
+}
+```
+
+For more information on Docker credential stores, please reference the [GitHub docker-credential-helpers project](https://github.com/docker/docker-credential-helpers/releases).
+
+
 # SEE ALSO
-    buildah-login(1), buildah-logout(1), podman-login(1), podman-logout(1)
+    buildah-login(1), buildah-logout(1), podman-login(1), podman-logout(1), skopeo-login(1), skopeo-logout(1)
 
 # HISTORY
 Feb 2020, Originally compiled by Tom Sweeney <tsweeney@redhat.com>

--- a/pkg/docker/config/testdata/docker-credential-helpertest
+++ b/pkg/docker/config/testdata/docker-credential-helpertest
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ACTION="${1}"
+shift
+
+case "${ACTION}" in
+get)
+    read DOCKER_REGISTRY
+    echo "{\"ServerURL\":\"${DOCKER_REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}"
+    exit 0
+    ;;
+*)
+    echo "not implemented"
+    exit 1
+    ;;
+esac

--- a/pkg/docker/config/testdata/helper.json
+++ b/pkg/docker/config/testdata/helper.json
@@ -1,0 +1,5 @@
+{
+    "auths": {
+    },
+    "credsStore":"helpertest"
+}


### PR DESCRIPTION
Support the "credsStore" in the auth.json file. If a credential helper configed, will save the authentication there.
Updated the containers-auth.json.5.md about the credsStore and credential helpers configuration.

Signed-off-by: Qi Wang <qiwan@redhat.com>