### PR TITLE
Retrieve digest from manifest HEAD request matching the platform

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -131,7 +132,13 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 
 	path := fmt.Sprintf(manifestPath, reference.Path(dr.ref), tagOrDigest)
 	headers := map[string][]string{
-		"Accept": manifest.DefaultRequestedManifestMIMETypes,
+		"Accept": {
+			imgspecv1.MediaTypeImageManifest,
+			manifest.DockerV2Schema2MediaType,
+			manifest.DockerV2Schema1SignedMediaType,
+			manifest.DockerV2Schema1MediaType,
+			imgspecv1.MediaTypeImageIndex,
+		},
 	}
 
 	res, err := client.makeRequest(ctx, "HEAD", path, headers, nil, v2Auth, nil)


### PR DESCRIPTION
Following what have been done in #1078, we need to make sure the digest from manifest HEAD request match the platform used. That's why we need to remove `application/vnd.docker.distribution.manifest.list.v2+json` to avoid returning the manifest list digest (crazy-max/diun#299).

As an example:

```shell
$ docker buildx imagetools inspect docker.io/alpine:latest
Name:      docker.io/library/alpine:latest
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f

Manifests:
  Name:      docker.io/library/alpine:latest@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      docker.io/library/alpine:latest@sha256:ea73ecf48cd45e250f65eb731dd35808175ae37d70cca5d41f9ef57210737f04
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v6

  Name:      docker.io/library/alpine:latest@sha256:9663906b1c3bf891618ebcac857961531357525b25493ef717bca0f86f581ad6
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v7

  Name:      docker.io/library/alpine:latest@sha256:8f18fae117ec6e5777cc62ba78cbb3be10a8a38639ccfb949521abd95c8301a4
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64/v8

  Name:      docker.io/library/alpine:latest@sha256:5de788243acadd50526e70868b86d12ad79f3793619719ae22e0d09e8c873a66
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/386

  Name:      docker.io/library/alpine:latest@sha256:827525365ff718681b0688621e09912af49a17611701ee4d421ba50d57c13f7e
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le

  Name:      docker.io/library/alpine:latest@sha256:a090d7c93c8e9ab88946367500756c5f50cd660e09deb4c57494989c1f23fa5a
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x
```

Previously:

```text
> HEAD /v2/library/alpine/manifests/latest HTTP/1.1
> Host: registry-1.docker.io
> Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json

____

< HTTP/1.1 200 OK
< content-length: 1638
< content-type: application/vnd.docker.distribution.manifest.list.v2+json
< docker-content-digest: sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f
< docker-distribution-api-version: registry/2.0
< etag: "sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"
< date: Sun, 06 Jun 2021 06:36:56 GMT
< strict-transport-security: max-age=31536000
```

Now:

```text
> HEAD /v2/library/alpine/manifests/latest HTTP/1.1
> Host: registry-1.docker.io
> Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v1+json,application/vnd.oci.image.index.v1+json

____

< HTTP/1.1 200 OK
< content-length: 528
< content-type: application/vnd.docker.distribution.manifest.v2+json
< docker-content-digest: sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748
< docker-distribution-api-version: registry/2.0
< etag: "sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748"
< date: Sun, 06 Jun 2021 06:34:34 GMT
< strict-transport-security: max-age=31536000
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>