### PR TITLE
pkg/docker/config/ModifyJSON: fix MkdirAll usage

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -257,17 +257,15 @@ func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (
 	if err != nil {
 		return err
 	}
-
-	dir := filepath.Dir(path)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err = os.MkdirAll(dir, 0700); err != nil {
-			return errors.Wrapf(err, "error creating directory %q", dir)
-		}
-	}
-
 	if legacyFormat {
 		return fmt.Errorf("writes to %s using legacy format are not supported", path)
 	}
+
+	dir := filepath.Dir(path)
+	if err = os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
 	auths, err := readJSONFile(path, false)
 	if err != nil {
 		return errors.Wrapf(err, "error reading JSON file %q", path)


### PR DESCRIPTION
1. Using os.Stat() without checking that the result is a directory is
   error-prone: there might be a file with the same name as target dir.

2. There is no need to use os.Stat() before calling os.MkdirAll() as
   the latter does it as well.

3. Reverse the checks, error out early in case of legacyFormat.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>