### PR TITLE
Respect XDG_CONFIG_HOME for policy.json

### DIFF
--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -39,8 +39,6 @@ const builtinDefaultPolicyPath = "/etc/containers/policy.json"
 // userPolicyFile is the path to the per user policy path.
 var userPolicyFile = filepath.FromSlash("containers/policy.json")
 
-const defaultConfigHomeDir = ".config"
-
 // InvalidPolicyFormatError is returned when parsing an invalid policy configuration.
 type InvalidPolicyFormatError string
 
@@ -63,13 +61,12 @@ func defaultPolicyPath(sys *types.SystemContext) string {
 	if sys != nil && sys.SignaturePolicyPath != "" {
 		return sys.SignaturePolicyPath
 	}
-	configHomeDir := os.Getenv("XDG_CONFIG_HOME")
-	if configHomeDir == "" {
-		configHomeDir = filepath.Join(homedir.Get(), defaultConfigHomeDir)
-	}
-	userPolicyFilePath := filepath.Join(configHomeDir, userPolicyFile)
-	if _, err := os.Stat(userPolicyFilePath); err == nil {
-		return userPolicyFilePath
+	configHomeDir, err := homedir.GetConfigHome()
+	if err == nil {
+		userPolicyFilePath := filepath.Join(configHomeDir, userPolicyFile)
+		if _, err := os.Stat(userPolicyFilePath); err == nil {
+			return userPolicyFilePath
+		}
 	}
 	if sys != nil && sys.RootForImplicitAbsolutePaths != "" {
 		return filepath.Join(sys.RootForImplicitAbsolutePaths, systemDefaultPolicyPath)

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -37,7 +37,9 @@ var systemDefaultPolicyPath = builtinDefaultPolicyPath
 const builtinDefaultPolicyPath = "/etc/containers/policy.json"
 
 // userPolicyFile is the path to the per user policy path.
-var userPolicyFile = filepath.FromSlash(".config/containers/policy.json")
+var userPolicyFile = filepath.FromSlash("containers/policy.json")
+
+const defaultConfigHomeDir = ".config"
 
 // InvalidPolicyFormatError is returned when parsing an invalid policy configuration.
 type InvalidPolicyFormatError string
@@ -61,7 +63,11 @@ func defaultPolicyPath(sys *types.SystemContext) string {
 	if sys != nil && sys.SignaturePolicyPath != "" {
 		return sys.SignaturePolicyPath
 	}
-	userPolicyFilePath := filepath.Join(homedir.Get(), userPolicyFile)
+	configHomeDir := os.Getenv("XDG_CONFIG_HOME")
+	if configHomeDir == "" {
+		configHomeDir = filepath.Join(homedir.Get(), defaultConfigHomeDir)
+	}
+	userPolicyFilePath := filepath.Join(configHomeDir, userPolicyFile)
 	if _, err := os.Stat(userPolicyFilePath); err == nil {
 		return userPolicyFilePath
 	}

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -107,7 +107,7 @@ func TestDefaultPolicyPath(t *testing.T) {
 			os.Unsetenv("HOME")
 		}
 	}()
-	userDefaultPolicyPath := filepath.Join(tempHome, userPolicyFile)
+	userDefaultPolicyPath := filepath.Join(tempHome, defaultConfigHomeDir, userPolicyFile)
 
 	for _, c := range []struct {
 		sys             *types.SystemContext

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -107,7 +107,7 @@ func TestDefaultPolicyPath(t *testing.T) {
 			os.Unsetenv("HOME")
 		}
 	}()
-	userDefaultPolicyPath := filepath.Join(tempHome, defaultConfigHomeDir, userPolicyFile)
+	userDefaultPolicyPath := filepath.Join(tempHome, ".config", userPolicyFile)
 
 	for _, c := range []struct {
 		sys             *types.SystemContext


### PR DESCRIPTION
The default path for (rootless) policy.json should respect XDG_CONFIG_HOME if present, as the paths for other configuration files like storage.conf and containers.conf do.

See also https://github.com/containers/common/pull/248