### PR TITLE
revert containers/storage to v1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b
 	github.com/containers/ocicrypt v1.0.3
-	github.com/containers/storage v1.23.1
+	github.com/containers/storage v1.23.0
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f
 	github.com/docker/docker-credential-helpers v0.6.3


### PR DESCRIPTION
v1.23.1 is causing regressions in Podman's `apiv2` tests.
I do not have the time to track it down but need to get
work done that's currently blocked by the regression [1].

```
[+0064s] not ok 291 [40-pods] POST libpod/pods/bar/start [] : status
[+0064s] #  expected: 200
[+0064s] #    actual: 500
[+0064s]   expected: 200
```

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>