### PR TITLE
storageImageSource.LayerInfosForCopy(): return uncompressed MediaTypes

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -275,8 +275,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 	case imgspecv1.MediaTypeImageManifest:
 		uncompressedLayerType = imgspecv1.MediaTypeImageLayer
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema2MediaType:
-		// This is actually a compressed type, but there's no uncompressed type defined
-		uncompressedLayerType = manifest.DockerV2Schema2LayerMediaType
+		uncompressedLayerType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
 	}
 
 	physicalBlobInfos := []types.BlobInfo{}


### PR DESCRIPTION
Since #1138, we've been paying attention to the MediaType values returned by LayerInfosForCopy(), so lying about layer data being compressed when the data we provide isn't would cause uncompressed layers to be mistakenly marked as compressed when we copied the image without attempting to add or modify the compression of layers.