### PR TITLE
docker/config - get all credentials

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -284,6 +284,13 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 		return dockerConfigFile{}, errors.Wrapf(err, "error unmarshaling JSON at %q", path)
 	}
 
+	if auths.AuthConfigs == nil {
+		auths.AuthConfigs = map[string]dockerAuthConfig{}
+	}
+	if auths.CredHelpers == nil {
+		auths.CredHelpers = make(map[string]string)
+	}
+
 	return auths, nil
 }
 


### PR DESCRIPTION
Add means to get all credentials and fix a minor issues.

I'm currently working on the Podman v2 API and need to throw auth.jsons over the wire.