### PR TITLE
Print warning if not using credential helpers

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -72,6 +72,9 @@ func SetAuthentication(sys *types.SystemContext, registry, username, password st
 			}
 			logrus.Debugf("failed to authenticate with the kernel keyring, falling back to authfiles. %v", err)
 		}
+		fmt.Fprintf(os.Stderr, "%s\n", `WARNING! Your password will be stored unencrypted in authentication file
+Configure a credential helper to remove this warning. See
+https://github.com/containers/image/blob/master/docs/containers-auth.json.5.md`)
 		creds := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 		newCreds := dockerAuthConfig{Auth: creds}
 		auths.AuthConfigs[registry] = newCreds


### PR DESCRIPTION
Print warning message if login command stores credentials as plain text without credential configuraiton.

close https://github.com/containers/libpod/issues/4119#issuecomment-641435325

Signed-off-by: Qi Wang <qiwan@redhat.com>