### PR TITLE
sysregistriesv2: Split configuration loading and merging

### DIFF
--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -98,7 +98,7 @@ func ResolveShortNameAlias(ctx *types.SystemContext, name string) (reference.Nam
 	if err != nil {
 		return nil, "", err
 	}
-	alias, resolved = config.namedAliases[name]
+	alias, resolved = config.v2.namedAliases[name]
 	if resolved {
 		return alias.value, alias.configOrigin, nil
 	}

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -271,15 +271,14 @@ func (conf *shortNameAliasConf) parseAndValidate(path string) error {
 			conf.namedAliases[name] = alias{named, path}
 		}
 	}
-	var err error // nil if no errors
-	for _, e := range errs {
-		if err == nil {
-			err = e
-		} else {
-			err = errors.Wrapf(err, "%v\n", e)
+	if len(errs) > 0 {
+		err := errs[0]
+		for i := 1; i < len(errs); i++ {
+			err = errors.Wrapf(err, "%v\n", errs[i])
 		}
+		return err
 	}
-	return err
+	return nil
 }
 
 func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, error) {

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -285,6 +285,14 @@ func newShortNameAliasCache(path string, conf *shortNameAliasConf) (*shortNameAl
 	return &res, nil
 }
 
+// updateWithConfigurationFrom updates c with configuration from updates.
+// In case of conflict, updates is preferred.
+func (c *shortNameAliasCache) updateWithConfigurationFrom(updates *shortNameAliasCache) {
+	for name, value := range updates.namedAliases {
+		c.namedAliases[name] = value
+	}
+}
+
 func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, *shortNameAliasCache, error) {
 	conf := shortNameAliasConf{}
 

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -245,10 +245,9 @@ func validateShortName(name string) error {
 	return nil
 }
 
-// parseAndValidate parses and validates all entries in conf.Aliases, and returns
-// a corresponding shortNameAliasCache.
-// the results in conf.namedAliases.
-func (conf *shortNameAliasConf) parseAndValidate(path string) (*shortNameAliasCache, error) {
+// newShortNameAliasCache parses shortNameAliasConf and returns the corresponding internal
+// representation.
+func newShortNameAliasCache(path string, conf *shortNameAliasConf) (*shortNameAliasCache, error) {
 	res := shortNameAliasCache{
 		namedAliases: make(map[string]alias),
 	}
@@ -295,9 +294,9 @@ func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, *shortNameAli
 		return nil, nil, errors.Wrapf(err, "error loading short-name aliases config file %q", confPath)
 	}
 
-	// Better safe than sorry: validate the machine-generated config.  The
+	// Even if we don’t always need the cache, doing so validates the machine-generated config.  The
 	// file could still be corrupted by another process or user.
-	cache, err := conf.parseAndValidate(confPath)
+	cache, err := newShortNameAliasCache(confPath, &conf)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error loading short-name aliases config file %q", confPath)
 	}

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -138,6 +138,9 @@ func editShortNameAlias(ctx *types.SystemContext, name string, value *string) er
 		return err
 	}
 
+	if conf.Aliases == nil { // Ensure we have a map to update.
+		conf.Aliases = make(map[string]string)
+	}
 	if value != nil {
 		conf.Aliases[name] = *value
 	} else {
@@ -246,9 +249,6 @@ func validateShortName(name string) error {
 // a corresponding shortNameAliasCache.
 // the results in conf.namedAliases.
 func (conf *shortNameAliasConf) parseAndValidate(path string) (*shortNameAliasCache, error) {
-	if conf.Aliases == nil {
-		conf.Aliases = make(map[string]string)
-	}
 	res := shortNameAliasCache{
 		namedAliases: make(map[string]alias),
 	}

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -102,7 +102,7 @@ func ResolveShortNameAlias(ctx *types.SystemContext, name string) (reference.Nam
 	if err != nil {
 		return nil, "", err
 	}
-	alias, resolved = config.v2.aliasCache.namedAliases[name]
+	alias, resolved = config.aliasCache.namedAliases[name]
 	if resolved {
 		return alias.value, alias.configOrigin, nil
 	}

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -94,7 +94,7 @@ func TestResolveShortNameAlias(t *testing.T) {
 		UserShortNameAliasConfPath:  tmp.Name(),
 	}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	conf, err := TryUpdatingCache(sys)
 	require.NoError(t, err)
 	assert.Len(t, conf.namedAliases, 4)
@@ -149,7 +149,7 @@ func TestAliasesWithDropInConfigs(t *testing.T) {
 		UserShortNameAliasConfPath:  tmp.Name(),
 	}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	conf, err := TryUpdatingCache(sys)
 	require.NoError(t, err)
 	assert.Len(t, conf.namedAliases, 8)
@@ -261,7 +261,7 @@ func TestInvalidAliases(t *testing.T) {
 		UserShortNameAliasConfPath:  tmp.Name(),
 	}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	_, err = TryUpdatingCache(sys)
 	require.Error(t, err)
 

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -98,7 +98,7 @@ func TestResolveShortNameAlias(t *testing.T) {
 	conf, err := tryUpdatingCache(sys, newConfigWrapper(sys))
 	require.NoError(t, err)
 	assert.Len(t, conf.aliasCache.namedAliases, 4)
-	assert.Len(t, conf.v2.Aliases, 0)
+	assert.Len(t, conf.partialV2.Aliases, 0) // This is an implementation detail, not an API guarantee.
 
 	aliases := []struct {
 		name, value string
@@ -153,7 +153,7 @@ func TestAliasesWithDropInConfigs(t *testing.T) {
 	conf, err := tryUpdatingCache(sys, newConfigWrapper(sys))
 	require.NoError(t, err)
 	assert.Len(t, conf.aliasCache.namedAliases, 8)
-	assert.Len(t, conf.v2.Aliases, 0)
+	assert.Len(t, conf.partialV2.Aliases, 0) // This is an implementation detail, not an API guarantee.
 
 	aliases := []struct {
 		name, value, config string

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -95,10 +95,10 @@ func TestResolveShortNameAlias(t *testing.T) {
 	}
 
 	InvalidateCache()
-	conf, err := TryUpdatingCache(sys)
+	conf, err := tryUpdatingCache(sys, newConfigWrapper(sys))
 	require.NoError(t, err)
 	assert.Len(t, conf.aliasCache.namedAliases, 4)
-	assert.Len(t, conf.Aliases, 0)
+	assert.Len(t, conf.v2.Aliases, 0)
 
 	aliases := []struct {
 		name, value string
@@ -150,10 +150,10 @@ func TestAliasesWithDropInConfigs(t *testing.T) {
 	}
 
 	InvalidateCache()
-	conf, err := TryUpdatingCache(sys)
+	conf, err := tryUpdatingCache(sys, newConfigWrapper(sys))
 	require.NoError(t, err)
 	assert.Len(t, conf.aliasCache.namedAliases, 8)
-	assert.Len(t, conf.Aliases, 0)
+	assert.Len(t, conf.v2.Aliases, 0)
 
 	aliases := []struct {
 		name, value, config string

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -97,7 +97,7 @@ func TestResolveShortNameAlias(t *testing.T) {
 	InvalidateCache()
 	conf, err := TryUpdatingCache(sys)
 	require.NoError(t, err)
-	assert.Len(t, conf.namedAliases, 4)
+	assert.Len(t, conf.aliasCache.namedAliases, 4)
 	assert.Len(t, conf.Aliases, 0)
 
 	aliases := []struct {
@@ -152,7 +152,7 @@ func TestAliasesWithDropInConfigs(t *testing.T) {
 	InvalidateCache()
 	conf, err := TryUpdatingCache(sys)
 	require.NoError(t, err)
-	assert.Len(t, conf.namedAliases, 8)
+	assert.Len(t, conf.aliasCache.namedAliases, 8)
 	assert.Len(t, conf.Aliases, 0)
 
 	aliases := []struct {

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -184,12 +184,6 @@ func (config *V2RegistriesConf) Nonempty() bool {
 		len(config.UnqualifiedSearchRegistries) != 0)
 }
 
-// tomlConfig is the data type used to unmarshal the toml config.
-type tomlConfig struct {
-	V2RegistriesConf
-	V1RegistriesConf // for backwards compatibility with sysregistries v1
-}
-
 // parsedConfig is the result of parsing, and possibly merging, configuration files;
 // it is the boundary between the process of reading+ingesting the files, and
 // later interpreting the configuraiton based on caller’s requests.
@@ -696,6 +690,12 @@ func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
 // Use forceV2 if the config must in the v2 format.
 func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 	logrus.Debugf("Loading registries configuration %q", path)
+
+	// tomlConfig allows us to unmarshal either V1 or V2 simultaneously.
+	type tomlConfig struct {
+		V2RegistriesConf
+		V1RegistriesConf // for backwards compatibility with sysregistries v1
+	}
 
 	// Load the tomlConfig. Note that `DecodeFile` will overwrite set fields.
 	combinedTOML := tomlConfig{

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -725,7 +725,7 @@ func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 	}
 
 	// Post process registries, set the correct prefixes, sanity checks, etc.
-	if err := combinedTOML.postProcessRegistries(); err != nil {
+	if err := combinedTOML.V2RegistriesConf.postProcessRegistries(); err != nil {
 		return err
 	}
 

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -798,15 +798,6 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 		return err
 	}
 
-	// Now check if the newly loaded config set the USRs.
-	if c.partialV2.UnqualifiedSearchRegistries != nil {
-		// USRs set -> record it as the new origin.
-		c.unqualifiedSearchRegistriesOrigin = updates.unqualifiedSearchRegistriesOrigin
-	} else {
-		// USRs not set -> restore the previous USRs
-		c.partialV2.UnqualifiedSearchRegistries = prevUSRs
-	}
-
 	// Merge the freshly loaded registries.
 	for i := range c.partialV2.Registries {
 		registryMap[c.partialV2.Registries[i].Prefix] = c.partialV2.Registries[i]
@@ -828,6 +819,20 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 		c.partialV2.Registries = append(c.partialV2.Registries, registryMap[prefix])
 	}
 
+	// Now check if the newly loaded config set the USRs.
+	if c.partialV2.UnqualifiedSearchRegistries != nil {
+		// USRs set -> record it as the new origin.
+		c.unqualifiedSearchRegistriesOrigin = updates.unqualifiedSearchRegistriesOrigin
+	} else {
+		// USRs not set -> restore the previous USRs
+		c.partialV2.UnqualifiedSearchRegistries = prevUSRs
+	}
+
+	// If set, parse & store the specified short-name mode.
+	if updates.shortNameMode != types.ShortNameModeInvalid {
+		c.shortNameMode = updates.shortNameMode
+	}
+
 	// Merge the alias maps.  New configs override previous entries.
 	if c.aliasCache == nil {
 		c.aliasCache = &shortNameAliasCache{
@@ -835,11 +840,6 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 		}
 	}
 	c.aliasCache.updateWithConfigurationFrom(updates.aliasCache)
-
-	// If set, parse & store the specified short-name mode.
-	if updates.shortNameMode != types.ShortNameModeInvalid {
-		c.shortNameMode = updates.shortNameMode
-	}
 
 	return nil
 }

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -746,8 +746,7 @@ func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 	}
 	combinedTOML.V2RegistriesConf.aliasCache = cache
 	// Nil conf.v2.Aliases to make it available for garbage collection and
-	// reduce memory consumption.  We're consulting conf.namedAliases for
-	// look ups.
+	// reduce memory consumption.  We're consulting aliasCache for lookups.
 	combinedTOML.V2RegistriesConf.Aliases = nil
 
 	*v2 = combinedTOML.V2RegistriesConf
@@ -823,10 +822,8 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 
 	// Merge the alias maps.  New configs override previous entries.
 	newAliases := c.v2.aliasCache
-	c.v2.aliasCache = prevAliases // point back to the previous map and override
-	for name, value := range newAliases.namedAliases {
-		c.v2.aliasCache.namedAliases[name] = value
-	}
+	c.v2.aliasCache = prevAliases
+	c.v2.aliasCache.updateWithConfigurationFrom(newAliases)
 
 	// If set, parse & store the specified short-name mode.
 	if len(c.v2.ShortNameMode) > 0 {

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -790,7 +790,7 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 	}
 
 	// Parse and validate short-name aliases.
-	cache, err := c.v2.shortNameAliasConf.parseAndValidate(path)
+	cache, err := newShortNameAliasCache(path, &c.v2.shortNameAliasConf)
 	if err != nil {
 		return errors.Wrap(err, "error validating short-name aliases")
 	}

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -739,6 +739,17 @@ func loadConfigFile(v2 *V2RegistriesConf, path string, forceV2 bool) error {
 		return err
 	}
 
+	// Parse and validate short-name aliases.
+	cache, err := newShortNameAliasCache(path, &combinedTOML.V2RegistriesConf.shortNameAliasConf)
+	if err != nil {
+		return errors.Wrap(err, "error validating short-name aliases")
+	}
+	combinedTOML.V2RegistriesConf.aliasCache = cache
+	// Nil conf.v2.Aliases to make it available for garbage collection and
+	// reduce memory consumption.  We're consulting conf.namedAliases for
+	// look ups.
+	combinedTOML.V2RegistriesConf.Aliases = nil
+
 	*v2 = combinedTOML.V2RegistriesConf
 	return nil
 }
@@ -788,17 +799,6 @@ func (c *parsedConfig) loadConfig(path string, forceV2 bool) error {
 		// USRs not set -> restore the previous USRs
 		c.v2.UnqualifiedSearchRegistries = prevUSRs
 	}
-
-	// Parse and validate short-name aliases.
-	cache, err := newShortNameAliasCache(path, &c.v2.shortNameAliasConf)
-	if err != nil {
-		return errors.Wrap(err, "error validating short-name aliases")
-	}
-	c.v2.aliasCache = cache
-	// Nil conf.v2.Aliases to make it available for garbage collection and
-	// reduce memory consumption.  We're consulting conf.namedAliases for
-	// look ups.
-	c.v2.Aliases = nil
 
 	// Merge the freshly loaded registries.
 	for i := range c.v2.Registries {

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -190,6 +190,15 @@ type tomlConfig struct {
 	V1RegistriesConf // for backwards compatibility with sysregistries v1
 }
 
+// parsedConfig is the result of parsing, and possibly merging, configuration files;
+// it is the boundary between the process of reading+ingesting the files, and
+// later interpreting the configuraiton based on caller’s requests.
+type parsedConfig struct {
+	// For now, just embed an unprocessed configuration. Later we may add data structures to
+	// amortize parsing cost or speed up lookups.
+	v2 V2RegistriesConf
+}
+
 // InvalidRegistries represents an invalid registry configurations.  An example
 // is when "registry.com" is defined multiple times in the configuration but
 // with conflicting security settings.
@@ -450,7 +459,7 @@ var configMutex = sync.Mutex{}
 // configCache caches already loaded configs with config paths as keys and is
 // used to avoid redundantly parsing configs. Concurrent accesses to the cache
 // are synchronized via configMutex.
-var configCache = make(map[configWrapper]*V2RegistriesConf)
+var configCache = make(map[configWrapper]*parsedConfig)
 
 // InvalidateCache invalidates the registry cache.  This function is meant to be
 // used for long-running processes that need to reload potential changes made to
@@ -458,11 +467,11 @@ var configCache = make(map[configWrapper]*V2RegistriesConf)
 func InvalidateCache() {
 	configMutex.Lock()
 	defer configMutex.Unlock()
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	configCache = make(map[configWrapper]*parsedConfig)
 }
 
 // getConfig returns the config object corresponding to ctx, loading it if it is not yet cached.
-func getConfig(ctx *types.SystemContext) (*V2RegistriesConf, error) {
+func getConfig(ctx *types.SystemContext) (*parsedConfig, error) {
 	wrapper := newConfigWrapper(ctx)
 	configMutex.Lock()
 	if config, inCache := configCache[wrapper]; inCache {
@@ -529,12 +538,16 @@ func dropInConfigs(wrapper configWrapper) ([]string, error) {
 // without using the internal cache. On success, the loaded configuration will
 // be added into the internal registry cache.
 func TryUpdatingCache(ctx *types.SystemContext) (*V2RegistriesConf, error) {
-	return tryUpdatingCache(ctx, newConfigWrapper(ctx))
+	config, err := tryUpdatingCache(ctx, newConfigWrapper(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &config.v2, err
 }
 
 // tryUpdatingCache implements TryUpdatingCache with an additional configWrapper
 // argument to avoid redundantly calculating the config paths.
-func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*V2RegistriesConf, error) {
+func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedConfig, error) {
 	configMutex.Lock()
 	defer configMutex.Unlock()
 
@@ -566,11 +579,11 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*V2Regis
 		}
 	}
 
-	v2Config := &config.V2RegistriesConf
+	parsedConfig := &parsedConfig{v2: config.V2RegistriesConf}
 
 	// populate the cache
-	configCache[wrapper] = v2Config
-	return v2Config, nil
+	configCache[wrapper] = parsedConfig
+	return parsedConfig, nil
 }
 
 // GetRegistries loads and returns the registries specified in the config.
@@ -581,7 +594,7 @@ func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return config.Registries, nil
+	return config.v2.Registries, nil
 }
 
 // UnqualifiedSearchRegistries returns a list of host[:port] entries to try
@@ -600,7 +613,7 @@ func UnqualifiedSearchRegistriesWithOrigin(ctx *types.SystemContext) ([]string, 
 	if err != nil {
 		return nil, "", err
 	}
-	return config.UnqualifiedSearchRegistries, config.unqualifiedSearchRegistriesOrigin, nil
+	return config.v2.UnqualifiedSearchRegistries, config.v2.unqualifiedSearchRegistriesOrigin, nil
 }
 
 // parseShortNameMode translates the string into well-typed
@@ -624,7 +637,7 @@ func GetShortNameMode(ctx *types.SystemContext) (types.ShortNameMode, error) {
 	if err != nil {
 		return -1, err
 	}
-	return config.shortNameMode, err
+	return config.v2.shortNameMode, err
 }
 
 // refMatchesPrefix returns true iff ref,
@@ -666,7 +679,7 @@ func FindRegistry(ctx *types.SystemContext, ref string) (*Registry, error) {
 
 	reg := Registry{}
 	prefixLen := 0
-	for _, r := range config.Registries {
+	for _, r := range config.v2.Registries {
 		if refMatchesPrefix(ref, r.Prefix) {
 			length := len(r.Prefix)
 			if length > prefixLen {

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -166,9 +166,6 @@ type V2RegistriesConf struct {
 	// potentially use all unqualified-search registries
 	ShortNameMode string `toml:"short-name-mode"`
 
-	// TODO: separate upper format from internal data below:
-	// https://github.com/containers/image/pull/1060#discussion_r503386541
-
 	shortNameAliasConf
 }
 

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -382,7 +382,7 @@ insecure = true`), 0600)
 
 	ctx := &types.SystemContext{SystemRegistriesConfPath: configFile.Name()}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -399,7 +399,7 @@ insecure = true`), 0600)
 func TestInvalidateCache(t *testing.T) {
 	ctx := &types.SystemContext{SystemRegistriesConfPath: "testdata/invalidate-cache.conf"}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := GetRegistries(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(registries))
@@ -524,7 +524,7 @@ func TestTryUpdatingCache(t *testing.T) {
 		SystemRegistriesConfPath:    "testdata/try-update-cache-valid.conf",
 		SystemRegistriesConfDirPath: "testdata/this-does-not-exist",
 	}
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := TryUpdatingCache(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(registries.Registries))
@@ -546,7 +546,7 @@ func TestRegistriesConfDirectory(t *testing.T) {
 		SystemRegistriesConfDirPath: "testdata/registries.conf.d",
 	}
 
-	configCache = make(map[configWrapper]*V2RegistriesConf)
+	InvalidateCache()
 	registries, err := TryUpdatingCache(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, registries)

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -563,6 +563,21 @@ func TestRegistriesConfDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"example-overwrite.com"}, usrs)
 	assert.Equal(t, "testdata/registries.conf.d/config-1.conf", origin)
+
+	// Test that unqualified-search-registries is merged correctly
+	usr, err := UnqualifiedSearchRegistries(&types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/unqualified-search.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d-usr1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"registry-a.com", "registry-c.com", "registry-d.com"}, usr) // Nothing overrides the base file
+
+	usr, err = UnqualifiedSearchRegistries(&types.SystemContext{
+		SystemRegistriesConfPath:    "testdata/unqualified-search.conf",
+		SystemRegistriesConfDirPath: "testdata/registries.conf.d-usr2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, usr) // Search overridden with an empty array
 }
 
 func TestParseShortNameMode(t *testing.T) {

--- a/pkg/sysregistriesv2/testdata/registries.conf.d-usr1/no-usr.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d-usr1/no-usr.conf
@@ -1,0 +1,1 @@
+# unqualified-search-registries is not set

--- a/pkg/sysregistriesv2/testdata/registries.conf.d-usr2/empty-usr.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d-usr2/empty-usr.conf
@@ -1,0 +1,1 @@
+unqualified-search-registries = []


### PR DESCRIPTION
This is a “rebase” of #1076 on top of #1060, but that more than doubles the scope.