### PR TITLE
copy: temporarily disable early commits

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -43,6 +43,10 @@ type digestingReader struct {
 	validationSucceeded bool
 }
 
+// FIXME: disable early layer commits temporarily until a solid solution to
+// address #1205 has been found.
+const enableEarlyCommit = false
+
 var (
 	// ErrDecryptParamsMissing is returned if there is missing decryption parameters
 	ErrDecryptParamsMissing = errors.New("Necessary DecryptParameters not present")
@@ -1185,7 +1189,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// layers which requires passing the index of the layer.
 		// Hence, we need to special case and cast.
 		dest, ok := ic.c.dest.(internalTypes.ImageDestinationWithOptions)
-		if ok {
+		if ok && enableEarlyCommit {
 			options := internalTypes.TryReusingBlobOptions{
 				Cache:         ic.c.blobInfoCache,
 				CanSubstitute: ic.canSubstituteBlobs,
@@ -1546,7 +1550,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	// which requires passing the index of the layer.  Hence, we need to
 	// special case and cast.
 	dest, ok := c.dest.(internalTypes.ImageDestinationWithOptions)
-	if ok {
+	if ok && enableEarlyCommit {
 		options := internalTypes.PutBlobOptions{
 			Cache:    c.blobInfoCache,
 			IsConfig: isConfig,

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -763,7 +763,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 	}
 
 	// Carry over the previous ID for empty non-base layers.
-	if blob.EmptyLayer && index > 0 {
+	if blob.EmptyLayer {
 		s.indexToStorageID[index] = &lastLayer
 		return nil
 	}


### PR DESCRIPTION
Temporarily disable committing blobs early to fix a bug related to
mistakenly committing empty layes [1].  The plan is to reeanble the
feature when a solid solution for passing down the layer information
is found.

[1] https://github.com/containers/image/pull/1205#issuecomment-822459523
