### PR TITLE
fix typo in docs/containers-registries.conf.d.5.md

### DIFF
--- a/docs/containers-registries.conf.d.5.md
+++ b/docs/containers-registries.conf.d.5.md
@@ -17,7 +17,7 @@ Once the main configuration at `/etc/containers/registries.conf` is loaded, the
 files in `/etc/containers/registries.conf.d` are loaded in alpha-numerical
 order. Then the conf files in `$HOME/.config/containers/registries.conf.d` are loaded in alpha-numerical order, if they exist. If the `$HOME/.config/containers/registries.conf` is loaded, only the conf files under `$HOME/.config/containers/registries.conf.d` are loaded in alpha-numerical order.
 Specified fields in a conf file will overwrite any previous setting.  Note
-that only files with the `.conf` prefix are loaded, other files and
+that only files with the `.conf` suffix are loaded, other files and
 sub-directories are ignored.
 
 For instance, setting the `unqualified-search-registries` in


### PR DESCRIPTION
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

The files loaded in `registries.conf.d` are filtered by suffix but not prefix, I think this is a typo.

https://github.com/containers/image/blob/71dd98800529ab55cc64da3735ff7675c2a84d8b/pkg/sysregistriesv2/system_registries_v2.go#L529