### PR TITLE
Set NoLchown to true in untar opts

### DIFF
--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -183,7 +183,12 @@ func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (temp
 	src := ref.resolvedFile
 	dst := tempDirRef.tempDirectory
 	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
-	if err := archive.UntarPath(src, dst); err != nil {
+	arch, err := os.Open(src)
+	if err != nil {
+		return tempDirOCIRef{}, err
+	}
+	defer arch.Close()
+	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
 			return tempDirOCIRef{}, errors.Wrapf(err, "error deleting temp directory %q", tempDirRef.tempDirectory)
 		}


### PR DESCRIPTION
Pass NoLchown in the Taroptions to avoid the lchown permission denied error dealing with archive.
Fix https://github.com/containers/image/issues/1017

Signed-off-by: Qi Wang <qiwan@redhat.com>