### PR TITLE
bump to v5.11.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,9 +6,9 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 10
+	VersionMinor = 11
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
Since we created a `release-5.10` branch, let's move the main branch
over to v5.11.0-dev to prevent any ambiguity or reduce potential
confusion.

Anything we want in 5.10.X must from now on be backported to the branch.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @lsm5 @giuseppe PTAL