### PR TITLE
Add hardcode Authfile for windows and mac

### DIFF
--- a/docs/containers-auth.json.5.md
+++ b/docs/containers-auth.json.5.md
@@ -5,8 +5,9 @@ containers-auth.json - syntax for the registry authentication file
 
 # DESCRIPTION
 
-A credentials file stored at `${XDG_RUNTIME_DIR}/containers/auth.json` in
-json format used to authenticate against container image registries.
+A credentials file in JSON format used to authenticate against container image registries.
+On Linux it is stored at `${XDG_RUNTIME_DIR}/containers/auth.json`;
+on Windows and macOS, at `$HOME/.config/containers/auth.json`
 
 ## FORMAT
 


### PR DESCRIPTION
Add hardcode Authfile for windows and mac used for the credential store.
fix https://github.com/containers/skopeo/issues/923

Signed-off-by: Qi Wang <qiwan@redhat.com>