### PR TITLE
Fix 'systemDefaultPolicyPath' linker flag comment

### DIFF
--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -21,7 +21,7 @@ import (
 
 // systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.
 // You can override this at build time with
-// -ldflags '-X github.com/containers/image/docker.systemRegistriesDirPath=$your_path'
+// -ldflags '-X github.com/containers/image/v5/docker.systemRegistriesDirPath=$your_path'
 var systemRegistriesDirPath = builtinRegistriesDirPath
 
 // builtinRegistriesDirPath is the path to registries.d.

--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -9,7 +9,7 @@ import (
 
 // unixTempDirForBigFiles is the directory path to store big files on non Windows systems.
 // You can override this at build time with
-// -ldflags '-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=$your_path'
+// -ldflags '-X github.com/containers/image/v5/internal/tmpdir.unixTempDirForBigFiles=$your_path'
 var unixTempDirForBigFiles = builtinUnixTempDirForBigFiles
 
 // builtinUnixTempDirForBigFiles is the directory path to store big files.

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -20,7 +20,7 @@ import (
 // systemRegistriesConfPath is the path to the system-wide registry
 // configuration file and is used to add/subtract potential registries for
 // obtaining images.  You can override this at build time with
-// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfPath=$your_path'
+// -ldflags '-X github.com/containers/image/v5/sysregistries.systemRegistriesConfPath=$your_path'
 var systemRegistriesConfPath = builtinRegistriesConfPath
 
 // builtinRegistriesConfPath is the path to the registry configuration file.
@@ -30,7 +30,7 @@ const builtinRegistriesConfPath = "/etc/containers/registries.conf"
 // systemRegistriesConfDirPath is the path to the system-wide registry
 // configuration directory and is used to add/subtract potential registries for
 // obtaining images.  You can override this at build time with
-// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfDirecotyPath=$your_path'
+// -ldflags '-X github.com/containers/image/v5/sysregistries.systemRegistriesConfDirecotyPath=$your_path'
 var systemRegistriesConfDirPath = builtinRegistriesConfDirPath
 
 // builtinRegistriesConfDirPath is the path to the registry configuration directory.

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -30,7 +30,7 @@ import (
 
 // systemDefaultPolicyPath is the policy path used for DefaultPolicy().
 // You can override this at build time with
-// -ldflags '-X github.com/containers/image/signature.systemDefaultPolicyPath=$your_path'
+// -ldflags '-X github.com/containers/image/v5/signature.systemDefaultPolicyPath=$your_path'
 var systemDefaultPolicyPath = builtinDefaultPolicyPath
 
 // builtinDefaultPolicyPath is the policy path used for DefaultPolicy().


### PR DESCRIPTION
Tweak the path in the comment, to avoid the next reader hitting the same copy&paste error (but in general, it seems annoying that this comment will go out of date next module version)