### PR TITLE
Fix missing gofmt and validate runtime environment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ env:
     PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c6032583541653504"
+    IMAGE_SUFFIX: "c4635821094469632"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
@@ -72,7 +72,7 @@ validate_task:
     script: |
         git remote update
         make tools
-        ${GOBIN}/git-validation -q -run DCO,short-subject,dangling-whitespace -range $(git merge-base ${DEST_BRANCH:-main} HEAD)..${CIRRUS_CHANGE_IN_REPO}
+        ${GOBIN}/git-validation -q -run DCO,short-subject,dangling-whitespace -range $(git merge-base origin/${DEST_BRANCH} HEAD)..${CIRRUS_CHANGE_IN_REPO}
         make validate
 
 

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,10 @@ test:
 	@$(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
 
 fmt:
-	@go fmt -l -s -w $(SOURCE_DIRS)
+	@gofmt -l -s -w $(SOURCE_DIRS)
 
 validate: lint
-	@GO111MODULE="on" go vet ./...
-	@test -z "$$(go fmt -s -l . | grep -ve '^vendor' | tee /dev/stderr)"
+	@hack/validate.sh
 
 lint:
 	$(GOBIN)/golangci-lint run --build-tags "$(BUILDTAGS)"

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+eval $(go env)
+PATH="$GOPATH/bin:$PATH"
+
+die() { echo "Error: ${1:-No message provided}" > /dev/stderr; exit 1; }
+
+# Always run from the repository root
+cd $(dirname "${BASH_SOURCE[0]}")/../
+
+if [[ -z $(type -P gofmt) ]]; then
+    die "Unable to find 'gofmt' binary in \$PATH: $PATH"
+fi
+
+echo "Executing go vet"
+GO111MODULE="on" go vet ./...
+
+echo "Executing gofmt"
+OUTPUT=$(gofmt -s -l . | sed -e '/^vendor/d')
+if [[ ! -z "$OUTPUT" ]]; then
+    die "Please fix the formatting of the following files:
+$OUTPUT"
+fi

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -79,7 +79,7 @@ func SetCredentials(sys *types.SystemContext, registry, username, password strin
 		// External helpers.
 		default:
 			path = fmt.Sprintf("credential helper: %s", helper)
-			err  = setAuthToCredHelper(helper, registry, username, password)
+			err = setAuthToCredHelper(helper, registry, username, password)
 		}
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
@@ -91,7 +91,6 @@ func SetCredentials(sys *types.SystemContext, registry, username, password strin
 	}
 	return "", multiErr
 }
-
 
 // SetAuthentication stores the username and password in the credential helper or file
 func SetAuthentication(sys *types.SystemContext, registry, username, password string) error {

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -108,7 +108,7 @@ func TestDefaultPolicy(t *testing.T) {
 
 	for _, path := range []string{
 		"/this/does/not/exist", // Error reading file
-		"/dev/null",          // A failure case; most are tested in the individual method unit tests.
+		"/dev/null",            // A failure case; most are tested in the individual method unit tests.
 	} {
 		policy, err := DefaultPolicy(&types.SystemContext{SignaturePolicyPath: path})
 		assert.Error(t, err)


### PR DESCRIPTION
An error was introduced in
https://github.com/containers/image/pull/1140 that incorrectly changed
the command.  However, it was observed the previous command contained
a hidden bug WRT pipefail being unset by default.  Fix both problems by
ensuring golang tooling is present, and calling out to a shell-script
where the environment can be more carefully controlled and verified.