### PR TITLE
docker: allow uncompressed layers

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -566,6 +566,8 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
 	DockerDisableDestSchema1MIMETypes bool
+
+	// === ostree.Transport overrides ===
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
 

--- a/types/types.go
+++ b/types/types.go
@@ -566,6 +566,8 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
 	DockerDisableDestSchema1MIMETypes bool
+	// Allow uncompressed image layers in Docker images
+	DockerAcceptUncompressedLayers bool
 
 	// === ostree.Transport overrides ===
 	// Directory to use for OSTree temporary files


### PR DESCRIPTION
We're interested in sending uncompressed layers to a docker registry, so
let's add a flag to support this.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>