### PR TITLE
Add logMirrorChoice to ctx for log

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -64,6 +64,11 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	attempts := []attempt{}
 	for _, pullSource := range pullSources {
+		if sys.DockerLogMirrorChoice {
+			logrus.Infof("Trying to access %q", pullSource.Reference)
+		} else {
+			logrus.Debugf("Trying to access %q", pullSource.Reference)
+		}
 		logrus.Debugf("Trying to access %q", pullSource.Reference)
 		s, err := newImageSourceAttempt(ctx, sys, ref, pullSource)
 		if err == nil {

--- a/types/types.go
+++ b/types/types.go
@@ -600,6 +600,8 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
 	DockerDisableDestSchema1MIMETypes bool
+	// If true, the physical pull source of docker transport images logged as info level
+	DockerLogMirrorChoice bool
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1881694
This BZ needs change the log level of the image pull location from the debug to info.
Add DockerLogMirrorChoice to types.SystemContext for keeping log level of the physical pull source of images.
Crio could set it to log the image source if it's from a mirror.

Signed-off-by: Qi Wang <qiwan@redhat.com>