### PR TITLE
blobinfocache: cache compression types

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/image"
+	internalblobinfocache "github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/pkg/platform"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
@@ -113,7 +114,7 @@ type copier struct {
 	progressOutput    io.Writer
 	progressInterval  time.Duration
 	progress          chan types.ProgressProperties
-	blobInfoCache     types.BlobInfoCache
+	blobInfoCache     internalblobinfocache.BlobInfoCache2
 	copyInParallel    bool
 	compressionFormat compression.Algorithm
 	compressionLevel  *int
@@ -265,7 +266,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
-		blobInfoCache:    blobinfocache.DefaultCache(options.DestinationCtx),
+		blobInfoCache:    internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
 		ociDecryptConfig: options.OciDecryptConfig,
 		ociEncryptConfig: options.OciEncryptConfig,
 	}
@@ -648,13 +649,19 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	// With docker/distribution registries we do not know whether the registry accepts schema2 or schema1 only;
 	// and at least with the OpenShift registry "acceptschema2" option, there is no way to detect the support
 	// without actually trying to upload something and getting a types.ManifestTypeRejectedError.
-	// So, try the preferred manifest MIME type. If the process succeeds, fine…
+	// So, try the preferred manifest MIME type with possibly-updated blob digests, media types, and sizes if
+	// we're altering how they're compressed.  If the process succeeds, fine…
 	manifestBytes, retManifestDigest, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
 	retManifestType = preferredManifestMIMEType
 	if err != nil {
 		logrus.Debugf("Writing manifest using preferred type %s failed: %v", preferredManifestMIMEType, err)
-		// … if it fails, _and_ the failure is because the manifest is rejected, we may have other options.
-		if _, isManifestRejected := errors.Cause(err).(types.ManifestTypeRejectedError); !isManifestRejected || len(otherManifestMIMETypeCandidates) == 0 {
+		// … if it fails, and the failure is either because the manifest is rejected by the registry, or
+		// because we failed to create a manifest of the specified type because the specific manifest type
+		// doesn't support the type of compression we're trying to use (e.g. docker v2s2 and zstd), we may
+		// have other options available that could still succeed.
+		_, isManifestRejected := errors.Cause(err).(types.ManifestTypeRejectedError)
+		_, isCompressionIncompatible := errors.Cause(err).(manifest.ManifestLayerCompressionIncompatibilityError)
+		if (!isManifestRejected && !isCompressionIncompatible) || len(otherManifestMIMETypeCandidates) == 0 {
 			// We don’t have other options.
 			// In principle the code below would handle this as well, but the resulting  error message is fairly ugly.
 			// Don’t bother the user with MIME types if we have no choice.
@@ -896,7 +903,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	return nil
 }
 
-// layerDigestsDiffer return true iff the digests in a and b differ (ignoring sizes and possible other fields)
+// layerDigestsDiffer returns true iff the digests in a and b differ (ignoring sizes and possible other fields)
 func layerDigestsDiffer(a, b []types.BlobInfo) bool {
 	if len(a) != len(b) {
 		return true
@@ -951,7 +958,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 		instanceDigest = &manifestDigest
 	}
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
-		return nil, "", errors.Wrap(err, "Error writing manifest")
+		return nil, "", errors.Wrapf(err, "Error writing manifest %q", string(man))
 	}
 	return man, manifestDigest, nil
 }
@@ -1058,6 +1065,12 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 
 	// If we already have the blob, and we don't need to compute the diffID, then we don't need to read it from the source.
 	if !diffIDIsNeeded {
+		// TODO: at this point we don't know whether or not a blob we end up reusing is compressed using an algorithm
+		// that is acceptable for use on layers in the manifest that we'll be writing later, so if we end up reusing
+		// a blob that's compressed with e.g. zstd, but we're only allowed to write a v2s2 manifest, this will cause
+		// a failure when we eventually try to update the manifest with the digest and MIME type of the reused blob.
+		// Fixing that will probably require passing more information to TryReusingBlob() than the current version of
+		// the ImageDestination interface lets us pass in.
 		reused, blobInfo, err := ic.c.dest.TryReusingBlob(ctx, srcInfo, ic.c.blobInfoCache, ic.canSubstituteBlobs)
 		if err != nil {
 			return types.BlobInfo{}, "", errors.Wrapf(err, "Error trying to reuse blob %s at destination", srcInfo.Digest)
@@ -1253,16 +1266,23 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		originalLayerReader = destStream
 	}
 
-	desiredCompressionFormat := c.compressionFormat
-
 	// === Deal with layer compression/decompression if necessary
 	var inputInfo types.BlobInfo
 	var compressionOperation types.LayerCompression
+	uploadCompressionFormat := &c.compressionFormat
+	srcCompressorName := internalblobinfocache.Uncompressed
+	if isCompressed {
+		srcCompressorName = compressionFormat.Name()
+	}
+	var uploadCompressorName string
 	if canModifyBlob && isOciEncrypted(srcInfo.MediaType) {
 		// PreserveOriginal due to any compression not being able to be done on an encrypted blob unless decrypted
 		logrus.Debugf("Using original blob without modification for encrypted blob")
 		compressionOperation = types.PreserveOriginal
 		inputInfo = srcInfo
+		srcCompressorName = internalblobinfocache.UnknownCompression
+		uploadCompressorName = internalblobinfocache.UnknownCompression
+		uploadCompressionFormat = nil
 	} else if canModifyBlob && c.dest.DesiredLayerCompression() == types.Compress && !isCompressed {
 		logrus.Debugf("Compressing blob on the fly")
 		compressionOperation = types.Compress
@@ -1272,11 +1292,12 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		// If this fails while writing data, it will do pipeWriter.CloseWithError(); if it fails otherwise,
 		// e.g. because we have exited and due to pipeReader.Close() above further writing to the pipe has failed,
 		// we don’t care.
-		go c.compressGoroutine(pipeWriter, destStream, desiredCompressionFormat) // Closes pipeWriter
+		go c.compressGoroutine(pipeWriter, destStream, *uploadCompressionFormat) // Closes pipeWriter
 		destStream = pipeReader
 		inputInfo.Digest = ""
 		inputInfo.Size = -1
-	} else if canModifyBlob && c.dest.DesiredLayerCompression() == types.Compress && isCompressed && desiredCompressionFormat.Name() != compressionFormat.Name() {
+		uploadCompressorName = uploadCompressionFormat.Name()
+	} else if canModifyBlob && c.dest.DesiredLayerCompression() == types.Compress && isCompressed && uploadCompressionFormat.Name() != compressionFormat.Name() {
 		// When the blob is compressed, but the desired format is different, it first needs to be decompressed and finally
 		// re-compressed using the desired format.
 		logrus.Debugf("Blob will be converted")
@@ -1291,11 +1312,12 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		pipeReader, pipeWriter := io.Pipe()
 		defer pipeReader.Close()
 
-		go c.compressGoroutine(pipeWriter, s, desiredCompressionFormat) // Closes pipeWriter
+		go c.compressGoroutine(pipeWriter, s, *uploadCompressionFormat) // Closes pipeWriter
 
 		destStream = pipeReader
 		inputInfo.Digest = ""
 		inputInfo.Size = -1
+		uploadCompressorName = uploadCompressionFormat.Name()
 	} else if canModifyBlob && c.dest.DesiredLayerCompression() == types.Decompress && isCompressed {
 		logrus.Debugf("Blob will be decompressed")
 		compressionOperation = types.Decompress
@@ -1307,11 +1329,15 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		destStream = s
 		inputInfo.Digest = ""
 		inputInfo.Size = -1
+		uploadCompressorName = internalblobinfocache.Uncompressed
+		uploadCompressionFormat = nil
 	} else {
 		// PreserveOriginal might also need to recompress the original blob if the desired compression format is different.
 		logrus.Debugf("Using original blob without modification")
 		compressionOperation = types.PreserveOriginal
 		inputInfo = srcInfo
+		uploadCompressorName = srcCompressorName
+		uploadCompressionFormat = nil
 	}
 
 	// Perform image encryption for valid mediatypes if ociEncryptConfig provided
@@ -1371,9 +1397,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 
 	uploadedInfo.CompressionOperation = compressionOperation
 	// If we can modify the layer's blob, set the desired algorithm for it to be set in the manifest.
-	if canModifyBlob && !isConfig {
-		uploadedInfo.CompressionAlgorithm = &desiredCompressionFormat
-	}
+	uploadedInfo.CompressionAlgorithm = uploadCompressionFormat
 	if decrypted {
 		uploadedInfo.CryptoOperation = types.Decrypt
 	} else if encrypted {
@@ -1390,7 +1414,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		}
 	}
 
-	// This is fairly horrible: the writer from getOriginalLayerCopyWriter wants to consumer
+	// This is fairly horrible: the writer from getOriginalLayerCopyWriter wants to consume
 	// all of the input (to compute DiffIDs), even if dest.PutBlob does not need it.
 	// So, read everything from originalLayerReader, which will cause the rest to be
 	// sent there if we are not already at EOF.
@@ -1422,6 +1446,12 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 			c.blobInfoCache.RecordDigestUncompressedPair(srcInfo.Digest, uploadedInfo.Digest)
 		default:
 			return types.BlobInfo{}, errors.Errorf("Internal error: Unexpected compressionOperation value %#v", compressionOperation)
+		}
+		if uploadCompressorName != "" && uploadCompressorName != internalblobinfocache.UnknownCompression {
+			c.blobInfoCache.RecordDigestCompressorName(uploadedInfo.Digest, uploadCompressorName)
+		}
+		if srcInfo.Digest != "" && srcCompressorName != "" && srcCompressorName != internalblobinfocache.UnknownCompression {
+			c.blobInfoCache.RecordDigestCompressorName(srcInfo.Digest, srcCompressorName)
 		}
 	}
 	return uploadedInfo, nil

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -194,7 +194,9 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
@@ -210,7 +212,6 @@ func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.Blo
 		return false, types.BlobInfo{}, err
 	}
 	return true, types.BlobInfo{Digest: info.Digest, Size: finfo.Size()}, nil
-
 }
 
 // PutManifest writes manifest to the destination.

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -159,7 +159,9 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -86,7 +86,9 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -154,6 +154,9 @@ func (m *manifestSchema2) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUp
 
 // UpdatedImage returns a types.Image modified according to options.
 // This does not change the state of the original Image object.
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError
+// if the CompressionOperation and CompressionAlgorithm specified in one or more
+// options.LayerInfos items is anything other than gzip.
 func (m *manifestSchema2) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
 	copy := manifestSchema2{ // NOTE: This is not a deep copy, it still shares slices etc.
 		src:        m.src,

--- a/image/oci.go
+++ b/image/oci.go
@@ -134,6 +134,10 @@ func (m *manifestOCI1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdat
 
 // UpdatedImage returns a types.Image modified according to options.
 // This does not change the state of the original Image object.
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError
+// if the combination of CompressionOperation and CompressionAlgorithm specified
+// in one or more options.LayerInfos items indicates that a layer is compressed using
+// an algorithm that is not allowed in OCI.
 func (m *manifestOCI1) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
 	copy := manifestOCI1{ // NOTE: This is not a deep copy, it still shares slices etc.
 		src:        m.src,

--- a/internal/blobinfocache/blobinfocache.go
+++ b/internal/blobinfocache/blobinfocache.go
@@ -1,0 +1,63 @@
+package blobinfocache
+
+import (
+	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// FromBlobInfoCache returns a BlobInfoCache2 based on a BlobInfoCache, returning the original
+// object if it implements BlobInfoCache2, or a wrapper which discards compression information
+// if it only implements BlobInfoCache.
+func FromBlobInfoCache(bic types.BlobInfoCache) BlobInfoCache2 {
+	if bic2, ok := bic.(BlobInfoCache2); ok {
+		return bic2
+	}
+	return &v1OnlyBlobInfoCache{
+		BlobInfoCache: bic,
+	}
+}
+
+type v1OnlyBlobInfoCache struct {
+	types.BlobInfoCache
+}
+
+func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+}
+
+func (bic *v1OnlyBlobInfoCache) CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []BICReplacementCandidate2 {
+	return nil
+}
+
+// CandidateLocationsFromV2 converts a slice of BICReplacementCandidate2 to a slice of
+// types.BICReplacementCandidate, dropping compression information.
+func CandidateLocationsFromV2(v2candidates []BICReplacementCandidate2) []types.BICReplacementCandidate {
+	candidates := make([]types.BICReplacementCandidate, 0, len(v2candidates))
+	for _, c := range v2candidates {
+		candidates = append(candidates, types.BICReplacementCandidate{
+			Digest:   c.Digest,
+			Location: c.Location,
+		})
+	}
+	return candidates
+}
+
+// OperationAndAlgorithmForCompressor returns CompressionOperation and CompressionAlgorithm
+// values suitable for inclusion in a types.BlobInfo structure, based on the name of the
+// compression algorithm, or Uncompressed, or UnknownCompression.  This is typically used by
+// TryReusingBlob() implementations to set values in the BlobInfo structure that they return
+// upon success.
+func OperationAndAlgorithmForCompressor(compressorName string) (types.LayerCompression, *compression.Algorithm, error) {
+	switch compressorName {
+	case Uncompressed:
+		return types.Decompress, nil, nil
+	case UnknownCompression:
+		return types.PreserveOriginal, nil, nil
+	default:
+		algo, err := compression.AlgorithmByName(compressorName)
+		if err == nil {
+			return types.Compress, &algo, nil
+		}
+		return types.PreserveOriginal, nil, err
+	}
+}

--- a/internal/blobinfocache/types.go
+++ b/internal/blobinfocache/types.go
@@ -1,0 +1,45 @@
+package blobinfocache
+
+import (
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+const (
+	// Uncompressed is the value we store in a blob info cache to indicate that we know that
+	// the blob in the corresponding location is not compressed.
+	Uncompressed = "uncompressed"
+	// UnknownCompression is the value we store in a blob info cache to indicate that we don't
+	// know if the blob in the corresponding location is compressed (and if so, how) or not.
+	UnknownCompression = "unknown"
+)
+
+// BlobInfoCache2 extends BlobInfoCache by adding the ability to track information about what kind
+// of compression was applied to the blobs it keeps information about.
+type BlobInfoCache2 interface {
+	types.BlobInfoCache
+	// RecordDigestCompressorName records a compressor for the blob with the specified digest,
+	// or Uncompressed or UnknownCompression.
+	// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
+	// digest just because some remote author claims so (e.g. because a manifest says so);
+	// otherwise the cache could be poisoned and cause us to make incorrect edits to type
+	// information in a manifest.
+	RecordDigestCompressorName(anyDigest digest.Digest, compressorName string)
+	// CandidateLocations2 returns a prioritized, limited, number of blobs and their locations
+	// that could possibly be reused within the specified (transport scope) (if they still
+	// exist, which is not guaranteed).
+	//
+	// If !canSubstitute, the returned cadidates will match the submitted digest exactly; if
+	// canSubstitute, data from previous RecordDigestUncompressedPair calls is used to also look
+	// up variants of the blob which have the same uncompressed digest.
+	//
+	// The CompressorName fields in returned data must never be UnknownCompression.
+	CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, canSubstitute bool) []BICReplacementCandidate2
+}
+
+// BICReplacementCandidate2 is an item returned by BlobInfoCache2.CandidateLocations2.
+type BICReplacementCandidate2 struct {
+	Digest         digest.Digest
+	CompressorName string // either the Name() of a known pkg/compression.Algorithm, or Uncompressed or UnknownCompression
+	Location       types.BICLocationReference
+}

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -226,6 +226,8 @@ var schema2CompressionMIMETypeSets = []compressionMIMETypeSet{
 }
 
 // UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls), in order (the root layer first, and then successive layered layers)
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError if any of the layerInfos includes a combination of CompressionOperation and
+// CompressionAlgorithm that would result in anything other than gzip compression.
 func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.LayersDescriptors) != len(layerInfos) {
 		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.LayersDescriptors), len(layerInfos))

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -108,6 +108,8 @@ var oci1CompressionMIMETypeSets = []compressionMIMETypeSet{
 }
 
 // UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls+mediatype), in order (the root layer first, and then successive layered layers)
+// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError if any of the layerInfos includes a combination of CompressionOperation and
+// CompressionAlgorithm that isn't supported by OCI.
 func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.Layers) != len(layerInfos) {
 		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.Layers), len(layerInfos))

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -103,7 +103,9 @@ func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Read
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -186,7 +186,9 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
@@ -204,6 +206,7 @@ func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.Blo
 	if err != nil {
 		return false, types.BlobInfo{}, err
 	}
+
 	return true, types.BlobInfo{Digest: info.Digest, Size: finfo.Size()}, nil
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -410,7 +410,9 @@ func (d *openshiftImageDestination) PutBlob(ctx context.Context, stream io.Reade
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *openshiftImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -339,7 +339,9 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -315,6 +315,6 @@ func TestReferenceSignaturePath(t *testing.T) {
 		{0, "-1"},
 		{42, "-43"},
 	} {
-		assert.Equal(t, fmt.Sprintf("manifest%csignature%s", filepath.Separator, c.suffix), ostreeRef.signaturePath(c.input), string(c.input))
+		assert.Equal(t, fmt.Sprintf("manifest%csignature%s", filepath.Separator, c.suffix), ostreeRef.signaturePath(c.input), fmt.Sprintf("%d", c.input))
 	}
 }

--- a/pkg/blobinfocache/boltdb/boltdb_test.go
+++ b/pkg/blobinfocache/boltdb/boltdb_test.go
@@ -6,19 +6,21 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/pkg/blobinfocache/internal/test"
-	"github.com/containers/image/v5/types"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCache(t *testing.T) (types.BlobInfoCache, func(t *testing.T)) {
+var _ blobinfocache.BlobInfoCache2 = &cache{}
+
+func newTestCache(t *testing.T) (blobinfocache.BlobInfoCache2, func(t *testing.T)) {
 	// We need a separate temporary directory here, because bolt.Open(…, &bolt.Options{Readonly:true}) can't deal with
 	// an existing but empty file, and incorrectly fails without releasing the lock - which in turn causes
 	// any future writes to hang.  Creating a temporary directory allows us to use a path to a
 	// non-existent file, thus replicating the expected conditions for creating a new DB.
 	dir, err := ioutil.TempDir("", "boltdb")
 	require.NoError(t, err)
-	return New(filepath.Join(dir, "db")), func(t *testing.T) {
+	return new2(filepath.Join(dir, "db")), func(t *testing.T) {
 		err = os.RemoveAll(dir)
 		require.NoError(t, err)
 	}

--- a/pkg/blobinfocache/internal/prioritize/prioritize.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/containers/image/v5/types"
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -17,8 +17,8 @@ const replacementAttempts = 5
 
 // CandidateWithTime is the input to types.BICReplacementCandidate prioritization.
 type CandidateWithTime struct {
-	Candidate types.BICReplacementCandidate // The replacement candidate
-	LastSeen  time.Time                     // Time the candidate was last known to exist (either read or written)
+	Candidate blobinfocache.BICReplacementCandidate2 // The replacement candidate
+	LastSeen  time.Time                              // Time the candidate was last known to exist (either read or written)
 }
 
 // candidateSortState is a local state implementing sort.Interface on candidates to prioritize,
@@ -79,7 +79,7 @@ func (css *candidateSortState) Swap(i, j int) {
 
 // destructivelyPrioritizeReplacementCandidatesWithMax is destructivelyPrioritizeReplacementCandidates with a parameter for the
 // number of entries to limit, only to make testing simpler.
-func destructivelyPrioritizeReplacementCandidatesWithMax(cs []CandidateWithTime, primaryDigest, uncompressedDigest digest.Digest, maxCandidates int) []types.BICReplacementCandidate {
+func destructivelyPrioritizeReplacementCandidatesWithMax(cs []CandidateWithTime, primaryDigest, uncompressedDigest digest.Digest, maxCandidates int) []blobinfocache.BICReplacementCandidate2 {
 	// We don't need to use sort.Stable() because nanosecond timestamps are (presumably?) unique, so no two elements should
 	// compare equal.
 	sort.Sort(&candidateSortState{
@@ -92,7 +92,7 @@ func destructivelyPrioritizeReplacementCandidatesWithMax(cs []CandidateWithTime,
 	if resLength > maxCandidates {
 		resLength = maxCandidates
 	}
-	res := make([]types.BICReplacementCandidate, resLength)
+	res := make([]blobinfocache.BICReplacementCandidate2, resLength)
 	for i := range res {
 		res[i] = cs[i].Candidate
 	}
@@ -105,6 +105,6 @@ func destructivelyPrioritizeReplacementCandidatesWithMax(cs []CandidateWithTime,
 //
 // WARNING: The array of candidates is destructively modified. (The implementation of this function could of course
 // make a copy, but all CandidateLocations implementations build the slice of candidates only for the single purpose of calling this function anyway.)
-func DestructivelyPrioritizeReplacementCandidates(cs []CandidateWithTime, primaryDigest, uncompressedDigest digest.Digest) []types.BICReplacementCandidate {
+func DestructivelyPrioritizeReplacementCandidates(cs []CandidateWithTime, primaryDigest, uncompressedDigest digest.Digest) []blobinfocache.BICReplacementCandidate2 {
 	return destructivelyPrioritizeReplacementCandidatesWithMax(cs, primaryDigest, uncompressedDigest, replacementAttempts)
 }

--- a/pkg/blobinfocache/memory/memory_test.go
+++ b/pkg/blobinfocache/memory/memory_test.go
@@ -3,12 +3,14 @@ package memory
 import (
 	"testing"
 
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/pkg/blobinfocache/internal/test"
-	"github.com/containers/image/v5/types"
 )
 
-func newTestCache(t *testing.T) (types.BlobInfoCache, func(t *testing.T)) {
-	return New(), func(t *testing.T) {}
+var _ blobinfocache.BlobInfoCache2 = &cache{}
+
+func newTestCache(t *testing.T) (blobinfocache.BlobInfoCache2, func(t *testing.T)) {
+	return new2(), func(t *testing.T) {}
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/blobinfocache/none/none.go
+++ b/pkg/blobinfocache/none/none.go
@@ -2,6 +2,7 @@
 package none
 
 import (
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 )
@@ -16,7 +17,7 @@ type noCache struct {
 // Manifest.Inspect, because configs only have one representation.
 // Any use of BlobInfoCache with blobs should usually use at least a
 // short-lived cache, ideally blobinfocache.DefaultCache.
-var NoCache types.BlobInfoCache = noCache{}
+var NoCache blobinfocache.BlobInfoCache2 = blobinfocache.FromBlobInfoCache(&noCache{})
 
 // UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
 // May return anyDigest if it is known to be uncompressed.

--- a/pkg/blobinfocache/none/none_test.go
+++ b/pkg/blobinfocache/none/none_test.go
@@ -1,0 +1,7 @@
+package none
+
+import (
+	"github.com/containers/image/v5/types"
+)
+
+var _ types.BlobInfoCache = &noCache{}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -463,7 +463,9 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
 // If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -126,14 +126,18 @@ type BlobInfo struct {
 	Annotations map[string]string
 	MediaType   string
 	// CompressionOperation is used in Image.UpdateLayerInfos to instruct
-	// whether the original layer should be preserved or (de)compressed. The
-	// field defaults to preserve the original layer.
+	// whether the original layer's "compressed or not" should be preserved,
+	// possibly while changing the compression algorithm from one to another,
+	// or if it should be compressed or decompressed.  The field defaults to
+	// preserve the original layer's compressedness.
 	// TODO: To remove together with CryptoOperation in re-design to remove
 	// field out out of BlobInfo.
 	CompressionOperation LayerCompression
 	// CompressionAlgorithm is used in Image.UpdateLayerInfos to set the correct
 	// MIME type for compressed layers (e.g., gzip or zstd). This field MUST be
-	// set when `CompressionOperation == Compress`.
+	// set when `CompressionOperation == Compress` and MAY be set when
+	// `CompressionOperation == PreserveOriginal` and the compression type is
+	// being changed for an already-compressed layer.
 	CompressionAlgorithm *compression.Algorithm
 	// CryptoOperation is used in Image.UpdateLayerInfos to instruct
 	// whether the original layer was encrypted/decrypted
@@ -194,6 +198,9 @@ type BICReplacementCandidate struct {
 //
 // None of the methods return an error indication: errors when neither reading from, nor writing to, the cache, should be fatal;
 // users of the cache should just fall back to copying the blobs the usual way.
+//
+// The BlobInfoCache interface is deprecated.  Consumers of this library should use one of the implementations provided by
+// subpackages of the library's "pkg/blobinfocache" package in preference to implementing the interface on their own.
 type BlobInfoCache interface {
 	// UncompressedDigest returns an uncompressed digest corresponding to anyDigest.
 	// May return anyDigest if it is known to be uncompressed.
@@ -306,7 +313,9 @@ type ImageDestination interface {
 	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 	// info.Digest must not be empty.
 	// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-	// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size.
+	// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+	// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+	// reflected in the manifest that will be written.
 	// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 	// May use and/or update cache.
 	TryReusingBlob(ctx context.Context, info BlobInfo, cache BlobInfoCache, canSubstitute bool) (bool, BlobInfo, error)
@@ -397,6 +406,12 @@ type Image interface {
 	// UpdatedImage returns a types.Image modified according to options.
 	// Everything in options.InformationOnly should be provided, other fields should be set only if a modification is desired.
 	// This does not change the state of the original Image object.
+	// The returned error will be a manifest.ManifestLayerCompressionIncompatibilityError if
+	// manifests of type options.ManifestMIMEType can not include layers that are compressed
+	// in accordance with the CompressionOperation and CompressionAlgorithm specified in one
+	// or more options.LayerInfos items, though retrying with a different
+	// options.ManifestMIMEType or with different CompressionOperation+CompressionAlgorithm
+	// values might succeed.
 	UpdatedImage(ctx context.Context, options ManifestUpdateOptions) (Image, error)
 	// SupportsEncryption returns an indicator that the image supports encryption
 	//


### PR DESCRIPTION
Extend the blob info cache to also cache the name of the type of compression used on a blob in a known location.  (An earlier version of this patch cached the full MIME type, but required additional logic to map the MIME types in cases where we converted images during copying, so the patch was larger.)

Pass an updated MIME type and information about compression changes to PutBlob() in its input BlobInfo, so that it can populate the blob info cache with correct compression information when it succeeds.  Some of the local tables we kept in `manifest/common.go` were moved to an internal package (`internal/mediatypes`) so that they could be reused there.

Make sure that when `dockerImageDestination.TryReusingBlob()` successfully uses a blob from the blob info cache, that it provides updated MIME type and compression information in the `BlobInfo` that it returns, so that converted manifests can use them to correctly update their `LayerInfo` fields.

This should fix #733.