### PR TITLE
Search credentials under XDG_CONFIG_HOME

### DIFF
--- a/docs/containers-auth.json.5.md
+++ b/docs/containers-auth.json.5.md
@@ -6,8 +6,15 @@ containers-auth.json - syntax for the registry authentication file
 # DESCRIPTION
 
 A credentials file in JSON format used to authenticate against container image registries.
-On Linux it is stored at `${XDG_RUNTIME_DIR}/containers/auth.json`;
-on Windows and macOS, at `$HOME/.config/containers/auth.json`
+The primary (read/write) file is stored at `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux;
+on Windows and macOS, at `$HOME/.config/containers/auth.json`.
+
+When searching for the credential for a registry, the following files will be read in sequence until the valid credential is found:
+first reading the primary (read/write) file, or the explicit override using an option of the calling application.
+If credentials are not present, search in `${XDG\_CONFIG\_HOME}/containers/auth.json`, `$HOME/.docker/config.json`, `$HOME/.dockercfg`.
+
+Except the primary (read/write) file, other files are read-only, unless the user use an option of the calling application explicitly points at it as an override.
+
 
 ## FORMAT
 

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -35,6 +35,7 @@ type authPath struct {
 
 var (
 	defaultPerUIDPathFormat = filepath.FromSlash("/run/containers/%d/auth.json")
+	xdgConfigHomePath       = filepath.FromSlash("containers/auth.json")
 	xdgRuntimeDirPath       = filepath.FromSlash("containers/auth.json")
 	dockerHomePath          = filepath.FromSlash(".docker/config.json")
 	dockerLegacyHomePath    = ".dockercfg"
@@ -136,6 +137,11 @@ func getAuthFilePaths(sys *types.SystemContext) []authPath {
 		// Logging the error as a warning instead and moving on to pulling the image
 		logrus.Warnf("%v: Trying to pull image in the event that it is a public image.", err)
 	}
+	xdgCfgHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgCfgHome == "" {
+		xdgCfgHome = filepath.Join(homedir.Get(), ".config")
+	}
+	paths = append(paths, authPath{path: filepath.Join(xdgCfgHome, xdgConfigHomePath), legacyFormat: false})
 	if dockerConfig := os.Getenv("DOCKER_CONFIG"); dockerConfig != "" {
 		paths = append(paths,
 			authPath{path: filepath.Join(dockerConfig, "config.json"), legacyFormat: false},


### PR DESCRIPTION
Add XDG_CONFIG_HOME to the paths to be searched when login a registry. If XDG_CONFIG_HOME is empty, search under $HOME/.config. In the order that first search for authfile, XDG_RUNTIME_DIR, XDG_CONFIG_HOME, and docker config file.

Close: https://github.com/containers/podman/issues/7563

Signed-off-by: Qi Wang <qiwan@redhat.com>