### PR TITLE
README: godoc: point to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/containers/image?status.svg)](https://godoc.org/github.com/containers/image) [![Build Status](https://travis-ci.org/containers/image.svg?branch=master)](https://travis-ci.org/containers/image)
+[![GoDoc](https://godoc.org/github.com/containers/image?status.svg)](https://godoc.org/github.com/containers/image/v5) [![Build Status](https://travis-ci.org/containers/image.svg?branch=master)](https://travis-ci.org/containers/image)
 =
 
 `image` is a set of Go libraries aimed at working in various way with


### PR DESCRIPTION
Update the godoc link to point to v5.

Fixes: #1154
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>