### PR TITLE
sysregistriesv2: Split configuration loading and merging

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/containers/storage v1.23.4/go.mod h1:KzpVgmUucelPYHq2YsseUTiTuucdVh3x
 github.com/containers/storage v1.23.5 h1:He9I6y1vRVXYoQg4v2Q9HFAcX4dI3V5MCCrjeBcjkCY=
 github.com/containers/storage v1.23.5/go.mod h1:ha26Q6ngehFNhf3AWoXldvAvwI4jFe3ETQAf/CeZPyM=
 github.com/containers/storage v1.23.6/go.mod h1:haFs0HRowKwyzvWEx9EgI3WsL8XCSnBDb5f8P5CAxJY=
+github.com/containers/storage v1.23.7 h1:43ImvG/npvQSZXRjaudVvKISIuZSfI6qvtSNQQSGO/A=
 github.com/containers/storage v1.23.7/go.mod h1:cUT2zHjtx+WlVri30obWmM2gpqpi8jfPsmIzP1TVpEI=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
@@ -432,6 +433,7 @@ golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIA
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed h1:WBkVNH1zd9jg/dK4HCM4lNANnmd12EHC9z+LmcCG4ns=
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -326,16 +326,25 @@ func (config *V2RegistriesConf) postProcess() error {
 	// rendering later items with the same prefix non-existent. We cannot error
 	// out anymore as this might break existing users, so let's just ignore them
 	// to guarantee that the same prefix exists only once.
-	knownPrefixes := make(map[string]bool)
-	uniqueRegistries := []Registry{}
+	//
+	// As a side effect of parsedConfig.updateWithConfigurationFrom, the Registries slice
+	// is always sorted. To be consistent in situations where it is not called (no drop-ins),
+	// sort it here as well.
+	prefixes := []string{}
+	uniqueRegistries := make(map[string]Registry)
 	for i := range config.Registries {
 		// TODO: should we warn if we see the same prefix being used multiple times?
-		if _, exists := knownPrefixes[config.Registries[i].Prefix]; !exists {
-			knownPrefixes[config.Registries[i].Prefix] = true
-			uniqueRegistries = append(uniqueRegistries, config.Registries[i])
+		prefix := config.Registries[i].Prefix
+		if _, exists := uniqueRegistries[prefix]; !exists {
+			uniqueRegistries[prefix] = config.Registries[i]
+			prefixes = append(prefixes, prefix)
 		}
 	}
-	config.Registries = uniqueRegistries
+	sort.Strings(prefixes)
+	config.Registries = []Registry{}
+	for _, prefix := range prefixes {
+		config.Registries = append(config.Registries, uniqueRegistries[prefix])
+	}
 
 	return nil
 }

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -162,12 +162,6 @@ func (config *V2RegistriesConf) Nonempty() bool {
 		len(config.UnqualifiedSearchRegistries) != 0)
 }
 
-// tomlConfig is the data type used to unmarshal the toml config.
-type tomlConfig struct {
-	V2RegistriesConf
-	V1RegistriesConf // for backwards compatibility with sysregistries v1
-}
-
 // parsedConfig is the result of parsing, and possibly merging, configuration files;
 // it is the boundary between the process of reading+ingesting the files, and
 // later interpreting the configuraiton based on caller’s requests.
@@ -639,6 +633,12 @@ func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
 // Use forceV2 if the config must in the v2 format.
 func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 	logrus.Debugf("Loading registries configuration %q", path)
+
+	// tomlConfig allows us to unmarshal either V1 or V2 simultaneously.
+	type tomlConfig struct {
+		V2RegistriesConf
+		V1RegistriesConf // for backwards compatibility with sysregistries v1
+	}
 
 	// Load the tomlConfig. Note that `DecodeFile` will overwrite set fields.
 	combinedTOML := tomlConfig{

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -668,7 +668,7 @@ func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 	}
 
 	// Post process registries, set the correct prefixes, sanity checks, etc.
-	if err := combinedTOML.postProcess(); err != nil {
+	if err := combinedTOML.V2RegistriesConf.postProcess(); err != nil {
 		return err
 	}
 

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -381,7 +381,7 @@ insecure = true`), 0600)
 
 	ctx := &types.SystemContext{SystemRegistriesConfPath: configFile.Name()}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -398,7 +398,7 @@ insecure = true`), 0600)
 func TestInvalidateCache(t *testing.T) {
 	ctx := &types.SystemContext{SystemRegistriesConfPath: "testdata/invalidate-cache.conf"}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -523,7 +523,7 @@ func TestTryUpdatingCache(t *testing.T) {
 		SystemRegistriesConfPath:    "testdata/try-update-cache-valid.conf",
 		SystemRegistriesConfDirPath: "testdata/this-does-not-exist",
 	}
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := TryUpdatingCache(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(registries.Registries))
@@ -545,7 +545,7 @@ func TestRegistriesConfDirectory(t *testing.T) {
 		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
 	}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := TryUpdatingCache(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, registries)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -557,4 +557,19 @@ func TestRegistriesConfDirectory(t *testing.T) {
 	reg, err := FindRegistry(ctx, "base.com/test:latest")
 	require.NoError(t, err)
 	assert.True(t, reg.Blocked)
+
+	// Test that unqualified-search-registries is merged correctly
+	usr, err := UnqualifiedSearchRegistries(&types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/unqualified-search.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d-usr1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, usr) // Nothing overrides the base file
+
+	usr, err = UnqualifiedSearchRegistries(&types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/unqualified-search.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d-usr2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, usr) // Search overridden with an empty array
 }

--- a/pkg/sysregistriesv2/testdata/registries.conf.d-usr1/no-usr.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d-usr1/no-usr.conf
@@ -1,0 +1,1 @@
+# unqualified-search-registries is not set

--- a/pkg/sysregistriesv2/testdata/registries.conf.d-usr2/empty-usr.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d-usr2/empty-usr.conf
@@ -1,0 +1,1 @@
+unqualified-search-registries = []


### PR DESCRIPTION
Currently just RFC and to run tests, depending on logistics we might end up making this change as part of, or after, #1060