### PR TITLE
Auth configs in registries.conf

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -16,6 +16,8 @@ Container engines will use the `$HOME/.config/containers/registries.conf` if it 
 `unqualified-search-registries`
 : An array of _host_[`:`_port_] registries to try when pulling an unqualified image, in order.
 
+`credential-helpers`: An array of credential helpers used as external credential store for the registries.
+
 ### NAMESPACED `[[registry]]` SETTINGS
 
 The bulk of the configuration is represented as an array of `[[registry]]`
@@ -50,6 +52,9 @@ Given an image name, a single `[[registry]]` TOML table is chosen based on its `
 `blocked`
 : `true` or `false`.
     If `true`, pulling images with matching names is forbidden.
+
+`credential-helper`
+: The credential helper for registry specified by the `prefix` field.  Global default `credential-helpers` is used if `credential-helper` is not specified. This configuration only works if the `prefix` field is a registry domain, not used for inner namespace.
 
 #### Remapping and mirroring registries
 

--- a/pkg/docker/config/testdata/cred-helper.conf
+++ b/pkg/docker/config/testdata/cred-helper.conf
@@ -1,0 +1,3 @@
+[[registry]]
+credential-helper = "helper-registry"
+location = "registry-a.com"

--- a/pkg/docker/config/testdata/docker-credential-helper-registry
+++ b/pkg/docker/config/testdata/docker-credential-helper-registry
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+case "${1}" in
+    get)
+        read REGISTRY
+        echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}"
+        exit 0
+    ;;
+    list)
+        read UNUSED
+        echo "{\"registry-a.com\":\"foo\"}"
+        exit 0
+    ;;
+    *)
+        echo "not implemented"
+        exit 1
+    ;;
+esac

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -636,3 +636,41 @@ func TestGetShortNameMode(t *testing.T) {
 		assert.Equal(t, test.mode, mode, "%s", test.path)
 	}
 }
+
+func TestCredentialHelpersForRegistry(t *testing.T) {
+	ctx := &types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/cred-helper.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
+	}
+	for _, c := range []struct {
+		registry string
+		helper   []string
+	}{
+		{"registry-a.com", []string{"helper-a"}},
+		{"registry-b.com", []string{"helper-b", "helper"}},
+		{"registry-c.com", []string{"helper-c"}},
+		{"registry-not-conf.com", []string{"helper-b", "helper"}},
+	} {
+		ret, err := CredentialHelpersForRegistry(ctx, c.registry)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, c.helper, ret)
+	}
+
+	ctx = &types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/cred-helper-invalid.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
+	}
+	_, err := CredentialHelpersForRegistry(ctx, "registry-c.com")
+	assert.NotEqual(t, nil, err)
+}
+
+func TestAllConfiguredCredentialHelpers(t *testing.T) {
+	ctx := &types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/cred-helper.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
+	}
+	expect := []string{"helper-b", "helper-c", "helper-a", "helper"}
+	ret, err := AllConfiguredCredentialHelpers(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expect, ret)
+}

--- a/pkg/sysregistriesv2/testdata/cred-helper-invalid.conf
+++ b/pkg/sysregistriesv2/testdata/cred-helper-invalid.conf
@@ -1,0 +1,4 @@
+credential-helpers = ["helper", "helper-c"]
+[[registry]]
+credential-helper = "helper-c"
+location = "registry-c.com/foo"

--- a/pkg/sysregistriesv2/testdata/cred-helper.conf
+++ b/pkg/sysregistriesv2/testdata/cred-helper.conf
@@ -1,0 +1,12 @@
+credential-helpers = ["helper-b", "helper"]
+[[registry]]
+credential-helper = "helper-a"
+location = "registry-a.com"
+
+[[registry]]
+location = "registry-b.com"
+
+[[registry]]
+credential-helper = "helper-c"
+location = "registry-c.com/foo"
+prefix = "registry-c.com"


### PR DESCRIPTION
Allow `credential-helpers = []` and `credential-helper = ""` configuration in registries.conf as defautl store for credentials.
```toml
credential-helpers = ["secretservice"] # general credential helpers
[[registry]]
credential-helper = "secretservice" # credhelper for specfic registry
location = "example.com/foo"
```

close https://github.com/containers/podman/issues/4119
Signed-off-by: Qi Wang <qiwan@redhat.com>