### PR TITLE
When we can't store signatures, point the user at the destination.

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -377,7 +377,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	if len(sigs) != 0 {
 		c.Printf("Checking if image list destination supports signatures\n")
 		if err := c.dest.SupportsSignatures(ctx); err != nil {
-			return nil, "", errors.Wrap(err, "Can not copy signatures")
+			return nil, "", errors.Wrapf(err, "Can not copy signatures to %s", transports.ImageName(c.dest.Reference()))
 		}
 	}
 	canModifyManifestList := (len(sigs) == 0)
@@ -595,7 +595,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	if len(sigs) != 0 {
 		c.Printf("Checking if image destination supports signatures\n")
 		if err := c.dest.SupportsSignatures(ctx); err != nil {
-			return nil, "", "", errors.Wrap(err, "Can not copy signatures")
+			return nil, "", "", errors.Wrapf(err, "Can not copy signatures to %s", transports.ImageName(c.dest.Reference()))
 		}
 	}
 


### PR DESCRIPTION
Currently the error message is:
> Can not copy signatures: X-Registry-Supports-Signatures extension not supported, and lookaside is not configured

which does not tell the user whether to check the source or the destination.

Mention the destination explicitly.