### PR TITLE
Implement credsStore in credential config files

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -60,7 +60,7 @@ var (
 // Returns a human-redable description of the location that was updated.
 // NOTE: The return value is only intended to be read by humans; its form is not an API,
 // it may change (or new forms can be added) any time.
-func SetCredentials(sys *types.SystemContext,  key, username, password string) (string, error) {
+func SetCredentials(sys *types.SystemContext, key, username, password string) (string, error) {
 	isNamespaced, err := validateKey(key)
 	if err != nil {
 		return "", err

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -161,10 +161,13 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 					addRegistry(registry)
 				}
 				if auths.CredsStore != "" {
-					if creds, err := listAuthsFromCredHelper(auths.CredsStore); err == nil {
+					creds, err := listAuthsFromCredHelper(auths.CredsStore)
+					if err == nil {
 						for registry := range creds {
 							addRegistry(registry)
 						}
+					} else {
+						return nil, err
 					}
 				}
 			}
@@ -467,10 +470,16 @@ func RemoveAllAuthentication(sys *types.SystemContext) error {
 				auths.CredHelpers = make(map[string]string)
 				auths.AuthConfigs = make(map[string]dockerAuthConfig)
 				if auths.CredsStore != "" {
-					if creds, err := listAuthsFromCredHelper(auths.CredsStore); err == nil {
+					creds, err := listAuthsFromCredHelper(auths.CredsStore)
+					if err == nil {
 						for registry := range creds {
-							_ = deleteAuthFromCredHelper(auths.CredsStore, registry)
+							err = deleteAuthFromCredHelper(auths.CredsStore, registry)
+							if err != nil {
+								return false, err
+							}
 						}
+					} else {
+						return false, err
 					}
 
 				}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -401,6 +401,21 @@ func RemoveAuthentication(sys *types.SystemContext, key string) error {
 				if innerHelper, exists := auths.CredHelpers[key]; exists {
 					removeFromCredHelper(innerHelper)
 				}
+				if auths.CredsStore != "" {
+					c, err := getAuthFromCredHelper(auths.CredsStore, key)
+					if err != nil {
+						multiErr = multierror.Append(multiErr, errors.Wrapf(err, "removing credentials for %s from credential helper %s", key, auths.CredsStore))
+					} else {
+						if c.Username != "" || c.IdentityToken != "" {
+							err = deleteAuthFromCredHelper(auths.CredsStore, key)
+							if err != nil {
+								multiErr = multierror.Append(multiErr, errors.Wrapf(err, "removing credentials for %s from credential helper %s", key, auths.CredsStore))
+							} else {
+								isLoggedIn = true
+							}
+						}
+					}
+				}
 				if _, ok := auths.AuthConfigs[key]; ok {
 					isLoggedIn = true
 					delete(auths.AuthConfigs, key)

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -559,7 +559,6 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 }
 
 func TestGetAllCredentials(t *testing.T) {
-	defer withTmpHome(t)()
 	// Create a temporary authentication file.
 	tmpFile, err := ioutil.TempFile("", "auth.json.")
 	require.NoError(t, err)
@@ -656,24 +655,6 @@ func TestGetAllCredentials(t *testing.T) {
 	require.Equal(t, "bar", authConfigs["registry-a.com"].Password)
 }
 
-func withTmpHome(t *testing.T) func() {
-	t.Helper()
-	dir, err := ioutil.TempDir("", "test-home")
-	if err != nil {
-		t.Fatal(err)
-		return func() {}
-	}
-	oldHome, oldHomeExists := os.LookupEnv("HOME")
-	os.Setenv("HOME", dir)
-	return func() {
-		if oldHomeExists {
-			os.Setenv("HOME", oldHome)
-		} else {
-			os.Unsetenv("HOME")
-		}
-		os.RemoveAll(dir)
-	}
-}
 
 func TestAuthKeysForRef(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -638,7 +638,7 @@ func TestGetAllCredentials(t *testing.T) {
 	}
 
 	// test "credStore"
-	f, err := os.OpenFile(authFilePath, os.O_RDWR | os.O_TRUNC, 0644)
+	f, err := os.OpenFile(authFilePath, os.O_RDWR|os.O_TRUNC, 0644)
 	require.NoError(t, err)
 	_, err = f.Write([]byte(`{ "credsStore": "helper-registry" }`))
 	require.NoError(t, err)
@@ -661,7 +661,7 @@ func withTmpHome(t *testing.T) func() {
 	dir, err := ioutil.TempDir("", "test-home")
 	if err != nil {
 		t.Fatal(err)
-		return func() { }
+		return func() {}
 	}
 	oldHome, oldHomeExists := os.LookupEnv("HOME")
 	os.Setenv("HOME", dir)

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -643,11 +643,6 @@ func TestGetAllCredentials(t *testing.T) {
 	require.NoError(t, err)
 	err = f.Close()
 	require.NoError(t, err)
-	sys = types.SystemContext{
-		AuthFilePath:                authFilePath,
-		SystemRegistriesConfPath:    "",
-		SystemRegistriesConfDirPath: "",
-	}
 	authConfigs, err = GetAllCredentials(&sys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(authConfigs))

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -559,6 +559,7 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 }
 
 func TestGetAllCredentials(t *testing.T) {
+	defer withTmpHome(t)()
 	// Create a temporary authentication file.
 	tmpFile, err := ioutil.TempFile("", "auth.json.")
 	require.NoError(t, err)
@@ -636,6 +637,25 @@ func TestGetAllCredentials(t *testing.T) {
 		require.Equal(t, d.password, conf.Password, "%v", d)
 	}
 
+}
+
+func withTmpHome(t *testing.T) func() {
+	t.Helper()
+	dir, err := ioutil.TempDir("", "test-home")
+	if err != nil {
+		t.Fatal(err)
+		return func() { }
+	}
+	oldHome, oldHomeExists := os.LookupEnv("HOME")
+	os.Setenv("HOME", dir)
+	return func() {
+		if oldHomeExists {
+			os.Setenv("HOME", oldHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		os.RemoveAll(dir)
+	}
 }
 
 func TestAuthKeysForRef(t *testing.T) {

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -637,6 +637,23 @@ func TestGetAllCredentials(t *testing.T) {
 		require.Equal(t, d.password, conf.Password, "%v", d)
 	}
 
+	// test "credStore"
+	f, err := os.OpenFile(authFilePath, os.O_RDWR | os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(`{ "credsStore": "helper-registry" }`))
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+	sys = types.SystemContext{
+		AuthFilePath:                authFilePath,
+		SystemRegistriesConfPath:    "",
+		SystemRegistriesConfDirPath: "",
+	}
+	authConfigs, err = GetAllCredentials(&sys)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(authConfigs))
+	require.Equal(t, "foo", authConfigs["registry-a.com"].Username)
+	require.Equal(t, "bar", authConfigs["registry-a.com"].Password)
 }
 
 func withTmpHome(t *testing.T) func() {

--- a/pkg/docker/config/testdata/docker-credential-mock-helper
+++ b/pkg/docker/config/testdata/docker-credential-mock-helper
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec /usr/bin/env go run ./testdata/docker-credential-mock-helper.go "$@"

--- a/pkg/docker/config/testdata/docker-credential-mock-helper.go
+++ b/pkg/docker/config/testdata/docker-credential-mock-helper.go
@@ -1,0 +1,126 @@
+///usr/bin/true; exec /usr/bin/env go run "$0" "$@"
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+)
+
+type userPasswordPair struct {
+	User, Password string
+}
+
+type serverUserSecretTriple struct {
+	ServerURL, Username, Secret string
+}
+
+func load() (map[string]userPasswordPair, error) {
+	credentials := make(map[string]userPasswordPair)
+	fname, ok := os.LookupEnv("CRED_HELPER_STORE_FILE")
+	if !ok {
+		return credentials, fmt.Errorf("the CRED_HELPER_STORE_FILE envvar not set")
+	}
+	f, err := os.OpenFile(fname, os.O_RDONLY, 0644)
+	if err != nil {
+		return credentials, err
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	err = dec.Decode(&credentials)
+	return credentials, err
+}
+
+func store(credentials map[string]userPasswordPair) error {
+	fname, ok := os.LookupEnv("CRED_HELPER_STORE_FILE")
+	if !ok {
+		return fmt.Errorf("the CRED_HELPER_STORE_FILE envvar not set")
+	}
+	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	return enc.Encode(&credentials)
+
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	var se syscall.Errno
+	if ok := errors.As(err, &se); ok {
+		os.Exit(int(se))
+	}
+	os.Exit(-1)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "exactly one argument expected\n")
+		os.Exit(int(syscall.EINVAL))
+	}
+
+	credentials, err := load()
+	if err != nil {
+		fatal(err)
+	}
+
+	switch os.Args[1] {
+	case "list":
+		outData := make(map[string]string)
+		for server, up := range credentials {
+			outData[server] = up.User
+		}
+		enc := json.NewEncoder(os.Stdout)
+		err = enc.Encode(&outData)
+		if err != nil {
+			fatal(err)
+		}
+	case "get":
+		inData, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fatal(err)
+		}
+		serverURL := string(inData)
+		serverURL = strings.Trim(serverURL, "\r\n")
+		up := credentials[serverURL]
+		outData := serverUserSecretTriple{ServerURL: serverURL, Username: up.User, Secret: up.Password}
+		enc := json.NewEncoder(os.Stdout)
+		if err = enc.Encode(outData); err != nil {
+			fatal(err)
+		}
+	case "erase":
+		inData, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fatal(err)
+		}
+		serverURL := string(inData)
+		serverURL = strings.Trim(serverURL, "\r\n")
+		delete(credentials, serverURL)
+		err = store(credentials)
+		if err != nil {
+			fatal(err)
+		}
+	case "store":
+		inData := serverUserSecretTriple{}
+		enc := json.NewDecoder(os.Stdin)
+		err = enc.Decode(&inData)
+		if err != nil {
+			fatal(err)
+		}
+		credentials[inData.ServerURL] = userPasswordPair{User: inData.Username, Password: inData.Secret}
+		err = store(credentials)
+		if err != nil {
+			fatal(err)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown sub-command %s\n", os.Args[1])
+		os.Exit(int(syscall.EINVAL))
+	}
+}


### PR DESCRIPTION
Config file on macOS may contain "credsStore" property indicating what cred store should be used.
This patch checks for its presence and uses it if appropriate.

Signed-off-by: Matej Vasek <mvasek@redhat.com>