### PR TITLE
docker/config: performed map creation action in advance

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -284,11 +284,11 @@ func getPathToAuth(sys *types.SystemContext) (string, bool, error) {
 // if the file exists and is empty, readJSONFile returns an error
 func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 	var auths dockerConfigFile
+	auths.AuthConfigs = map[string]dockerAuthConfig{}
 
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			auths.AuthConfigs = map[string]dockerAuthConfig{}
 			return auths, nil
 		}
 		return dockerConfigFile{}, err


### PR DESCRIPTION
When auth.json is modified and try to readJSONFile, the panic will
happened because `auths.AuthConfigs` is a nil map. So we need to create
map in advance to avoid panic.

Fix: #972

Signed-off-by: CooperLi <a710905118@gmail.com>