### PR TITLE
copy: compute blob compression on reused blobs based on source MediaType

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1353,7 +1353,15 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		compressionOperation = types.PreserveOriginal
 		inputInfo = srcInfo
 		uploadCompressorName = srcCompressorName
-		uploadCompressionFormat = nil
+		// Remember if the original blob was compressed, and if so how, so that if
+		// LayerInfosForCopy() returned something that differs from what was in the
+		// source's manifest, and UpdatedImage() needs to call UpdateLayerInfos(),
+		// it will be able to correctly derive the MediaType for the copied blob.
+		if isCompressed {
+			uploadCompressionFormat = &compressionFormat
+		} else {
+			uploadCompressionFormat = nil
+		}
 	}
 
 	// === Encrypt the stream for valid mediatypes if ociEncryptConfig provided

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1069,6 +1069,26 @@ type diffIDResult struct {
 // copyLayer copies a layer with srcInfo (with known Digest and Annotations and possibly known Size) in src to dest, perhaps (de/re/)compressing it,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, toEncrypt bool, pool *mpb.Progress) (types.BlobInfo, digest.Digest, error) {
+	// If the srcInfo doesn't contain compression information, try to compute it from the
+	// MediaType, which was either read from a manifest by way of LayerInfos() or constructed
+	// by LayerInfosForCopy(), if it was supplied at all.  If we succeed in copying the blob,
+	// the BlobInfo we return will be passed to UpdatedImage() and then to UpdateLayerInfos(),
+	// which uses the compression information to compute the updated MediaType values.
+	// (Sadly UpdatedImage() is documented to not update MediaTypes from
+	//  ManifestUpdateOptions.LayerInfos[].MediaType, so we are doing it indirectly.)
+	//
+	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
+	// package (but we should preferably replace/change UpdatedImage instead of productizing
+	// this workaround).
+	if srcInfo.CompressionAlgorithm == nil {
+		switch srcInfo.MediaType {
+		case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
+			srcInfo.CompressionAlgorithm = &compression.Gzip
+		case imgspecv1.MediaTypeImageLayerZstd:
+			srcInfo.CompressionAlgorithm = &compression.Zstd
+		}
+	}
+
 	cachedDiffID := ic.c.blobInfoCache.UncompressedDigest(srcInfo.Digest) // May be ""
 	// Diffs are needed if we are encrypting an image or trying to decrypt an image
 	diffIDIsNeeded := ic.diffIDsAreNeeded && cachedDiffID == "" || toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.ociDecryptConfig != nil)
@@ -1096,6 +1116,19 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 					Event:    types.ProgressEventSkipped,
 					Artifact: srcInfo,
 				}
+			}
+
+			// If the reused blob has the same digest as the one we asked for, but
+			// the transport didn't/couldn't supply compression info, fill it in based
+			// on what we know from the srcInfos we were given.
+			// If the srcInfos came from LayerInfosForCopy(), then UpdatedImage() will
+			// call UpdateLayerInfos(), which uses this information to compute the
+			// MediaType value for the updated layer infos, and it the transport
+			// didn't pass the information along from its input to its output, then
+			// it can derive the MediaType incorrectly.
+			if blobInfo.Digest == srcInfo.Digest && blobInfo.CompressionAlgorithm == nil {
+				blobInfo.CompressionOperation = srcInfo.CompressionOperation
+				blobInfo.CompressionAlgorithm = srcInfo.CompressionAlgorithm
 			}
 			return blobInfo, cachedDiffID, nil
 		}


### PR DESCRIPTION
Teach `BlobInfoCache2` implementations to be able to retrieve the type of compression that was applied to a blob with a given digest, if we know it.

If we successfully reuse a blob while writing an image, and we know how a blob with that reused blob's digest was compressed, use that information when updating the MIME type for the reused blob.

This covers situations where `TryReusingBlob()` returns a `BlobInfo` containing a different digest and MIME type than the one we originally asked it to reuse.  `copy.imageCopier.copyLayers()` sets it up as part of the `LayerInfos` in update info that `copy.imageCopier.copyUpdatedConfigAndManifest()` passes to `src.UpdatedImage()`, and the `UpdateLayerInfos()` implementations discard the MIME type from the new `BlobInfo` in favor of the MIME type in the original layers list.

The buildah blob cache triggers this case when we use it while pushing an image where the local copy of the manifest specifies an uncompressed digest and MIME type, and the blob cache tries to substitute the digest of the compressed version in `LayerInfosForCopy()`, since it knows it can retrieve the compressed version from its cache.  The blob cache doesn't get used very often, so we've only recently started noticing it since we started testing #1089 in https://github.com/openshift/origin/pull/25830.