### PR TITLE
Add override of SignaturePolicyPath

### DIFF
--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -65,6 +65,11 @@ func defaultPolicyPath(sys *types.SystemContext) string {
 // defaultPolicyPathWithHomeDir is an internal implementation detail of defaultPolicyPath,
 // it exists only to allow testing it with an artificial home directory.
 func defaultPolicyPathWithHomeDir(sys *types.SystemContext, homeDir string) string {
+	if envSigPath, ok := os.LookupEnv("CONTAINERS_POLICY_JSON"); ok {
+		if _, err := os.Stat(envSigPath); err == nil {
+			return envSigPath
+		}
+	}
 	if sys != nil && sys.SignaturePolicyPath != "" {
 		return sys.SignaturePolicyPath
 	}


### PR DESCRIPTION
Using podman with paths overridden by various CONTAINERS_* environment
variables still requires 'policy.json' to be present in '/etc/containers'
for root and in '$HOME/.config/containers' for rootless set-ups.

This commit adds the environment variable 'CONTAINERS_POLICY_JSON' to
override this path like all other similar paths.
