### PR TITLE
Bump to v5.12.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 11
+	VersionMinor = 12
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 12
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
* Update F34beta -> F34 and U2010 -> U2104
* Bump github.com/containers/storage from 1.30.0 to 1.30.1
* Skip pulling layers reusable from additional layer store
* Bump github.com/containers/storage from 1.29.0 to 1.30.0
* Cirrus: Improve test synchronization with c/skopeo