### PR TITLE
Cleanup description of shortname expansion

### DIFF
--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -149,9 +149,9 @@ const (
 func (r *Resolved) Description() string {
 	switch r.rationale {
 	case rationaleAlias:
-		return fmt.Sprintf("Resolved short name %q to a recorded short-name alias (origin: %s)", r.userInput, r.originDescription)
+		return fmt.Sprintf("Resolved %q as an alias (%s)", r.userInput, r.originDescription)
 	case rationaleUSR:
-		return fmt.Sprintf("Completed short name %q with unqualified-search registries (origin: %s)", r.userInput, r.originDescription)
+		return fmt.Sprintf("Resolving %q using unqualified-search registries (%s)", r.userInput, r.originDescription)
 	case rationaleUserSelection, rationaleNone:
 		fallthrough
 	default:


### PR DESCRIPTION
When short name expansion is happening in Podman and Buildah there
are two many useless words being repeated on the screen. Also the
actual expansion is never shown. This PR shortens the text to only
the key descriptions and displays the actual long name.

podman pull ubi8
Resolved "ubi8" (/etc/containers/registries.conf.d/shortnames.conf)
...

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>