### PR TITLE
V5.10.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 10
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 9
+	VersionMinor = 10
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION

- tarball: fix example code
- Bump github.com/ulikunitz/xz from 0.5.8 to 0.5.9
- Bump github.com/opencontainers/selinux from 1.6.0 to 1.8.0
- Bump github.com/vbauerster/mpb/v5 from 5.3.0 to 5.4.0
- Add DockerLogMirrirChoice to ctx for log
- Rename variables in pkg/docker/config tests
- Fix pkg/docker/config tests on non-Linux systems
- Add macOS test cases to GetPathToAuth
- Fix docker tests with recent c/storage
- Fix signature tests with recent c/storage
- Fix sysregistriesv2 tests with recent c/storage
- Fix pkg/docker/config tests with recent c/storage
- Bump github.com/containers/storage from 1.23.7 to 1.24.5
- Bump github.com/klauspost/compress from 1.11.3 to 1.11.6
- Enable subdomain matching in policy.json
- Bump github.com/stretchr/testify from 1.6.1 to 1.7.0
- Bump github.com/klauspost/compress from 1.11.6 to 1.11.7
- ostree.TestReferenceSignaturePath: fix a compiler warning in a test
- manifest: add a test for UpdatedMIMEType
- blobinfocache: track compression types for locations
- Actually make a copy of ctx as the comment claims
- Actually use the SystemContext copy in the one place that matters
- Update golangci-lint
- Clarify the canModifyBlob condition in copyBlobFromStream
- Cleanup description of shortname expansion
- Allow callers to set the MaxParallelDownloads field
- Fix up errors linter is complaining about
- Set a default User-Agent if unset
