### PR TITLE
Do not prepend Error on each wrapped error message.

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -92,7 +92,7 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 			// Coverage: This should not happen, the hash.Hash interface requires
 			// d.digest.Write to never return an error, and the io.Writer interface
 			// requires n2 == len(input) if no error is returned.
-			return 0, errors.Wrapf(err, "Error updating digest during verification: %d vs. %d", n2, n)
+			return 0, errors.Wrapf(err, "updating digest during verification: %d vs. %d", n2, n)
 		}
 	}
 	if err == io.EOF {
@@ -240,7 +240,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	dest, err := destRef.NewImageDestination(ctx, options.DestinationCtx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error initializing destination %s", transports.ImageName(destRef))
+		return nil, errors.Wrapf(err, "initializing destination %s", transports.ImageName(destRef))
 	}
 	defer func() {
 		if err := dest.Close(); err != nil {
@@ -250,7 +250,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	rawSource, err := srcRef.NewImageSource(ctx, options.SourceCtx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error initializing source %s", transports.ImageName(srcRef))
+		return nil, errors.Wrapf(err, "initializing source %s", transports.ImageName(srcRef))
 	}
 	defer func() {
 		if err := rawSource.Close(); err != nil {
@@ -302,7 +302,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	unparsedToplevel := image.UnparsedInstance(rawSource, nil)
 	multiImage, err := isMultiImage(ctx, unparsedToplevel)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error determining manifest MIME type for %s", transports.ImageName(srcRef))
+		return nil, errors.Wrapf(err, "determining manifest MIME type for %s", transports.ImageName(srcRef))
 	}
 
 	if !multiImage {
@@ -315,15 +315,15 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// matches the current system to copy, and copy it.
 		mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error reading manifest for %s", transports.ImageName(srcRef))
+			return nil, errors.Wrapf(err, "reading manifest for %s", transports.ImageName(srcRef))
 		}
 		manifestList, err := manifest.ListFromBlob(mfest, manifestType)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error parsing primary manifest as list for %s", transports.ImageName(srcRef))
+			return nil, errors.Wrapf(err, "parsing primary manifest as list for %s", transports.ImageName(srcRef))
 		}
 		instanceDigest, err := manifestList.ChooseInstance(options.SourceCtx) // try to pick one that matches options.SourceCtx
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error choosing an image from manifest list %s", transports.ImageName(srcRef))
+			return nil, errors.Wrapf(err, "choosing an image from manifest list %s", transports.ImageName(srcRef))
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
@@ -334,7 +334,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {
-			return nil, errors.Errorf("Error copying multiple images: destination transport %q does not support copying multiple images as a group", destRef.Transport().Name())
+			return nil, errors.Errorf("copying multiple images: destination transport %q does not support copying multiple images as a group", destRef.Transport().Name())
 		}
 		// Copy some or all of the images.
 		switch options.ImageListSelection {
@@ -349,7 +349,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	if err := c.dest.Commit(ctx, unparsedToplevel); err != nil {
-		return nil, errors.Wrap(err, "Error committing the finished image")
+		return nil, errors.Wrap(err, "committing the finished image")
 	}
 
 	return copiedManifest, nil
@@ -376,12 +376,12 @@ func supportsMultipleImages(dest types.ImageDestination) bool {
 func compareImageDestinationManifestEqual(ctx context.Context, options *Options, src types.Image, targetInstance *digest.Digest, dest types.ImageDestination) (bool, []byte, string, digest.Digest, error) {
 	srcManifest, _, err := src.Manifest(ctx)
 	if err != nil {
-		return false, nil, "", "", errors.Wrapf(err, "Error reading manifest from image")
+		return false, nil, "", "", errors.Wrapf(err, "reading manifest from image")
 	}
 
 	srcManifestDigest, err := manifest.Digest(srcManifest)
 	if err != nil {
-		return false, nil, "", "", errors.Wrapf(err, "Error calculating manifest digest")
+		return false, nil, "", "", errors.Wrapf(err, "calculating manifest digest")
 	}
 
 	destImageSource, err := dest.Reference().NewImageSource(ctx, options.DestinationCtx)
@@ -398,7 +398,7 @@ func compareImageDestinationManifestEqual(ctx context.Context, options *Options,
 
 	destManifestDigest, err := manifest.Digest(destManifest)
 	if err != nil {
-		return false, nil, "", "", errors.Wrapf(err, "Error calculating manifest digest")
+		return false, nil, "", "", errors.Wrapf(err, "calculating manifest digest")
 	}
 
 	logrus.Debugf("Comparing source and destination manifest digests: %v vs. %v", srcManifestDigest, destManifestDigest)
@@ -416,11 +416,11 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error reading manifest list")
+		return nil, errors.Wrapf(err, "reading manifest list")
 	}
 	originalList, err := manifest.ListFromBlob(manifestList, manifestType)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing manifest list %q", string(manifestList))
+		return nil, errors.Wrapf(err, "parsing manifest list %q", string(manifestList))
 	}
 	updatedList := originalList.Clone()
 
@@ -432,7 +432,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		c.Printf("Getting image list signatures\n")
 		s, err := c.rawSource.GetSignatures(ctx, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error reading signatures")
+			return nil, errors.Wrap(err, "reading signatures")
 		}
 		sigs = s
 	}
@@ -454,11 +454,11 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	selectedListType, otherManifestMIMETypeCandidates, err := c.determineListConversion(manifestType, c.dest.SupportedManifestMIMETypes(), forceListMIMEType)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error determining manifest list type to write to destination")
+		return nil, errors.Wrapf(err, "determining manifest list type to write to destination")
 	}
 	if selectedListType != originalList.MIMEType() {
 		if !canModifyManifestList {
-			return nil, errors.Errorf("Error: manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", selectedListType)
+			return nil, errors.Errorf("manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", selectedListType)
 		}
 	}
 
@@ -510,7 +510,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 
 	// Now reset the digest/size/types of the manifests in the list to account for any conversions that we made.
 	if err = updatedList.UpdateInstances(updates); err != nil {
-		return nil, errors.Wrapf(err, "Error updating manifest list")
+		return nil, errors.Wrapf(err, "updating manifest list")
 	}
 
 	// Iterate through supported list types, preferred format first.
@@ -525,7 +525,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		if thisListType != updatedList.MIMEType() {
 			attemptedList, err = updatedList.ConvertToMIMEType(thisListType)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Error converting manifest list to list with MIME type %q", thisListType)
+				return nil, errors.Wrapf(err, "converting manifest list to list with MIME type %q", thisListType)
 			}
 		}
 
@@ -533,17 +533,17 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		// by serializing them both so that we can compare them.
 		attemptedManifestList, err := attemptedList.Serialize()
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error encoding updated manifest list (%q: %#v)", updatedList.MIMEType(), updatedList.Instances())
+			return nil, errors.Wrapf(err, "encoding updated manifest list (%q: %#v)", updatedList.MIMEType(), updatedList.Instances())
 		}
 		originalManifestList, err := originalList.Serialize()
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error encoding original manifest list for comparison (%q: %#v)", originalList.MIMEType(), originalList.Instances())
+			return nil, errors.Wrapf(err, "encoding original manifest list for comparison (%q: %#v)", originalList.MIMEType(), originalList.Instances())
 		}
 
 		// If we can't just use the original value, but we have to change it, flag an error.
 		if !bytes.Equal(attemptedManifestList, originalManifestList) {
 			if !canModifyManifestList {
-				return nil, errors.Errorf("Error: manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", thisListType)
+				return nil, errors.Errorf(" manifest list must be converted to type %q to be written to destination, but that would invalidate signatures", thisListType)
 			}
 			logrus.Debugf("Manifest list has been updated")
 		} else {
@@ -577,7 +577,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 
 	c.Printf("Storing list signatures\n")
 	if err := c.dest.PutSignatures(ctx, sigs, nil); err != nil {
-		return nil, errors.Wrap(err, "Error writing signatures")
+		return nil, errors.Wrap(err, "writing signatures")
 	}
 
 	return manifestList, nil
@@ -591,7 +591,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	multiImage, err := isMultiImage(ctx, unparsedImage)
 	if err != nil {
 		// FIXME FIXME: How to name a reference for the sub-image?
-		return nil, "", "", errors.Wrapf(err, "Error determining manifest MIME type for %s", transports.ImageName(unparsedImage.Reference()))
+		return nil, "", "", errors.Wrapf(err, "determining manifest MIME type for %s", transports.ImageName(unparsedImage.Reference()))
 	}
 	if multiImage {
 		return nil, "", "", fmt.Errorf("Unexpectedly received a manifest list instead of a manifest for a single image")
@@ -605,7 +605,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	}
 	src, err := image.FromUnparsedImage(ctx, options.SourceCtx, unparsedImage)
 	if err != nil {
-		return nil, "", "", errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(c.rawSource.Reference()))
+		return nil, "", "", errors.Wrapf(err, "initializing image from source %s", transports.ImageName(c.rawSource.Reference()))
 	}
 
 	// If the destination is a digested reference, make a note of that, determine what digest value we're
@@ -617,20 +617,20 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 			destIsDigestedReference = true
 			sourceManifest, _, err := src.Manifest(ctx)
 			if err != nil {
-				return nil, "", "", errors.Wrapf(err, "Error reading manifest from source image")
+				return nil, "", "", errors.Wrapf(err, "reading manifest from source image")
 			}
 			matches, err := manifest.MatchesDigest(sourceManifest, digested.Digest())
 			if err != nil {
-				return nil, "", "", errors.Wrapf(err, "Error computing digest of source image's manifest")
+				return nil, "", "", errors.Wrapf(err, "computing digest of source image's manifest")
 			}
 			if !matches {
 				manifestList, _, err := unparsedToplevel.Manifest(ctx)
 				if err != nil {
-					return nil, "", "", errors.Wrapf(err, "Error reading manifest from source image")
+					return nil, "", "", errors.Wrapf(err, "reading manifest from source image")
 				}
 				matches, err = manifest.MatchesDigest(manifestList, digested.Digest())
 				if err != nil {
-					return nil, "", "", errors.Wrapf(err, "Error computing digest of source image's manifest")
+					return nil, "", "", errors.Wrapf(err, "computing digest of source image's manifest")
 				}
 				if !matches {
 					return nil, "", "", errors.New("Digest of source image's manifest would not match destination reference")
@@ -650,7 +650,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		c.Printf("Getting image source signatures\n")
 		s, err := src.Signatures(ctx)
 		if err != nil {
-			return nil, "", "", errors.Wrap(err, "Error reading signatures")
+			return nil, "", "", errors.Wrap(err, "reading signatures")
 		}
 		sigs = s
 	}
@@ -785,7 +785,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 
 	c.Printf("Storing signatures\n")
 	if err := c.dest.PutSignatures(ctx, sigs, targetInstance); err != nil {
-		return nil, "", "", errors.Wrap(err, "Error writing signatures")
+		return nil, "", "", errors.Wrap(err, "writing signatures")
 	}
 
 	return manifestBytes, retManifestType, retManifestDigest, nil
@@ -805,11 +805,11 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 	if dest.MustMatchRuntimeOS() {
 		c, err := src.OCIConfig(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "Error parsing image configuration")
+			return errors.Wrapf(err, "parsing image configuration")
 		}
 		wantedPlatforms, err := platform.WantedPlatforms(sys)
 		if err != nil {
-			return errors.Wrapf(err, "error getting current platform information %#v", sys)
+			return errors.Wrapf(err, "getting current platform information %#v", sys)
 		}
 
 		options := newOrderedSet()
@@ -1034,13 +1034,13 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 		}
 		pi, err := ic.src.UpdatedImage(ctx, *ic.manifestUpdates)
 		if err != nil {
-			return nil, "", errors.Wrap(err, "Error creating an updated image manifest")
+			return nil, "", errors.Wrap(err, "creating an updated image manifest")
 		}
 		pendingImage = pi
 	}
 	man, _, err := pendingImage.Manifest(ctx)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "Error reading manifest")
+		return nil, "", errors.Wrap(err, "reading manifest")
 	}
 
 	if err := ic.c.copyConfig(ctx, pendingImage); err != nil {
@@ -1056,7 +1056,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 		instanceDigest = &manifestDigest
 	}
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
-		return nil, "", errors.Wrapf(err, "Error writing manifest %q", string(man))
+		return nil, "", errors.Wrapf(err, "writing manifest %q", string(man))
 	}
 	return man, manifestDigest, nil
 }
@@ -1123,7 +1123,7 @@ func (c *copier) copyConfig(ctx context.Context, src types.Image) error {
 	if srcInfo.Digest != "" {
 		configBlob, err := src.ConfigBlob(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "Error reading config blob %s", srcInfo.Digest)
+			return errors.Wrapf(err, "reading config blob %s", srcInfo.Digest)
 		}
 
 		destInfo, err := func() (types.BlobInfo, error) { // A scope for defer
@@ -1213,7 +1213,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		}
 
 		if err != nil {
-			return types.BlobInfo{}, "", errors.Wrapf(err, "Error trying to reuse blob %s at destination", srcInfo.Digest)
+			return types.BlobInfo{}, "", errors.Wrapf(err, "trying to reuse blob %s at destination", srcInfo.Digest)
 		}
 		if reused {
 			logrus.Debugf("Skipping blob %s (already present):", srcInfo.Digest)
@@ -1247,7 +1247,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// Fallback: copy the layer, computing the diffID if we need to do so
 	srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(ctx, srcInfo, ic.c.blobInfoCache)
 	if err != nil {
-		return types.BlobInfo{}, "", errors.Wrapf(err, "Error reading blob %s", srcInfo.Digest)
+		return types.BlobInfo{}, "", errors.Wrapf(err, "reading blob %s", srcInfo.Digest)
 	}
 	defer srcStream.Close()
 
@@ -1265,7 +1265,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			return types.BlobInfo{}, "", ctx.Err()
 		case diffIDResult := <-diffIDChan:
 			if diffIDResult.err != nil {
-				return types.BlobInfo{}, "", errors.Wrap(diffIDResult.err, "Error computing layer DiffID")
+				return types.BlobInfo{}, "", errors.Wrap(diffIDResult.err, "computing layer DiffID")
 			}
 			logrus.Debugf("Computed DiffID %s for layer %s", diffIDResult.digest, srcInfo.Digest)
 			// This is safe because we have just computed diffIDResult.Digest ourselves, and in the process
@@ -1288,7 +1288,7 @@ func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Rea
 	var getDiffIDRecorder func(compression.DecompressorFunc) io.Writer // = nil
 	var diffIDChan chan diffIDResult
 
-	err := errors.New("Internal error: unexpected panic in copyLayer") // For pipeWriter.CloseWithError below
+	err := errors.New("Internal error: unexpected panic in copyLayer") // For pipeWriter.CloseWithbelow
 	if diffIDIsNeeded {
 		diffIDChan = make(chan diffIDResult, 1) // Buffered, so that sending a value after this or our caller has failed and exited does not block.
 		pipeReader, pipeWriter := io.Pipe()
@@ -1350,7 +1350,7 @@ type errorAnnotationReader struct {
 func (r errorAnnotationReader) Read(b []byte) (n int, err error) {
 	n, err = r.reader.Read(b)
 	if err != io.EOF {
-		return n, errors.Wrapf(err, "error happened during read")
+		return n, errors.Wrapf(err, "happened during read")
 	}
 	return n, err
 }
@@ -1377,7 +1377,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	// read stream to the end, and validation does not happen.
 	digestingReader, err := newDigestingReader(srcStream, srcInfo.Digest)
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrapf(err, "Error preparing to verify blob %s", srcInfo.Digest)
+		return types.BlobInfo{}, errors.Wrapf(err, "preparing to verify blob %s", srcInfo.Digest)
 	}
 	var destStream io.Reader = digestingReader
 
@@ -1391,7 +1391,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		var d digest.Digest
 		destStream, d, err = ocicrypt.DecryptLayer(c.ociDecryptConfig, destStream, newDesc, false)
 		if err != nil {
-			return types.BlobInfo{}, errors.Wrapf(err, "Error decrypting layer %s", srcInfo.Digest)
+			return types.BlobInfo{}, errors.Wrapf(err, "decrypting layer %s", srcInfo.Digest)
 		}
 
 		srcInfo.Digest = d
@@ -1408,7 +1408,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	// This requires us to “peek ahead” into the stream to read the initial part, which requires us to chain through another io.Reader returned by DetectCompression.
 	compressionFormat, decompressor, destStream, err := compression.DetectCompressionFormat(destStream) // We could skip this in some cases, but let's keep the code path uniform
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrapf(err, "Error reading blob %s", srcInfo.Digest)
+		return types.BlobInfo{}, errors.Wrapf(err, "reading blob %s", srcInfo.Digest)
 	}
 	isCompressed := decompressor != nil
 	if expectedCompressionFormat, known := expectedCompressionFormats[srcInfo.MediaType]; known && isCompressed && compressionFormat.Name() != expectedCompressionFormat.Name() {
@@ -1533,7 +1533,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 
 			s, fin, err := ocicrypt.EncryptLayer(c.ociEncryptConfig, destStream, desc)
 			if err != nil {
-				return types.BlobInfo{}, errors.Wrapf(err, "Error encrypting blob %s", srcInfo.Digest)
+				return types.BlobInfo{}, errors.Wrapf(err, "encrypting blob %s", srcInfo.Digest)
 			}
 
 			destStream = s
@@ -1576,7 +1576,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		uploadedInfo, err = c.dest.PutBlob(ctx, &errorAnnotationReader{destStream}, inputInfo, c.blobInfoCache, isConfig)
 	}
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrap(err, "Error writing blob")
+		return types.BlobInfo{}, errors.Wrap(err, "writing blob")
 	}
 
 	uploadedInfo.Annotations = srcInfo.Annotations
@@ -1608,7 +1608,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		logrus.Debugf("Consuming rest of the original blob to satisfy getOriginalLayerCopyWriter")
 		_, err := io.Copy(ioutil.Discard, originalLayerReader)
 		if err != nil {
-			return types.BlobInfo{}, errors.Wrapf(err, "Error reading input blob %s", srcInfo.Digest)
+			return types.BlobInfo{}, errors.Wrapf(err, "reading input blob %s", srcInfo.Digest)
 		}
 	}
 

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -45,7 +45,7 @@ func (os *orderedSet) append(s string) {
 func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (string, []string, error) {
 	_, srcType, err := ic.src.Manifest(ctx)
 	if err != nil { // This should have been cached?!
-		return "", nil, errors.Wrap(err, "Error reading manifest")
+		return "", nil, errors.Wrap(err, "reading manifest")
 	}
 	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
 	if srcType != normalizedSrcType {

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -10,7 +10,7 @@ import (
 func (c *copier) createSignature(manifest []byte, keyIdentity string) ([]byte, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error initializing GPG")
+		return nil, errors.Wrap(err, "initializing GPG")
 	}
 	defer mech.Close()
 	if err := mech.SupportsSigning(); err != nil {
@@ -25,7 +25,7 @@ func (c *copier) createSignature(manifest []byte, keyIdentity string) ([]byte, e
 	c.Printf("Signing manifest\n")
 	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating signature")
+		return nil, errors.Wrap(err, "creating signature")
 	}
 	return newSig, nil
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -34,7 +34,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 	// if the contents don't match throw an error
 	dirExists, err := pathExists(d.ref.resolvedPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error checking for path %q", d.ref.resolvedPath)
+		return nil, errors.Wrapf(err, "checking for path %q", d.ref.resolvedPath)
 	}
 	if dirExists {
 		isEmpty, err := isDirEmpty(d.ref.resolvedPath)
@@ -45,7 +45,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 		if !isEmpty {
 			versionExists, err := pathExists(d.ref.versionPath())
 			if err != nil {
-				return nil, errors.Wrapf(err, "error checking if path exists %q", d.ref.versionPath())
+				return nil, errors.Wrapf(err, "checking if path exists %q", d.ref.versionPath())
 			}
 			if versionExists {
 				contents, err := ioutil.ReadFile(d.ref.versionPath())
@@ -61,7 +61,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 			}
 			// delete directory contents so that only one image is in the directory at a time
 			if err = removeDirContents(d.ref.resolvedPath); err != nil {
-				return nil, errors.Wrapf(err, "error erasing contents in %q", d.ref.resolvedPath)
+				return nil, errors.Wrapf(err, "erasing contents in %q", d.ref.resolvedPath)
 			}
 			logrus.Debugf("overwriting existing container image directory %q", d.ref.resolvedPath)
 		}
@@ -74,7 +74,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 	// create version file
 	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating version file %q", d.ref.versionPath())
+		return nil, errors.Wrapf(err, "creating version file %q", d.ref.versionPath())
 	}
 	return d, nil
 }

--- a/docker/archive/reader.go
+++ b/docker/archive/reader.go
@@ -81,14 +81,14 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 			}
 			ref, err := newReference(r.path, nt, -1, r.archive, nil)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Error creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
+				return nil, errors.Wrapf(err, "creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
 			}
 			refs = append(refs, ref)
 		}
 		if len(refs) == 0 {
 			ref, err := newReference(r.path, nil, imageIndex, r.archive, nil)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Error creating a reference for manifest item @%d", imageIndex)
+				return nil, errors.Wrapf(err, "creating a reference for manifest item @%d", imageIndex)
 			}
 			refs = append(refs, ref)
 		}

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -60,7 +60,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	// only in a different way. Either way, it’s up to the user to not have two writers to the same path.)
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening file %q", path)
+		return nil, errors.Wrapf(err, "opening file %q", path)
 	}
 	succeeded := false
 	defer func() {
@@ -70,7 +70,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	}()
 	fhStat, err := fh.Stat()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error statting file %q", path)
+		return nil, errors.Wrapf(err, "statting file %q", path)
 	}
 
 	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -42,7 +42,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error initializing docker engine client")
+		return nil, errors.Wrap(err, "initializing docker engine client")
 	}
 
 	reader, writer := io.Pipe()
@@ -84,7 +84,7 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 
 	resp, err := c.ImageLoad(ctx, reader, true)
 	if err != nil {
-		err = errors.Wrap(err, "Error saving image to docker engine")
+		err = errors.Wrap(err, "saving image to docker engine")
 		return
 	}
 	defer resp.Body.Close()

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -25,13 +25,13 @@ type daemonImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonReference) (types.ImageSource, error) {
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error initializing docker engine client")
+		return nil, errors.Wrap(err, "initializing docker engine client")
 	}
 	// Per NewReference(), ref.StringWithinTransport() is either an image ID (config digest), or a !reference.NameOnly() reference.
 	// Either way ImageSave should create a tarball with exactly one image.
 	inputStream, err := c.ImageSave(ctx, []string{ref.StringWithinTransport()})
 	if err != nil {
-		return nil, errors.Wrap(err, "Error loading image from docker engine")
+		return nil, errors.Wrap(err, "loading image from docker engine")
 	}
 	defer inputStream.Close()
 

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -215,7 +215,7 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write bool, actions string) (*dockerClient, error) {
 	auth, err := config.GetCredentialsForRef(sys, ref.ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting username and password")
+		return nil, errors.Wrapf(err, "getting username and password")
 	}
 
 	sigBase, err := SignatureStorageBaseURL(sys, ref, write)
@@ -269,7 +269,7 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 	skipVerify := false
 	reg, err := sysregistriesv2.FindRegistry(sys, reference)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error loading registries")
+		return nil, errors.Wrapf(err, "loading registries")
 	}
 	if reg != nil {
 		if reg.Blocked {
@@ -297,7 +297,7 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password, registry string) error {
 	client, err := newDockerClient(sys, registry, registry)
 	if err != nil {
-		return errors.Wrapf(err, "error creating new docker client")
+		return errors.Wrapf(err, "creating new docker client")
 	}
 	client.auth = types.DockerAuthConfig{
 		Username: username,
@@ -346,7 +346,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	// lint:ignore SA1019 We can't use GetCredentialsForRef because we want to search the whole registry.
 	auth, err := config.GetCredentials(sys, registry) // nolint:staticcheck // https://github.com/golangci/golangci-lint/issues/741
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting username and password")
+		return nil, errors.Wrapf(err, "getting username and password")
 	}
 
 	// The /v2/_catalog endpoint has been disabled for docker.io therefore
@@ -360,7 +360,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 
 	client, err := newDockerClient(sys, hostname, registry)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating new docker client")
+		return nil, errors.Wrapf(err, "creating new docker client")
 	}
 	client.auth = auth
 	if sys != nil {
@@ -752,7 +752,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		err = ping("http")
 	}
 	if err != nil {
-		err = errors.Wrapf(err, "error pinging container registry %s", c.registry)
+		err = errors.Wrapf(err, "pinging container registry %s", c.registry)
 		if c.sys != nil && c.sys.DockerDisableV1Ping {
 			return err
 		}
@@ -800,7 +800,7 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(clientLib.HandleErrorResponse(res), "Error downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
+		return nil, errors.Wrapf(clientLib.HandleErrorResponse(res), "downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
 	}
 
 	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureListBodySize)
@@ -810,7 +810,7 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 
 	var parsedBody extensionSignatureList
 	if err := json.Unmarshal(body, &parsedBody); err != nil {
-		return nil, errors.Wrapf(err, "Error decoding signature list")
+		return nil, errors.Wrapf(err, "decoding signature list")
 	}
 	return &parsedBody, nil
 }

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -73,7 +73,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if err := httpResponseToError(res, "Error fetching tags list"); err != nil {
+		if err := httpResponseToError(res, "fetching tags list"); err != nil {
 			return nil, err
 		}
 
@@ -141,7 +141,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", errors.Wrapf(registryHTTPResponseToError(res), "Error reading digest %s in %s", tagOrDigest, dr.ref.Name())
+		return "", errors.Wrapf(registryHTTPResponseToError(res), "reading digest %s in %s", tagOrDigest, dr.ref.Name())
 	}
 
 	dig, err := digest.Parse(res.Header.Get("Docker-Content-Digest"))

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -154,11 +154,11 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusAccepted {
 		logrus.Debugf("Error initiating layer upload, response %#v", *res)
-		return types.BlobInfo{}, errors.Wrapf(registryHTTPResponseToError(res), "Error initiating layer upload to %s in %s", uploadPath, d.c.registry)
+		return types.BlobInfo{}, errors.Wrapf(registryHTTPResponseToError(res), "initiating layer upload to %s in %s", uploadPath, d.c.registry)
 	}
 	uploadLocation, err := res.Location()
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrap(err, "Error determining upload URL")
+		return types.BlobInfo{}, errors.Wrap(err, "determining upload URL")
 	}
 
 	digester := digest.Canonical.Digester()
@@ -175,11 +175,11 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 		}
 		defer res.Body.Close()
 		if !successStatus(res.StatusCode) {
-			return nil, errors.Wrapf(registryHTTPResponseToError(res), "Error uploading layer chunked")
+			return nil, errors.Wrapf(registryHTTPResponseToError(res), "uploading layer chunked")
 		}
 		uploadLocation, err := res.Location()
 		if err != nil {
-			return nil, errors.Wrap(err, "Error determining upload URL")
+			return nil, errors.Wrap(err, "determining upload URL")
 		}
 		return uploadLocation, nil
 	}()
@@ -201,7 +201,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
 		logrus.Debugf("Error uploading layer, response %#v", *res)
-		return types.BlobInfo{}, errors.Wrapf(registryHTTPResponseToError(res), "Error uploading layer to %s", uploadLocation)
+		return types.BlobInfo{}, errors.Wrapf(registryHTTPResponseToError(res), "uploading layer to %s", uploadLocation)
 	}
 
 	logrus.Debugf("Upload of layer %s complete", computedDigest)
@@ -226,7 +226,7 @@ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.
 		return true, getBlobSize(res), nil
 	case http.StatusUnauthorized:
 		logrus.Debugf("... not authorized")
-		return false, -1, errors.Wrapf(registryHTTPResponseToError(res), "Error checking whether a blob %s exists in %s", digest, repo.Name())
+		return false, -1, errors.Wrapf(registryHTTPResponseToError(res), "checking whether a blob %s exists in %s", digest, repo.Name())
 	case http.StatusNotFound:
 		logrus.Debugf("... not present")
 		return false, -1, nil
@@ -261,7 +261,7 @@ func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo referenc
 		// NOTE: This does not really work in docker/distribution servers, which incorrectly require the "delete" action in the token's scope, and is thus entirely untested.
 		uploadLocation, err := res.Location()
 		if err != nil {
-			return errors.Wrap(err, "Error determining upload URL after a mount attempt")
+			return errors.Wrap(err, "determining upload URL after a mount attempt")
 		}
 		logrus.Debugf("... started an upload instead of mounting, trying to cancel at %s", uploadLocation.String())
 		res2, err := d.c.makeRequestToResolvedURL(ctx, "DELETE", uploadLocation.String(), nil, nil, -1, v2Auth, extraScope)
@@ -277,7 +277,7 @@ func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo referenc
 		return fmt.Errorf("Mounting %s from %s to %s started an upload instead", srcDigest, srcRepo.Name(), d.ref.ref.Name())
 	default:
 		logrus.Debugf("Error mounting, response %#v", *res)
-		return errors.Wrapf(registryHTTPResponseToError(res), "Error mounting %s from %s to %s", srcDigest, srcRepo.Name(), d.ref.ref.Name())
+		return errors.Wrapf(registryHTTPResponseToError(res), "mounting %s from %s to %s", srcDigest, srcRepo.Name(), d.ref.ref.Name())
 	}
 }
 
@@ -392,7 +392,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 		// Double-check that the manifest we've been given matches the digest we've been given.
 		matches, err := manifest.MatchesDigest(m, *instanceDigest)
 		if err != nil {
-			return errors.Wrapf(err, "error digesting manifest in PutManifest")
+			return errors.Wrapf(err, "digesting manifest in PutManifest")
 		}
 		if !matches {
 			manifestDigest, merr := manifest.Digest(m)
@@ -430,7 +430,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 	}
 	defer res.Body.Close()
 	if !successStatus(res.StatusCode) {
-		err = errors.Wrapf(registryHTTPResponseToError(res), "Error uploading manifest %s to %s", refTail, d.ref.ref.Name())
+		err = errors.Wrapf(registryHTTPResponseToError(res), "uploading manifest %s to %s", refTail, d.ref.ref.Name())
 		if isManifestInvalidError(errors.Cause(err)) {
 			err = types.ManifestTypeRejectedError{Err: err}
 		}
@@ -621,7 +621,7 @@ sigExists:
 			randBytes := make([]byte, 16)
 			n, err := rand.Read(randBytes)
 			if err != nil || n != 16 {
-				return errors.Wrapf(err, "Error generating random signature len %d", n)
+				return errors.Wrapf(err, "generating random signature len %d", n)
 			}
 			signatureName = fmt.Sprintf("%s@%032x", manifestDigest.String(), randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {
@@ -651,7 +651,7 @@ sigExists:
 				logrus.Debugf("Error body %s", string(body))
 			}
 			logrus.Debugf("Error uploading signature, status %d, %#v", res.StatusCode, res)
-			return errors.Wrapf(registryHTTPResponseToError(res), "Error uploading signature to %s in %s", path, d.c.registry)
+			return errors.Wrapf(registryHTTPResponseToError(res), "uploading signature to %s in %s", path, d.c.registry)
 		}
 	}
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -36,7 +36,7 @@ type dockerImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerReference) (*dockerImageSource, error) {
 	registry, err := sysregistriesv2.FindRegistry(sys, ref.ref.Name())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error loading registries configuration")
+		return nil, errors.Wrapf(err, "loading registries configuration")
 	}
 	if registry == nil {
 		// No configuration was found for the provided reference, so use the
@@ -196,7 +196,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	logrus.Debugf("Content-Type from manifest GET is %q", res.Header.Get("Content-Type"))
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, "", errors.Wrapf(registryHTTPResponseToError(res), "Error reading manifest %s in %s", tagOrDigest, s.physicalRef.ref.Name())
+		return nil, "", errors.Wrapf(registryHTTPResponseToError(res), "reading manifest %s in %s", tagOrDigest, s.physicalRef.ref.Name())
 	}
 
 	manblob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxManifestBodySize)

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -140,11 +140,11 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 	if isConfig {
 		buf, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
-			return types.BlobInfo{}, errors.Wrap(err, "Error reading Config file stream")
+			return types.BlobInfo{}, errors.Wrap(err, "reading Config file stream")
 		}
 		d.config = buf
 		if err := d.archive.sendFileLocked(d.archive.configPath(inputInfo.Digest), inputInfo.Size, bytes.NewReader(buf)); err != nil {
-			return types.BlobInfo{}, errors.Wrap(err, "Error writing Config file")
+			return types.BlobInfo{}, errors.Wrap(err, "writing Config file")
 		}
 	} else {
 		if err := d.archive.sendFileLocked(d.archive.physicalLayerPath(inputInfo.Digest), inputInfo.Size, stream); err != nil {
@@ -187,7 +187,7 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest 
 	// so the caller trying a different manifest kind would be pointless.
 	var man manifest.Schema2
 	if err := json.Unmarshal(m, &man); err != nil {
-		return errors.Wrap(err, "Error parsing manifest")
+		return errors.Wrap(err, "parsing manifest")
 	}
 	if man.SchemaVersion != 2 || man.MediaType != manifest.DockerV2Schema2MediaType {
 		return errors.Errorf("Unsupported manifest type, need a Docker schema 2 manifest")

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -30,7 +30,7 @@ type Reader struct {
 func NewReaderFromFile(sys *types.SystemContext, path string) (*Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening file %q", path)
+		return nil, errors.Wrapf(err, "opening file %q", path)
 	}
 	defer file.Close()
 
@@ -38,7 +38,7 @@ func NewReaderFromFile(sys *types.SystemContext, path string) (*Reader, error) {
 	// as a source. Otherwise we pass the stream to NewReaderFromStream.
 	stream, isCompressed, err := compression.AutoDecompress(file)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error detecting compression for file %q", path)
+		return nil, errors.Wrapf(err, "detecting compression for file %q", path)
 	}
 	defer stream.Close()
 	if !isCompressed {
@@ -55,7 +55,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// Save inputStream to a temporary file
 	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating temporary file")
+		return nil, errors.Wrap(err, "creating temporary file")
 	}
 	defer tarCopyFile.Close()
 
@@ -71,7 +71,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// giving users really confusing "invalid tar header" errors).
 	uncompressedStream, _, err := compression.AutoDecompress(inputStream)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error auto-decompressing input")
+		return nil, errors.Wrap(err, "auto-decompressing input")
 	}
 	defer uncompressedStream.Close()
 
@@ -80,7 +80,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// TODO: This can take quite some time, and should ideally be cancellable
 	//       using a context.Context.
 	if _, err := io.Copy(tarCopyFile, uncompressedStream); err != nil {
-		return nil, errors.Wrapf(err, "error copying contents to temporary file %q", tarCopyFile.Name())
+		return nil, errors.Wrapf(err, "copying contents to temporary file %q", tarCopyFile.Name())
 	}
 	succeeded = true
 
@@ -113,7 +113,7 @@ func newReader(path string, removeOnClose bool) (*Reader, error) {
 		return nil, err
 	}
 	if err := json.Unmarshal(bytes, &r.Manifest); err != nil {
-		return nil, errors.Wrap(err, "Error decoding tar manifest.json")
+		return nil, errors.Wrap(err, "decoding tar manifest.json")
 	}
 
 	succeeded = true
@@ -258,7 +258,7 @@ func findTarComponent(inputFile io.Reader, componentPath string) (*tar.Reader, *
 func (r *Reader) readTarComponent(path string, limit int) ([]byte, error) {
 	file, err := r.openTarComponent(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading tar component %s", path)
+		return nil, errors.Wrapf(err, "loading tar component %s", path)
 	}
 	defer file.Close()
 	bytes, err := iolimits.ReadAtMost(file, limit)

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -80,7 +80,7 @@ func (s *Source) ensureCachedDataIsPresentPrivate() error {
 	}
 	var parsedConfig manifest.Schema2Image // There's a lot of info there, but we only really care about layer DiffIDs.
 	if err := json.Unmarshal(configBytes, &parsedConfig); err != nil {
-		return errors.Wrapf(err, "Error decoding tar config %s", tarManifest.Config)
+		return errors.Wrapf(err, "decoding tar config %s", tarManifest.Config)
 	}
 	if parsedConfig.RootFS == nil {
 		return errors.Errorf("Invalid image config (rootFS is not set): %s", tarManifest.Config)
@@ -164,7 +164,7 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 			// the slower method of checking if it's compressed.
 			uncompressedStream, isCompressed, err := compression.AutoDecompress(t)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Error auto-decompressing %s to determine its size", layerPath)
+				return nil, errors.Wrapf(err, "auto-decompressing %s to determine its size", layerPath)
 			}
 			defer uncompressedStream.Close()
 
@@ -172,7 +172,7 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 			if isCompressed {
 				uncompressedSize, err = io.Copy(ioutil.Discard, uncompressedStream)
 				if err != nil {
-					return nil, errors.Wrapf(err, "Error reading %s to find its size", layerPath)
+					return nil, errors.Wrapf(err, "reading %s to find its size", layerPath)
 				}
 			}
 			li.size = uncompressedSize
@@ -292,7 +292,7 @@ func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.B
 
 		uncompressedStream, _, err := compression.AutoDecompress(underlyingStream)
 		if err != nil {
-			return nil, 0, errors.Wrapf(err, "Error auto-decompressing blob %s", info.Digest)
+			return nil, 0, errors.Wrapf(err, "auto-decompressing blob %s", info.Digest)
 		}
 
 		newStream := uncompressedReadCloser{

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -94,16 +94,16 @@ func (w *Writer) ensureSingleLegacyLayerLocked(layerID string, layerDigest diges
 		// See also the comment in physicalLayerPath.
 		physicalLayerPath := w.physicalLayerPath(layerDigest)
 		if err := w.sendSymlinkLocked(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
-			return errors.Wrap(err, "Error creating layer symbolic link")
+			return errors.Wrap(err, "creating layer symbolic link")
 		}
 
 		b := []byte("1.0")
 		if err := w.sendBytesLocked(filepath.Join(layerID, legacyVersionFileName), b); err != nil {
-			return errors.Wrap(err, "Error writing VERSION file")
+			return errors.Wrap(err, "writing VERSION file")
 		}
 
 		if err := w.sendBytesLocked(filepath.Join(layerID, legacyConfigFileName), configBytes); err != nil {
-			return errors.Wrap(err, "Error writing config json file")
+			return errors.Wrap(err, "writing config json file")
 		}
 
 		w.legacyLayers[layerID] = struct{}{}
@@ -128,7 +128,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 			var config map[string]*json.RawMessage
 			err := json.Unmarshal(configBytes, &config)
 			if err != nil {
-				return errors.Wrap(err, "Error unmarshaling config")
+				return errors.Wrap(err, "unmarshaling config")
 			}
 			for _, attr := range [7]string{"architecture", "config", "container", "container_config", "created", "docker_version", "os"} {
 				layerConfig[attr] = config[attr]
@@ -152,7 +152,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 		layerConfig["layer_id"] = chainID
 		b, err := json.Marshal(layerConfig) // Note that layerConfig["id"] is not set yet at this point.
 		if err != nil {
-			return errors.Wrap(err, "Error marshaling layer config")
+			return errors.Wrap(err, "marshaling layer config")
 		}
 		delete(layerConfig, "layer_id")
 		layerID := digest.Canonical.FromBytes(b).Hex()
@@ -160,7 +160,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 
 		configBytes, err := json.Marshal(layerConfig)
 		if err != nil {
-			return errors.Wrap(err, "Error marshaling layer config")
+			return errors.Wrap(err, "marshaling layer config")
 		}
 
 		if err := w.ensureSingleLegacyLayerLocked(layerID, l.Digest, configBytes); err != nil {
@@ -280,10 +280,10 @@ func (w *Writer) Close() error {
 
 	b, err = json.Marshal(w.repositories)
 	if err != nil {
-		return errors.Wrap(err, "Error marshaling repositories")
+		return errors.Wrap(err, "marshaling repositories")
 	}
 	if err := w.sendBytesLocked(legacyRepositoriesFileName, b); err != nil {
-		return errors.Wrap(err, "Error writing config json file")
+		return errors.Wrap(err, "writing config json file")
 	}
 
 	if err := w.tar.Close(); err != nil {

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -154,7 +154,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 		var config registryConfiguration
 		err = yaml.Unmarshal(configBytes, &config)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error parsing %s", configPath)
+			return nil, errors.Wrapf(err, "parsing %s", configPath)
 		}
 
 		if config.DefaultDocker != nil {

--- a/image/docker_list.go
+++ b/image/docker_list.go
@@ -11,20 +11,20 @@ import (
 func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	list, err := manifest.Schema2ListFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing schema2 manifest list")
+		return nil, errors.Wrapf(err, "parsing schema2 manifest list")
 	}
 	targetManifestDigest, err := list.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error choosing image instance")
+		return nil, errors.Wrapf(err, "choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading manifest for target platform")
+		return nil, errors.Wrapf(err, "loading manifest for target platform")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error computing manifest digest")
+		return nil, errors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
 		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/image/docker_schema2.go
+++ b/image/docker_schema2.go
@@ -289,7 +289,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 				// and anyway this blob is so small that it’s easier to just copy it than to worry about figuring out another location where to get it.
 				info, err := dest.PutBlob(ctx, bytes.NewReader(GzippedEmptyLayer), emptyLayerBlobInfo, none.NoCache, false)
 				if err != nil {
-					return nil, errors.Wrap(err, "Error uploading empty layer")
+					return nil, errors.Wrap(err, "uploading empty layer")
 				}
 				if info.Digest != emptyLayerBlobInfo.Digest {
 					return nil, errors.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)

--- a/image/oci_index.go
+++ b/image/oci_index.go
@@ -11,20 +11,20 @@ import (
 func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	index, err := manifest.OCI1IndexFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing OCI1 index")
+		return nil, errors.Wrapf(err, "parsing OCI1 index")
 	}
 	targetManifestDigest, err := index.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error choosing image instance")
+		return nil, errors.Wrapf(err, "choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading manifest for target platform")
+		return nil, errors.Wrapf(err, "loading manifest for target platform")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error computing manifest digest")
+		return nil, errors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
 		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -53,7 +53,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
 			matches, err := manifest.MatchesDigest(m, digest)
 			if err != nil {
-				return nil, "", errors.Wrap(err, "Error computing manifest digest")
+				return nil, "", errors.Wrap(err, "computing manifest digest")
 			}
 			if !matches {
 				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -109,7 +109,7 @@ func (m *Schema1) initialize() error {
 	m.ExtractedV1Compatibility = make([]Schema1V1Compatibility, len(m.History))
 	for i, h := range m.History {
 		if err := json.Unmarshal([]byte(h.V1Compatibility), &m.ExtractedV1Compatibility[i]); err != nil {
-			return errors.Wrapf(err, "Error parsing v2s1 history entry %d", i)
+			return errors.Wrapf(err, "parsing v2s1 history entry %d", i)
 		}
 	}
 	return nil
@@ -242,14 +242,14 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	config := []byte(m.History[0].V1Compatibility)
 	err := json.Unmarshal(config, &s1)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error decoding configuration")
+		return nil, errors.Wrapf(err, "decoding configuration")
 	}
 	// Images created with versions prior to 1.8.3 require us to re-encode the encoded object,
 	// adding some fields that aren't "omitempty".
 	if s1.DockerVersion != "" && versions.LessThan(s1.DockerVersion, "1.8.3") {
 		config, err = json.Marshal(&s1)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error re-encoding compat image config %#v", s1)
+			return nil, errors.Wrapf(err, "re-encoding compat image config %#v", s1)
 		}
 	}
 	// Build the history.
@@ -276,7 +276,7 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	raw := make(map[string]*json.RawMessage)
 	err = json.Unmarshal(config, &raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error re-decoding compat image config %#v", s1)
+		return nil, errors.Wrapf(err, "re-decoding compat image config %#v", s1)
 	}
 	// Drop some fields.
 	delete(raw, "id")

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -242,7 +242,7 @@ func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(schema2CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return errors.Wrapf(err, "Error preparing updated manifest, layer %q", info.Digest)
+			return errors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
 		}
 		m.LayersDescriptors[i].MediaType = mimeType
 		m.LayersDescriptors[i].Digest = info.Digest

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -91,7 +91,7 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "error getting platform information %#v", ctx)
+		return "", errors.Wrapf(err, "getting platform information %#v", ctx)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range list.Manifests {
@@ -115,7 +115,7 @@ func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest
 func (list *Schema2List) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(list)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error marshaling Schema2List %#v", list)
+		return nil, errors.Wrapf(err, "marshaling Schema2List %#v", list)
 	}
 	return buf, nil
 }
@@ -190,7 +190,7 @@ func Schema2ListFromManifest(manifest []byte) (*Schema2List, error) {
 		Manifests: []Schema2ManifestDescriptor{},
 	}
 	if err := json.Unmarshal(manifest, &list); err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling Schema2List %q", string(manifest))
+		return nil, errors.Wrapf(err, "unmarshaling Schema2List %q", string(manifest))
 	}
 	return &list, nil
 }

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -127,7 +127,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(oci1CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return errors.Wrapf(err, "Error preparing updated manifest, layer %q", info.Digest)
+			return errors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
 		}
 		if info.CryptoOperation == types.Encrypt {
 			encMediaType, err := getEncryptedMediaType(mimeType)

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -75,7 +75,7 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "error getting platform information %#v", ctx)
+		return "", errors.Wrapf(err, "getting platform information %#v", ctx)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range index.Manifests {
@@ -108,7 +108,7 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 func (index *OCI1Index) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(index)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error marshaling OCI1Index %#v", index)
+		return nil, errors.Wrapf(err, "marshaling OCI1Index %#v", index)
 	}
 	return buf, nil
 }
@@ -200,7 +200,7 @@ func OCI1IndexFromManifest(manifest []byte) (*OCI1Index, error) {
 		},
 	}
 	if err := json.Unmarshal(manifest, &index); err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling OCI1Index %q", string(manifest))
+		return nil, errors.Wrapf(err, "unmarshaling OCI1Index %q", string(manifest))
 	}
 	return &index, nil
 }

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -22,12 +22,12 @@ type ociArchiveImageDestination struct {
 func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating oci reference")
+		return nil, errors.Wrapf(err, "creating oci reference")
 	}
 	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, errors.Wrapf(err, "error deleting temp directory %q", tempDirRef.tempDirectory)
+			return nil, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (d *ociArchiveImageDestination) PutSignatures(ctx context.Context, signatur
 // after the directory is made, it is tarred up into a file and the directory is deleted
 func (d *ociArchiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if err := d.unpackedDest.Commit(ctx, unparsedToplevel); err != nil {
-		return errors.Wrapf(err, "error storing image %q", d.ref.image)
+		return errors.Wrapf(err, "storing image %q", d.ref.image)
 	}
 
 	// path of directory to tar up
@@ -150,13 +150,13 @@ func tarDirectory(src, dst string) error {
 	// input is a stream of bytes from the archive of the directory at path
 	input, err := archive.Tar(src, archive.Uncompressed)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving stream of bytes from %q", src)
+		return errors.Wrapf(err, "retrieving stream of bytes from %q", src)
 	}
 
 	// creates the tar file
 	outFile, err := os.Create(dst)
 	if err != nil {
-		return errors.Wrapf(err, "error creating tar file %q", dst)
+		return errors.Wrapf(err, "creating tar file %q", dst)
 	}
 	defer outFile.Close()
 

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -23,13 +23,13 @@ type ociArchiveImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(sys, ref)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating temp directory")
+		return nil, errors.Wrap(err, "creating temp directory")
 	}
 
 	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, errors.Wrapf(err, "error deleting temp directory %q", tempDirRef.tempDirectory)
+			return nil, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.Im
 	}
 	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {
-		return imgspecv1.Descriptor{}, errors.Wrap(err, "error creating temp directory")
+		return imgspecv1.Descriptor{}, errors.Wrap(err, "creating temp directory")
 	}
 	defer func() {
 		err := tempDirRef.deleteTempDir()
@@ -61,7 +61,7 @@ func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.Im
 
 	descriptor, err := ocilayout.LoadManifestDescriptor(tempDirRef.ociRefExtracted)
 	if err != nil {
-		return imgspecv1.Descriptor{}, errors.Wrap(err, "error loading index")
+		return imgspecv1.Descriptor{}, errors.Wrap(err, "loading index")
 	}
 	return descriptor, nil
 }

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -163,7 +163,7 @@ func (t *tempDirOCIRef) deleteTempDir() error {
 func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error) {
 	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
 	if err != nil {
-		return tempDirOCIRef{}, errors.Wrapf(err, "error creating temp directory")
+		return tempDirOCIRef{}, errors.Wrapf(err, "creating temp directory")
 	}
 	ociRef, err := ocilayout.NewReference(dir, image)
 	if err != nil {
@@ -178,7 +178,7 @@ func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error)
 func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (tempDirOCIRef, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
-		return tempDirOCIRef{}, errors.Wrap(err, "error creating oci reference")
+		return tempDirOCIRef{}, errors.Wrap(err, "creating oci reference")
 	}
 	src := ref.resolvedFile
 	dst := tempDirRef.tempDirectory
@@ -190,9 +190,9 @@ func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (temp
 	defer arch.Close()
 	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return tempDirOCIRef{}, errors.Wrapf(err, "error deleting temp directory %q", tempDirRef.tempDirectory)
+			return tempDirOCIRef{}, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
-		return tempDirOCIRef{}, errors.Wrapf(err, "error untarring file %q", tempDirRef.tempDirectory)
+		return tempDirOCIRef{}, errors.Wrapf(err, "untarring file %q", tempDirRef.tempDirectory)
 	}
 	return tempDirRef, nil
 }

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -579,7 +579,7 @@ func (rules *clientConfigLoadingRules) Load() (*clientcmdConfig, error) {
 			continue
 		}
 		if err != nil {
-			errlist = append(errlist, errors.Wrapf(err, "Error loading config file \"%s\"", filename))
+			errlist = append(errlist, errors.Wrapf(err, "loading config file \"%s\"", filename))
 			continue
 		}
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -475,7 +475,7 @@ sigExists:
 			randBytes := make([]byte, 16)
 			n, err := rand.Read(randBytes)
 			if err != nil || n != 16 {
-				return errors.Wrapf(err, "Error generating random signature len %d", n)
+				return errors.Wrapf(err, "generating random signature len %d", n)
 			}
 			signatureName = fmt.Sprintf("%s@%032x", imageStreamImageName, randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -135,13 +135,13 @@ func DetectCompression(input io.Reader) (DecompressorFunc, io.Reader, error) {
 func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
 	decompressor, stream, err := DetectCompression(stream)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "Error detecting compression")
+		return nil, false, errors.Wrapf(err, "detecting compression")
 	}
 	var res io.ReadCloser
 	if decompressor != nil {
 		res, err = decompressor(stream)
 		if err != nil {
-			return nil, false, errors.Wrapf(err, "Error initializing decompression")
+			return nil, false, errors.Wrapf(err, "initializing decompression")
 		}
 	} else {
 		res = ioutil.NopCloser(stream)

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -126,7 +126,7 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 				// readJSONFile returns an empty map in case the path doesn't exist.
 				auths, err := readJSONFile(path.path, path.legacyFormat)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error reading JSON file %q", path.path)
+					return nil, errors.Wrapf(err, "reading JSON file %q", path.path)
 				}
 				// Credential helpers in the auth file have a
 				// direct mapping to a registry, so we can just
@@ -348,7 +348,7 @@ func RemoveAuthentication(sys *types.SystemContext, registry string) error {
 			logrus.Debugf("Not logged in to %s with credential helper %s", registry, helper)
 			return
 		}
-		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "error removing credentials for %s from credential helper %s", registry, helper))
+		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "removing credentials for %s from credential helper %s", registry, helper))
 	}
 
 	for _, helper := range helpers {
@@ -508,13 +508,13 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 
 	if legacyFormat {
 		if err = json.Unmarshal(raw, &auths.AuthConfigs); err != nil {
-			return dockerConfigFile{}, errors.Wrapf(err, "error unmarshaling JSON at %q", path)
+			return dockerConfigFile{}, errors.Wrapf(err, "unmarshaling JSON at %q", path)
 		}
 		return auths, nil
 	}
 
 	if err = json.Unmarshal(raw, &auths); err != nil {
-		return dockerConfigFile{}, errors.Wrapf(err, "error unmarshaling JSON at %q", path)
+		return dockerConfigFile{}, errors.Wrapf(err, "unmarshaling JSON at %q", path)
 	}
 
 	if auths.AuthConfigs == nil {
@@ -546,21 +546,21 @@ func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (
 
 	auths, err := readJSONFile(path, false)
 	if err != nil {
-		return "", errors.Wrapf(err, "error reading JSON file %q", path)
+		return "", errors.Wrapf(err, "reading JSON file %q", path)
 	}
 
 	updated, err := editor(&auths)
 	if err != nil {
-		return "", errors.Wrapf(err, "error updating %q", path)
+		return "", errors.Wrapf(err, "updating %q", path)
 	}
 	if updated {
 		newData, err := json.MarshalIndent(auths, "", "\t")
 		if err != nil {
-			return "", errors.Wrapf(err, "error marshaling JSON %q", path)
+			return "", errors.Wrapf(err, "marshaling JSON %q", path)
 		}
 
 		if err = ioutil.WriteFile(path, newData, 0600); err != nil {
-			return "", errors.Wrapf(err, "error writing to file %q", path)
+			return "", errors.Wrapf(err, "writing to file %q", path)
 		}
 	}
 
@@ -603,7 +603,7 @@ func deleteAuthFromCredHelper(credHelper, registry string) error {
 func findAuthentication(ref reference.Named, registry, path string, legacyFormat bool) (types.DockerAuthConfig, error) {
 	auths, err := readJSONFile(path, legacyFormat)
 	if err != nil {
-		return types.DockerAuthConfig{}, errors.Wrapf(err, "error reading JSON file %q", path)
+		return types.DockerAuthConfig{}, errors.Wrapf(err, "reading JSON file %q", path)
 	}
 
 	// First try cred helpers. They should always be normalized.

--- a/pkg/docker/config/config_linux.go
+++ b/pkg/docker/config/config_linux.go
@@ -73,7 +73,7 @@ func removeAllAuthFromKernelKeyring() error { //nolint:deadcode,unused
 		if strings.HasPrefix(keyDescribe, keyDescribePrefix) {
 			err := keyctl.Unlink(userkeyring, k)
 			if err != nil {
-				return errors.Wrapf(err, "error unlinking key %d", k.ID())
+				return errors.Wrapf(err, "unlinking key %d", k.ID())
 			}
 			logrus.Debugf("unlinked key %d:%s", k.ID(), keyAttr)
 		}
@@ -100,16 +100,16 @@ func setAuthToKernelKeyring(registry, username, password string) error { //nolin
 	// link the key to userKeyring
 	userKeyring, err := keyctl.UserKeyring()
 	if err != nil {
-		return errors.Wrapf(err, "error getting user keyring")
+		return errors.Wrapf(err, "getting user keyring")
 	}
 	err = keyctl.Link(userKeyring, id)
 	if err != nil {
-		return errors.Wrapf(err, "error linking the key to user keyring")
+		return errors.Wrapf(err, "linking the key to user keyring")
 	}
 	// unlink the key from session keyring
 	err = keyctl.Unlink(keyring, id)
 	if err != nil {
-		return errors.Wrapf(err, "error unlinking the key from session keyring")
+		return errors.Wrapf(err, "unlinking the key from session keyring")
 	}
 	return nil
 }

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -519,7 +519,7 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 	if err == nil {
 		t.Fatalf("got unexpected non-error: username=%q, password=%q", auth.Username, auth.Password)
 	}
-	if !strings.Contains(err.Error(), "error unmarshaling JSON") {
+	if !strings.Contains(err.Error(), "unmarshaling JSON") {
 		t.Fatalf("expected JSON syntax error, not: %#+v", err)
 	}
 
@@ -540,7 +540,7 @@ func TestGetAuthFailsOnBadInput(t *testing.T) {
 	if err == nil {
 		t.Fatalf("got unexpected non-error: username=%q, password=%q", auth.Username, auth.Password)
 	}
-	if !strings.Contains(err.Error(), "error unmarshaling JSON") {
+	if !strings.Contains(err.Error(), "unmarshaling JSON") {
 		t.Fatalf("expected JSON syntax error, not: %#+v", err)
 	}
 }

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -211,7 +211,7 @@ func (c *PullCandidate) Record() error {
 	value := reference.TrimNamed(c.Value)
 
 	if err := Add(c.resolved.systemContext, name.String(), value); err != nil {
-		return errors.Wrapf(err, "error recording short-name alias (%q=%q)", c.resolved.userInput, c.Value)
+		return errors.Wrapf(err, "recording short-name alias (%q=%q)", c.resolved.userInput, c.Value)
 	}
 	return nil
 }
@@ -323,7 +323,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	for _, reg := range unqualifiedSearchRegistries {
 		named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
 		if err != nil {
-			return nil, errors.Wrapf(err, "error creating reference with unqualified-search registry %q", reg)
+			return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
 		}
 		// Make sure to add ":latest" if needed
 		named = reference.TagNameOnly(named)
@@ -450,7 +450,7 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 	for _, reg := range append([]string{"localhost"}, unqualifiedSearchRegistries...) {
 		named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
 		if err != nil {
-			return nil, errors.Wrapf(err, "error creating reference with unqualified-search registry %q", reg)
+			return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
 		}
 		// Make sure to add ":latest" if needed
 		named = reference.TagNameOnly(named)

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -209,7 +209,7 @@ func RemoveShortNameAlias(ctx *types.SystemContext, name string) error {
 func parseShortNameValue(alias string) (reference.Named, error) {
 	ref, err := reference.Parse(alias)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing alias %q", alias)
+		return nil, errors.Wrapf(err, "parsing alias %q", alias)
 	}
 
 	if _, ok := ref.(reference.Digested); ok {
@@ -318,14 +318,14 @@ func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, *shortNameAli
 	_, err := toml.DecodeFile(confPath, &conf)
 	if err != nil && !os.IsNotExist(err) {
 		// It's okay if the config doesn't exist.  Other errors are not.
-		return nil, nil, errors.Wrapf(err, "error loading short-name aliases config file %q", confPath)
+		return nil, nil, errors.Wrapf(err, "loading short-name aliases config file %q", confPath)
 	}
 
 	// Even if we don’t always need the cache, doing so validates the machine-generated config.  The
 	// file could still be corrupted by another process or user.
 	cache, err := newShortNameAliasCache(confPath, &conf)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error loading short-name aliases config file %q", confPath)
+		return nil, nil, errors.Wrapf(err, "loading short-name aliases config file %q", confPath)
 	}
 
 	return &conf, cache, nil

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -88,7 +88,7 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 	newNamedRef = e.Location + refString[prefixLen:]
 	newParsedRef, err := reference.ParseNamed(newNamedRef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error rewriting reference")
+		return nil, errors.Wrapf(err, "rewriting reference")
 	}
 
 	return newParsedRef, nil
@@ -627,7 +627,7 @@ func dropInConfigs(wrapper configWrapper) ([]string, error) {
 		if err != nil && !os.IsNotExist(err) {
 			// Ignore IsNotExist errors: most systems won't have a registries.conf.d
 			// directory.
-			return nil, errors.Wrapf(err, "error reading registries.conf.d")
+			return nil, errors.Wrapf(err, "reading registries.conf.d")
 		}
 	}
 
@@ -669,7 +669,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 				return nil, err // Should never happen
 			}
 		} else {
-			return nil, errors.Wrapf(err, "error loading registries configuration %q", wrapper.configPath)
+			return nil, errors.Wrapf(err, "loading registries configuration %q", wrapper.configPath)
 		}
 	}
 
@@ -682,7 +682,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 		// Enforce v2 format for drop-in-configs.
 		dropIn, err := loadConfigFile(path, true)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error loading drop-in registries configuration %q", path)
+			return nil, errors.Wrapf(err, "loading drop-in registries configuration %q", path)
 		}
 		config.updateWithConfigurationFrom(dropIn)
 	}
@@ -933,7 +933,7 @@ func loadConfigFile(path string, forceV2 bool) (*parsedConfig, error) {
 	// Parse and validate short-name aliases.
 	cache, err := newShortNameAliasCache(path, &res.partialV2.shortNameAliasConf)
 	if err != nil {
-		return nil, errors.Wrap(err, "error validating short-name aliases")
+		return nil, errors.Wrap(err, "validating short-name aliases")
 	}
 	res.aliasCache = cache
 	// Clear conf.partialV2.shortNameAliasConf to make it available for garbage collection and

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -122,7 +122,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, imageRef stor
 	}
 	if img.Metadata != "" {
 		if err := json.Unmarshal([]byte(img.Metadata), image); err != nil {
-			return nil, errors.Wrap(err, "error decoding metadata for source image")
+			return nil, errors.Wrap(err, "decoding metadata for source image")
 		}
 	}
 	return image, nil
@@ -240,7 +240,7 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 		key := manifestBigDataKey(*instanceDigest)
 		blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 		if err != nil {
-			return nil, "", errors.Wrapf(err, "error reading manifest for image instance %q", *instanceDigest)
+			return nil, "", errors.Wrapf(err, "reading manifest for image instance %q", *instanceDigest)
 		}
 		return blob, manifest.GuessMIMEType(blob), err
 	}
@@ -277,14 +277,14 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
 	manifestBlob, manifestType, err := s.GetManifest(ctx, instanceDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image manifest for %q", s.image.ID)
+		return nil, errors.Wrapf(err, "reading image manifest for %q", s.image.ID)
 	}
 	if manifest.MIMETypeIsMultiImage(manifestType) {
 		return nil, errors.Errorf("can't copy layers for a manifest list (shouldn't be attempted)")
 	}
 	man, err := manifest.FromBlob(manifestBlob, manifestType)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing image manifest for %q", s.image.ID)
+		return nil, errors.Wrapf(err, "parsing image manifest for %q", s.image.ID)
 	}
 
 	uncompressedLayerType := ""
@@ -300,7 +300,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 	for layerID != "" {
 		layer, err := s.imageRef.transport.store.Layer(layerID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading layer %q in image %q", layerID, s.image.ID)
+			return nil, errors.Wrapf(err, "reading layer %q in image %q", layerID, s.image.ID)
 		}
 		if layer.UncompressedDigest == "" {
 			return nil, errors.Errorf("uncompressed digest for layer %q is unknown", layerID)
@@ -319,7 +319,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 
 	res, err := buildLayerInfosForCopy(man.LayerInfos(), physicalBlobInfos)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating LayerInfosForCopy of image %q", s.image.ID)
+		return nil, errors.Wrapf(err, "creating LayerInfosForCopy of image %q", s.image.ID)
 	}
 	return res, nil
 }
@@ -368,13 +368,13 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 	if len(signatureSizes) > 0 {
 		signatureBlob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error looking up signatures data for image %q (%s)", s.image.ID, instance)
+			return nil, errors.Wrapf(err, "looking up signatures data for image %q (%s)", s.image.ID, instance)
 		}
 		signature = signatureBlob
 	}
 	for _, length := range signatureSizes {
 		if offset+length > len(signature) {
-			return nil, errors.Wrapf(err, "error looking up signatures data for image %q (%s): expected at least %d bytes, only found %d", s.image.ID, instance, len(signature), offset+length)
+			return nil, errors.Wrapf(err, "looking up signatures data for image %q (%s): expected at least %d bytes, only found %d", s.image.ID, instance, len(signature), offset+length)
 		}
 		sigslice = append(sigslice, signature[offset:offset+length])
 		offset += length
@@ -390,7 +390,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*storageImageDestination, error) {
 	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "storage")
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating a temporary directory")
+		return nil, errors.Wrapf(err, "creating a temporary directory")
 	}
 	image := &storageImageDestination{
 		imageRef:               imageRef,
@@ -484,21 +484,21 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 	filename := s.computeNextBlobCacheFile()
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_EXCL, 0600)
 	if err != nil {
-		return errorBlobInfo, errors.Wrapf(err, "error creating temporary file %q", filename)
+		return errorBlobInfo, errors.Wrapf(err, "creating temporary file %q", filename)
 	}
 	defer file.Close()
 	counter := ioutils.NewWriteCounter(hasher.Hash())
 	reader := io.TeeReader(io.TeeReader(stream, counter), file)
 	decompressed, err := archive.DecompressStream(reader)
 	if err != nil {
-		return errorBlobInfo, errors.Wrap(err, "error setting up to decompress blob")
+		return errorBlobInfo, errors.Wrap(err, "setting up to decompress blob")
 	}
 	// Copy the data to the file.
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	_, err = io.Copy(diffID.Hash(), decompressed)
 	decompressed.Close()
 	if err != nil {
-		return errorBlobInfo, errors.Wrapf(err, "error storing blob to file %q", filename)
+		return errorBlobInfo, errors.Wrapf(err, "storing blob to file %q", filename)
 	}
 	// Ensure that any information that we were given about the blob is correct.
 	if blobinfo.Digest.Validate() == nil && blobinfo.Digest != hasher.Digest() {
@@ -557,7 +557,7 @@ func (s *storageImageDestination) tryReusingBlobWithSrcRef(ctx context.Context, 
 		// Check if we have the layer in the underlying additional layer store.
 		aLayer, err := s.imageRef.transport.store.LookupAdditionalLayer(blobinfo.Digest, ref.String())
 		if err != nil && errors.Cause(err) != storage.ErrLayerUnknown {
-			return false, types.BlobInfo{}, errors.Wrapf(err, `Error looking for compressed layers with digest %q and labels`, blobinfo.Digest)
+			return false, types.BlobInfo{}, errors.Wrapf(err, `looking for compressed layers with digest %q and labels`, blobinfo.Digest)
 		} else if err == nil {
 			// Record the uncompressed value so that we can use it to calculate layer IDs.
 			s.blobDiffIDs[blobinfo.Digest] = aLayer.UncompressedDigest()
@@ -612,7 +612,7 @@ func (s *storageImageDestination) tryReusingBlobLocked(ctx context.Context, blob
 	// Check if we have a wasn't-compressed layer in storage that's based on that blob.
 	layers, err := s.imageRef.transport.store.LayersByUncompressedDigest(blobinfo.Digest)
 	if err != nil && errors.Cause(err) != storage.ErrLayerUnknown {
-		return false, types.BlobInfo{}, errors.Wrapf(err, `Error looking for layers with digest %q`, blobinfo.Digest)
+		return false, types.BlobInfo{}, errors.Wrapf(err, `looking for layers with digest %q`, blobinfo.Digest)
 	}
 	if len(layers) > 0 {
 		// Save this for completeness.
@@ -627,7 +627,7 @@ func (s *storageImageDestination) tryReusingBlobLocked(ctx context.Context, blob
 	// Check if we have a was-compressed layer in storage that's based on that blob.
 	layers, err = s.imageRef.transport.store.LayersByCompressedDigest(blobinfo.Digest)
 	if err != nil && errors.Cause(err) != storage.ErrLayerUnknown {
-		return false, types.BlobInfo{}, errors.Wrapf(err, `Error looking for compressed layers with digest %q`, blobinfo.Digest)
+		return false, types.BlobInfo{}, errors.Wrapf(err, `looking for compressed layers with digest %q`, blobinfo.Digest)
 	}
 	if len(layers) > 0 {
 		// Record the uncompressed value so that we can use it to calculate layer IDs.
@@ -646,7 +646,7 @@ func (s *storageImageDestination) tryReusingBlobLocked(ctx context.Context, blob
 		if uncompressedDigest := cache.UncompressedDigest(blobinfo.Digest); uncompressedDigest != "" && uncompressedDigest != blobinfo.Digest {
 			layers, err := s.imageRef.transport.store.LayersByUncompressedDigest(uncompressedDigest)
 			if err != nil && errors.Cause(err) != storage.ErrLayerUnknown {
-				return false, types.BlobInfo{}, errors.Wrapf(err, `Error looking for layers with digest %q`, uncompressedDigest)
+				return false, types.BlobInfo{}, errors.Wrapf(err, `looking for layers with digest %q`, uncompressedDigest)
 			}
 			if len(layers) > 0 {
 				if blobinfo.Size != -1 {
@@ -721,7 +721,7 @@ func (s *storageImageDestination) getConfigBlob(info types.BlobInfo) ([]byte, er
 	if filename, ok := s.filenames[info.Digest]; ok {
 		contents, err2 := ioutil.ReadFile(filename)
 		if err2 != nil {
-			return nil, errors.Wrapf(err2, `error reading blob from file %q`, filename)
+			return nil, errors.Wrapf(err2, `reading blob from file %q`, filename)
 		}
 		return contents, nil
 	}
@@ -823,7 +823,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 		// NOTE: use `TryReusingBlob` to prevent recursion.
 		has, _, err := s.TryReusingBlob(ctx, blob.BlobInfo, none.NoCache, false)
 		if err != nil {
-			return errors.Wrapf(err, "error checking for a layer based on blob %q", blob.Digest.String())
+			return errors.Wrapf(err, "checking for a layer based on blob %q", blob.Digest.String())
 		}
 		if !has {
 			return errors.Errorf("error determining uncompressed digest for blob %q", blob.Digest.String())
@@ -875,7 +875,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 			}
 		}
 		if layer == "" {
-			return errors.Wrapf(err2, "error locating layer for blob %q", blob.Digest)
+			return errors.Wrapf(err2, "locating layer for blob %q", blob.Digest)
 		}
 		// Read the layer's contents.
 		noCompression := archive.Uncompressed
@@ -884,7 +884,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 		}
 		diff, err2 := s.imageRef.transport.store.Diff("", layer, diffOptions)
 		if err2 != nil {
-			return errors.Wrapf(err2, "error reading layer %q for blob %q", layer, blob.Digest)
+			return errors.Wrapf(err2, "reading layer %q for blob %q", layer, blob.Digest)
 		}
 		// Copy the layer diff to a file.  Diff() takes a lock that it holds
 		// until the ReadCloser that it returns is closed, and PutLayer() wants
@@ -894,7 +894,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 		file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_EXCL, 0600)
 		if err != nil {
 			diff.Close()
-			return errors.Wrapf(err, "error creating temporary file %q", filename)
+			return errors.Wrapf(err, "creating temporary file %q", filename)
 		}
 		// Copy the data to the file.
 		// TODO: This can take quite some time, and should ideally be cancellable using
@@ -903,7 +903,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 		diff.Close()
 		file.Close()
 		if err != nil {
-			return errors.Wrapf(err, "error storing blob to file %q", filename)
+			return errors.Wrapf(err, "storing blob to file %q", filename)
 		}
 		// Make sure that we can find this file later, should we need the layer's
 		// contents again.
@@ -914,14 +914,14 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 	// Read the cached blob and use it as a diff.
 	file, err := os.Open(filename)
 	if err != nil {
-		return errors.Wrapf(err, "error opening file %q", filename)
+		return errors.Wrapf(err, "opening file %q", filename)
 	}
 	defer file.Close()
 	// Build the new layer using the diff, regardless of where it came from.
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	layer, _, err := s.imageRef.transport.store.PutLayer(id, lastLayer, nil, "", false, nil, file)
 	if err != nil && errors.Cause(err) != storage.ErrDuplicateID {
-		return errors.Wrapf(err, "error adding layer with blob %q", blob.Digest)
+		return errors.Wrapf(err, "adding layer with blob %q", blob.Digest)
 	}
 
 	s.indexToStorageID[index] = &layer.ID
@@ -941,7 +941,7 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	}
 	toplevelManifest, _, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving top-level manifest")
+		return errors.Wrapf(err, "retrieving top-level manifest")
 	}
 	// If the name we're saving to includes a digest, then check that the
 	// manifests that we're about to save all either match the one from the
@@ -966,7 +966,7 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	// Find the list of layer blobs.
 	man, err := manifest.FromBlob(s.manifest, manifest.GuessMIMEType(s.manifest))
 	if err != nil {
-		return errors.Wrapf(err, "error parsing manifest")
+		return errors.Wrapf(err, "parsing manifest")
 	}
 	layerBlobs := man.LayerInfos()
 	// Extract, commit, or find the layers.
@@ -1001,11 +1001,11 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	if err != nil {
 		if errors.Cause(err) != storage.ErrDuplicateID {
 			logrus.Debugf("error creating image: %q", err)
-			return errors.Wrapf(err, "error creating image %q", intendedID)
+			return errors.Wrapf(err, "creating image %q", intendedID)
 		}
 		img, err = s.imageRef.transport.store.Image(intendedID)
 		if err != nil {
-			return errors.Wrapf(err, "error reading image %q", intendedID)
+			return errors.Wrapf(err, "reading image %q", intendedID)
 		}
 		if img.TopLayer != lastLayer {
 			logrus.Debugf("error creating image: image with ID %q exists, but uses different layers", intendedID)
@@ -1041,23 +1041,23 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	for blob := range dataBlobs {
 		v, err := ioutil.ReadFile(s.filenames[blob])
 		if err != nil {
-			return errors.Wrapf(err, "error copying non-layer blob %q to image", blob)
+			return errors.Wrapf(err, "copying non-layer blob %q to image", blob)
 		}
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, blob.String(), v, manifest.Digest); err != nil {
 			logrus.Debugf("error saving big data %q for image %q: %v", blob.String(), img.ID, err)
-			return errors.Wrapf(err, "error saving big data %q for image %q", blob.String(), img.ID)
+			return errors.Wrapf(err, "saving big data %q for image %q", blob.String(), img.ID)
 		}
 	}
 	// Save the unparsedToplevel's manifest if it differs from the per-platform one, which is saved below.
 	if len(toplevelManifest) != 0 && !bytes.Equal(toplevelManifest, s.manifest) {
 		manifestDigest, err := manifest.Digest(toplevelManifest)
 		if err != nil {
-			return errors.Wrapf(err, "error digesting top-level manifest")
+			return errors.Wrapf(err, "digesting top-level manifest")
 		}
 		key := manifestBigDataKey(manifestDigest)
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, toplevelManifest, manifest.Digest); err != nil {
 			logrus.Debugf("error saving top-level manifest for image %q: %v", img.ID, err)
-			return errors.Wrapf(err, "error saving top-level manifest for image %q", img.ID)
+			return errors.Wrapf(err, "saving top-level manifest for image %q", img.ID)
 		}
 	}
 	// Save the image's manifest.  Allow looking it up by digest by using the key convention defined by the Store.
@@ -1066,37 +1066,37 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	key := manifestBigDataKey(s.manifestDigest)
 	if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, s.manifest, manifest.Digest); err != nil {
 		logrus.Debugf("error saving manifest for image %q: %v", img.ID, err)
-		return errors.Wrapf(err, "error saving manifest for image %q", img.ID)
+		return errors.Wrapf(err, "saving manifest for image %q", img.ID)
 	}
 	key = storage.ImageDigestBigDataKey
 	if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, s.manifest, manifest.Digest); err != nil {
 		logrus.Debugf("error saving manifest for image %q: %v", img.ID, err)
-		return errors.Wrapf(err, "error saving manifest for image %q", img.ID)
+		return errors.Wrapf(err, "saving manifest for image %q", img.ID)
 	}
 	// Save the signatures, if we have any.
 	if len(s.signatures) > 0 {
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, "signatures", s.signatures, manifest.Digest); err != nil {
 			logrus.Debugf("error saving signatures for image %q: %v", img.ID, err)
-			return errors.Wrapf(err, "error saving signatures for image %q", img.ID)
+			return errors.Wrapf(err, "saving signatures for image %q", img.ID)
 		}
 	}
 	for instanceDigest, signatures := range s.signatureses {
 		key := signatureBigDataKey(instanceDigest)
 		if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, signatures, manifest.Digest); err != nil {
 			logrus.Debugf("error saving signatures for image %q: %v", img.ID, err)
-			return errors.Wrapf(err, "error saving signatures for image %q", img.ID)
+			return errors.Wrapf(err, "saving signatures for image %q", img.ID)
 		}
 	}
 	// Save our metadata.
 	metadata, err := json.Marshal(s)
 	if err != nil {
 		logrus.Debugf("error encoding metadata for image %q: %v", img.ID, err)
-		return errors.Wrapf(err, "error encoding metadata for image %q", img.ID)
+		return errors.Wrapf(err, "encoding metadata for image %q", img.ID)
 	}
 	if len(metadata) != 0 {
 		if err = s.imageRef.transport.store.SetMetadata(img.ID, string(metadata)); err != nil {
 			logrus.Debugf("error saving metadata for image %q: %v", img.ID, err)
-			return errors.Wrapf(err, "error saving metadata for image %q", img.ID)
+			return errors.Wrapf(err, "saving metadata for image %q", img.ID)
 		}
 		logrus.Debugf("saved image metadata %q", string(metadata))
 	}
@@ -1112,7 +1112,7 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		}
 		if err := s.imageRef.transport.store.SetNames(img.ID, names); err != nil {
 			logrus.Debugf("error setting names %v on image %q: %v", names, img.ID, err)
-			return errors.Wrapf(err, "error setting names %v on image %q", names, img.ID)
+			return errors.Wrapf(err, "setting names %v on image %q", names, img.ID)
 		}
 		logrus.Debugf("set names of image %q to %v", img.ID, names)
 	}
@@ -1202,12 +1202,12 @@ func (s *storageImageSource) getSize() (int64, error) {
 	// Size up the data blobs.
 	dataNames, err := s.imageRef.transport.store.ListImageBigData(s.image.ID)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading image %q", s.image.ID)
+		return -1, errors.Wrapf(err, "reading image %q", s.image.ID)
 	}
 	for _, dataName := range dataNames {
 		bigSize, err := s.imageRef.transport.store.ImageBigDataSize(s.image.ID, dataName)
 		if err != nil {
-			return -1, errors.Wrapf(err, "error reading data blob size %q for %q", dataName, s.image.ID)
+			return -1, errors.Wrapf(err, "reading data blob size %q for %q", dataName, s.image.ID)
 		}
 		sum += bigSize
 	}

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -149,7 +149,7 @@ func (s *storageReference) resolveImage(sys *types.SystemContext) (*storage.Imag
 	if loadedImage == nil {
 		img, err := s.transport.store.Image(s.id)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading image %q", s.id)
+			return nil, errors.Wrapf(err, "reading image %q", s.id)
 		}
 		loadedImage = img
 	}

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -172,7 +172,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		var err error
 		named, err = reference.ParseNormalizedNamed(ref)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing named reference %q", ref)
+			return nil, errors.Wrapf(err, "parsing named reference %q", ref)
 		}
 		named = reference.TagNameOnly(named)
 	}


### PR DESCRIPTION
Podman and other tools already add Error: to the front of returned error
message, and this ends up as a stutter.

podman pull fedora.io/fred
Trying to pull fedora.io/fred:latest...
Error: Error initializing image from source docker://fedora.io/fred:latest: invalid character '<' looking for beginning of value

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>