### PR TITLE
WIP - support multi-image docker archives

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/docker/tarfile"
 	"github.com/containers/image/v5/types"
 	"github.com/pkg/errors"
@@ -17,32 +18,36 @@ type archiveImageDestination struct {
 }
 
 func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
+	return newArchiveImageDestination(sys, ref.path, ref.destinationRef)
+}
+
+func newArchiveImageDestination(sys *types.SystemContext, path string, ref reference.NamedTagged) (*archiveImageDestination, error) {
 	// ref.path can be either a pipe or a regular file
 	// in the case of a pipe, we require that we can open it for write
 	// in the case of a regular file, we don't want to overwrite any pre-existing file
 	// so we check for Size() == 0 below (This is racy, but using O_EXCL would also be racy,
 	// only in a different way. Either way, it’s up to the user to not have two writers to the same path.)
-	fh, err := os.OpenFile(ref.path, os.O_WRONLY|os.O_CREATE, 0644)
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening file %q", ref.path)
+		return nil, errors.Wrapf(err, "error opening file %q", path)
 	}
 
 	fhStat, err := fh.Stat()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error statting file %q", ref.path)
+		return nil, errors.Wrapf(err, "error statting file %q", path)
 	}
 
 	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {
 		return nil, errors.New("docker-archive doesn't support modifying existing images")
 	}
 
-	tarDest := tarfile.NewDestinationWithContext(sys, fh, ref.destinationRef)
+	tarDest := tarfile.NewDestinationWithContext(sys, fh, ref)
 	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
 		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
 	}
 	return &archiveImageDestination{
 		Destination: tarDest,
-		ref:         ref,
+		ref:         archiveReference{path, ref},
 		writer:      fh,
 	}, nil
 }
@@ -69,4 +74,62 @@ func (d *archiveImageDestination) Close() error {
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (d *archiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	return d.Destination.Commit(ctx)
+}
+
+func (m multiImageDestinationReference) NewImageDestination(_ context.Context, _ *types.SystemContext) (types.ImageDestination, error) {
+	return m.dest, nil
+}
+
+// MultiImageDestinations allows for creating and writing to docker archives
+// that include more than one image.
+type MultiImageDestination struct {
+	*archiveImageDestination
+	path string
+}
+
+// multiImageDestinationReference is a types.ImageReference embedding a MultiImageDestination.
+type multiImageDestinationReference struct {
+	*archiveReference
+	dest *MultiImageDestination
+}
+
+// NewMultiImageDestination returns a MultiImageDestination for the specified path.
+func NewMultiImageDestination(sys *types.SystemContext, path string) (*MultiImageDestination, error) {
+	dest, err := newArchiveImageDestination(sys, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiImageDestination{dest, path}, nil
+}
+
+// Reference returns an ImageReference embedding the MultiImageDestination.
+func (m *MultiImageDestination) Reference() types.ImageReference {
+	ref := &archiveReference{path: m.path}
+	return &multiImageDestinationReference{ref, m}
+}
+
+// Close is a NOP.  Please use Finalize() for committing the archive and
+// closing the underlying resources.
+func (m *MultiImageDestination) Close() error {
+	return nil
+}
+
+// Commit is a NOP.  Please use Finalize() for committing the archive and
+// closing the underlying resources.
+func (m *MultiImageDestination) Commit(_ context.Context, _ types.UnparsedImage) error {
+	return nil
+}
+
+// Finalize commits pending data and closes the underlying tarfile.
+func (m *MultiImageDestination) Finalize(ctx context.Context) (finalErr error) {
+	defer func() {
+		if err := m.writer.Close(); err != nil {
+			if finalErr == nil {
+				finalErr = err
+			} else {
+				finalErr = errors.Wrap(finalErr, err.Error())
+			}
+		}
+	}()
+	return m.Destination.Commit(ctx)
 }

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/containers/image/v5/docker/tarfile"
+	ctrImage "github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
 )
@@ -33,4 +34,84 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveRe
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (s *archiveImageSource) Reference() types.ImageReference {
 	return s.ref
+}
+
+// MultiImageSourceItem is a reference to _one_ image in a multi-image archive.
+// Note that MultiImageSourceItem implements types.ImageReference.  It's a
+// long-lived object that can only be closed via it's parent MultiImageSource.
+type MultiImageSourceItem struct {
+	*archiveReference
+	tarSource *tarfile.Source
+}
+
+// Manifest returns the tarfile.ManifestItem.
+func (m *MultiImageSourceItem) Manifest() (*tarfile.ManifestItem, error) {
+	items, err := m.tarSource.LoadTarManifest()
+	if err != nil {
+		return nil, err
+	}
+	return &items[0], nil
+}
+
+// NewImage returns a types.ImageCloser for this reference, possibly
+// specialized for this ImageTransport.
+func (m MultiImageSourceItem) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := m.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, err
+	}
+	return ctrImage.FromSource(ctx, sys, src)
+}
+
+// NewImageSource returns a types.ImageSource for this reference.
+func (m MultiImageSourceItem) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	return &archiveImageSource{
+		Source: m.tarSource,
+		ref:    *m.archiveReference,
+	}, nil
+}
+
+// MultiImageSource allows for reading docker archives that includes more
+// than one image.  Use Items() to extract
+type MultiImageSource struct {
+	path      string
+	tarSource *tarfile.Source
+}
+
+// NewMultiImageSource creates a MultiImageSource for the
+// specified path pointing to a docker-archive.
+func NewMultiImageSource(ctx context.Context, sys *types.SystemContext, path string) (*MultiImageSource, error) {
+	src, err := tarfile.NewSourceFromFileWithContext(sys, path)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiImageSource{path: path, tarSource: src}, nil
+}
+
+// Close closes the underlying tarfile.
+func (m *MultiImageSource) Close() error {
+	return m.tarSource.Close()
+}
+
+// Items returns a MultiImageSourceItem for all manifests/images in the archive.
+// Each references embeds an ImageSource pointing to the corresponding image in
+// the archive.
+func (m *MultiImageSource) Items() ([]MultiImageSourceItem, error) {
+	items, err := m.tarSource.LoadTarManifest()
+	if err != nil {
+		return nil, err
+	}
+	references := []MultiImageSourceItem{}
+	for index := range items {
+		src, err := m.tarSource.FromManifest(index)
+		if err != nil {
+			return nil, err
+		}
+		newRef := MultiImageSourceItem{
+			&archiveReference{path: m.path},
+			src,
+		}
+		references = append(references, newRef)
+	}
+	return references, nil
 }


### PR DESCRIPTION
Add a `MultiImageArchive{Reader,Writer}` to `docker/archive` to support
docker archives with more than one image.

To allow the new archive reader/writer to be used for copying images,
add an `Image{Destination,Source}` to `copy.Options`.  When set, the
destination/source referenced will be ignored and the specified
`Image{Destination,Source}` will be used instead.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>