### PR TITLE
docker_client: Handle "invalid_scope" errors

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -335,8 +335,9 @@ func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.
 		// Checking candidateRepo, and mounting from it, requires an
 		// expanded token scope.
 		extraScope := &authScope{
-			remoteName: reference.Path(candidateRepo),
-			actions:    "pull",
+			resourceType: "repository",
+			remoteName:   reference.Path(candidateRepo),
+			actions:      "pull",
 		}
 		// This existence check is not, strictly speaking, necessary: We only _really_ need it to get the blob size, and we could record that in the cache instead.
 		// But a "failed" d.mountBlob currently leaves around an unterminated server-side upload, which we would try to cancel.


### PR DESCRIPTION
podman 2.1.1 (which uses containers/images 5.7.0) fails to search some registries. E.g.

`podman --log-level=debug search registry.suse.com/`

gives:
```
[...]
DEBU[0000] trying to talk to v2 search endpoint         
DEBU[0000] GET https://registry.suse.com/v2/            
DEBU[0000] Ping https://registry.suse.com/v2/ status 401 
DEBU[0000] GET https://registry.suse.com/auth?service=SUSE+Linux+Docker+Registry 
DEBU[0000] Increasing token expiration to: 60 seconds   
DEBU[0000] GET https://registry.suse.com/v2/_catalog    
ERRO[0000] error getting search results from v2 endpoint "registry.suse.com": unable to retrieve auth token: invalid username/password: 
denied: requested access to the resource is denied
```

Looking into the details of the requests and response and trying to repeat it with `curl` I can see that the request to `/v2/_catalog` failes with Status 401 and the www-authenticate containing this error:

```
< www-authenticate: Bearer realm="https://registry.suse.com/auth",service="SUSE Linux Docker Registry",scope="registry:catalog:*",error="insufficient_scope"
```
This can be fixed by simply fetching a new token with the `scope` value set to the value return in that header.

This PR tries to implement a fix for the above behavior by checking for the error and retrying the request with and updated token.
