### PR TITLE
Tidy up TestParseShortNameMode

### DIFF
--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -589,7 +589,7 @@ func TestParseShortNameMode(t *testing.T) {
 		{"disabled", types.ShortNameModeDisabled, false},
 		{"enforcing", types.ShortNameModeEnforcing, false},
 		{"permissive", types.ShortNameModePermissive, false},
-		{"", types.ShortNameModePermissive, true},
+		{"", -1, true},
 		{"xxx", -1, true},
 	}
 


### PR DESCRIPTION
Now that empty strings are rejected, don't include a valid value in the result.  This does not actualy change what is being tested, just makes it a tiny bit more readable.