### PR TITLE
Copy cleanups

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -702,6 +702,9 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 			return nil, "", "", fmt.Errorf("Uploading manifest failed, attempted the following formats: %s", strings.Join(errs, ", "))
 		}
 	}
+	if targetInstance != nil {
+		targetInstance = &retManifestDigest
+	}
 
 	if options.SignBy != "" {
 		newSig, err := c.createSignature(manifestBytes, options.SignBy)


### PR DESCRIPTION
Primarily fixes writing of signatures if a manifest of a multi-arch image is updated.

Also cleans up the documentation of the blob copy pipeline to be a bit more consistent.