### PR TITLE
Reduce duplication in signature/policy_config_test.go

### DIFF
--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -69,6 +69,13 @@ var policyFixtureContents = &Policy{
 	},
 }
 
+func TestInvalidPolicyFormatError(t *testing.T) {
+	// A stupid test just to keep code coverage
+	s := "test"
+	err := InvalidPolicyFormatError(s)
+	assert.Equal(t, s, err.Error())
+}
+
 func TestDefaultPolicy(t *testing.T) {
 	// We can't test the actual systemDefaultPolicyPath, so override.
 	// TestDefaultPolicyPath below tests that we handle the overrides and defaults
@@ -238,13 +245,6 @@ func addExtraJSONMember(t *testing.T, encoded []byte, name string, extra interfa
 	preservedLen := len(encoded) - 1
 
 	return bytes.Join([][]byte{encoded[:preservedLen], []byte(`,"`), []byte(name), []byte(`":`), extraJSON, []byte("}")}, nil)
-}
-
-func TestInvalidPolicyFormatError(t *testing.T) {
-	// A stupid test just to keep code coverage
-	s := "test"
-	err := InvalidPolicyFormatError(s)
-	assert.Equal(t, s, err.Error())
 }
 
 // Return the result of modifying validJSON with fn and unmarshaling it into *p


### PR DESCRIPTION
policy_config_test.go was created by copy&pasting the same ideas quite a few times, consolidate most of the JSON-related test code and parametrize only the parts that actually differ.

See individual commit messages for a bit more detail.

This is +385-648, or +243-506 when ignoring white space changes.