### PR TITLE
manifest: GuessMIMEType: support OCI artifacts

### DIFF
--- a/manifest/fixtures/ociv1.artifact.json
+++ b/manifest/fixtures/ociv1.artifact.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.oci.custom.artifact.config.v1+json",
+    "digest": "",
+    "size": 0
+  },
+  "layers": null
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -132,9 +132,16 @@ func GuessMIMEType(manifest []byte) string {
 		if err := json.Unmarshal(manifest, &ociMan); err != nil {
 			return ""
 		}
-		if ociMan.Config.MediaType == imgspecv1.MediaTypeImageConfig {
+		switch ociMan.Config.MediaType {
+		case imgspecv1.MediaTypeImageConfig:
 			return imgspecv1.MediaTypeImageManifest
+		case DockerV2Schema2ConfigMediaType:
+			// This case should not happen since a Docker image
+			// must declare a top-level media type and
+			// `meta.MediaType` has already been checked.
+			return DockerV2Schema2MediaType
 		}
+		// Maybe an image index or an OCI artifact.
 		ociIndex := struct {
 			Manifests []imgspecv1.Descriptor `json:"manifests"`
 		}{}
@@ -145,9 +152,13 @@ func GuessMIMEType(manifest []byte) string {
 			if ociMan.Config.MediaType == "" {
 				return imgspecv1.MediaTypeImageIndex
 			}
+			// FIXME: this is mixing media types of manifests and configs.
 			return ociMan.Config.MediaType
 		}
-		return DockerV2Schema2MediaType
+		// It's most likely an OCI artifact with a custom config media
+		// type which is not (and cannot) be covered by the media-type
+		// checks cabove.
+		return imgspecv1.MediaTypeImageManifest
 	}
 	return ""
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -30,6 +30,7 @@ func TestGuessMIMEType(t *testing.T) {
 		{"unknown-version.manifest.json", ""},
 		{"non-json.manifest.json", ""}, // Not a manifest (nor JSON) at all
 		{"ociv1.manifest.json", imgspecv1.MediaTypeImageManifest},
+		{"ociv1.artifact.json", imgspecv1.MediaTypeImageManifest},
 		{"ociv1.image.index.json", imgspecv1.MediaTypeImageIndex},
 	}
 

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type ociImageSource struct {
@@ -94,6 +95,7 @@ func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 
 	m, err := ioutil.ReadFile(manifestPath)
 	if err != nil {
+		logrus.Errorf("Error HERE")
 		return nil, "", err
 	}
 	if mimeType == "" {


### PR DESCRIPTION
If a schema version 2 manifest doesn't include a top-level media type,
default to "guessing" it's an OCI v1 manifest.

Previously, we defaulted to a Docker v2s2 manifest which is causing
issues for OCI artifacts which may ship a custom config media type.
In that case, we guessed it's a Docker image which is wrong.

To harden the code a bit further, add an additional media-type check for
the config to not only check for an ordinary OCI config but also a
Docker one.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

Found the issues while prototyping source containers in Buildah. @rhatdan @nalind @giuseppe @lsm5 PTAL