### PR TITLE
Return error body if UnexpectedHTTPResponseError

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
-	"github.com/docker/distribution/registry/client"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -193,7 +192,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	logrus.Debugf("Content-Type from manifest GET is %q", res.Header.Get("Content-Type"))
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, "", errors.Wrapf(client.HandleErrorResponse(res), "Error reading manifest %s in %s", tagOrDigest, s.physicalRef.ref.Name())
+		return nil, "", errors.Wrapf(registryHTTPResponseToError(res), "Error reading manifest %s in %s", tagOrDigest, s.physicalRef.ref.Name())
 	}
 
 	manblob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxManifestBodySize)

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -44,3 +44,17 @@ func httpResponseToError(res *http.Response, context string) error {
 		return perrors.Errorf("%sinvalid status code from registry %d (%s)", context, res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }
+
+// registryHTTPResponseToError creates a Go error from an HTTP error response of a docker/distribution
+// registry
+func registryHTTPResponseToError(res *http.Response) error {
+	errResponse := client.HandleErrorResponse(res)
+	if e, ok := perrors.Cause(errResponse).(*client.UnexpectedHTTPResponseError); ok {
+		response := string(e.Response)
+		if len(response) > 50 {
+			response = response[:50] + "..."
+		}
+		errResponse = fmt.Errorf("StatusCode: %d, %s", e.StatusCode, response)
+	}
+	return errResponse
+}


### PR DESCRIPTION
Format the error message use the response body if the original error is returned as client.UnexpectedHTTPResponseError type

Use this pach:

```
$ skopeo copy --dest-tls-verify=false docker://library/alpine:latest docker://127.0.0.1:5000/cp:latest

FATA[0000] Error writing blob: Error initiating layer upload to /v2/cp1/blobs/uploads/ in 127.0.0.1:5000: StatusCode: 405, Method not allowed
```

Signed-off-by: Qi Wang <qiwan@redhat.com>