### PR TITLE
Manifest list support nits

### DIFF
--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -258,11 +258,11 @@ func TestDetermineManifestListConversion(t *testing.T) {
 		// Destination accepts the unmodified original
 		{"s2→s1s2OCI", manifest.DockerV2ListMediaType, supportS1S2OCI, "", []string{v1.MediaTypeImageIndex}},
 		{"OCI→s1s2OCI", v1.MediaTypeImageIndex, supportS1S2OCI, "", []string{manifest.DockerV2ListMediaType}},
-		{"s2→s1s2", manifest.DockerV2ListMediaType, supportS1S2, "", nil},
-		{"OCI→OCI", v1.MediaTypeImageIndex, supportOnlyOCI, "", nil},
+		{"s2→s1s2", manifest.DockerV2ListMediaType, supportS1S2, "", []string{}},
+		{"OCI→OCI", v1.MediaTypeImageIndex, supportOnlyOCI, "", []string{}},
 		// Conversion necessary, try the preferred formats in order.
 		{"special→OCI", "unrecognized", supportS1S2OCI, v1.MediaTypeImageIndex, []string{manifest.DockerV2ListMediaType}},
-		{"special→s2", "unrecognized", supportS1S2, manifest.DockerV2ListMediaType, nil},
+		{"special→s2", "unrecognized", supportS1S2, manifest.DockerV2ListMediaType, []string{}},
 	}
 
 	for _, c := range cases {
@@ -283,7 +283,7 @@ func TestDetermineManifestListConversion(t *testing.T) {
 		preferredMIMEType, otherCandidates, err := copier.determineListConversion(c.sourceType, c.destTypes, v1.MediaTypeImageIndex)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, v1.MediaTypeImageIndex, preferredMIMEType, c.description)
-		assert.Equal(t, []string(nil), otherCandidates, c.description)
+		assert.Equal(t, []string{}, otherCandidates, c.description)
 	}
 
 	// The destination doesn’t support list formats at all

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -218,5 +218,76 @@ func TestIsMultiImage(t *testing.T) {
 	// Error getting manifest MIME type
 	src := fakeImageSource("")
 	_, err := isMultiImage(context.Background(), src)
+	assert.Error(t, err)
+}
+
+func TestDetermineManifestListConversion(t *testing.T) {
+	supportS1S2OCI := []string{
+		v1.MediaTypeImageIndex,
+		v1.MediaTypeImageManifest,
+		manifest.DockerV2ListMediaType,
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+	supportS1S2 := []string{
+		manifest.DockerV2ListMediaType,
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+	supportOnlyOCI := []string{
+		v1.MediaTypeImageIndex,
+		v1.MediaTypeImageManifest,
+	}
+	supportOnlyS1 := []string{
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
+
+	cases := []struct {
+		description             string
+		sourceType              string
+		destTypes               []string
+		expectedUpdate          string
+		expectedOtherCandidates []string
+	}{
+		// Destination accepts anything — try all variants
+		{"s2→anything", manifest.DockerV2ListMediaType, nil, "", []string{v1.MediaTypeImageIndex}},
+		{"OCI→anything", v1.MediaTypeImageIndex, nil, "", []string{manifest.DockerV2ListMediaType}},
+		// Destination accepts the unmodified original
+		{"s2→s1s2OCI", manifest.DockerV2ListMediaType, supportS1S2OCI, "", []string{v1.MediaTypeImageIndex}},
+		{"OCI→s1s2OCI", v1.MediaTypeImageIndex, supportS1S2OCI, "", []string{manifest.DockerV2ListMediaType}},
+		{"s2→s1s2", manifest.DockerV2ListMediaType, supportS1S2, "", nil},
+		{"OCI→OCI", v1.MediaTypeImageIndex, supportOnlyOCI, "", nil},
+		// Conversion necessary, try the preferred formats in order.
+		{"special→OCI", "unrecognized", supportS1S2OCI, v1.MediaTypeImageIndex, []string{manifest.DockerV2ListMediaType}},
+		{"special→s2", "unrecognized", supportS1S2, manifest.DockerV2ListMediaType, nil},
+	}
+
+	for _, c := range cases {
+		copier := &copier{}
+		preferredMIMEType, otherCandidates, err := copier.determineListConversion(c.sourceType, c.destTypes, "")
+		require.NoError(t, err, c.description)
+		if c.expectedUpdate == "" {
+			assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), preferredMIMEType, c.description)
+		} else {
+			assert.Equal(t, c.expectedUpdate, preferredMIMEType, c.description)
+		}
+		assert.Equal(t, c.expectedOtherCandidates, otherCandidates, c.description)
+	}
+
+	// With forceManifestMIMEType, the output is always the forced manifest type (in this case OCI index)
+	for _, c := range cases {
+		copier := &copier{}
+		preferredMIMEType, otherCandidates, err := copier.determineListConversion(c.sourceType, c.destTypes, v1.MediaTypeImageIndex)
+		require.NoError(t, err, c.description)
+		assert.Equal(t, v1.MediaTypeImageIndex, preferredMIMEType, c.description)
+		assert.Equal(t, []string(nil), otherCandidates, c.description)
+	}
+
+	// The destination doesn’t support list formats at all
+	copier := &copier{}
+	_, _, err := copier.determineListConversion(v1.MediaTypeImageIndex, supportOnlyS1, "")
 	assert.Error(t, err)
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -239,6 +239,9 @@ func (d *dirImageDestination) PutSignatures(ctx context.Context, signatures [][]
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -42,7 +42,7 @@ func TestGetPutManifest(t *testing.T) {
 	assert.NoError(t, err)
 	err = dest.PutManifest(context.Background(), list, nil)
 	assert.NoError(t, err)
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(context.Background(), nil)
@@ -71,7 +71,7 @@ func TestGetPutBlob(t *testing.T) {
 	assert.Equal(t, types.PreserveOriginal, dest.DesiredLayerCompression())
 	info, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{Digest: digest.Digest("sha256:digest-test"), Size: int64(9)}, cache, false)
 	assert.NoError(t, err)
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), info.Size)
 	assert.Equal(t, digest.FromBytes(blob), info.Digest)
@@ -130,7 +130,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, cache, false)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
@@ -175,7 +175,7 @@ func TestGetPutSignatures(t *testing.T) {
 	assert.NoError(t, err)
 	err = dest.PutSignatures(context.Background(), signatures, &md)
 	assert.NoError(t, err)
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	src, err := ref.NewImageSource(context.Background(), nil)

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -142,38 +142,33 @@ func TestGetPutSignatures(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
-	dest, err := ref.NewImageDestination(context.Background(), nil)
-	require.NoError(t, err)
-	defer dest.Close()
 	man := []byte("test-manifest")
+	list := []byte("test-manifest-list")
+	md, err := manifest.Digest(man)
+	require.NoError(t, err)
 	signatures := [][]byte{
 		[]byte("sig1"),
 		[]byte("sig2"),
 	}
-	err = dest.SupportsSignatures(context.Background())
-	assert.NoError(t, err)
-	err = dest.PutManifest(context.Background(), man, nil)
-	require.NoError(t, err)
-
-	err = dest.PutSignatures(context.Background(), signatures, nil)
-	require.NoError(t, err)
 	listSignatures := [][]byte{
 		[]byte("sig3"),
 		[]byte("sig4"),
 	}
-	md, err := manifest.Digest(man)
-	require.NoError(t, err)
 
+	dest, err := ref.NewImageDestination(context.Background(), nil)
+	require.NoError(t, err)
+	defer dest.Close()
 	err = dest.SupportsSignatures(context.Background())
 	assert.NoError(t, err)
-	err = dest.PutManifest(context.Background(), man, nil)
-	require.NoError(t, err)
+
 	err = dest.PutManifest(context.Background(), man, &md)
 	require.NoError(t, err)
+	err = dest.PutManifest(context.Background(), list, nil)
+	require.NoError(t, err)
 
-	err = dest.PutSignatures(context.Background(), listSignatures, nil)
-	assert.NoError(t, err)
 	err = dest.PutSignatures(context.Background(), signatures, &md)
+	assert.NoError(t, err)
+	err = dest.PutSignatures(context.Background(), listSignatures, nil)
 	assert.NoError(t, err)
 	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -160,7 +160,7 @@ func TestReferenceNewImage(t *testing.T) {
 	require.NoError(t, err)
 	err = dest.PutManifest(context.Background(), mFixture, nil)
 	assert.NoError(t, err)
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	img, err := ref.NewImage(context.Background(), nil)
@@ -177,7 +177,7 @@ func TestReferenceNewImageNoValidManifest(t *testing.T) {
 	defer dest.Close()
 	err = dest.PutManifest(context.Background(), []byte(`{"schemaVersion":1}`), nil)
 	assert.NoError(t, err)
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	_, err = ref.NewImage(context.Background(), nil)

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -67,6 +67,9 @@ func (d *archiveImageDestination) Close() error {
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -128,6 +128,9 @@ func (d *daemonImageDestination) Reference() types.ImageReference {
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -659,6 +659,9 @@ sigExists:
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/manifest/list_test.go
+++ b/manifest/list_test.go
@@ -113,9 +113,8 @@ func TestChooseInstance(t *testing.T) {
 			},
 		},
 	} {
-		man, err := ioutil.ReadFile(filepath.Join("..", "image", "fixtures", manifestList.listFile))
+		rawManifest, err := ioutil.ReadFile(filepath.Join("..", "image", "fixtures", manifestList.listFile))
 		require.NoError(t, err)
-		rawManifest := man
 		list, err := ListFromBlob(rawManifest, GuessMIMEType(rawManifest))
 		require.NoError(t, err)
 		// Match found

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -149,6 +149,7 @@ func TestNormalizedMIMEType(t *testing.T) {
 		DockerV2Schema2MediaType,
 		DockerV2ListMediaType,
 		imgspecv1.MediaTypeImageManifest,
+		imgspecv1.MediaTypeImageIndex,
 	} {
 		res := NormalizedMIMEType(c)
 		assert.Equal(t, c, res, c)

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -129,6 +129,9 @@ func (d *ociArchiveImageDestination) PutSignatures(ctx context.Context, signatur
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // after the directory is made, it is tarred up into a file and the directory is deleted
 func (d *ociArchiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if err := d.unpackedDest.Commit(ctx, unparsedToplevel); err != nil {

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -303,6 +303,9 @@ func (d *ociImageDestination) PutSignatures(ctx context.Context, signatures [][]
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -60,7 +60,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	_, err = dest.PutBlob(context.Background(), reader, types.BlobInfo{Digest: blobDigest, Size: -1}, cache, false)
 	assert.Error(t, err)
 	assert.Contains(t, digestErrorString, err.Error())
-	err = dest.Commit(context.Background(), nil)
+	err = dest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	_, err = os.Lstat(blobPath)
@@ -144,7 +144,7 @@ func putTestConfig(t *testing.T, ociRef ociReference, tmpDir string) {
 	_, err = imageDest.PutBlob(context.Background(), bytes.NewReader(data), types.BlobInfo{Size: int64(len(data)), Digest: digest.FromBytes(data)}, cache, true)
 	assert.NoError(t, err)
 
-	err = imageDest.Commit(context.Background(), nil)
+	err = imageDest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	paths := []string{}
@@ -167,7 +167,7 @@ func putTestManifest(t *testing.T, ociRef ociReference, tmpDir string) {
 	err = imageDest.PutManifest(context.Background(), data, nil)
 	assert.NoError(t, err)
 
-	err = imageDest.Commit(context.Background(), nil)
+	err = imageDest.Commit(context.Background(), nil) // nil unparsedToplevel is invalid, we don’t currently use the value
 	assert.NoError(t, err)
 
 	paths := []string{}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -506,6 +506,9 @@ sigExists:
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -435,14 +435,14 @@ func (d *openshiftImageDestination) PutManifest(ctx context.Context, m []byte, i
 }
 
 func (d *openshiftImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
-	var imageStreamName string
+	var imageStreamImageName string
 	if instanceDigest == nil {
 		if d.imageStreamImageName == "" {
 			return errors.Errorf("Internal error: Unknown manifest digest, can't add signatures")
 		}
-		imageStreamName = d.imageStreamImageName
+		imageStreamImageName = d.imageStreamImageName
 	} else {
-		imageStreamName = instanceDigest.String()
+		imageStreamImageName = instanceDigest.String()
 	}
 
 	// Because image signatures are a shared resource in Atomic Registry, the default upload
@@ -452,7 +452,7 @@ func (d *openshiftImageDestination) PutSignatures(ctx context.Context, signature
 		return nil // No need to even read the old state.
 	}
 
-	image, err := d.client.getImage(ctx, imageStreamName)
+	image, err := d.client.getImage(ctx, imageStreamImageName)
 	if err != nil {
 		return err
 	}
@@ -477,7 +477,7 @@ sigExists:
 			if err != nil || n != 16 {
 				return errors.Wrapf(err, "Error generating random signature len %d", n)
 			}
-			signatureName = fmt.Sprintf("%s@%032x", imageStreamName, randBytes)
+			signatureName = fmt.Sprintf("%s@%032x", imageStreamImageName, randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {
 				break
 			}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -1183,10 +1183,10 @@ func (s *storageImageDestination) PutSignatures(ctx context.Context, signatures 
 	if instanceDigest == nil {
 		s.signatures = sigblob
 		s.SignatureSizes = sizes
-	}
-	if instanceDigest == nil && len(s.manifest) > 0 {
-		manifestDigest := s.manifestDigest
-		instanceDigest = &manifestDigest
+		if len(s.manifest) > 0 {
+			manifestDigest := s.manifestDigest
+			instanceDigest = &manifestDigest
+		}
 	}
 	if instanceDigest != nil {
 		s.signatureses[*instanceDigest] = sigblob

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -927,6 +927,13 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 	return nil
 }
 
+// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+// original manifest list digest, if desired.
+// WARNING: This does not have any transactional semantics:
+// - Uploaded data MAY be visible to others before Commit() is called
+// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if len(s.manifest) == 0 {
 		return errors.New("Internal error: storageImageDestination.Commit() called without PutManifest()")

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -1048,8 +1048,8 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 			return errors.Wrapf(err, "error saving big data %q for image %q", blob.String(), img.ID)
 		}
 	}
-	// Save the unparsedToplevel's manifest.
-	if len(toplevelManifest) != 0 {
+	// Save the unparsedToplevel's manifest if it differs from the per-platform one, which is saved below.
+	if len(toplevelManifest) != 0 && !bytes.Equal(toplevelManifest, s.manifest) {
 		manifestDigest, err := manifest.Digest(toplevelManifest)
 		if err != nil {
 			return errors.Wrapf(err, "error digesting top-level manifest")

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -963,9 +963,6 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		}
 	}
 	// Find the list of layer blobs.
-	if len(s.manifest) == 0 {
-		return errors.New("Internal error: storageImageDestination.Commit() called without PutManifest()")
-	}
 	man, err := manifest.FromBlob(s.manifest, manifest.GuessMIMEType(s.manifest))
 	if err != nil {
 		return errors.Wrapf(err, "error parsing manifest")

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -59,6 +59,7 @@ type storageImageDestination struct {
 	directory       string                   // Temporary directory where we store blobs until Commit() time
 	nextTempFileID  int32                    // A counter that we use for computing filenames to assign to blobs
 	manifest        []byte                   // Manifest contents, temporary
+	manifestDigest  digest.Digest            // Valid if len(manifest) != 0
 	signatures      []byte                   // Signature contents, temporary
 	signatureses    map[digest.Digest][]byte // Instance signature contents, temporary
 	SignatureSizes  []int                    `json:"signature-sizes,omitempty"`  // List of sizes of each signature slice
@@ -1062,11 +1063,7 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	// Save the image's manifest.  Allow looking it up by digest by using the key convention defined by the Store.
 	// Record the manifest twice: using a digest-specific key to allow references to that specific digest instance,
 	// and using storage.ImageDigestBigDataKey for future users that don’t specify any digest and for compatibility with older readers.
-	manifestDigest, err := manifest.Digest(s.manifest)
-	if err != nil {
-		return errors.Wrapf(err, "error computing manifest digest")
-	}
-	key := manifestBigDataKey(manifestDigest)
+	key := manifestBigDataKey(s.manifestDigest)
 	if err := s.imageRef.transport.store.SetImageBigData(img.ID, key, s.manifest, manifest.Digest); err != nil {
 		logrus.Debugf("error saving manifest for image %q: %v", img.ID, err)
 		return errors.Wrapf(err, "error saving manifest for image %q", img.ID)
@@ -1137,9 +1134,14 @@ func (s *storageImageDestination) SupportedManifestMIMETypes() []string {
 
 // PutManifest writes the manifest to the destination.
 func (s *storageImageDestination) PutManifest(ctx context.Context, manifestBlob []byte, instanceDigest *digest.Digest) error {
+	digest, err := manifest.Digest(manifestBlob)
+	if err != nil {
+		return err
+	}
 	newBlob := make([]byte, len(manifestBlob))
 	copy(newBlob, manifestBlob)
 	s.manifest = newBlob
+	s.manifestDigest = digest
 	return nil
 }
 
@@ -1183,10 +1185,7 @@ func (s *storageImageDestination) PutSignatures(ctx context.Context, signatures 
 		s.SignatureSizes = sizes
 	}
 	if instanceDigest == nil && len(s.manifest) > 0 {
-		manifestDigest, err := manifest.Digest(s.manifest)
-		if err != nil {
-			return err
-		}
+		manifestDigest := s.manifestDigest
 		instanceDigest = &manifestDigest
 	}
 	if instanceDigest != nil {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -35,11 +35,11 @@ import (
 )
 
 var (
-	topwd                             = ""
-	_imgd      types.ImageDestination = &storageImageDestination{} //nolint
-	_imgs      types.ImageSource      = &storageImageSource{}      //nolint
-	_ref       types.ImageReference   = &storageReference{}        //nolint
-	_transport types.ImageTransport   = &storageTransport{}        //nolint
+	topwd                        = ""
+	_     types.ImageDestination = &storageImageDestination{}
+	_     types.ImageSource      = &storageImageSource{}
+	_     types.ImageReference   = &storageReference{}
+	_     types.ImageTransport   = &storageTransport{}
 )
 
 const (

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -303,7 +303,7 @@ func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageRefe
 	}
 	if sref, ok := ref.(*storageReference); ok {
 		tmpRef := *sref
-		if img, err := tmpRef.resolveImage(&types.SystemContext{}); err == nil {
+		if img, err := tmpRef.resolveImage(nil); err == nil {
 			return img, nil
 		}
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -334,6 +334,9 @@ type ImageDestination interface {
 	// MUST be called after PutManifest (signatures may reference manifest contents).
 	PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error
 	// Commit marks the process of storing the image as successful and asks for the image to be persisted.
+	// unparsedToplevel contains data about the top-level manifest of the source (which may be a single-arch image or a manifest list
+	// if PutManifest was only called for the single-arch image with instanceDigest == nil), primarily to allow lookups by the
+	// original manifest list digest, if desired.
 	// WARNING: This does not have any transactional semantics:
 	// - Uploaded data MAY be visible to others before Commit() is called
 	// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)


### PR DESCRIPTION
An assorted set of small cleanups and some test extensions, mostly related to #400 .

See individual commit messages for details.