### PR TITLE
Fix CI in cri-o-release-1.11 branch

### DIFF
--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:18.04
 
 RUN apt-get -qq update && \
     apt-get install -y sudo docker.io git make btrfs-tools libdevmapper-dev libgpgme-dev libostree-dev


### PR DESCRIPTION
Update the ubuntu version used in cri-o-release-1.11 branch to a supported one.
Cherry-pick #4f49520d32f91aa02fe04623d85d89af86845e7c

----

Use the latest stable version of Ubuntu, since Ubuntu 17.10 (i.e.,
ArtfulAardvark) hit EOL.

Fixes: #648
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
