### PR TITLE
Support reading any/all images from docker-archive: tarballs

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -30,7 +30,7 @@ func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.
 		archive = tarfile.NewWriter(fh)
 		writer = fh
 	}
-	tarDest := tarfile.NewDestination(sys, archive, ref.destinationRef)
+	tarDest := tarfile.NewDestination(sys, archive, ref.ref)
 	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
 		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
 	}

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
 )
 
 type archiveImageDestination struct {
@@ -16,6 +17,10 @@ type archiveImageDestination struct {
 }
 
 func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
+	if ref.sourceIndex != -1 {
+		return nil, errors.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
+	}
+
 	var archive *tarfile.Writer
 	var writer io.Closer
 	if ref.archiveWriter != nil {

--- a/docker/archive/reader.go
+++ b/docker/archive/reader.go
@@ -49,14 +49,14 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 			if !ok {
 				return nil, errors.Errorf("Invalid tag %s (%s): does not contain a tag", tag, parsedTag.String())
 			}
-			ref, err := NewReference(r.path, nt)
+			ref, err := newReference(r.path, nt, -1, r.archive, nil)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Error creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
 			}
 			refs = append(refs, ref)
 		}
 		if len(refs) == 0 {
-			ref, err := NewIndexReference(r.path, imageIndex)
+			ref, err := newReference(r.path, nil, imageIndex, r.archive, nil)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Error creating a reference for manifest item @%d", imageIndex)
 			}

--- a/docker/archive/reader.go
+++ b/docker/archive/reader.go
@@ -1,0 +1,68 @@
+package archive
+
+import (
+	"github.com/containers/image/v5/docker/internal/tarfile"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+)
+
+// Reader manages a single Docker archive, allows listing its contents and accessing
+// individual images with less overhead than creating image references individually
+// (because the archive is, if necessary, copied or decompressed only once).
+type Reader struct {
+	path    string // The original, user-specified path; not the maintained temporary file, if any
+	archive *tarfile.Reader
+}
+
+// NewReader returns a Reader for path.
+// The caller should call .Close() on the returned object.
+func NewReader(sys *types.SystemContext, path string) (*Reader, error) {
+	archive, err := tarfile.NewReaderFromFile(sys, path)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		path:    path,
+		archive: archive,
+	}, nil
+}
+
+// Close deletes temporary files associated with the Reader, if any.
+func (r *Reader) Close() error {
+	return r.archive.Close()
+}
+
+// List returns the a set of references for images in the Reader,
+// grouped by the image the references point to.
+// The references are valid only until the Reader is closed.
+func (r *Reader) List() ([][]types.ImageReference, error) {
+	res := [][]types.ImageReference{}
+	for imageIndex, image := range r.archive.Manifest {
+		refs := []types.ImageReference{}
+		for _, tag := range image.RepoTags {
+			parsedTag, err := reference.ParseNormalizedNamed(tag)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Invalid tag %#v in manifest item @%d", tag, imageIndex)
+			}
+			nt, ok := parsedTag.(reference.NamedTagged)
+			if !ok {
+				return nil, errors.Errorf("Invalid tag %s (%s): does not contain a tag", tag, parsedTag.String())
+			}
+			ref, err := NewReference(r.path, nt)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Error creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
+			}
+			refs = append(refs, ref)
+		}
+		if len(refs) == 0 {
+			ref, err := NewIndexReference(r.path, imageIndex)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Error creating a reference for manifest item @%d", imageIndex)
+			}
+			refs = append(refs, ref)
+		}
+		res = append(res, refs)
+	}
+	return res, nil
+}

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -19,7 +19,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveRe
 	if err != nil {
 		return nil, err
 	}
-	src := tarfile.NewSource(archive, true, ref.ref)
+	src := tarfile.NewSource(archive, true, ref.ref, ref.sourceIndex)
 	return &archiveImageSource{
 		Source: src,
 		ref:    ref,

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
-	"github.com/sirupsen/logrus"
 )
 
 type archiveImageSource struct {
@@ -16,14 +15,11 @@ type archiveImageSource struct {
 // newImageSource returns a types.ImageSource for the specified image reference.
 // The caller must call .Close() on the returned ImageSource.
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveReference) (types.ImageSource, error) {
-	if ref.destinationRef != nil {
-		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
-	}
 	archive, err := tarfile.NewReaderFromFile(sys, ref.path)
 	if err != nil {
 		return nil, err
 	}
-	src := tarfile.NewSource(archive, true)
+	src := tarfile.NewSource(archive, true, ref.ref)
 	return &archiveImageSource{
 		Source: src,
 		ref:    ref,

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -19,7 +19,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveRe
 	if ref.destinationRef != nil {
 		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
 	}
-	src, err := tarfile.NewSourceFromFileWithContext(sys, ref.path)
+	src, err := tarfile.NewSourceFromFile(sys, ref.path)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -19,10 +19,11 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref archiveRe
 	if ref.destinationRef != nil {
 		logrus.Warnf("docker-archive: references are not supported for sources (ignoring)")
 	}
-	src, err := tarfile.NewSourceFromFile(sys, ref.path)
+	archive, err := tarfile.NewReaderFromFile(sys, ref.path)
 	if err != nil {
 		return nil, err
 	}
+	src := tarfile.NewSource(archive, true)
 	return &archiveImageSource{
 		Source: src,
 		ref:    ref,

--- a/docker/archive/src.go
+++ b/docker/archive/src.go
@@ -3,7 +3,7 @@ package archive
 import (
 	"context"
 
-	"github.com/containers/image/v5/docker/tarfile"
+	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
 )

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -68,9 +68,8 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		}
 		ref = reference.TagNameOnly(ref)
 		refTagged, isTagged := ref.(reference.NamedTagged)
-		if !isTagged {
-			// Really shouldn't be hit...
-			return nil, errors.Errorf("internal error: reference is not tagged even after reference.TagNameOnly: %s", refString)
+		if !isTagged { // If ref contains a digest, TagNameOnly does not change it
+			return nil, errors.Errorf("reference does not include a tag: %s", ref.String())
 		}
 		destinationRef = refTagged
 	}

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -49,6 +49,9 @@ type archiveReference struct {
 	// If not -1, a zero-based index of the image in the manifest. Valid only for sources.
 	// Must not be set if ref is set.
 	sourceIndex int
+	// If not nil, must have been created from path (but archiveReader.path may point at a temporary
+	// file, not necesarily path precisely).
+	archiveReader *tarfile.Reader
 	// If not nil, must have been created for path
 	archiveWriter *tarfile.Writer
 }
@@ -89,22 +92,23 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		}
 	}
 
-	return newReference(path, nt, sourceIndex, nil)
+	return newReference(path, nt, sourceIndex, nil, nil)
 }
 
 // NewReference returns a Docker archive reference for a path and an optional reference.
 func NewReference(path string, ref reference.NamedTagged) (types.ImageReference, error) {
-	return newReference(path, ref, -1, nil)
+	return newReference(path, ref, -1, nil, nil)
 }
 
 // NewIndexReference returns a Docker archive reference for a path and a zero-based source manifest index.
 func NewIndexReference(path string, sourceIndex int) (types.ImageReference, error) {
-	return newReference(path, nil, sourceIndex, nil)
+	return newReference(path, nil, sourceIndex, nil, nil)
 }
 
 // newReference returns a docker archive reference for a path, an optional reference or sourceIndex,
-// and optionally a tarfile.Writer matching path.
-func newReference(path string, ref reference.NamedTagged, sourceIndex int, archiveWriter *tarfile.Writer) (types.ImageReference, error) {
+// and optionally a tarfile.Reader and/or a tarfile.Writer matching path.
+func newReference(path string, ref reference.NamedTagged, sourceIndex int,
+	archiveReader *tarfile.Reader, archiveWriter *tarfile.Writer) (types.ImageReference, error) {
 	if strings.Contains(path, ":") {
 		return nil, errors.Errorf("Invalid docker-archive: reference: colon in path %q is not supported", path)
 	}
@@ -121,6 +125,7 @@ func newReference(path string, ref reference.NamedTagged, sourceIndex int, archi
 		path:          path,
 		ref:           ref,
 		sourceIndex:   sourceIndex,
+		archiveReader: archiveReader,
 		archiveWriter: archiveWriter,
 	}, nil
 }

--- a/docker/archive/transport_test.go
+++ b/docker/archive/transport_test.go
@@ -67,10 +67,10 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 			require.True(t, ok, c.input)
 			assert.Equal(t, c.expectedPath, archiveRef.path, c.input)
 			if c.expectedRef == "" {
-				assert.Nil(t, archiveRef.destinationRef, c.input)
+				assert.Nil(t, archiveRef.ref, c.input)
 			} else {
-				require.NotNil(t, archiveRef.destinationRef, c.input)
-				assert.Equal(t, c.expectedRef, archiveRef.destinationRef.String(), c.input)
+				require.NotNil(t, archiveRef.ref, c.input)
+				assert.Equal(t, c.expectedRef, archiveRef.ref.String(), c.input)
 			}
 		}
 	}
@@ -104,10 +104,10 @@ func TestNewReference(t *testing.T) {
 				require.True(t, ok, c.ref)
 				assert.Equal(t, path, archiveRef.path)
 				if c.ref == "" {
-					assert.Nil(t, archiveRef.destinationRef, c.ref)
+					assert.Nil(t, archiveRef.ref, c.ref)
 				} else {
-					require.NotNil(t, archiveRef.destinationRef, c.ref)
-					assert.Equal(t, ntRef.String(), archiveRef.destinationRef.String(), c.ref)
+					require.NotNil(t, archiveRef.ref, c.ref)
+					assert.Equal(t, ntRef.String(), archiveRef.ref.String(), c.ref)
 				}
 			}
 
@@ -176,21 +176,21 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 }
 
 func TestReferenceNewImage(t *testing.T) {
-	for _, suffix := range []string{"", ":thisisignoredbutaccepted"} {
+	for _, suffix := range []string{"", ":emptyimage:latest"} {
 		ref, err := ParseReference(tarFixture + suffix)
 		require.NoError(t, err, suffix)
 		img, err := ref.NewImage(context.Background(), nil)
-		assert.NoError(t, err, suffix)
+		require.NoError(t, err, suffix)
 		defer img.Close()
 	}
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
-	for _, suffix := range []string{"", ":thisisignoredbutaccepted"} {
+	for _, suffix := range []string{"", ":emptyimage:latest"} {
 		ref, err := ParseReference(tarFixture + suffix)
 		require.NoError(t, err, suffix)
 		src, err := ref.NewImageSource(context.Background(), nil)
-		assert.NoError(t, err, suffix)
+		require.NoError(t, err, suffix)
 		defer src.Close()
 	}
 }
@@ -218,7 +218,7 @@ func TestReferenceDeleteImage(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	for i, suffix := range []string{"", ":thisisignoredbutaccepted"} {
+	for i, suffix := range []string{"", ":some-reference"} {
 		testFile := filepath.Join(tmpDir, fmt.Sprintf("file%d.tar", i))
 		err := ioutil.WriteFile(testFile, []byte("nonempty"), 0644)
 		require.NoError(t, err, suffix)

--- a/docker/archive/transport_test.go
+++ b/docker/archive/transport_test.go
@@ -134,7 +134,7 @@ func TestNewReference(t *testing.T) {
 
 	// Complete coverage testing of the private newReference here as well
 	ntRef := namedTaggedRef(t, "busybox:latest")
-	_, err = newReference("path", ntRef, 0, nil)
+	_, err = newReference("path", ntRef, 0, nil, nil)
 	assert.Error(t, err)
 }
 

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -47,7 +47,7 @@ func (w *Writer) Close() error {
 // NewReference returns an ImageReference that allows adding an image to Writer,
 // with an optional reference.
 func (w *Writer) NewReference(destinationRef reference.NamedTagged) (types.ImageReference, error) {
-	return newReference(w.path, destinationRef, -1, w.archive)
+	return newReference(w.path, destinationRef, -1, nil, w.archive)
 }
 
 // openArchiveForWriting opens path for writing a tar archive,

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -47,7 +47,7 @@ func (w *Writer) Close() error {
 // NewReference returns an ImageReference that allows adding an image to Writer,
 // with an optional reference.
 func (w *Writer) NewReference(destinationRef reference.NamedTagged) (types.ImageReference, error) {
-	return newReference(w.path, destinationRef, w.archive)
+	return newReference(w.path, destinationRef, -1, w.archive)
 }
 
 // openArchiveForWriting opens path for writing a tar archive,

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -39,7 +39,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 	if err != nil {
 		return nil, err
 	}
-	src := tarfile.NewSource(archive, true, nil)
+	src := tarfile.NewSource(archive, true, nil, -1)
 	return &daemonImageSource{
 		ref:    ref,
 		Source: src,

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -39,7 +39,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 	if err != nil {
 		return nil, err
 	}
-	src := tarfile.NewSource(archive, true)
+	src := tarfile.NewSource(archive, true, nil)
 	return &daemonImageSource{
 		ref:    ref,
 		Source: src,

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -35,7 +35,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 	}
 	defer inputStream.Close()
 
-	src, err := tarfile.NewSourceFromStreamWithSystemContext(sys, inputStream)
+	src, err := tarfile.NewSourceFromStream(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -35,10 +35,11 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 	}
 	defer inputStream.Close()
 
-	src, err := tarfile.NewSourceFromStream(sys, inputStream)
+	archive, err := tarfile.NewReaderFromStream(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}
+	src := tarfile.NewSource(archive, true)
 	return &daemonImageSource{
 		ref:    ref,
 		Source: src,

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"context"
 
-	"github.com/containers/image/v5/docker/tarfile"
+	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
 	"github.com/pkg/errors"
 )

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -126,28 +126,42 @@ func (r *Reader) Close() error {
 	return nil
 }
 
-// chooseManifestItem selects a manifest item from r.Manifest matching ref (which may be nil)
-func (r *Reader) chooseManifestItem(ref reference.NamedTagged) (*ManifestItem, error) {
-	if ref == nil {
+// chooseManifestItem selects a manifest item from r.Manifest matching (ref, sourceIndex), one or
+// both of which should be (nil, -1).
+func (r *Reader) chooseManifestItem(ref reference.NamedTagged, sourceIndex int) (*ManifestItem, error) {
+	switch {
+	case ref != nil && sourceIndex != -1:
+		return nil, errors.Errorf("Internal error: Cannot have both ref %s and source index @%d",
+			ref.String(), sourceIndex)
+
+	case ref != nil:
+		refString := ref.String()
+		for i := range r.Manifest {
+			for _, tag := range r.Manifest[i].RepoTags {
+				parsedTag, err := reference.ParseNormalizedNamed(tag)
+				if err != nil {
+					return nil, errors.Wrapf(err, "Invalid tag %#v in manifest.json item @%d", tag, i)
+				}
+				if parsedTag.String() == refString {
+					return &r.Manifest[i], nil
+				}
+			}
+		}
+		return nil, errors.Errorf("Tag %#v not found", refString)
+
+	case sourceIndex != -1:
+		if sourceIndex >= len(r.Manifest) {
+			return nil, errors.Errorf("Invalid source index @%d, only %d manifest items available",
+				sourceIndex, len(r.Manifest))
+		}
+		return &r.Manifest[sourceIndex], nil
+
+	default:
 		if len(r.Manifest) != 1 {
 			return nil, errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(r.Manifest))
 		}
 		return &r.Manifest[0], nil
 	}
-
-	refString := ref.String()
-	for i := range r.Manifest {
-		for _, tag := range r.Manifest[i].RepoTags {
-			parsedTag, err := reference.ParseNormalizedNamed(tag)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Invalid tag %#v in manifest.json item %d", tag, i+1)
-			}
-			if parsedTag.String() == refString {
-				return &r.Manifest[i], nil
-			}
-		}
-	}
-	return nil, errors.Errorf("Tag %#v not found", refString)
 }
 
 // tarReadCloser is a way to close the backing file of a tar.Reader when the user no longer needs the tar component.

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -18,7 +18,9 @@ import (
 
 // Reader is a ((docker save)-formatted) tar archive that allows random access to any component.
 type Reader struct {
-	path          string
+	// None of the fields below are modified after the archive is created, until .Close();
+	// this allows concurrent readers of the same archive.
+	path          string         // "" if the archive has already been closed.
 	removeOnClose bool           // Remove file on close if true
 	Manifest      []ManifestItem // Guaranteed to exist after the archive is created.
 }
@@ -120,8 +122,10 @@ func newReader(path string, removeOnClose bool) (*Reader, error) {
 
 // Close removes resources associated with an initialized Reader, if any.
 func (r *Reader) Close() error {
+	path := r.path
+	r.path = "" // Mark the archive as closed
 	if r.removeOnClose {
-		return os.Remove(r.path)
+		return os.Remove(path)
 	}
 	return nil
 }
@@ -177,8 +181,15 @@ func (t *tarReadCloser) Close() error {
 // openTarComponent returns a ReadCloser for the specific file within the archive.
 // This is linear scan; we assume that the tar file will have a fairly small amount of files (~layers),
 // and that filesystem caching will make the repeated seeking over the (uncompressed) tarPath cheap enough.
+// It is safe to call this method from multiple goroutines simultaneously.
 // The caller should call .Close() on the returned stream.
 func (r *Reader) openTarComponent(componentPath string) (io.ReadCloser, error) {
+	// This is only a sanity check; if anyone did concurrently close ra, this access is technically
+	// racy against the write in .Close().
+	if r.path == "" {
+		return nil, errors.New("Internal error: trying to read an already closed tarfile.Reader")
+	}
+
 	f, err := os.Open(r.path)
 	if err != nil {
 		return nil, err
@@ -241,6 +252,7 @@ func findTarComponent(inputFile io.Reader, componentPath string) (*tar.Reader, *
 }
 
 // readTarComponent returns full contents of componentPath.
+// It is safe to call this method from multiple goroutines simultaneously.
 func (r *Reader) readTarComponent(path string, limit int) ([]byte, error) {
 	file, err := r.openTarComponent(path)
 	if err != nil {

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -68,7 +68,7 @@ func (s *Source) ensureCachedDataIsPresent() error {
 // ensureCachedDataIsPresentPrivate is a private implementation detail of ensureCachedDataIsPresent.
 // Call ensureCachedDataIsPresent instead.
 func (s *Source) ensureCachedDataIsPresentPrivate() error {
-	tarManifest, err := s.archive.chooseManifestItem(s.ref, s.sourceIndex)
+	tarManifest, _, err := s.archive.ChooseManifestItem(s.ref, s.sourceIndex)
 	if err != nil {
 		return err
 	}

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -107,9 +107,9 @@ func (s *Source) Close() error {
 	return nil
 }
 
-// LoadTarManifest loads and decodes the manifest.json
-func (s *Source) LoadTarManifest() ([]ManifestItem, error) {
-	return s.archive.Manifest, nil
+// TarManifest returns contents of manifest.json
+func (s *Source) TarManifest() []ManifestItem {
+	return s.archive.Manifest
 }
 
 func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manifest.Schema2Image) (map[digest.Digest]*layerInfo, error) {

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -47,14 +47,7 @@ type layerInfo struct {
 // 	To do for both the NewSourceFromFile and NewSourceFromStream functions
 
 // NewSourceFromFile returns a tarfile.Source for the specified path.
-// Deprecated: Please use NewSourceFromFileWithContext which will allows you to configure temp directory
-// for big files through SystemContext.BigFilesTemporaryDir
-func NewSourceFromFile(path string) (*Source, error) {
-	return NewSourceFromFileWithContext(nil, path)
-}
-
-// NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
-func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
+func NewSourceFromFile(sys *types.SystemContext, path string) (*Source, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error opening file %q", path)
@@ -73,22 +66,13 @@ func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Sourc
 			tarPath: path,
 		}, nil
 	}
-	return NewSourceFromStreamWithSystemContext(sys, stream)
+	return NewSourceFromStream(sys, stream)
 }
 
 // NewSourceFromStream returns a tarfile.Source for the specified inputStream,
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
-// Deprecated: Please use NewSourceFromStreamWithSystemContext which will allows you to configure
-// temp directory for big files through SystemContext.BigFilesTemporaryDir
-func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
-	return NewSourceFromStreamWithSystemContext(nil, inputStream)
-}
-
-// NewSourceFromStreamWithSystemContext returns a tarfile.Source for the specified inputStream,
-// which can be either compressed or uncompressed. The caller can close the
-// inputStream immediately after NewSourceFromFile returns.
-func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
+func NewSourceFromStream(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
 	// Save inputStream to a temporary file
 	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
 	if err != nil {

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -1,0 +1,511 @@
+package tarfile
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/internal/tmpdir"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+// Source is a partial implementation of types.ImageSource for reading from tarPath.
+type Source struct {
+	tarPath              string
+	removeTarPathOnClose bool // Remove temp file on close if true
+	// The following data is only available after ensureCachedDataIsPresent() succeeds
+	tarManifest       *ManifestItem // nil if not available yet.
+	configBytes       []byte
+	configDigest      digest.Digest
+	orderedDiffIDList []digest.Digest
+	knownLayers       map[digest.Digest]*layerInfo
+	// Other state
+	generatedManifest []byte    // Private cache for GetManifest(), nil if not set yet.
+	cacheDataLock     sync.Once // Private state for ensureCachedDataIsPresent to make it concurrency-safe
+	cacheDataResult   error     // Private state for ensureCachedDataIsPresent
+}
+
+type layerInfo struct {
+	path string
+	size int64
+}
+
+// TODO: We could add support for multiple images in a single archive, so
+//       that people could use docker-archive:opensuse.tar:opensuse:leap as
+//       the source of an image.
+// 	To do for both the NewSourceFromFile and NewSourceFromStream functions
+
+// NewSourceFromFile returns a tarfile.Source for the specified path.
+// Deprecated: Please use NewSourceFromFileWithContext which will allows you to configure temp directory
+// for big files through SystemContext.BigFilesTemporaryDir
+func NewSourceFromFile(path string) (*Source, error) {
+	return NewSourceFromFileWithContext(nil, path)
+}
+
+// NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
+func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error opening file %q", path)
+	}
+	defer file.Close()
+
+	// If the file is already not compressed we can just return the file itself
+	// as a source. Otherwise we pass the stream to NewSourceFromStream.
+	stream, isCompressed, err := compression.AutoDecompress(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error detecting compression for file %q", path)
+	}
+	defer stream.Close()
+	if !isCompressed {
+		return &Source{
+			tarPath: path,
+		}, nil
+	}
+	return NewSourceFromStreamWithSystemContext(sys, stream)
+}
+
+// NewSourceFromStream returns a tarfile.Source for the specified inputStream,
+// which can be either compressed or uncompressed. The caller can close the
+// inputStream immediately after NewSourceFromFile returns.
+// Deprecated: Please use NewSourceFromStreamWithSystemContext which will allows you to configure
+// temp directory for big files through SystemContext.BigFilesTemporaryDir
+func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
+	return NewSourceFromStreamWithSystemContext(nil, inputStream)
+}
+
+// NewSourceFromStreamWithSystemContext returns a tarfile.Source for the specified inputStream,
+// which can be either compressed or uncompressed. The caller can close the
+// inputStream immediately after NewSourceFromFile returns.
+func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
+	// Save inputStream to a temporary file
+	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating temporary file")
+	}
+	defer tarCopyFile.Close()
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			os.Remove(tarCopyFile.Name())
+		}
+	}()
+
+	// In order to be compatible with docker-load, we need to support
+	// auto-decompression (it's also a nice quality-of-life thing to avoid
+	// giving users really confusing "invalid tar header" errors).
+	uncompressedStream, _, err := compression.AutoDecompress(inputStream)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error auto-decompressing input")
+	}
+	defer uncompressedStream.Close()
+
+	// Copy the plain archive to the temporary file.
+	//
+	// TODO: This can take quite some time, and should ideally be cancellable
+	//       using a context.Context.
+	if _, err := io.Copy(tarCopyFile, uncompressedStream); err != nil {
+		return nil, errors.Wrapf(err, "error copying contents to temporary file %q", tarCopyFile.Name())
+	}
+	succeeded = true
+
+	return &Source{
+		tarPath:              tarCopyFile.Name(),
+		removeTarPathOnClose: true,
+	}, nil
+}
+
+// tarReadCloser is a way to close the backing file of a tar.Reader when the user no longer needs the tar component.
+type tarReadCloser struct {
+	*tar.Reader
+	backingFile *os.File
+}
+
+func (t *tarReadCloser) Close() error {
+	return t.backingFile.Close()
+}
+
+// openTarComponent returns a ReadCloser for the specific file within the archive.
+// This is linear scan; we assume that the tar file will have a fairly small amount of files (~layers),
+// and that filesystem caching will make the repeated seeking over the (uncompressed) tarPath cheap enough.
+// The caller should call .Close() on the returned stream.
+func (s *Source) openTarComponent(componentPath string) (io.ReadCloser, error) {
+	f, err := os.Open(s.tarPath)
+	if err != nil {
+		return nil, err
+	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			f.Close()
+		}
+	}()
+
+	tarReader, header, err := findTarComponent(f, componentPath)
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		return nil, os.ErrNotExist
+	}
+	if header.FileInfo().Mode()&os.ModeType == os.ModeSymlink { // FIXME: untested
+		// We follow only one symlink; so no loops are possible.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		// The new path could easily point "outside" the archive, but we only compare it to existing tar headers without extracting the archive,
+		// so we don't care.
+		tarReader, header, err = findTarComponent(f, path.Join(path.Dir(componentPath), header.Linkname))
+		if err != nil {
+			return nil, err
+		}
+		if header == nil {
+			return nil, os.ErrNotExist
+		}
+	}
+
+	if !header.FileInfo().Mode().IsRegular() {
+		return nil, errors.Errorf("Error reading tar archive component %s: not a regular file", header.Name)
+	}
+	succeeded = true
+	return &tarReadCloser{Reader: tarReader, backingFile: f}, nil
+}
+
+// findTarComponent returns a header and a reader matching componentPath within inputFile,
+// or (nil, nil, nil) if not found.
+func findTarComponent(inputFile io.Reader, componentPath string) (*tar.Reader, *tar.Header, error) {
+	t := tar.NewReader(inputFile)
+	componentPath = path.Clean(componentPath)
+	for {
+		h, err := t.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		if path.Clean(h.Name) == componentPath {
+			return t, h, nil
+		}
+	}
+	return nil, nil, nil
+}
+
+// readTarComponent returns full contents of componentPath.
+func (s *Source) readTarComponent(path string, limit int) ([]byte, error) {
+	file, err := s.openTarComponent(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error loading tar component %s", path)
+	}
+	defer file.Close()
+	bytes, err := iolimits.ReadAtMost(file, limit)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// ensureCachedDataIsPresent loads data necessary for any of the public accessors.
+// It is safe to call this from multi-threaded code.
+func (s *Source) ensureCachedDataIsPresent() error {
+	s.cacheDataLock.Do(func() {
+		s.cacheDataResult = s.ensureCachedDataIsPresentPrivate()
+	})
+	return s.cacheDataResult
+}
+
+// ensureCachedDataIsPresentPrivate is a private implementation detail of ensureCachedDataIsPresent.
+// Call ensureCachedDataIsPresent instead.
+func (s *Source) ensureCachedDataIsPresentPrivate() error {
+	// Read and parse manifest.json
+	tarManifest, err := s.loadTarManifest()
+	if err != nil {
+		return err
+	}
+
+	// Check to make sure length is 1
+	if len(tarManifest) != 1 {
+		return errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(tarManifest))
+	}
+
+	// Read and parse config.
+	configBytes, err := s.readTarComponent(tarManifest[0].Config, iolimits.MaxConfigBodySize)
+	if err != nil {
+		return err
+	}
+	var parsedConfig manifest.Schema2Image // There's a lot of info there, but we only really care about layer DiffIDs.
+	if err := json.Unmarshal(configBytes, &parsedConfig); err != nil {
+		return errors.Wrapf(err, "Error decoding tar config %s", tarManifest[0].Config)
+	}
+	if parsedConfig.RootFS == nil {
+		return errors.Errorf("Invalid image config (rootFS is not set): %s", tarManifest[0].Config)
+	}
+
+	knownLayers, err := s.prepareLayerData(&tarManifest[0], &parsedConfig)
+	if err != nil {
+		return err
+	}
+
+	// Success; commit.
+	s.tarManifest = &tarManifest[0]
+	s.configBytes = configBytes
+	s.configDigest = digest.FromBytes(configBytes)
+	s.orderedDiffIDList = parsedConfig.RootFS.DiffIDs
+	s.knownLayers = knownLayers
+	return nil
+}
+
+// loadTarManifest loads and decodes the manifest.json.
+func (s *Source) loadTarManifest() ([]ManifestItem, error) {
+	// FIXME? Do we need to deal with the legacy format?
+	bytes, err := s.readTarComponent(manifestFileName, iolimits.MaxTarFileManifestSize)
+	if err != nil {
+		return nil, err
+	}
+	var items []ManifestItem
+	if err := json.Unmarshal(bytes, &items); err != nil {
+		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
+	}
+	return items, nil
+}
+
+// Close removes resources associated with an initialized Source, if any.
+func (s *Source) Close() error {
+	if s.removeTarPathOnClose {
+		return os.Remove(s.tarPath)
+	}
+	return nil
+}
+
+// LoadTarManifest loads and decodes the manifest.json
+func (s *Source) LoadTarManifest() ([]ManifestItem, error) {
+	return s.loadTarManifest()
+}
+
+func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manifest.Schema2Image) (map[digest.Digest]*layerInfo, error) {
+	// Collect layer data available in manifest and config.
+	if len(tarManifest.Layers) != len(parsedConfig.RootFS.DiffIDs) {
+		return nil, errors.Errorf("Inconsistent layer count: %d in manifest, %d in config", len(tarManifest.Layers), len(parsedConfig.RootFS.DiffIDs))
+	}
+	knownLayers := map[digest.Digest]*layerInfo{}
+	unknownLayerSizes := map[string]*layerInfo{} // Points into knownLayers, a "to do list" of items with unknown sizes.
+	for i, diffID := range parsedConfig.RootFS.DiffIDs {
+		if _, ok := knownLayers[diffID]; ok {
+			// Apparently it really can happen that a single image contains the same layer diff more than once.
+			// In that case, the diffID validation ensures that both layers truly are the same, and it should not matter
+			// which of the tarManifest.Layers paths is used; (docker save) actually makes the duplicates symlinks to the original.
+			continue
+		}
+		layerPath := path.Clean(tarManifest.Layers[i])
+		if _, ok := unknownLayerSizes[layerPath]; ok {
+			return nil, errors.Errorf("Layer tarfile %s used for two different DiffID values", layerPath)
+		}
+		li := &layerInfo{ // A new element in each iteration
+			path: layerPath,
+			size: -1,
+		}
+		knownLayers[diffID] = li
+		unknownLayerSizes[layerPath] = li
+	}
+
+	// Scan the tar file to collect layer sizes.
+	file, err := os.Open(s.tarPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	t := tar.NewReader(file)
+	for {
+		h, err := t.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		layerPath := path.Clean(h.Name)
+		if li, ok := unknownLayerSizes[layerPath]; ok {
+			// Since GetBlob will decompress layers that are compressed we need
+			// to do the decompression here as well, otherwise we will
+			// incorrectly report the size. Pretty critical, since tools like
+			// umoci always compress layer blobs. Obviously we only bother with
+			// the slower method of checking if it's compressed.
+			uncompressedStream, isCompressed, err := compression.AutoDecompress(t)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Error auto-decompressing %s to determine its size", layerPath)
+			}
+			defer uncompressedStream.Close()
+
+			uncompressedSize := h.Size
+			if isCompressed {
+				uncompressedSize, err = io.Copy(ioutil.Discard, uncompressedStream)
+				if err != nil {
+					return nil, errors.Wrapf(err, "Error reading %s to find its size", layerPath)
+				}
+			}
+			li.size = uncompressedSize
+			delete(unknownLayerSizes, layerPath)
+		}
+	}
+	if len(unknownLayerSizes) != 0 {
+		return nil, errors.Errorf("Some layer tarfiles are missing in the tarball") // This could do with a better error reporting, if this ever happened in practice.
+	}
+
+	return knownLayers, nil
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+// This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
+// as the primary manifest can not be a list, so there can be no secondary instances.
+func (s *Source) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, "", errors.New(`Manifest lists are not supported by "docker-daemon:"`)
+	}
+	if s.generatedManifest == nil {
+		if err := s.ensureCachedDataIsPresent(); err != nil {
+			return nil, "", err
+		}
+		m := manifest.Schema2{
+			SchemaVersion: 2,
+			MediaType:     manifest.DockerV2Schema2MediaType,
+			ConfigDescriptor: manifest.Schema2Descriptor{
+				MediaType: manifest.DockerV2Schema2ConfigMediaType,
+				Size:      int64(len(s.configBytes)),
+				Digest:    s.configDigest,
+			},
+			LayersDescriptors: []manifest.Schema2Descriptor{},
+		}
+		for _, diffID := range s.orderedDiffIDList {
+			li, ok := s.knownLayers[diffID]
+			if !ok {
+				return nil, "", errors.Errorf("Internal inconsistency: Information about layer %s missing", diffID)
+			}
+			m.LayersDescriptors = append(m.LayersDescriptors, manifest.Schema2Descriptor{
+				Digest:    diffID, // diffID is a digest of the uncompressed tarball
+				MediaType: manifest.DockerV2Schema2LayerMediaType,
+				Size:      li.size,
+			})
+		}
+		manifestBytes, err := json.Marshal(&m)
+		if err != nil {
+			return nil, "", err
+		}
+		s.generatedManifest = manifestBytes
+	}
+	return s.generatedManifest, manifest.DockerV2Schema2MediaType, nil
+}
+
+// uncompressedReadCloser is an io.ReadCloser that closes both the uncompressed stream and the underlying input.
+type uncompressedReadCloser struct {
+	io.Reader
+	underlyingCloser   func() error
+	uncompressedCloser func() error
+}
+
+func (r uncompressedReadCloser) Close() error {
+	var res error
+	if err := r.uncompressedCloser(); err != nil {
+		res = err
+	}
+	if err := r.underlyingCloser(); err != nil && res == nil {
+		res = err
+	}
+	return res
+}
+
+// HasThreadSafeGetBlob indicates whether GetBlob can be executed concurrently.
+func (s *Source) HasThreadSafeGetBlob() bool {
+	return true
+}
+
+// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
+// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+// May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
+func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	if err := s.ensureCachedDataIsPresent(); err != nil {
+		return nil, 0, err
+	}
+
+	if info.Digest == s.configDigest { // FIXME? Implement a more general algorithm matching instead of assuming sha256.
+		return ioutil.NopCloser(bytes.NewReader(s.configBytes)), int64(len(s.configBytes)), nil
+	}
+
+	if li, ok := s.knownLayers[info.Digest]; ok { // diffID is a digest of the uncompressed tarball,
+		underlyingStream, err := s.openTarComponent(li.path)
+		if err != nil {
+			return nil, 0, err
+		}
+		closeUnderlyingStream := true
+		defer func() {
+			if closeUnderlyingStream {
+				underlyingStream.Close()
+			}
+		}()
+
+		// In order to handle the fact that digests != diffIDs (and thus that a
+		// caller which is trying to verify the blob will run into problems),
+		// we need to decompress blobs. This is a bit ugly, but it's a
+		// consequence of making everything addressable by their DiffID rather
+		// than by their digest...
+		//
+		// In particular, because the v2s2 manifest being generated uses
+		// DiffIDs, any caller of GetBlob is going to be asking for DiffIDs of
+		// layers not their _actual_ digest. The result is that copy/... will
+		// be verifing a "digest" which is not the actual layer's digest (but
+		// is instead the DiffID).
+
+		uncompressedStream, _, err := compression.AutoDecompress(underlyingStream)
+		if err != nil {
+			return nil, 0, errors.Wrapf(err, "Error auto-decompressing blob %s", info.Digest)
+		}
+
+		newStream := uncompressedReadCloser{
+			Reader:             uncompressedStream,
+			underlyingCloser:   underlyingStream.Close,
+			uncompressedCloser: uncompressedStream.Close,
+		}
+		closeUnderlyingStream = false
+
+		return newStream, li.size, nil
+	}
+
+	return nil, 0, errors.Errorf("Unknown blob %s", info.Digest)
+}
+
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
+// as there can be no secondary manifests.
+func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
+	}
+	return [][]byte{}, nil
+}
+
+// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+// to read the image's layers.
+// This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
+// as the primary manifest can not be a list, so there can be no secondary manifests.
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (s *Source) LayerInfosForCopy(context.Context, *digest.Digest) ([]types.BlobInfo, error) {
+	return nil, nil
+}

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -46,7 +46,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 
 		reader, err := NewReaderFromStream(nil, &tarfileBuffer)
 		require.NoError(t, err, c.config)
-		src := NewSource(reader, true)
+		src := NewSource(reader, true, nil)
 		require.NoError(t, err, c.config)
 		defer src.Close()
 		configStream, _, err := src.GetBlob(ctx, types.BlobInfo{

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -44,7 +44,9 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		err = writer.Close()
 		require.NoError(t, err, c.config)
 
-		src, err := NewSourceFromStream(nil, &tarfileBuffer)
+		reader, err := NewReaderFromStream(nil, &tarfileBuffer)
+		require.NoError(t, err, c.config)
+		src := NewSource(reader, true)
 		require.NoError(t, err, c.config)
 		defer src.Close()
 		configStream, _, err := src.GetBlob(ctx, types.BlobInfo{

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -44,7 +44,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		err = writer.Close()
 		require.NoError(t, err, c.config)
 
-		src, err := NewSourceFromStreamWithSystemContext(nil, &tarfileBuffer)
+		src, err := NewSourceFromStream(nil, &tarfileBuffer)
 		require.NoError(t, err, c.config)
 		defer src.Close()
 		configStream, _, err := src.GetBlob(ctx, types.BlobInfo{

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -46,7 +46,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 
 		reader, err := NewReaderFromStream(nil, &tarfileBuffer)
 		require.NoError(t, err, c.config)
-		src := NewSource(reader, true, nil)
+		src := NewSource(reader, true, nil, -1)
 		require.NoError(t, err, c.config)
 		defer src.Close()
 		configStream, _, err := src.GetBlob(ctx, types.BlobInfo{

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -26,7 +26,8 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		var tarfileBuffer bytes.Buffer
 		ctx := context.Background()
 
-		dest := NewDestinationWithContext(nil, &tarfileBuffer, nil)
+		writer := NewWriter(&tarfileBuffer)
+		dest := NewDestination(nil, writer, nil)
 		// No layers
 		configInfo, err := dest.PutBlob(ctx, bytes.NewBufferString(c.config),
 			types.BlobInfo{Size: -1}, cache, true)
@@ -40,7 +41,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		require.NoError(t, err, c.config)
 		err = dest.PutManifest(ctx, manifest, nil)
 		require.NoError(t, err, c.config)
-		err = dest.Commit(ctx)
+		err = writer.Close()
 		require.NoError(t, err, c.config)
 
 		src, err := NewSourceFromStreamWithSystemContext(nil, &tarfileBuffer)

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -24,7 +24,7 @@ func NewSourceFromFile(path string) (*Source, error) {
 
 // NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
 func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
-	src, err := internal.NewSourceFromFileWithContext(sys, path)
+	src, err := internal.NewSourceFromFile(sys, path)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
 func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
-	src, err := internal.NewSourceFromStreamWithSystemContext(sys, inputStream)
+	src, err := internal.NewSourceFromStream(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -60,7 +60,7 @@ func (s *Source) Close() error {
 
 // LoadTarManifest loads and decodes the manifest.json
 func (s *Source) LoadTarManifest() ([]ManifestItem, error) {
-	return s.internal.LoadTarManifest()
+	return s.internal.TarManifest(), nil
 }
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -89,7 +89,6 @@ func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
 func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
-	// FIXME: use SystemContext here.
 	// Save inputStream to a temporary file
 	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
 	if err != nil {

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -24,10 +24,11 @@ func NewSourceFromFile(path string) (*Source, error) {
 
 // NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
 func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
-	src, err := internal.NewSourceFromFile(sys, path)
+	archive, err := internal.NewReaderFromFile(sys, path)
 	if err != nil {
 		return nil, err
 	}
+	src := internal.NewSource(archive, true)
 	return &Source{internal: src}, nil
 }
 
@@ -44,10 +45,11 @@ func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
 func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
-	src, err := internal.NewSourceFromStream(sys, inputStream)
+	archive, err := internal.NewReaderFromStream(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}
+	src := internal.NewSource(archive, true)
 	return &Source{internal: src}, nil
 }
 

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -1,50 +1,19 @@
 package tarfile
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
-	"encoding/json"
 	"io"
-	"io/ioutil"
-	"os"
-	"path"
-	"sync"
 
-	"github.com/containers/image/v5/internal/iolimits"
-	"github.com/containers/image/v5/internal/tmpdir"
-	"github.com/containers/image/v5/manifest"
-	"github.com/containers/image/v5/pkg/compression"
+	internal "github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 // Source is a partial implementation of types.ImageSource for reading from tarPath.
+// Most users should use this via implementations of ImageReference from docker/archive or docker/daemon.
 type Source struct {
-	tarPath              string
-	removeTarPathOnClose bool // Remove temp file on close if true
-	// The following data is only available after ensureCachedDataIsPresent() succeeds
-	tarManifest       *ManifestItem // nil if not available yet.
-	configBytes       []byte
-	configDigest      digest.Digest
-	orderedDiffIDList []digest.Digest
-	knownLayers       map[digest.Digest]*layerInfo
-	// Other state
-	generatedManifest []byte    // Private cache for GetManifest(), nil if not set yet.
-	cacheDataLock     sync.Once // Private state for ensureCachedDataIsPresent to make it concurrency-safe
-	cacheDataResult   error     // Private state for ensureCachedDataIsPresent
+	internal *internal.Source
 }
-
-type layerInfo struct {
-	path string
-	size int64
-}
-
-// TODO: We could add support for multiple images in a single archive, so
-//       that people could use docker-archive:opensuse.tar:opensuse:leap as
-//       the source of an image.
-// 	To do for both the NewSourceFromFile and NewSourceFromStream functions
 
 // NewSourceFromFile returns a tarfile.Source for the specified path.
 // Deprecated: Please use NewSourceFromFileWithContext which will allows you to configure temp directory
@@ -55,25 +24,11 @@ func NewSourceFromFile(path string) (*Source, error) {
 
 // NewSourceFromFileWithContext returns a tarfile.Source for the specified path.
 func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Source, error) {
-	file, err := os.Open(path)
+	src, err := internal.NewSourceFromFileWithContext(sys, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening file %q", path)
+		return nil, err
 	}
-	defer file.Close()
-
-	// If the file is already not compressed we can just return the file itself
-	// as a source. Otherwise we pass the stream to NewSourceFromStream.
-	stream, isCompressed, err := compression.AutoDecompress(file)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error detecting compression for file %q", path)
-	}
-	defer stream.Close()
-	if !isCompressed {
-		return &Source{
-			tarPath: path,
-		}, nil
-	}
-	return NewSourceFromStreamWithSystemContext(sys, stream)
+	return &Source{internal: src}, nil
 }
 
 // NewSourceFromStream returns a tarfile.Source for the specified inputStream,
@@ -89,281 +44,21 @@ func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 // which can be either compressed or uncompressed. The caller can close the
 // inputStream immediately after NewSourceFromFile returns.
 func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream io.Reader) (*Source, error) {
-	// Save inputStream to a temporary file
-	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating temporary file")
-	}
-	defer tarCopyFile.Close()
-
-	succeeded := false
-	defer func() {
-		if !succeeded {
-			os.Remove(tarCopyFile.Name())
-		}
-	}()
-
-	// In order to be compatible with docker-load, we need to support
-	// auto-decompression (it's also a nice quality-of-life thing to avoid
-	// giving users really confusing "invalid tar header" errors).
-	uncompressedStream, _, err := compression.AutoDecompress(inputStream)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error auto-decompressing input")
-	}
-	defer uncompressedStream.Close()
-
-	// Copy the plain archive to the temporary file.
-	//
-	// TODO: This can take quite some time, and should ideally be cancellable
-	//       using a context.Context.
-	if _, err := io.Copy(tarCopyFile, uncompressedStream); err != nil {
-		return nil, errors.Wrapf(err, "error copying contents to temporary file %q", tarCopyFile.Name())
-	}
-	succeeded = true
-
-	return &Source{
-		tarPath:              tarCopyFile.Name(),
-		removeTarPathOnClose: true,
-	}, nil
-}
-
-// tarReadCloser is a way to close the backing file of a tar.Reader when the user no longer needs the tar component.
-type tarReadCloser struct {
-	*tar.Reader
-	backingFile *os.File
-}
-
-func (t *tarReadCloser) Close() error {
-	return t.backingFile.Close()
-}
-
-// openTarComponent returns a ReadCloser for the specific file within the archive.
-// This is linear scan; we assume that the tar file will have a fairly small amount of files (~layers),
-// and that filesystem caching will make the repeated seeking over the (uncompressed) tarPath cheap enough.
-// The caller should call .Close() on the returned stream.
-func (s *Source) openTarComponent(componentPath string) (io.ReadCloser, error) {
-	f, err := os.Open(s.tarPath)
+	src, err := internal.NewSourceFromStreamWithSystemContext(sys, inputStream)
 	if err != nil {
 		return nil, err
 	}
-	succeeded := false
-	defer func() {
-		if !succeeded {
-			f.Close()
-		}
-	}()
-
-	tarReader, header, err := findTarComponent(f, componentPath)
-	if err != nil {
-		return nil, err
-	}
-	if header == nil {
-		return nil, os.ErrNotExist
-	}
-	if header.FileInfo().Mode()&os.ModeType == os.ModeSymlink { // FIXME: untested
-		// We follow only one symlink; so no loops are possible.
-		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			return nil, err
-		}
-		// The new path could easily point "outside" the archive, but we only compare it to existing tar headers without extracting the archive,
-		// so we don't care.
-		tarReader, header, err = findTarComponent(f, path.Join(path.Dir(componentPath), header.Linkname))
-		if err != nil {
-			return nil, err
-		}
-		if header == nil {
-			return nil, os.ErrNotExist
-		}
-	}
-
-	if !header.FileInfo().Mode().IsRegular() {
-		return nil, errors.Errorf("Error reading tar archive component %s: not a regular file", header.Name)
-	}
-	succeeded = true
-	return &tarReadCloser{Reader: tarReader, backingFile: f}, nil
-}
-
-// findTarComponent returns a header and a reader matching componentPath within inputFile,
-// or (nil, nil, nil) if not found.
-func findTarComponent(inputFile io.Reader, componentPath string) (*tar.Reader, *tar.Header, error) {
-	t := tar.NewReader(inputFile)
-	componentPath = path.Clean(componentPath)
-	for {
-		h, err := t.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, nil, err
-		}
-		if path.Clean(h.Name) == componentPath {
-			return t, h, nil
-		}
-	}
-	return nil, nil, nil
-}
-
-// readTarComponent returns full contents of componentPath.
-func (s *Source) readTarComponent(path string, limit int) ([]byte, error) {
-	file, err := s.openTarComponent(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading tar component %s", path)
-	}
-	defer file.Close()
-	bytes, err := iolimits.ReadAtMost(file, limit)
-	if err != nil {
-		return nil, err
-	}
-	return bytes, nil
-}
-
-// ensureCachedDataIsPresent loads data necessary for any of the public accessors.
-// It is safe to call this from multi-threaded code.
-func (s *Source) ensureCachedDataIsPresent() error {
-	s.cacheDataLock.Do(func() {
-		s.cacheDataResult = s.ensureCachedDataIsPresentPrivate()
-	})
-	return s.cacheDataResult
-}
-
-// ensureCachedDataIsPresentPrivate is a private implementation detail of ensureCachedDataIsPresent.
-// Call ensureCachedDataIsPresent instead.
-func (s *Source) ensureCachedDataIsPresentPrivate() error {
-	// Read and parse manifest.json
-	tarManifest, err := s.loadTarManifest()
-	if err != nil {
-		return err
-	}
-
-	// Check to make sure length is 1
-	if len(tarManifest) != 1 {
-		return errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(tarManifest))
-	}
-
-	// Read and parse config.
-	configBytes, err := s.readTarComponent(tarManifest[0].Config, iolimits.MaxConfigBodySize)
-	if err != nil {
-		return err
-	}
-	var parsedConfig manifest.Schema2Image // There's a lot of info there, but we only really care about layer DiffIDs.
-	if err := json.Unmarshal(configBytes, &parsedConfig); err != nil {
-		return errors.Wrapf(err, "Error decoding tar config %s", tarManifest[0].Config)
-	}
-	if parsedConfig.RootFS == nil {
-		return errors.Errorf("Invalid image config (rootFS is not set): %s", tarManifest[0].Config)
-	}
-
-	knownLayers, err := s.prepareLayerData(&tarManifest[0], &parsedConfig)
-	if err != nil {
-		return err
-	}
-
-	// Success; commit.
-	s.tarManifest = &tarManifest[0]
-	s.configBytes = configBytes
-	s.configDigest = digest.FromBytes(configBytes)
-	s.orderedDiffIDList = parsedConfig.RootFS.DiffIDs
-	s.knownLayers = knownLayers
-	return nil
-}
-
-// loadTarManifest loads and decodes the manifest.json.
-func (s *Source) loadTarManifest() ([]ManifestItem, error) {
-	// FIXME? Do we need to deal with the legacy format?
-	bytes, err := s.readTarComponent(manifestFileName, iolimits.MaxTarFileManifestSize)
-	if err != nil {
-		return nil, err
-	}
-	var items []ManifestItem
-	if err := json.Unmarshal(bytes, &items); err != nil {
-		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
-	}
-	return items, nil
+	return &Source{internal: src}, nil
 }
 
 // Close removes resources associated with an initialized Source, if any.
 func (s *Source) Close() error {
-	if s.removeTarPathOnClose {
-		return os.Remove(s.tarPath)
-	}
-	return nil
+	return s.internal.Close()
 }
 
 // LoadTarManifest loads and decodes the manifest.json
 func (s *Source) LoadTarManifest() ([]ManifestItem, error) {
-	return s.loadTarManifest()
-}
-
-func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manifest.Schema2Image) (map[digest.Digest]*layerInfo, error) {
-	// Collect layer data available in manifest and config.
-	if len(tarManifest.Layers) != len(parsedConfig.RootFS.DiffIDs) {
-		return nil, errors.Errorf("Inconsistent layer count: %d in manifest, %d in config", len(tarManifest.Layers), len(parsedConfig.RootFS.DiffIDs))
-	}
-	knownLayers := map[digest.Digest]*layerInfo{}
-	unknownLayerSizes := map[string]*layerInfo{} // Points into knownLayers, a "to do list" of items with unknown sizes.
-	for i, diffID := range parsedConfig.RootFS.DiffIDs {
-		if _, ok := knownLayers[diffID]; ok {
-			// Apparently it really can happen that a single image contains the same layer diff more than once.
-			// In that case, the diffID validation ensures that both layers truly are the same, and it should not matter
-			// which of the tarManifest.Layers paths is used; (docker save) actually makes the duplicates symlinks to the original.
-			continue
-		}
-		layerPath := path.Clean(tarManifest.Layers[i])
-		if _, ok := unknownLayerSizes[layerPath]; ok {
-			return nil, errors.Errorf("Layer tarfile %s used for two different DiffID values", layerPath)
-		}
-		li := &layerInfo{ // A new element in each iteration
-			path: layerPath,
-			size: -1,
-		}
-		knownLayers[diffID] = li
-		unknownLayerSizes[layerPath] = li
-	}
-
-	// Scan the tar file to collect layer sizes.
-	file, err := os.Open(s.tarPath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	t := tar.NewReader(file)
-	for {
-		h, err := t.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		layerPath := path.Clean(h.Name)
-		if li, ok := unknownLayerSizes[layerPath]; ok {
-			// Since GetBlob will decompress layers that are compressed we need
-			// to do the decompression here as well, otherwise we will
-			// incorrectly report the size. Pretty critical, since tools like
-			// umoci always compress layer blobs. Obviously we only bother with
-			// the slower method of checking if it's compressed.
-			uncompressedStream, isCompressed, err := compression.AutoDecompress(t)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Error auto-decompressing %s to determine its size", layerPath)
-			}
-			defer uncompressedStream.Close()
-
-			uncompressedSize := h.Size
-			if isCompressed {
-				uncompressedSize, err = io.Copy(ioutil.Discard, uncompressedStream)
-				if err != nil {
-					return nil, errors.Wrapf(err, "Error reading %s to find its size", layerPath)
-				}
-			}
-			li.size = uncompressedSize
-			delete(unknownLayerSizes, layerPath)
-		}
-	}
-	if len(unknownLayerSizes) != 0 {
-		return nil, errors.Errorf("Some layer tarfiles are missing in the tarball") // This could do with a better error reporting, if this ever happened in practice.
-	}
-
-	return knownLayers, nil
+	return s.internal.LoadTarManifest()
 }
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
@@ -373,130 +68,26 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 // This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
 // as the primary manifest can not be a list, so there can be no secondary instances.
 func (s *Source) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
-	if instanceDigest != nil {
-		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
-		return nil, "", errors.New(`Manifest lists are not supported by "docker-daemon:"`)
-	}
-	if s.generatedManifest == nil {
-		if err := s.ensureCachedDataIsPresent(); err != nil {
-			return nil, "", err
-		}
-		m := manifest.Schema2{
-			SchemaVersion: 2,
-			MediaType:     manifest.DockerV2Schema2MediaType,
-			ConfigDescriptor: manifest.Schema2Descriptor{
-				MediaType: manifest.DockerV2Schema2ConfigMediaType,
-				Size:      int64(len(s.configBytes)),
-				Digest:    s.configDigest,
-			},
-			LayersDescriptors: []manifest.Schema2Descriptor{},
-		}
-		for _, diffID := range s.orderedDiffIDList {
-			li, ok := s.knownLayers[diffID]
-			if !ok {
-				return nil, "", errors.Errorf("Internal inconsistency: Information about layer %s missing", diffID)
-			}
-			m.LayersDescriptors = append(m.LayersDescriptors, manifest.Schema2Descriptor{
-				Digest:    diffID, // diffID is a digest of the uncompressed tarball
-				MediaType: manifest.DockerV2Schema2LayerMediaType,
-				Size:      li.size,
-			})
-		}
-		manifestBytes, err := json.Marshal(&m)
-		if err != nil {
-			return nil, "", err
-		}
-		s.generatedManifest = manifestBytes
-	}
-	return s.generatedManifest, manifest.DockerV2Schema2MediaType, nil
-}
-
-// uncompressedReadCloser is an io.ReadCloser that closes both the uncompressed stream and the underlying input.
-type uncompressedReadCloser struct {
-	io.Reader
-	underlyingCloser   func() error
-	uncompressedCloser func() error
-}
-
-func (r uncompressedReadCloser) Close() error {
-	var res error
-	if err := r.uncompressedCloser(); err != nil {
-		res = err
-	}
-	if err := r.underlyingCloser(); err != nil && res == nil {
-		res = err
-	}
-	return res
+	return s.internal.GetManifest(ctx, instanceDigest)
 }
 
 // HasThreadSafeGetBlob indicates whether GetBlob can be executed concurrently.
 func (s *Source) HasThreadSafeGetBlob() bool {
-	return true
+	return s.internal.HasThreadSafeGetBlob()
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-	if err := s.ensureCachedDataIsPresent(); err != nil {
-		return nil, 0, err
-	}
-
-	if info.Digest == s.configDigest { // FIXME? Implement a more general algorithm matching instead of assuming sha256.
-		return ioutil.NopCloser(bytes.NewReader(s.configBytes)), int64(len(s.configBytes)), nil
-	}
-
-	if li, ok := s.knownLayers[info.Digest]; ok { // diffID is a digest of the uncompressed tarball,
-		underlyingStream, err := s.openTarComponent(li.path)
-		if err != nil {
-			return nil, 0, err
-		}
-		closeUnderlyingStream := true
-		defer func() {
-			if closeUnderlyingStream {
-				underlyingStream.Close()
-			}
-		}()
-
-		// In order to handle the fact that digests != diffIDs (and thus that a
-		// caller which is trying to verify the blob will run into problems),
-		// we need to decompress blobs. This is a bit ugly, but it's a
-		// consequence of making everything addressable by their DiffID rather
-		// than by their digest...
-		//
-		// In particular, because the v2s2 manifest being generated uses
-		// DiffIDs, any caller of GetBlob is going to be asking for DiffIDs of
-		// layers not their _actual_ digest. The result is that copy/... will
-		// be verifing a "digest" which is not the actual layer's digest (but
-		// is instead the DiffID).
-
-		uncompressedStream, _, err := compression.AutoDecompress(underlyingStream)
-		if err != nil {
-			return nil, 0, errors.Wrapf(err, "Error auto-decompressing blob %s", info.Digest)
-		}
-
-		newStream := uncompressedReadCloser{
-			Reader:             uncompressedStream,
-			underlyingCloser:   underlyingStream.Close,
-			uncompressedCloser: uncompressedStream.Close,
-		}
-		closeUnderlyingStream = false
-
-		return newStream, li.size, nil
-	}
-
-	return nil, 0, errors.Errorf("Unknown blob %s", info.Digest)
+	return s.internal.GetBlob(ctx, info, cache)
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 // This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
 // as there can be no secondary manifests.
 func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
-	if instanceDigest != nil {
-		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
-		return nil, errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
-	}
-	return [][]byte{}, nil
+	return s.internal.GetSignatures(ctx, instanceDigest)
 }
 
 // LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
@@ -506,6 +97,6 @@ func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Diges
 // as the primary manifest can not be a list, so there can be no secondary manifests.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (s *Source) LayerInfosForCopy(context.Context, *digest.Digest) ([]types.BlobInfo, error) {
-	return nil, nil
+func (s *Source) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
+	return s.internal.LayerInfosForCopy(ctx, instanceDigest)
 }

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -28,7 +28,7 @@ func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Sourc
 	if err != nil {
 		return nil, err
 	}
-	src := internal.NewSource(archive, true, nil)
+	src := internal.NewSource(archive, true, nil, -1)
 	return &Source{internal: src}, nil
 }
 
@@ -49,7 +49,7 @@ func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream 
 	if err != nil {
 		return nil, err
 	}
-	src := internal.NewSource(archive, true, nil)
+	src := internal.NewSource(archive, true, nil, -1)
 	return &Source{internal: src}, nil
 }
 

--- a/docker/tarfile/src.go
+++ b/docker/tarfile/src.go
@@ -28,7 +28,7 @@ func NewSourceFromFileWithContext(sys *types.SystemContext, path string) (*Sourc
 	if err != nil {
 		return nil, err
 	}
-	src := internal.NewSource(archive, true)
+	src := internal.NewSource(archive, true, nil)
 	return &Source{internal: src}, nil
 }
 
@@ -49,7 +49,7 @@ func NewSourceFromStreamWithSystemContext(sys *types.SystemContext, inputStream 
 	if err != nil {
 		return nil, err
 	}
-	src := internal.NewSource(archive, true)
+	src := internal.NewSource(archive, true, nil)
 	return &Source{internal: src}, nil
 }
 

--- a/docker/tarfile/types.go
+++ b/docker/tarfile/types.go
@@ -4,12 +4,5 @@ import (
 	internal "github.com/containers/image/v5/docker/internal/tarfile"
 )
 
-// Various data structures.
-
-// Based on github.com/docker/docker/image/tarexport/tarexport.go
-const (
-	manifestFileName = "manifest.json"
-)
-
 // ManifestItem is an element of the array stored in the top-level manifest.json file.
 type ManifestItem = internal.ManifestItem // All public members from the internal package remain accessible.

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -41,11 +41,13 @@ If `name` does not contain a slash, it is treated as `docker.io/library/name`.
 Otherwise, the component before the first slash is checked if it is recognized as a `hostname[:port]` (i.e., it contains either a . or a :, or the component is exactly localhost).
 If the first component of name is not recognized as a `hostname[:port]`, `name` is treated as `docker.io/name`.
 
-### **docker-archive:**_path[:docker-reference]_
+### **docker-archive:**_path[:{docker-reference|@source-index}]_
 
 An image is stored in the docker-save(1) formatted file.
 _docker-reference_ must not contain a digest.
-If _docker-reference_ is missing when reading an archive, the archive must contain exactly one image.
+Alternatively, for reading archives, @_source-index_ is a zero-based index in archive manifest
+(to access untagged images).
+If neither _docker-reference_ nor @_source_index is specified when reading an archive, the archive must contain exactly one image.
 
 It is further possible to copy data to stdin by specifying `docker-archive:/dev/stdin` but note that the used file must be seekable.
 

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -44,7 +44,9 @@ If the first component of name is not recognized as a `hostname[:port]`, `name` 
 ### **docker-archive:**_path[:docker-reference]_
 
 An image is stored in the docker-save(1) formatted file.
-_docker-reference_ is only used when creating such a file, and it must not contain a digest.
+_docker-reference_ must not contain a digest.
+If _docker-reference_ is missing when reading an archive, the archive must contain exactly one image.
+
 It is further possible to copy data to stdin by specifying `docker-archive:/dev/stdin` but note that the used file must be seekable.
 
 ### **docker-daemon:**_docker-reference|algo:digest_


### PR DESCRIPTION
- Add support for choosing an image to read from a `docker-archive:`, either by reference (using the existing syntax) or by index (`docker-archive:/some/path:@0`).
- Add `docker/archive.Reader` that allows listing all images in a `docker-archive`-formatted file, and reading any/all of them, only copying/extracting the archive once.

See individual commit messages for details.