### PR TITLE
Cleanup tests

### DIFF
--- a/pkg/blobinfocache/default_test.go
+++ b/pkg/blobinfocache/default_test.go
@@ -117,7 +117,7 @@ func TestBlobInfoCacheDir(t *testing.T) {
 func TestDefaultCache(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "TestDefaultCache")
 	require.NoError(t, err)
-	//defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 
 	// Success
 	normalDir := filepath.Join(tmpDir, "normal")

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -20,6 +20,7 @@ func TestGetPathToAuth(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir("", "TestGetPathToAuth")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
 	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.


### PR DESCRIPTION
Some tests were leaking their dirs in /tmp.