### PR TITLE
SetCredentials nits

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -511,34 +511,34 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (bool, error)) (string, error) {
 	path, legacyFormat, err := getPathToAuth(sys)
 	if err != nil {
-		return path, err
+		return "", err
 	}
 	if legacyFormat {
-		return path, fmt.Errorf("writes to %s using legacy format are not supported", path)
+		return "", fmt.Errorf("writes to %s using legacy format are not supported", path)
 	}
 
 	dir := filepath.Dir(path)
 	if err = os.MkdirAll(dir, 0700); err != nil {
-		return path, err
+		return "", err
 	}
 
 	auths, err := readJSONFile(path, false)
 	if err != nil {
-		return path, errors.Wrapf(err, "error reading JSON file %q", path)
+		return "", errors.Wrapf(err, "error reading JSON file %q", path)
 	}
 
 	updated, err := editor(&auths)
 	if err != nil {
-		return path, errors.Wrapf(err, "error updating %q", path)
+		return "", errors.Wrapf(err, "error updating %q", path)
 	}
 	if updated {
 		newData, err := json.MarshalIndent(auths, "", "\t")
 		if err != nil {
-			return path, errors.Wrapf(err, "error marshaling JSON %q", path)
+			return "", errors.Wrapf(err, "error marshaling JSON %q", path)
 		}
 
 		if err = ioutil.WriteFile(path, newData, 0600); err != nil {
-			return path, errors.Wrapf(err, "error writing to file %q", path)
+			return "", errors.Wrapf(err, "error writing to file %q", path)
 		}
 	}
 

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -52,7 +52,10 @@ var (
 )
 
 // SetCredentials stores the username and password in the credential helper or file
-// and returns path to file or helper name in format (helper:%s)
+// and returns path to file or helper name in format (helper:%s).
+// Returns a human-redable description of the location that was updated.
+// NOTE: The return value is only intended to be read by humans; its form is not an API,
+// it may change (or new forms can be added) any time.
 func SetCredentials(sys *types.SystemContext, registry, username, password string) (string, error) {
 	path := ""
 	helpers, err := sysregistriesv2.CredentialHelpers(sys)
@@ -502,7 +505,9 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 	return auths, nil
 }
 
-// modifyJSON writes to auth.json if the dockerConfigFile has been updated
+// modifyJSON finds an auth.json file, calls editor on the contents, and
+// writes it back if editor returns true.
+// Returns a human-redable description of the file, to be returned by SetCredentials.
 func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (bool, error)) (string, error) {
 	path, legacyFormat, err := getPathToAuth(sys)
 	if err != nil {


### PR DESCRIPTION
Small cleanups for #1204, primarily documenting that the value returned from `SetCredentials` is not an API.