### PR TITLE
Add support for ProgressEventSkipped

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1060,6 +1060,14 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			logrus.Debugf("Skipping blob %s (already present):", srcInfo.Digest)
 			bar := ic.c.createProgressBar(pool, srcInfo, "blob", "skipped: already exists")
 			bar.SetTotal(0, true)
+
+			// Throw an event that the layer has been skipped
+			if ic.c.progress != nil && ic.c.progressInterval > 0 {
+				ic.c.progress <- types.ProgressProperties{
+					Event:    types.ProgressEventSkipped,
+					Artifact: srcInfo,
+				}
+			}
 			return blobInfo, cachedDiffID, nil
 		}
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -604,6 +604,10 @@ const (
 	// ProgressEventDone is fired when the data transfer has been finished for
 	// the specific artifact
 	ProgressEventDone
+
+	// ProgressEventSkipped is fired when the artifact has been skipped because
+	// its already available at the destination
+	ProgressEventSkipped
 )
 
 // ProgressProperties is used to pass information from the copy code to a monitor which


### PR DESCRIPTION
The new event indicates that a blob has been skipped. This information
can be used by CRI-O for more detailed image layer re-use metrics.