### PR TITLE
fix tarball example code

### DIFF
--- a/tarball/doc.go
+++ b/tarball/doc.go
@@ -5,11 +5,13 @@
 //	package main
 //
 //	import (
-//		"fmt"
+//		"context"
 //
 //		cp "github.com/containers/image/v5/copy"
+//		"github.com/containers/image/v5/signature"
 //		"github.com/containers/image/v5/tarball"
 //		"github.com/containers/image/v5/transports/alltransports"
+//		"github.com/containers/image/v5/types"
 //		imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 //	)
 //
@@ -39,7 +41,18 @@
 //		if err != nil {
 //			panic(err)
 //		}
-//		err = cp.Image(nil, dest, src, nil)
+//
+//		policy, err := signature.DefaultPolicy(nil)
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		pc, err := signature.NewPolicyContext(policy)
+//		if err != nil {
+//			panic(err)
+//		}
+//		defer pc.Destroy()
+//		_, err = cp.Image(context.TODO(), pc, dest, src, nil)
 //		if err != nil {
 //			panic(err)
 //		}


### PR DESCRIPTION
Looks like the `copy.Image` interface has changed, small update to example documentation for new interface.