### PR TITLE
Add a signedIdentity choice "type": "remapIdentity"

### DIFF
--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -75,6 +75,18 @@
                     }
                 }
             ],
+            "private-mirror:5000/vendor-mirror": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/vendor-gpg-keyring",
+                    "signedIdentity": {
+                        "type": "remapIdentity",
+                        "prefix": "private-mirror:5000/vendor-mirror",
+                        "signedPrefix": "vendor.example.com"
+                    }
+                }
+            ],
             "bogus/key-data-example": [
                 {
                     "type": "signedBy",

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -57,6 +57,11 @@ var policyFixtureContents = &Policy{
 					"/keys/RH-key-signing-key-gpg-keyring",
 					NewPRMMatchRepoDigestOrExact()),
 			},
+			"private-mirror:5000/vendor-mirror": {
+				xNewPRSignedByKeyPath(SBKeyTypeGPGKeys,
+					"/keys/vendor-gpg-keyring",
+					xNewPRMRemapIdentity("private-mirror:5000/vendor-mirror", "vendor.example.com")),
+			},
 			"bogus/key-data-example": {
 				xNewPRSignedByKeyData(SBKeyTypeSignedByGPGKeys,
 					[]byte("nonsense"),
@@ -1167,5 +1172,105 @@ func TestPRMExactRepositoryUnmarshalJSON(t *testing.T) {
 			func(v mSI) { v["dockerRepository"] = 1 },
 		},
 		duplicateFields: []string{"type", "dockerRepository"},
+	}.run(t)
+}
+
+func TestValidateIdentityRemappingPrefix(t *testing.T) {
+	for _, s := range []string{
+		"localhost",
+		"example.com",
+		"example.com:80",
+		"example.com/repo",
+		"example.com/ns1/ns2/ns3/repo.with.dots-dashes_underscores",
+		"example.com:80/ns1/ns2/ns3/repo.with.dots-dashes_underscores",
+		// NOTE: These values are invalid, do not actually work, and may be rejected by this function
+		// and in NewPRMRemapIdentity in the future.
+		"shortname",
+		"ns/shortname",
+	} {
+		err := validateIdentityRemappingPrefix(s)
+		assert.NoError(t, err, s)
+	}
+
+	for _, s := range []string{
+		"",
+		"repo_with_underscores", // Not a valid DNS name, at least per docker/reference
+		"example.com/",
+		"example.com/UPPERCASEISINVALID",
+		"example.com/repo/",
+		"example.com/repo:tag",
+		"example.com/repo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"example.com/repo:tag@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	} {
+		err := validateIdentityRemappingPrefix(s)
+		assert.Error(t, err, s)
+	}
+}
+
+// xNewPRMRemapIdentity is like NewPRMRemapIdentity, except it must not fail.
+func xNewPRMRemapIdentity(prefix, signedPrefix string) PolicyReferenceMatch {
+	pr, err := NewPRMRemapIdentity(prefix, signedPrefix)
+	if err != nil {
+		panic("xNewPRMRemapIdentity failed")
+	}
+	return pr
+}
+
+func TestNewPRMRemapIdentity(t *testing.T) {
+	const testPrefix = "example.com/docker-library"
+	const testSignedPrefix = "docker.io/library"
+
+	// Success
+	_prm, err := NewPRMRemapIdentity(testPrefix, testSignedPrefix)
+	require.NoError(t, err)
+	prm, ok := _prm.(*prmRemapIdentity)
+	require.True(t, ok)
+	assert.Equal(t, &prmRemapIdentity{
+		prmCommon:    prmCommon{prmTypeRemapIdentity},
+		Prefix:       testPrefix,
+		SignedPrefix: testSignedPrefix,
+	}, prm)
+
+	// Invalid prefix
+	_, err = NewPRMRemapIdentity("", testSignedPrefix)
+	assert.Error(t, err)
+	_, err = NewPRMRemapIdentity("example.com/UPPERCASEISINVALID", testSignedPrefix)
+	assert.Error(t, err)
+	// Invalid signedPrefix
+	_, err = NewPRMRemapIdentity(testPrefix, "")
+	assert.Error(t, err)
+	_, err = NewPRMRemapIdentity(testPrefix, "example.com/UPPERCASEISINVALID")
+	assert.Error(t, err)
+}
+
+func TestPRMRemapIdentityUnmarshalJSON(t *testing.T) {
+	policyJSONUmarshallerTests{
+		newDest: func() json.Unmarshaler { return &prmRemapIdentity{} },
+		newValidObject: func() (interface{}, error) {
+			return NewPRMRemapIdentity("example.com/docker-library", "docker.io/library")
+		},
+		otherJSONParser: func(validJSON []byte) (interface{}, error) {
+			return newPolicyReferenceMatchFromJSON(validJSON)
+		},
+		breakFns: []func(mSI){
+			// The "type" field is missing
+			func(v mSI) { delete(v, "type") },
+			// Wrong "type" field
+			func(v mSI) { v["type"] = 1 },
+			func(v mSI) { v["type"] = "this is invalid" },
+			// Extra top-level sub-object
+			func(v mSI) { v["unexpected"] = 1 },
+			// The "prefix" field is missing
+			func(v mSI) { delete(v, "prefix") },
+			// Invalid "prefix" field
+			func(v mSI) { v["prefix"] = 1 },
+			func(v mSI) { v["prefix"] = "this is invalid" },
+			// The "signedPrefix" field is missing
+			func(v mSI) { delete(v, "signedPrefix") },
+			// Invalid "signedPrefix" field
+			func(v mSI) { v["signedPrefix"] = 1 },
+			func(v mSI) { v["signedPrefix"] = "this is invalid" },
+		},
+		duplicateFields: []string{"type", "prefix", "signedPrefix"},
 	}.run(t)
 }

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -250,7 +250,7 @@ func testInvalidJSONInput(t *testing.T, dest json.Unmarshaler) {
 	assert.Error(t, err)
 }
 
-// addExtraJSONMember adds adds an additional member "$name": $extra,
+// addExtraJSONMember adds an additional member "$name": $extra,
 // possibly with a duplicate name, to encoded.
 // Errors, if any, are reported through t.
 func addExtraJSONMember(t *testing.T, encoded []byte, name string, extra interface{}) []byte {
@@ -260,7 +260,13 @@ func addExtraJSONMember(t *testing.T, encoded []byte, name string, extra interfa
 	require.True(t, bytes.HasSuffix(encoded, []byte("}")))
 	preservedLen := len(encoded) - 1
 
-	return bytes.Join([][]byte{encoded[:preservedLen], []byte(`,"`), []byte(name), []byte(`":`), extraJSON, []byte("}")}, nil)
+	res := bytes.Join([][]byte{encoded[:preservedLen], []byte(`,"`), []byte(name), []byte(`":`), extraJSON, []byte("}")}, nil)
+	// Verify that the result is valid JSON, as a sanity check that we are actually triggering
+	// the “duplicate member” case in the caller.
+	var raw map[string]interface{}
+	err = json.Unmarshal(res, &raw)
+	require.NoError(t, err)
+	return res
 }
 
 // policyJSONUnmarshallerTests formalizes the repeated structure of the JSON unmasrhaller

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -1104,7 +1104,7 @@ func TestPRMExactReferenceUnmarshalJSON(t *testing.T) {
 			// Invalid "dockerReference" field
 			func(v mSI) { v["dockerReference"] = 1 },
 		},
-		duplicateFields: []string{"type", "baseLayerIdentity"},
+		duplicateFields: []string{"type", "dockerReference"},
 	}.run(t)
 }
 
@@ -1160,6 +1160,6 @@ func TestPRMExactRepositoryUnmarshalJSON(t *testing.T) {
 			// Invalid "dockerRepository" field
 			func(v mSI) { v["dockerRepository"] = 1 },
 		},
-		duplicateFields: []string{"type", "baseLayerIdentity"},
+		duplicateFields: []string{"type", "dockerRepository"},
 	}.run(t)
 }

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -36,12 +36,9 @@ func (prm *prmMatchExact) matchesDockerReference(image types.UnparsedImage, sign
 	return signature.String() == intended.String()
 }
 
-func (prm *prmMatchRepoDigestOrExact) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
-	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
-	if err != nil {
-		return false
-	}
-
+// matchRepoDigestOrExactReferenceValues implements prmMatchRepoDigestOrExact.matchesDockerReference
+// using reference.Named values.
+func matchRepoDigestOrExactReferenceValues(intended, signature reference.Named) bool {
 	// Do not add default tags: image.Reference().DockerReference() should contain it already, and signatureDockerReference should be exact; so, verify that now.
 	if reference.IsNameOnly(signature) {
 		return false
@@ -57,6 +54,13 @@ func (prm *prmMatchRepoDigestOrExact) matchesDockerReference(image types.Unparse
 	default: // !reference.IsNameOnly(intended)
 		return false
 	}
+}
+func (prm *prmMatchRepoDigestOrExact) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
+	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
+	if err != nil {
+		return false
+	}
+	return matchRepoDigestOrExactReferenceValues(intended, signature)
 }
 
 func (prm *prmMatchRepository) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -4,6 +4,7 @@ package signature
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports"
@@ -102,4 +103,52 @@ func (prm *prmExactRepository) matchesDockerReference(image types.UnparsedImage,
 		return false
 	}
 	return signature.Name() == intended.Name()
+}
+
+// refMatchesPrefix returns true if ref matches prm.Prefix.
+func (prm *prmRemapIdentity) refMatchesPrefix(ref reference.Named) bool {
+	name := ref.Name()
+	switch {
+	case len(name) < len(prm.Prefix):
+		return false
+	case len(name) == len(prm.Prefix):
+		return name == prm.Prefix
+	case len(name) > len(prm.Prefix):
+		// We are matching only ref.Name(), not ref.String(), so the only separator we are
+		// expecting is '/':
+		// - '@' is only valid to separate a digest, i.e. not a part of ref.Name()
+		// - similarly ':' to mark a tag would not be a part of ref.Name(); it can be a part of a
+		//   host:port domain syntax, but we don't treat that specially and require an exact match
+		//   of the domain.
+		return strings.HasPrefix(name, prm.Prefix) && name[len(prm.Prefix)] == '/'
+	default:
+		panic("Internal error: impossible comparison outcome")
+	}
+}
+
+// remapReferencePrefix returns the result of remapping ref, if it matches prm.Prefix
+// or the original ref if it does not.
+func (prm *prmRemapIdentity) remapReferencePrefix(ref reference.Named) (reference.Named, error) {
+	if !prm.refMatchesPrefix(ref) {
+		return ref, nil
+	}
+	refString := ref.String()
+	newNamedRef := strings.Replace(refString, prm.Prefix, prm.SignedPrefix, 1)
+	newParsedRef, err := reference.ParseNamed(newNamedRef)
+	if err != nil {
+		return nil, fmt.Errorf(`error rewriting reference from "%s" to "%s": %v`, refString, newNamedRef, err)
+	}
+	return newParsedRef, nil
+}
+
+func (prm *prmRemapIdentity) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
+	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
+	if err != nil {
+		return false
+	}
+	intended, err = prm.remapReferencePrefix(intended)
+	if err != nil {
+		return false
+	}
+	return matchRepoDigestOrExactReferenceValues(intended, signature)
 }

--- a/signature/policy_reference_match_test.go
+++ b/signature/policy_reference_match_test.go
@@ -412,3 +412,193 @@ func TestPRMExactRepositoryMatchesDockerReference(t *testing.T) {
 		testExactPRMAndSig(t, prmExactRepositoryFactory, test.refB, test.refA, test.result)
 	}
 }
+
+func TestPRMRemapIdentityRefMatchesPrefix(t *testing.T) {
+	for _, c := range []struct {
+		ref, prefix string
+		expected    bool
+	}{
+		// Prefix is a reference.Domain() value
+		{"docker.io/image", "docker.io", true},
+		{"docker.io/image", "example.com", false},
+		{"example.com:5000/image", "example.com:5000", true},
+		{"example.com:50000/image", "example.com:5000", false},
+		{"example.com:5000/image", "example.com", false},
+		{"example.com/foo", "example.com", true},
+		{"example.com/foo/bar", "example.com", true},
+		{"example.com/foo/bar:baz", "example.com", true},
+		{"example.com/foo/bar" + digestSuffix, "example.com", true},
+		// Prefix is a reference.Named.Name() value or a repo namespace
+		{"docker.io/ns/image", "docker.io/library", false},
+		{"example.com/library", "docker.io/library", false},
+		{"docker.io/libraryy/image", "docker.io/library", false},
+		{"docker.io/library/busybox", "docker.io/library", true},
+		{"example.com/ns/image", "example.com/ns", true},
+		{"example.com/ns2/image", "example.com/ns", false},
+		{"example.com/n2/image", "example.com/ns", false},
+		{"example.com", "example.com/library/busybox", false},
+		{"example.com:5000/ns/image", "example.com/ns", false},
+		{"example.com/ns/image", "example.com:5000/ns", false},
+		{"docker.io/library/busybox", "docker.io/library/busybox", true},
+		{"example.com/library/busybox", "docker.io/library/busybox", false},
+		{"docker.io/library/busybox2", "docker.io/library/busybox", false},
+		{"example.com/ns/image", "example.com/ns/image", true},
+		{"example.com/ns/imag2", "example.com/ns/image", false},
+		{"example.com/ns/imagee", "example.com/ns/image", false},
+		{"example.com:5000/ns/image", "example.com/ns/image", false},
+		{"example.com/ns/image", "example.com:5000/ns/image", false},
+		{"example.com/ns/image:tag", "example.com/ns/image", true},
+		{"example.com/ns/image" + digestSuffix, "example.com/ns/image", true},
+		{"example.com/ns/image:tag" + digestSuffix, "example.com/ns/image", true},
+	} {
+		prm, err := newPRMRemapIdentity(c.prefix, "docker.io/library/signed-prefix")
+		require.NoError(t, err, c.prefix)
+		ref, err := reference.ParseNormalizedNamed(c.ref)
+		require.NoError(t, err, c.ref)
+		res := prm.refMatchesPrefix(ref)
+		assert.Equal(t, c.expected, res, fmt.Sprintf("%s vs. %s", c.ref, c.prefix))
+	}
+}
+
+func TestPRMRemapIdentityRemapReferencePrefix(t *testing.T) {
+	for _, c := range []struct{ prefix, signedPrefix, ref, expected string }{
+		// Match sanity checking, primarily tested in TestPRMRefMatchesPrefix
+		{"mirror.example", "vendor.example", "mirror.example/ns/image:tag", "vendor.example/ns/image:tag"},
+		{"mirror.example", "vendor.example", "different.com/ns/image:tag", "different.com/ns/image:tag"},
+		{"mirror.example/ns", "vendor.example/vendor-ns", "mirror.example/different-ns/image:tag", "mirror.example/different-ns/image:tag"},
+		{"docker.io", "not-docker-signed.example/ns", "busybox", "not-docker-signed.example/ns/library/busybox"},
+		// Rewrites work as expected
+		{"mirror.example", "vendor.example", "mirror.example/ns/image:tag", "vendor.example/ns/image:tag"},
+		{"example.com/mirror", "example.com/vendor", "example.com/mirror/image:tag", "example.com/vendor/image:tag"},
+		{"example.com/ns/mirror", "example.com/ns/vendor", "example.com/ns/mirror:tag", "example.com/ns/vendor:tag"},
+		{"mirror.example", "vendor.example", "prefixmirror.example/ns/image:tag", "prefixmirror.example/ns/image:tag"},
+		{"docker.io", "not-docker-signed.example", "busybox", "not-docker-signed.example/library/busybox"},
+		{"docker.io/library", "not-docker-signed.example/ns", "busybox", "not-docker-signed.example/ns/busybox"},
+		{"docker.io/library/busybox", "not-docker-signed.example/ns/notbusybox", "busybox", "not-docker-signed.example/ns/notbusybox"},
+		// On match, tag/digest is preserved
+		{"mirror.example", "vendor.example", "mirror.example/image", "vendor.example/image"}, // This one should not actually happen, testing for completeness
+		{"mirror.example", "vendor.example", "mirror.example/image:tag", "vendor.example/image:tag"},
+		{"mirror.example", "vendor.example", "mirror.example/image" + digestSuffix, "vendor.example/image" + digestSuffix},
+		{"mirror.example", "vendor.example", "mirror.example/image:tag" + digestSuffix, "vendor.example/image:tag" + digestSuffix},
+		// Rewrite creating an invalid reference
+		{"mirror.example/ns/image", "vendor.example:5000", "mirror.example/ns/image:tag", ""},
+		// Rewrite creating a valid reference string in short format, which would imply a docker.io prefix and is rejected
+		{"mirror.example/ns/image", "vendor.example:5000", "mirror.example/ns/image" + digestSuffix, ""}, // vendor.example:5000@digest
+		{"mirror.example/ns/image", "notlocalhost", "mirror.example/ns/image:tag", ""},                   // notlocalhost:tag
+	} {
+		testName := fmt.Sprintf("%#v", c)
+		prm, err := newPRMRemapIdentity(c.prefix, c.signedPrefix)
+		require.NoError(t, err, testName)
+		ref, err := reference.ParseNormalizedNamed(c.ref)
+		require.NoError(t, err, testName)
+		res, err := prm.remapReferencePrefix(ref)
+		if c.expected == "" {
+			assert.Error(t, err, testName)
+		} else {
+			require.NoError(t, err, testName)
+			assert.Equal(t, c.expected, res.String(), testName)
+		}
+	}
+}
+
+// modifiedString returns some string that is different from the input,
+// consistent across calls with the same input;
+// in particular it just replaces the first letter.
+func modifiedString(t *testing.T, input string) string {
+	c := input[0]
+	switch {
+	case c >= 'a' && c <= 'y':
+		c = c + 1
+	case c == 'z':
+		c = 'a'
+	default:
+		require.Fail(t, "unimplemented leading character '%c'", c)
+	}
+	return string(c) + input[1:]
+}
+
+// prmRemapIdentityMRDOETestCase is a helper for TestPRMRemapIdentityMatchesDockerReference,
+// verifying that the behavior is consistent with prmMatchRepoDigestOrExact,
+// while still smoke-testing the rewriting behavior.
+// The test succeeds if imageRefString is invalid and ignoreInvalidImageRef.
+func prmRemapIdentityMRDOETestCase(t *testing.T, ignoreInvalidImageRef bool, imageRef, sigRef string, result bool) {
+	parsedImageRef, err := reference.ParseNormalizedNamed(imageRef)
+	if ignoreInvalidImageRef && err != nil {
+		return
+	}
+	require.NoError(t, err)
+
+	// No rewriting happens.
+	prm, err := NewPRMRemapIdentity("never-causes-a-rewrite.example", "never-causes-a-rewrite.example")
+	require.NoError(t, err)
+	testImageAndSig(t, prm, imageRef, sigRef, result)
+
+	// Rewrite imageRef
+	domain := reference.Domain(parsedImageRef)
+	prm, err = NewPRMRemapIdentity(modifiedString(t, domain), domain)
+	require.NoError(t, err)
+	modifiedImageRef, err := reference.ParseNormalizedNamed(modifiedString(t, parsedImageRef.String()))
+	require.NoError(t, err)
+	testImageAndSig(t, prm, modifiedImageRef.String(), sigRef, result)
+}
+
+func TestPRMRemapIdentityMatchesDockerReference(t *testing.T) {
+	// Basic sanity checks. More detailed testing is done in TestPRMRemapIdentityRemapReferencePrefix
+	// and TestMatchRepoDigestOrExactReferenceValues.
+	for _, c := range []struct {
+		prefix, signedPrefix, imageRef, sigRef string
+		result                                 bool
+	}{
+		// No match rewriting
+		{"does-not-match.com", "does-not-match.rewritten", "busybox:latest", "busybox:latest", true},
+		{"does-not-match.com", "does-not-match.rewritten", "busybox:latest", "notbusybox:latest", false},
+		// Match rewriting non-docker
+		{"mirror.example", "public.com", "mirror.example/busybox:1", "public.com/busybox:1", true},
+		{"mirror.example", "public.com", "mirror.example/busybox:1", "public.com/busybox:not1", false},
+		// Rewriting to docker.io
+		{"mirror.example", "docker.io/library", "mirror.example/busybox:latest", "busybox:latest", true},
+		{"mirror.example", "docker.io/library", "mirror.example/alpine:latest", "busybox:latest", false},
+		// Rewriting from docker.io
+		{"docker.io/library", "original.com", "copied:latest", "original.com/copied:latest", true},
+		{"docker.io/library", "original.com", "copied:latest", "original.com/ns/copied:latest", false},
+		// Invalid object: prefix is not a host name
+		{"busybox", "example.com/busybox", "busybox:latest", "example.com/busybox:latest", false},
+		// Invalid object: signedPrefix is not a host name
+		{"docker.io/library/busybox", "busybox", "docker.io/library/busybox:latest", "busybox:latest", false},
+		// Invalid object: invalid prefix
+		{"UPPERCASE", "example.com", "example.com/foo:latest", "example.com/foo:latest", true}, // Happens to work, not an API promise
+		{"example.com", "UPPERCASE", "example.com/foo:latest", "UPPERCASE/foo:latest", false},
+	} {
+		// Do not use NewPRMRemapIdentity, we want to also test the cases with invalid values,
+		// even though NewPRMExactReference should never let it happen.
+		prm := &prmRemapIdentity{Prefix: c.prefix, SignedPrefix: c.signedPrefix}
+		testImageAndSig(t, prm, c.imageRef, c.sigRef, c.result)
+	}
+	// Even if they are signed with an empty string as a reference, unidentified images are rejected.
+	prm, err := NewPRMRemapIdentity("docker.io", "docker.io")
+	require.NoError(t, err)
+	res := prm.matchesDockerReference(refImageMock{nil}, "")
+	assert.False(t, res, `unidentified vs. ""`)
+
+	// Verify that the behavior is otherwise the same as for prmMatchRepoDigestOrExact:
+	// prmMatchRepoDigestOrExact is a middle ground between prmMatchExact and prmMatchRepository:
+	// It accepts anything prmMatchExact accepts,…
+	for _, test := range prmExactMatchTestTable {
+		if test.result == true {
+			prmRemapIdentityMRDOETestCase(t, true, test.refA, test.refB, test.result)
+			prmRemapIdentityMRDOETestCase(t, true, test.refB, test.refA, test.result)
+		}
+	}
+	// … and it rejects everything prmMatchRepository rejects.
+	for _, test := range prmRepositoryMatchTestTable {
+		if test.result == false {
+			prmRemapIdentityMRDOETestCase(t, true, test.refA, test.refB, test.result)
+			prmRemapIdentityMRDOETestCase(t, true, test.refB, test.refA, test.result)
+		}
+	}
+
+	// The other cases, possibly asymmetrical:
+	for _, test := range matchRepoDigestOrExactTestTable {
+		prmRemapIdentityMRDOETestCase(t, false, test.imageRef, test.sigRef, test.result)
+	}
+}

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -121,6 +121,7 @@ const (
 	prmTypeMatchRepository        prmTypeIdentifier = "matchRepository"
 	prmTypeExactReference         prmTypeIdentifier = "exactReference"
 	prmTypeExactRepository        prmTypeIdentifier = "exactRepository"
+	prmTypeRemapIdentity          prmTypeIdentifier = "remapIdentity"
 )
 
 // prmMatchExact is a PolicyReferenceMatch with type = prmMatchExact: the two references must match exactly.
@@ -149,4 +150,14 @@ type prmExactReference struct {
 type prmExactRepository struct {
 	prmCommon
 	DockerRepository string `json:"dockerRepository"`
+}
+
+// prmRemapIdentity is a PolicyReferenceMatch with type = prmRemapIdentity: like prmMatchRepoDigestOrExact,
+// except that a namespace (at least a host:port, at most a single repository) is substituted before matching the two references.
+type prmRemapIdentity struct {
+	prmCommon
+	Prefix       string `json:"prefix"`
+	SignedPrefix string `json:"signedPrefix"`
+	// Possibly let the users make a choice for tag/digest matching behavior
+	// similar to prmMatchExact/prmMatchRepository?
 }


### PR DESCRIPTION
This allows accepting signatures for a complete or partial mirror of some other repository namespace in a single step, similar in signing effect to setting up mirrors in `registries.conf`, but letting image consumers refer to the mirrors directly.

For tag/digest matching, this currently only implemnents the default `matchRepoDigestOrExact`-like semantics; it's the right choice for almost all users, and we can add other alternatives later if it turned out to be necessary.