### PR TITLE
Update `golangci-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ tools: .install.gitvalidation .install.golangci-lint .install.golint
 
 .install.golangci-lint:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.21.0; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.35.2; \
 	fi
 
 .install.golint:

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,7 @@ github.com/klauspost/compress v1.11.5 h1:xNCE0uE6yvTPRS+0wGNMHPo3NIpwnk6aluQZ6R6
 github.com/klauspost/compress v1.11.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.6 h1:EgWPCW6O3n1D5n99Zq3xXBt9uCwRGvpwGOusOLNBRSQ=
 github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.3 h1:Ce2to9wvs/cuJ2b86/CKQoTYr9VHfpanYosZ0UBJqdw=
 github.com/klauspost/pgzip v1.2.3/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
@@ -353,6 +354,7 @@ github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgh
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -240,15 +240,14 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 
 	// Create a copy of the system context to make it usable beyond this
 	// function call.
-	var sys *types.SystemContext
 	if ctx != nil {
 		copy := *ctx
-		sys = &copy
+		ctx = &copy
 	}
 	resolved.systemContext = ctx
 
 	// Detect which mode we're running in.
-	mode, err := sysregistriesv2.GetShortNameMode(sys)
+	mode, err := sysregistriesv2.GetShortNameMode(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +276,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	resolved.userInput = shortNameRepo
 
 	// If there's already an alias, use it.
-	namedAlias, aliasOriginDescription, err := sysregistriesv2.ResolveShortNameAlias(sys, shortNameRepo.String())
+	namedAlias, aliasOriginDescription, err := sysregistriesv2.ResolveShortNameAlias(ctx, shortNameRepo.String())
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +307,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	resolved.rationale = rationaleUSR
 
 	// Query the registry for unqualified-search registries.
-	unqualifiedSearchRegistries, usrConfig, err := sysregistriesv2.UnqualifiedSearchRegistriesWithOrigin(sys)
+	unqualifiedSearchRegistries, usrConfig, err := sysregistriesv2.UnqualifiedSearchRegistriesWithOrigin(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -242,7 +242,8 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	// function call.
 	var sys *types.SystemContext
 	if ctx != nil {
-		sys = &(*ctx)
+		copy := *ctx
+		sys = &copy
 	}
 	resolved.systemContext = ctx
 


### PR DESCRIPTION
… because it fails with recent Go versions.

(But first fix some problems the new version can find.)