### PR TITLE
Allow callers to set the MaxParallelDownloads field

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -252,7 +252,7 @@ func pathExists(path string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if err != nil && os.IsNotExist(err) {
+	if os.IsNotExist(err) {
 		return false, nil
 	}
 	return false, err

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -200,9 +200,7 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 			logrus.Debugf("error accessing certs directory due to permissions: %v", err)
 			continue
 		}
-		if err != nil {
-			return "", err
-		}
+		return "", err
 	}
 	return fullCertDirPath, nil
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -121,9 +121,6 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseStoreReference(%q) returned error %v", "test", err)
 	}
-	if ref == nil {
-		t.Fatalf("ParseStoreReference(%q) returned nil reference", "test")
-	}
 
 	strRef := ref.StringWithinTransport()
 	ref, err = Transport.ParseReference(strRef)


### PR DESCRIPTION
Users should be able to set the number of ParallelDownloads so that
they can customize how container/tools perform based on the
characteristics of their network.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>