### PR TITLE
RFC: Consolidate deleting a partial c/storage image on Commit failure

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -1017,8 +1017,9 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	commitSucceeded := false
 	defer func() {
 		if !commitSucceeded {
+			logrus.Errorf("Updating image %q (old names %v) failed, deleting it", img.ID, oldNames)
 			if _, err := s.imageRef.transport.store.DeleteImage(img.ID, true); err != nil {
-				logrus.Debugf("error deleting incomplete image %q: %v", img.ID, err)
+				logrus.Errorf("Error deleting incomplete image %q: %v", img.ID, err)
 			}
 		}
 	}()


### PR DESCRIPTION
Do it from `defer`, so that any new error paths (and quite a few pre-existing ones that missed this) delete the image without
having to specifically care.  Also makes the code a bit shorter.

Note also the added comment; is deleting the image always the right thing to do?

Cc: @nalind . Looking at the existing code paths that didn’t clean up the image, it kind of looks as if failures to write to c/storage should cause the image to be deleted, but other failures (e.g. error computing a digest) should not delete it — but nothing documents such an intent and the code is not consistently behaving that way either.