### PR TITLE
Enable subdomain matching in registries.conf

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -34,10 +34,15 @@ Given an image name, a single `[[registry]]` TOML table is chosen based on its `
   - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]
   - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_
   - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_(`:`_tag|`@`_digest_)
+  - [`*.`]_host_
 
     The user-specified image name must start with the specified `prefix` (and continue
     with the appropriate separator) for a particular `[[registry]]` TOML table to be
-    considered; (only) the TOML table with the longest match is used.
+    considered; (only) the TOML table with the longest match is used. It can
+    also include wildcarded subdomains in the format `*.example.com` along as mentioned
+    above. The wildcard should only be present at the beginning as shown in the formats
+    above. Other cases will not work. For example, `*.example.com` is valid but
+    `example.*.com`, `*.example.com/foo` and `*.example.com:5000/foo/bar:baz` are not.
 
     As a special case, the `prefix` field can be missing; if so, it defaults to the value
     of the `location` field (described below).
@@ -76,6 +81,19 @@ internet without having to change `Dockerfile`s, or to add redundancy).
     ```
     requests for the image `example.com/foo/myimage:latest` will actually work with the
     `internal-registry-for-example.net/bar/myimage:latest` image.
+
+    With a `prefix` containing a wildcard in the format: "*.example.com" for subdomain matching,
+    the location can be empty. In such a case,
+    prefix matching will occur, but no reference rewrite will occur. The
+    original requested image string will be used as-is. But other settings like
+    `insecure` / `blocked` / `mirrors` will be applied to matching images.
+
+    Example: Given
+    ```
+    prefix = "*.example.com"
+    ```
+    requests for the image `blah.example.com/foo/myimage:latest` will be used
+    as-is. But other settings like insecure/blocked/mirrors will be applied to matching images
 
 `mirror`
 : An array of TOML tables specifying (possibly-partial) mirrors for the

--- a/pkg/sysregistriesv2/testdata/find-registry.conf
+++ b/pkg/sysregistriesv2/testdata/find-registry.conf
@@ -16,3 +16,47 @@ location = "no-prefix.com"
 [[registry]]
 location = "empty-prefix.com"
 prefix = ""
+
+[[registry]]
+location = "subdomain-prefix.com"
+prefix = "*.so.simple-prefix.com"
+
+[[registry]]
+location = "subdomain-prefix-2.com"
+prefix = "*.simple-prefix.com"
+
+# For subdomain override using dropin registries.conf.d/subdomain-override-1.conf
+[[registry]]
+location = "subdomain-prefix-1.com"
+prefix = "*.not.quite.simple-prefix.com"
+
+# For subdomain override failure using registries.conf.d/subdomain-override-2.conf
+# with unmatched prefix = "*.example.com"
+[[registry]]
+location = "subdomain-prefix-2.com"
+prefix = "*.docker.io"
+
+# For subdomain override using dropin registries.conf.d/subdomain-override-3.conf
+[[registry]]
+location = "subdomain-prefix-3.com"
+prefix = "*.bar.example.com"
+
+# For longest wildcarded prefix match in comparison with "*.docker.io"
+[[registry]]
+location = "subdomain-prefix-4.com"
+prefix = "*.bar.docker.io"
+
+# For longest prefix match in comaprison with *.bar.example.com
+[[registry]]
+location = "subdomain-prefix-5.com"
+prefix = "foo.bar.example.com:5000"
+
+# For empty location with wildcard prefix
+[[registry]]
+prefix="*.internal.registry.com"
+
+[[registry]]
+prefix="*.com"
+
+[[registry]]
+prefix="*.foobar.io"

--- a/pkg/sysregistriesv2/testdata/missing-registry-location.conf
+++ b/pkg/sysregistriesv2/testdata/missing-registry-location.conf
@@ -1,9 +1,0 @@
-unqualified-search-registries = ["registry-a.com"]
-
-[[registry]]
-location = "registry-a.com"
-
-[[registry]]
-location = "registry-b.com"
-
-[[registry]]

--- a/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-1.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-1.conf
@@ -1,0 +1,3 @@
+[[registry]]
+location = "subdomain-prefix-1-overridden-by-dropin-location.com"
+prefix = "*.not.quite.simple-prefix.com"

--- a/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-2.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-2.conf
@@ -1,0 +1,3 @@
+[[registry]]
+location = "subdomain-prefix-2-overridden-by-dropin-location.com"
+prefix = "*.docker.com"

--- a/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-3.conf
+++ b/pkg/sysregistriesv2/testdata/registries.conf.d/subdomain-override-3.conf
@@ -1,0 +1,3 @@
+[[registry]]
+location = "subdomain-prefix-3-overridden-by-dropin-location.com"
+prefix = "*.bar.example.com"

--- a/registries.conf
+++ b/registries.conf
@@ -24,6 +24,9 @@
 # # The "prefix" field is used to choose the relevant [[registry]] TOML table;
 # # (only) the TOML table with the longest match for the input image name
 # # (taking into account namespace/repo/tag/digest separators) is used.
+# # 
+# # The prefix can also be of the form: *.example.com for wildcard subdomain
+# # matching.
 # #
 # # If the prefix field is missing, it defaults to be the same as the "location" field.
 # prefix = "example.com/foo"
@@ -37,7 +40,7 @@
 #
 # # The physical location of the "prefix"-rooted namespace.
 # #
-# # By default, this equal to "prefix" (in which case "prefix" can be omitted
+# # By default, this is equal to "prefix" (in which case "prefix" can be omitted
 # # and the [[registry]] TOML table can only specify "location").
 # #
 # # Example: Given
@@ -45,6 +48,10 @@
 # #   location = "internal-registry-for-example.net/bar"
 # # requests for the image example.com/foo/myimage:latest will actually work with the
 # # internal-registry-for-example.net/bar/myimage:latest image.
+#
+# # The location can be empty iff prefix is in a
+# # wildcarded format: "*.example.com". In this case, the input reference will
+# # be used as-is without any rewrite.
 # location = internal-registry-for-example.com/bar"
 #
 # # (Possibly-partial) mirrors for the "prefix"-rooted namespace.

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 11
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This commit allows the prefix field in registries.conf to be of the
form: `prefix = "*.example.com" for wildcard subdomain matching.

refMatchesPrefix now returns the length of the prefix if there's a match
and the prefix doesn't contain `*.`. If prefix contains `*.` and there's
a match, then refMatchesPrefix returns the length of the refString
without the image. This change removes the need for
any additional string comparison in `rewriteReference`.

Co-authored-by: Valentin Rothberg <rothberg@redhat.com>
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

/cc @ashcrow 