### PR TITLE
backports pagination fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export GOPROXY=https://proxy.golang.org
 
 # Which github repository and branch to use for testing with skopeo
 SKOPEO_REPO = containers/skopeo
-SKOPEO_BRANCH = master
+SKOPEO_BRANCH = release-1.1
 # Set SUDO=sudo to run container integration tests using sudo.
 SUDO =
 


### PR DESCRIPTION
Backports pagination fix #964 to release-5.5
Enable search registry uses the pagination until the search result reaches the limit, instead of returning default 100 limit from registry API.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1866153

Signed-off-by: Qi Wang <qiwan@redhat.com>