### PR TITLE
[WIP] tags+digest together in pull 

### DIFF
--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -77,7 +77,7 @@ func newReference(ref reference.Named) (dockerReference, error) {
 	_, isTagged := ref.(reference.NamedTagged)
 	_, isDigested := ref.(reference.Canonical)
 	if isTagged && isDigested {
-		return dockerReference{}, errors.Errorf("Docker references with both a tag and digest are currently not supported")
+		return dockerReference{ref: ref}, nil //..errors.Errorf("Docker references with both a tag and digest are currently not supported")
 	}
 
 	return dockerReference{

--- a/docker/policyconfiguration/naming.go
+++ b/docker/policyconfiguration/naming.go
@@ -16,7 +16,9 @@ func DockerReferenceIdentity(ref reference.Named) (string, error) {
 	digested, isDigested := ref.(reference.Canonical)
 	switch {
 	case isTagged && isDigested: // Note that this CAN actually happen.
-		return "", errors.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
+		res = res + ":" + tagged.Tag() + "@" + digested.Digest().String() //return "", errors.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
+
+	//return "", errors.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
 	case !isTagged && !isDigested: // This should not happen, the caller is expected to ensure !reference.IsNameOnly()
 		return "", errors.Errorf("Internal inconsistency: Docker reference %s with neither a tag nor a digest", reference.FamiliarString(ref))
 	case isTagged:


### PR DESCRIPTION
https://github.com/containers/podman/issues/6721 tried to reproduce the 'docker-style' action here of ignoring the tag. I was successful, but it is not a clean method as these files are basically a jungle.
 

'Docker will accept a tag and a digest to pull an image. It will pull that specific digest only, and completely ignore the tag.'

Proof of concept:
docker.io/fedora@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326 
...
2a8d315e6208e83b094dc86933051bf53944fea3c372a63f8cc7d5ad8c582895


podman pull docker.io/fedora:32@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
...
2a8d315e6208e83b094dc86933051bf53944fea3c372a63f8cc7d5ad8c582895

podman pull docker.io/fedora:32                                 
...
a368cbcfa6789bc347345f6d19132afe138b62ff5373d2aa5f37120277c90b54



Signed-off-by: Parker Van Roy <pvanroy@redhat.com>