### PR TITLE
Update to Go 1.13

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:18.04
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev curl
 
-ADD https://storage.googleapis.com/golang/go1.11.12.linux-amd64.tar.gz /tmp
+ADD https://golang.org/dl/go1.13.13.linux-amd64.tar.gz /tmp
 
-RUN tar -C /usr/local -xzf /tmp/go1.11.12.linux-amd64.tar.gz && \
-    rm /tmp/go1.11.12.linux-amd64.tar.gz && \
+RUN tar -C /usr/local -xzf /tmp/go1.13.13.linux-amd64.tar.gz && \
+    rm /tmp/go1.13.13.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/* /usr/local/bin/


### PR DESCRIPTION
Skopeo (via `make test-skopeo` ) now uses github.com/hashicorp/go-multierror , which requires Go 1.13.
