### PR TITLE
Add reader/writer to for oci-archive multi image

### DIFF
--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -57,14 +57,16 @@ An image stored in the docker daemon's internal storage.
 The image must be specified as a _docker-reference_ or in an alternative _algo:digest_ format when being used as an image source.
 The _algo:digest_ refers to the image ID reported by docker-inspect(1).
 
-### **oci:**_path[:tag]_
+### **oci:**_path[:tag|@source-index]_
 
 An image compliant with the "Open Container Image Layout Specification" at _path_.
 Using a _tag_ is optional and allows for storing multiple images at the same _path_.
+@_source-index_ is a zero-based index in manifest (to access untagged images).
+If neither tag nor @_source_index is specified when reading an image, the path must contain exactly one image.
 
-### **oci-archive:**_path[:tag]_
+### **oci-archive:**_path[:{tag|@source-index}]_
 
-An image compliant with the "Open Container Image Layout Specification" stored as a tar(1) archive at _path_.
+An image compliant with the "Open Container Image Layout Specification" stored as a tar(1) archive at _path_.  For reading archives, @_source-index_ is a zero-based index in archive manifest (to access untagged images).  If neither tag nor @_source_index is specified when reading an archive, the archive must contain exactly one image.
 
 ### **ostree:**_docker-reference[@/absolute/repo/path]_
 

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -61,7 +61,7 @@ The _algo:digest_ refers to the image ID reported by docker-inspect(1).
 
 An image compliant with the "Open Container Image Layout Specification" at _path_.
 Using a _tag_ is optional and allows for storing multiple images at the same _path_.
-@_source-index_ is a zero-based index in manifest (to access untagged images).
+For reading images, @_source-index_ is a zero-based index in manifest (to access untagged images).
 If neither tag nor @_source_index is specified when reading an image, the path must contain exactly one image.
 
 ### **oci-archive:**_path[:{tag|@source-index}]_

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -20,7 +20,10 @@ type ociArchiveImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
-	tempDirRef, err := createOCIRef(sys, ref.image)
+	if ref.sourceIndex != -1 {
+		return nil, errors.Errorf("invalid sourceIndex %d for creating image destination", ref.sourceIndex)
+	}
+	tempDirRef, err := createOCIRef(sys, ref.image, -1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating oci reference")
 	}

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -13,19 +13,30 @@ import (
 )
 
 type ociArchiveImageDestination struct {
-	ref          ociArchiveReference
-	unpackedDest types.ImageDestination
-	tempDirRef   tempDirOCIRef
+	ref              ociArchiveReference
+	unpackedDest     types.ImageDestination
+	tempDirRef       tempDirOCIRef
+	archiveWriterRef *tempDirOCIRef
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference, archiveWriterRef *tempDirOCIRef) (types.ImageDestination, error) {
+	var (
+		tempDirRef tempDirOCIRef
+		err        error
+	)
+
 	if ref.sourceIndex != -1 {
-		return nil, errors.Errorf("invalid sourceIndex %d for creating image destination", ref.sourceIndex)
+		return nil, errors.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
 	}
-	tempDirRef, err := createOCIRef(sys, ref.image, -1)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error creating oci reference")
+
+	if archiveWriterRef != nil {
+		tempDirRef = *archiveWriterRef
+	} else {
+		tempDirRef, err = createOCIRef(sys, ref.image, -1)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error creating oci reference")
+		}
 	}
 	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx, sys)
 	if err != nil {
@@ -35,8 +46,9 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociA
 		return nil, err
 	}
 	return &ociArchiveImageDestination{ref: ref,
-		unpackedDest: unpackedDest,
-		tempDirRef:   tempDirRef}, nil
+		unpackedDest:     unpackedDest,
+		archiveWriterRef: archiveWriterRef,
+		tempDirRef:       tempDirRef}, nil
 }
 
 // Reference returns the reference used to set up this destination.
@@ -47,6 +59,9 @@ func (d *ociArchiveImageDestination) Reference() types.ImageReference {
 // Close removes resources associated with an initialized ImageDestination, if any
 // Close deletes the temp directory of the oci-archive image
 func (d *ociArchiveImageDestination) Close() error {
+	if d.archiveWriterRef != nil {
+		return nil
+	}
 	defer func() {
 		err := d.tempDirRef.deleteTempDir()
 		logrus.Debugf("Error deleting temporary directory: %v", err)
@@ -134,6 +149,10 @@ func (d *ociArchiveImageDestination) PutSignatures(ctx context.Context, signatur
 func (d *ociArchiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if err := d.unpackedDest.Commit(ctx, unparsedToplevel); err != nil {
 		return errors.Wrapf(err, "error storing image %q", d.ref.image)
+	}
+
+	if d.archiveWriterRef != nil {
+		return nil
 	}
 
 	// path of directory to tar up

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -32,10 +32,12 @@ type ociArchiveTransport struct{}
 
 // ociArchiveReference is an ImageReference for OCI Archive paths
 type ociArchiveReference struct {
-	file         string
-	resolvedFile string
-	image        string
-	sourceIndex  int
+	file             string
+	resolvedFile     string
+	image            string
+	sourceIndex      int
+	archiveReaderRef *tempDirOCIRef
+	archiveWriterRef *tempDirOCIRef
 }
 
 func (t ociArchiveTransport) Name() string {
@@ -55,20 +57,24 @@ func (t ociArchiveTransport) ValidatePolicyConfigurationScope(scope string) erro
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
 func ParseReference(reference string) (types.ImageReference, error) {
-	file, image := internal.SplitPathAndImage(reference)
-	image, index, err := internal.ParseOCIReferenceName(image)
+	file, image, index, err := internal.ParseReferenceIntoElements(reference)
 	if err != nil {
 		return nil, err
 	}
-	return newReference(file, image, index)
+	return newReference(file, image, index, nil, nil)
 }
 
 // NewReference returns an OCI reference for a file and an image.
 func NewReference(file, image string) (types.ImageReference, error) {
-	return newReference(file, image, -1)
+	return newReference(file, image, -1, nil, nil)
 }
 
-func newReference(file, image string, sourceIndex int) (types.ImageReference, error) {
+// NewIndexReference returns an OCI reference for a file and sourecIndex points to the image.
+func NewIndexReference(file string, sourceIndex int) (types.ImageReference, error) {
+	return newReference(file, "", sourceIndex, nil, nil)
+}
+
+func newReference(file, image string, sourceIndex int, archiveReaderRef, archiveWriterRef *tempDirOCIRef) (types.ImageReference, error) {
 	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(file)
 	if err != nil {
 		return nil, err
@@ -85,7 +91,10 @@ func newReference(file, image string, sourceIndex int) (types.ImageReference, er
 	if sourceIndex != -1 && sourceIndex < 0 {
 		return nil, errors.Errorf("Invalid oci archive: reference: index @%d must not be negative", sourceIndex)
 	}
-	return ociArchiveReference{file: file, resolvedFile: resolved, image: image, sourceIndex: sourceIndex}, nil
+	if sourceIndex != -1 && image != "" {
+		return nil, errors.Errorf("Can not set image %s and index @%d at same time", image, sourceIndex)
+	}
+	return ociArchiveReference{file: file, resolvedFile: resolved, image: image, sourceIndex: sourceIndex, archiveReaderRef: archiveReaderRef, archiveWriterRef: archiveWriterRef}, nil
 }
 
 func (ref ociArchiveReference) Transport() types.ImageTransport {
@@ -138,7 +147,7 @@ func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 // WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
 func (ref ociArchiveReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
-	src, err := newImageSource(ctx, sys, ref)
+	src, err := newImageSource(ctx, sys, ref, ref.archiveReaderRef)
 	if err != nil {
 		return nil, err
 	}
@@ -148,13 +157,13 @@ func (ref ociArchiveReference) NewImage(ctx context.Context, sys *types.SystemCo
 // NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ociArchiveReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
-	return newImageSource(ctx, sys, ref)
+	return newImageSource(ctx, sys, ref, ref.archiveReaderRef)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ctx, sys, ref)
+	return newImageDestination(ctx, sys, ref, ref.archiveWriterRef)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -180,9 +189,15 @@ func createOCIRef(sys *types.SystemContext, image string, sourceIndex int) (temp
 	if err != nil {
 		return tempDirOCIRef{}, errors.Wrapf(err, "error creating temp directory")
 	}
-	ociRef, err := ocilayout.NewReferenceWithIndex(dir, image, sourceIndex)
-	if err != nil {
-		return tempDirOCIRef{}, err
+	var ociRef types.ImageReference
+	if sourceIndex > -1 {
+		if ociRef, err = ocilayout.NewIndexReference(dir, sourceIndex); err != nil {
+			return tempDirOCIRef{}, err
+		}
+	} else {
+		if ociRef, err = ocilayout.NewReference(dir, image); err != nil {
+			return tempDirOCIRef{}, err
+		}
 	}
 
 	tempDirRef := tempDirOCIRef{tempDirectory: dir, ociRefExtracted: ociRef}

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -35,6 +35,7 @@ type ociArchiveReference struct {
 	file         string
 	resolvedFile string
 	image        string
+	sourceIndex  int
 }
 
 func (t ociArchiveTransport) Name() string {
@@ -55,11 +56,19 @@ func (t ociArchiveTransport) ValidatePolicyConfigurationScope(scope string) erro
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
 func ParseReference(reference string) (types.ImageReference, error) {
 	file, image := internal.SplitPathAndImage(reference)
-	return NewReference(file, image)
+	image, index, err := internal.ParseOCIReferenceName(image)
+	if err != nil {
+		return nil, err
+	}
+	return newReference(file, image, index)
 }
 
-// NewReference returns an OCI reference for a file and a image.
+// NewReference returns an OCI reference for a file and an image.
 func NewReference(file, image string) (types.ImageReference, error) {
+	return newReference(file, image, -1)
+}
+
+func newReference(file, image string, sourceIndex int) (types.ImageReference, error) {
 	resolved, err := explicitfilepath.ResolvePathToFullyExplicit(file)
 	if err != nil {
 		return nil, err
@@ -73,7 +82,10 @@ func NewReference(file, image string) (types.ImageReference, error) {
 		return nil, err
 	}
 
-	return ociArchiveReference{file: file, resolvedFile: resolved, image: image}, nil
+	if sourceIndex != -1 && sourceIndex < 0 {
+		return nil, errors.Errorf("Invalid oci archive: reference: index @%d must not be negative", sourceIndex)
+	}
+	return ociArchiveReference{file: file, resolvedFile: resolved, image: image, sourceIndex: sourceIndex}, nil
 }
 
 func (ref ociArchiveReference) Transport() types.ImageTransport {
@@ -83,7 +95,10 @@ func (ref ociArchiveReference) Transport() types.ImageTransport {
 // StringWithinTransport returns a string representation of the reference, which MUST be such that
 // reference.Transport().ParseReference(reference.StringWithinTransport()) returns an equivalent reference.
 func (ref ociArchiveReference) StringWithinTransport() string {
-	return fmt.Sprintf("%s:%s", ref.file, ref.image)
+	if ref.sourceIndex == -1 {
+		return fmt.Sprintf("%s:%s", ref.file, ref.image)
+	}
+	return fmt.Sprintf("%s:@%d", ref.file, ref.sourceIndex)
 }
 
 // DockerReference returns a Docker reference associated with this reference
@@ -160,12 +175,12 @@ func (t *tempDirOCIRef) deleteTempDir() error {
 
 // createOCIRef creates the oci reference of the image
 // If SystemContext.BigFilesTemporaryDir not "", overrides the temporary directory to use for storing big files
-func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error) {
+func createOCIRef(sys *types.SystemContext, image string, sourceIndex int) (tempDirOCIRef, error) {
 	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
 	if err != nil {
 		return tempDirOCIRef{}, errors.Wrapf(err, "error creating temp directory")
 	}
-	ociRef, err := ocilayout.NewReference(dir, image)
+	ociRef, err := ocilayout.NewReferenceWithIndex(dir, image, sourceIndex)
 	if err != nil {
 		return tempDirOCIRef{}, err
 	}
@@ -176,7 +191,7 @@ func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error)
 
 // creates the temporary directory and copies the tarred content to it
 func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (tempDirOCIRef, error) {
-	tempDirRef, err := createOCIRef(sys, ref.image)
+	tempDirRef, err := createOCIRef(sys, ref.image, ref.sourceIndex)
 	if err != nil {
 		return tempDirOCIRef{}, errors.Wrap(err, "error creating oci reference")
 	}

--- a/oci/archive/oci_transport_test.go
+++ b/oci/archive/oci_transport_test.go
@@ -66,12 +66,12 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 		}{
 			{":notlatest:image", "notlatest:image", -1},
 			{":latestimage", "latestimage", -1},
-			{":", "", -1},
+			{":busybox@0", "busybox@0", -1},
+			{":", "", -1}, // No Image
 			{"", "", -1},
-			{":@0", "", 0},
+			{":@0", "", 0}, // Explicit sourceIndex of image
 			{":@10", "", 10},
 			{":@999999", "", 999999},
-			{":busybox@0", "busybox@0", -1},
 		} {
 			input := path + image.suffix
 			ref, err := fn(input)
@@ -130,6 +130,10 @@ func TestNewReference(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = NewReference(tmpDir+"/has:colon", imageValue)
+	assert.Error(t, err)
+
+	// Test private newReference
+	_, err = newReference(tmpDir, "imageName", 1, nil, nil) // Both image and sourceIndex specified
 	assert.Error(t, err)
 }
 

--- a/oci/archive/reader.go
+++ b/oci/archive/reader.go
@@ -1,0 +1,98 @@
+package archive
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/image/v5/internal/tmpdir"
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage/pkg/archive"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// Reader keeps the temp directory the oci archive will be untarred to and the manifest of the images
+type Reader struct {
+	manifest      *imgspecv1.Index
+	tempDirectory string
+}
+
+// NewReader creates the temp directory that keeps the untarred archive from src.
+// The caller should call .Close() on the returned object.
+func NewReader(ctx context.Context, src string, sys *types.SystemContext) (*Reader, error) {
+	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
+	arch, err := os.Open(src)
+	if err != nil {
+		return nil, err
+	}
+	defer arch.Close()
+
+	dst, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating temp directory")
+	}
+
+	reader := Reader{
+		tempDirectory: dst,
+	}
+
+	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
+		if err := reader.Close(); err != nil {
+			return nil, errors.Wrapf(err, "error deleting temp directory %q", dst)
+		}
+		return nil, errors.Wrapf(err, "error untarring file %q", dst)
+	}
+
+	indexJSON, err := os.Open(filepath.Join(dst, "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer indexJSON.Close()
+	reader.manifest = &imgspecv1.Index{}
+	if err := json.NewDecoder(indexJSON).Decode(reader.manifest); err != nil {
+		return nil, err
+	}
+
+	return &reader, nil
+}
+
+// List returns a (name, reference) map for images in the reader
+// the name will be used to determin reference name of the dest image.
+// the ImageReferences are valid only until the Reader is closed.
+func (r *Reader) List() (map[string]types.ImageReference, error) {
+	res := make(map[string]types.ImageReference)
+	var (
+		ref types.ImageReference
+		err error
+	)
+	for i, md := range r.manifest.Manifests {
+		if md.MediaType != imgspecv1.MediaTypeImageManifest && md.MediaType != imgspecv1.MediaTypeImageIndex {
+			continue
+		}
+		refName, ok := md.Annotations[imgspecv1.AnnotationRefName]
+		if !ok {
+			refName = "@" + md.Digest.Encoded()
+			if ref, err = layout.NewIndexReference(r.tempDirectory, i); err != nil {
+				return nil, err
+			}
+		} else {
+			if ref, err = layout.NewReference(r.tempDirectory, refName); err != nil {
+				return nil, err
+			}
+		}
+		if _, ok := res[refName]; ok {
+			return nil, errors.Errorf("image descriptor %s conflict", refName)
+		}
+		res[refName] = ref
+	}
+	return res, nil
+}
+
+// Close deletes temporary files associated with the Reader, if any.
+func (r *Reader) Close() error {
+	return os.RemoveAll(r.tempDirectory)
+}

--- a/oci/archive/writer.go
+++ b/oci/archive/writer.go
@@ -1,0 +1,54 @@
+package archive
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/image/v5/directory/explicitfilepath"
+	"github.com/containers/image/v5/internal/tmpdir"
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+)
+
+// Writer keeps the tempDir for creating oci archive and archive destination
+type Writer struct {
+	// tempDir will be tarred to oci archive
+	tempDir string
+	// user-specified path
+	path string
+}
+
+// NewWriter creates a temp directory will be tarred to oci-archive.
+// The caller should call .Close() on the returned object.
+func NewWriter(sys *types.SystemContext, file string) (*Writer, error) {
+	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating temp directory")
+	}
+	dst, err := explicitfilepath.ResolvePathToFullyExplicit(file)
+	if err != nil {
+		return nil, err
+	}
+	ociWriter := &Writer{
+		tempDir: dir,
+		path:    dst,
+	}
+	return ociWriter, nil
+}
+
+// NewReference returns an ImageReference that allows adding an image to Writer,
+// with an optional image name
+func (w *Writer) NewReference(name string) (types.ImageReference, error) {
+	return layout.NewReference(w.tempDir, name)
+}
+
+// Close converts the data about images in the temp directory to the archive and
+// deletes temporary files associated with the Writer
+func (w *Writer) Close() error {
+	err := tarDirectory(w.tempDir, w.path)
+	if err2 := os.RemoveAll(w.tempDir); err2 != nil && err == nil {
+		err = err2
+	}
+	return err
+}

--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -144,3 +144,13 @@ func ParseOCIReferenceName(image string) (img string, index int, err error) {
 	}
 	return img, index, nil
 }
+
+// ParseReferenceIntoElements splits the oci reference into location, image name and source index if exists
+func ParseReferenceIntoElements(reference string) (string, string, int, error) {
+	dir, image := SplitPathAndImage(reference)
+	image, index, err := ParseOCIReferenceName(image)
+	if err != nil {
+		return "", "", -1, err
+	}
+	return dir, image, index, nil
+}

--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -1,11 +1,13 @@
 package internal
 
 import (
-	"github.com/pkg/errors"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -123,4 +125,22 @@ func validateScopeNonWindows(scope string) error {
 	}
 
 	return nil
+}
+
+// ParseOCIReferenceName parses the image from the oci reference that contains an index.
+func ParseOCIReferenceName(image string) (img string, index int, err error) {
+	index = -1
+	if strings.HasPrefix(image, "@") {
+		idx, err := strconv.Atoi(image[1:])
+		if err != nil {
+			return "", index, errors.Wrapf(err, "Invalid source index @%s: not an integer", image[1:])
+		}
+		if idx < 0 {
+			return "", index, errors.Errorf("Invalid source index @%d: must not be negative", idx)
+		}
+		index = idx
+	} else {
+		img = image
+	}
+	return img, index, nil
 }

--- a/oci/internal/oci_util_test.go
+++ b/oci/internal/oci_util_test.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testDataSplitReference struct {
@@ -59,4 +60,22 @@ func TestValidateScopeWindows(t *testing.T) {
 			assert.EqualError(t, err, test.errMessage, fmt.Sprintf("No error for scope '%s'", test.scope))
 		}
 	}
+}
+
+func TestParseOCIReferenceName(t *testing.T) {
+	image, idx, err := ParseOCIReferenceName("@0")
+	assert.NoError(t, err)
+	assert.Equal(t, image, "")
+	assert.Equal(t, idx, 0)
+
+	image, idx, err = ParseOCIReferenceName("notlatest@1")
+	assert.NoError(t, err)
+	assert.Equal(t, image, "notlatest@1")
+	assert.Equal(t, idx, -1)
+
+	_, _, err = ParseOCIReferenceName("@-5")
+	assert.NotEmpty(t, err)
+
+	_, _, err = ParseOCIReferenceName("@invalidIndex")
+	assert.NotEmpty(t, err)
 }

--- a/oci/layout/fixtures/two_names_manifest/index.json
+++ b/oci/layout/fixtures/two_names_manifest/index.json
@@ -1,0 +1,25 @@
+{
+    "schemaVersion": 2,
+    "manifests": [
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "size": 7143,
+            "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+            "platform": {
+                "architecture": "ppc64le",
+                "os": "linux"
+            },
+            "annotations": {
+                "org.opencontainers.image.ref.name": "imageValue0"
+            }
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:62ae1939cdb49e93f32cdb29d61ad276552532c6ae7fd543de7bf22511e4965e",
+            "size": 348,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "imageValue1"
+            }
+        }
+    ]
+}

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -26,6 +26,9 @@ type ociImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
+	if ref.sourceIndex != -1 {
+		return nil, errors.Errorf("invalid sourceIndex %d for creating image destination", ref.sourceIndex)
+	}
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -27,7 +27,7 @@ type ociImageDestination struct {
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
 	if ref.sourceIndex != -1 {
-		return nil, errors.Errorf("invalid sourceIndex %d for creating image destination", ref.sourceIndex)
+		return nil, errors.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
 	}
 	var index *imgspecv1.Index
 	if indexExists(ref) {

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -13,24 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGetManifestDescriptor is testing a regression issue where a nil error was being wrapped,
-// this causes the returned error to be nil as well and the user wasn't getting a proper error output.
-//
-// More info: https://github.com/containers/skopeo/issues/496
 func TestGetManifestDescriptor(t *testing.T) {
 	imageRef, err := NewReference("fixtures/two_images_manifest", "")
 	require.NoError(t, err)
 
+	// test a regression issue where a nil error was being wrapped,
+	// this causes the returned error to be nil as well and the user wasn't getting a proper error output.
+	//
+	// More info: https://github.com/containers/skopeo/issues/496
 	_, err = imageRef.(ociReference).getManifestDescriptor()
 	assert.EqualError(t, err, ErrMoreThanOneImage.Error())
 
-	imageRef, err = NewReferenceWithIndex("fixtures/two_names_manifest", "imageValue0", -1)
+	imageRef, err = NewReference("fixtures/two_names_manifest", "imageValue0")
 	require.NoError(t, err)
 	manDescriptor, err := imageRef.(ociReference).getManifestDescriptor()
 	require.NoError(t, err)
 	assert.Equal(t, manDescriptor.Annotations["org.opencontainers.image.ref.name"], "imageValue0")
 
-	imageRef, err = NewReferenceWithIndex("fixtures/two_names_manifest", "", 1)
+	imageRef, err = NewIndexReference("fixtures/two_names_manifest", 1)
 	require.NoError(t, err)
 	manDescriptor, err = imageRef.(ociReference).getManifestDescriptor()
 	require.NoError(t, err)
@@ -135,6 +135,10 @@ func TestNewReference(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = NewReference(tmpDir+"/has:colon", imageValue)
+	assert.Error(t, err)
+
+	// Test private newReference
+	_, err = newReference(tmpDir, imageValue, 1)
 	assert.Error(t, err)
 }
 

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -23,6 +23,18 @@ func TestGetManifestDescriptor(t *testing.T) {
 
 	_, err = imageRef.(ociReference).getManifestDescriptor()
 	assert.EqualError(t, err, ErrMoreThanOneImage.Error())
+
+	imageRef, err = NewReferenceWithIndex("fixtures/two_names_manifest", "imageValue0", -1)
+	require.NoError(t, err)
+	manDescriptor, err := imageRef.(ociReference).getManifestDescriptor()
+	require.NoError(t, err)
+	assert.Equal(t, manDescriptor.Annotations["org.opencontainers.image.ref.name"], "imageValue0")
+
+	imageRef, err = NewReferenceWithIndex("fixtures/two_names_manifest", "", 1)
+	require.NoError(t, err)
+	manDescriptor, err = imageRef.(ociReference).getManifestDescriptor()
+	require.NoError(t, err)
+	assert.Equal(t, manDescriptor.Annotations["org.opencontainers.image.ref.name"], "imageValue1")
 }
 
 func TestTransportName(t *testing.T) {
@@ -170,7 +182,8 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 
 	for _, c := range []struct{ input, result string }{
 		{"/dir1:notlatest:notlatest", "/dir1:notlatest:notlatest"}, // Explicit image
-		{"/dir3:", "/dir3:"}, // No image
+		{"/dir3:", "/dir3:"},     // No image
+		{"/dir1:@1", "/dir1:@1"}, // Explicit sourceIndex of image
 	} {
 		ref, err := ParseReference(tmpDir + c.input)
 		require.NoError(t, err, c.input)


### PR DESCRIPTION
Add read/writer with helpers to allow podman save/load multi oci-archive images.
work with PR: https://github.com/containers/podman/pull/8218
close: https://github.com/containers/podman/issues/4646

Signed-off-by: Qi Wang <qiwan@redhat.com>