### PR TITLE
copy: check our assumptions about compression

### DIFF
--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -91,7 +91,8 @@ func CompressStream(dest io.Writer, algo Algorithm, level *int) (io.WriteCloser,
 	return internal.AlgorithmCompressor(algo)(dest, level)
 }
 
-// DetectCompressionFormat returns a DecompressorFunc if the input is recognized as a compressed format, nil otherwise.
+// DetectCompressionFormat returns an Algorithm and DecompressorFunc if the input is recognized as a compressed format, an invalid
+// value and nil otherwise.
 // Because it consumes the start of input, other consumers must use the returned io.Reader instead to also read from the beginning.
 func DetectCompressionFormat(input io.Reader) (Algorithm, DecompressorFunc, io.Reader, error) {
 	buffer := [8]byte{}


### PR DESCRIPTION
When copying a blob where we know to associate a compression algorithm with its MIME type, check if the blob was in fact compressed using that algorithm, and log a diagnostic message at level "debug" if it isn't.  Our local storage backend is less sensitive to this than others, but it's useful to me at least to be able to tell.  I'm not too sure about just adding a table for it, though.