### PR TITLE
shortnames: resolution error: point to manpage if config is absent

### DIFF
--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -313,7 +313,10 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	}
 	// Error out if there's no matching alias and no search registries.
 	if len(unqualifiedSearchRegistries) == 0 {
-		return nil, errors.Errorf("short-name %q did not resolve to an alias and no unqualified-search registries are defined in %q", name, usrConfig)
+		if usrConfig != "" {
+			return nil, errors.Errorf("short-name %q did not resolve to an alias and no unqualified-search registries are defined in %q", name, usrConfig)
+		}
+		return nil, errors.Errorf("short-name %q did not resolve to an alias and no containers-registries.conf(5) was found", name)
 	}
 	resolved.originDescription = usrConfig
 


### PR DESCRIPTION
When a short name could not be resolved via `shortnames.Resolve(...)`
the error message attempts to help the users solve the issue by pointing
to short-name aliases and the registries.conf.

Until now, the error implied the existence of a registries.conf which
may not always be the case.  Hence, check whether a registries.conf
was used during short-name resolution and point to the manpage if none
was present.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @giuseppe  @lsm5 @umohnani8 PTAL