### PR TITLE
pkg/docker/config: correct default file mode when create auth.json file

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -345,7 +345,7 @@ func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (
 			return errors.Wrapf(err, "error marshaling JSON %q", path)
 		}
 
-		if err = ioutil.WriteFile(path, newData, 0755); err != nil {
+		if err = ioutil.WriteFile(path, newData, 0600); err != nil {
 			return errors.Wrapf(err, "error writing to file %q", path)
 		}
 	}


### PR DESCRIPTION
`auth.json` contains sensitive info which should not be seen or modified by other people
and no need for execution right, so we change the default filemode from
0755 to 0600

Fix: #974

Signed-off-by: CooperLi <a710905118@gmail.com>