### PR TITLE
Skip checking if the manifest difest matches for docker-daemon source. Fixes #1049

### DIFF
--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -55,7 +55,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 			if err != nil {
 				return nil, "", errors.Wrap(err, "Error computing manifest digest")
 			}
-			if !matches {
+			if i.Reference().Transport().Name() != "docker-daemon" && !matches {
 				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
 			}
 		}


### PR DESCRIPTION
As described in https://github.com/containers/container-libs/issues/261, the manifest digest specified in the repo@sha256:digest won't match the digest calculated from the locally generated manifest when using docker-daemon source.

This fix skips the verification for docker-daemon source.
