### PR TITLE
fix docker socket leak

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -502,6 +502,8 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 			attempts == backoffNumIterations {
 			return res, err
 		}
+		// close response body before retry or context done
+		res.Body.Close()
 
 		delay = parseRetryAfter(res, delay)
 		if delay > backoffMaxDelay {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -139,6 +139,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 		return "", err
 	}
 
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return "", errors.Wrapf(registryHTTPResponseToError(res), "Error reading digest %s in %s", tagOrDigest, dr.ref.Name())
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -251,6 +251,7 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 			if resp.StatusCode != http.StatusOK {
 				err = errors.Errorf("error fetching external blob from %q: %d (%s)", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 				logrus.Debug(err)
+				resp.Body.Close()
 				continue
 			}
 			break


### PR DESCRIPTION
fix socket leak for this:

- `docker.GetDigest (even on success)`
- `docker.makeRequestToResolvedURL`
- `docker.getExternalBlob`