### PR TITLE
storage: skip GzippedEmptyLayer on TryResuingBlob

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -476,6 +476,9 @@ func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo t
 	if err := blobinfo.Digest.Validate(); err != nil {
 		return false, types.BlobInfo{}, errors.Wrapf(err, `Can not check for a blob with invalid digest`)
 	}
+	if blobinfo.Digest == image.GzippedEmptyLayerDigest {
+		return true, blobinfo, nil
+	}
 
 	// Check if we've already cached it in a file.
 	if size, ok := s.fileSizes[blobinfo.Digest]; ok {


### PR DESCRIPTION
so we don't have to ask the registry for it, similarly to GetBlob

fixes half of https://github.com/containers/container-libs/issues/267

Signed-off-by: Peter Hunt <pehunt@redhat.com>