### PR TITLE
Fix (make)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,6 @@ lint:
 # When this is running in CI, it will only check the CI commit range
 .gitvalidation:
 	@which $(GOBIN)/git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make clean && make tools'" && false)
-	git fetch -q "https://github.com/containers/image.git" "refs/heads/master"
+	git fetch -q "https://github.com/containers/image.git" "refs/heads/main"
 	upstream="$$(git rev-parse --verify FETCH_HEAD)" ; \
 		$(GOBIN)/git-validation -q -run DCO,short-subject,dangling-whitespace -range $$upstream..HEAD

--- a/pkg/docker/config/config_linux.go
+++ b/pkg/docker/config/config_linux.go
@@ -13,9 +13,9 @@ import (
 // reenable keyring support, we should introduce a similar built-in credential
 // helpers as for `sysregistriesv2.AuthenticationFileHelper`.
 
-const keyDescribePrefix = "container-registry-login:" // nolint
+const keyDescribePrefix = "container-registry-login:" //nolint:deadcode,unused
 
-func getAuthFromKernelKeyring(registry string) (string, string, error) { // nolint
+func getAuthFromKernelKeyring(registry string) (string, string, error) { //nolint:deadcode,unused
 	userkeyring, err := keyctl.UserKeyring()
 	if err != nil {
 		return "", "", err
@@ -35,7 +35,7 @@ func getAuthFromKernelKeyring(registry string) (string, string, error) { // noli
 	return parts[0], parts[1], nil
 }
 
-func deleteAuthFromKernelKeyring(registry string) error { // nolint
+func deleteAuthFromKernelKeyring(registry string) error { //nolint:deadcode,unused
 	userkeyring, err := keyctl.UserKeyring()
 
 	if err != nil {
@@ -48,7 +48,7 @@ func deleteAuthFromKernelKeyring(registry string) error { // nolint
 	return key.Unlink()
 }
 
-func removeAllAuthFromKernelKeyring() error { // nolint
+func removeAllAuthFromKernelKeyring() error { //nolint:deadcode,unused
 	keys, err := keyctl.ReadUserKeyring()
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func removeAllAuthFromKernelKeyring() error { // nolint
 	return nil
 }
 
-func setAuthToKernelKeyring(registry, username, password string) error { // nolint
+func setAuthToKernelKeyring(registry, username, password string) error { //nolint:deadcode,unused
 	keyring, err := keyctl.SessionKeyring()
 	if err != nil {
 		return err
@@ -114,6 +114,6 @@ func setAuthToKernelKeyring(registry, username, password string) error { // noli
 	return nil
 }
 
-func genDescription(registry string) string { // nolint
+func genDescription(registry string) string { //nolint:deadcode,unused
 	return fmt.Sprintf("%s%s", keyDescribePrefix, registry)
 }

--- a/pkg/docker/config/config_unsupported.go
+++ b/pkg/docker/config/config_unsupported.go
@@ -3,18 +3,18 @@
 
 package config
 
-func getAuthFromKernelKeyring(registry string) (string, string, error) {
+func getAuthFromKernelKeyring(registry string) (string, string, error) { //nolint:deadcode,unused
 	return "", "", ErrNotSupported
 }
 
-func deleteAuthFromKernelKeyring(registry string) error {
+func deleteAuthFromKernelKeyring(registry string) error { //nolint:deadcode,unused
 	return ErrNotSupported
 }
 
-func setAuthToKernelKeyring(registry, username, password string) error {
+func setAuthToKernelKeyring(registry, username, password string) error { //nolint:deadcode,unused
 	return ErrNotSupported
 }
 
-func removeAllAuthFromKernelKeyring() error {
+func removeAllAuthFromKernelKeyring() error { //nolint:deadcode,unused
 	return ErrNotSupported
 }


### PR DESCRIPTION
This at least allows `make` not to fail (on non-Linux, and after the master/main rename).

https://github.com/containers/image/issues/1252 still needs addressing.