### PR TITLE
Add support for registry paths in auth.json

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -213,8 +213,7 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 // “write” specifies whether the client will be used for "write" access (in particular passed to lookaside.go:toplevelFromSection)
 // signatureBase is always set in the return value
 func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write bool, actions string) (*dockerClient, error) {
-	registry := reference.Domain(ref.ref)
-	auth, err := config.GetCredentials(sys, registry)
+	auth, err := config.GetCredentialsForRef(sys, ref.ref)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}
@@ -224,6 +223,7 @@ func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write
 		return nil, err
 	}
 
+	registry := reference.Domain(ref.ref)
 	client, err := newDockerClient(sys, registry, ref.ref.Name())
 	if err != nil {
 		return nil, err
@@ -343,7 +343,8 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	v1Res := &V1Results{}
 
 	// Get credentials from authfile for the underlying hostname
-	auth, err := config.GetCredentials(sys, registry)
+	// lint:ignore SA1019 We can't use GetCredentialsForRef because we want to search the whole registry.
+	auth, err := config.GetCredentials(sys, registry) // nolint:staticcheck // https://github.com/golangci/golangci-lint/issues/741
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}

--- a/docs/containers-auth.json.5.md
+++ b/docs/containers-auth.json.5.md
@@ -23,7 +23,20 @@ user to container image registries.  The file can have zero to many entries and
 is created by a `login` command from a container tool such as `podman login`,
 `buildah login` or `skopeo login`.  Each entry includes the name of the registry and then an auth
 token in the form of a base64 encoded string from the concatenation of the
-username, a colon, and the password.
+username, a colon, and the password. The registry name can additionally contain
+a path or repository name (an image name without tag or digest). The path (or
+namespace) is matched in its hierarchical order when checking for available
+authentications. For example, an image pull for
+`my-registry.local/namespace/user/image:latest` will result in a lookup in
+`auth.json` in the following order:
+
+- `my-registry.local/namespace/user/image`
+- `my-registry.local/namespace/user`
+- `my-registry.local/namespace`
+- `my-registry.local`
+
+This way it is possible to setup multiple credentials for a single registry
+which can be distinguished by their path.
 
 The following example shows the values found in auth.json after the user logged in to
 their accounts on quay.io and docker.io:
@@ -37,6 +50,25 @@ their accounts on quay.io and docker.io:
 		"quay.io": {
 			"auth": "juQAqGmz5eR1ipzx8Evn6KGdw8fEa1w5MWczmgY="
 		}
+	}
+}
+```
+
+This example demonstrates how to use multiple paths for a single registry, while
+preserving a fallback for `my-registry.local`:
+
+```
+{
+	"auths": {
+		"my-registry.local/foo/bar/image": {
+			"auth": "…"
+		},
+		"my-registry.local/foo": {
+			"auth": "…"
+		},
+		"my-registry.local": {
+			"auth": "…"
+		},
 	}
 }
 ```

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
@@ -215,13 +216,34 @@ func getAuthFilePaths(sys *types.SystemContext, homeDir string) []authPath {
 // helpers with falling back to using either auth.json
 // file or .docker/config.json, including support for OAuth2 and IdentityToken.
 // If an entry is not found, an empty struct is returned.
+//
+// Deprecated: GetCredentialsForRef should be used in favor of this API
+// because it allows different credentials for different repositories on the
+// same registry.
 func GetCredentials(sys *types.SystemContext, registry string) (types.DockerAuthConfig, error) {
-	return getCredentialsWithHomeDir(sys, registry, homedir.Get())
+	return getCredentialsWithHomeDir(sys, nil, registry, homedir.Get())
 }
 
-// getCredentialsWithHomeDir is an internal implementation detail of GetCredentials,
-// it exists only to allow testing it with an artificial home directory.
-func getCredentialsWithHomeDir(sys *types.SystemContext, registry, homeDir string) (types.DockerAuthConfig, error) {
+// GetCredentialsForRef returns the registry credentials necessary for
+// accessing ref on the registry ref points to,
+// appropriate for sys and the users’ configuration.
+// If an entry is not found, an empty struct is returned.
+func GetCredentialsForRef(sys *types.SystemContext, ref reference.Named) (types.DockerAuthConfig, error) {
+	return getCredentialsWithHomeDir(sys, ref, reference.Domain(ref), homedir.Get())
+}
+
+// getCredentialsWithHomeDir is an internal implementation detail of
+// GetCredentialsForRef and GetCredentials. It exists only to allow testing it
+// with an artificial home directory.
+func getCredentialsWithHomeDir(sys *types.SystemContext, ref reference.Named, registry, homeDir string) (types.DockerAuthConfig, error) {
+	// consistency check of the ref and registry arguments
+	if ref != nil && reference.Domain(ref) != registry {
+		return types.DockerAuthConfig{}, errors.Errorf(
+			"internal error: provided reference domain %q name does not match registry %q",
+			reference.Domain(ref), registry,
+		)
+	}
+
 	if sys != nil && sys.DockerAuthConfig != nil {
 		logrus.Debugf("Returning credentials for %s from DockerAuthConfig", registry)
 		return *sys.DockerAuthConfig, nil
@@ -230,7 +252,7 @@ func getCredentialsWithHomeDir(sys *types.SystemContext, registry, homeDir strin
 	// Anonymous function to query credentials from auth files.
 	getCredentialsFromAuthFiles := func() (types.DockerAuthConfig, error) {
 		for _, path := range getAuthFilePaths(sys, homeDir) {
-			authConfig, err := findAuthentication(registry, path.path, path.legacyFormat)
+			authConfig, err := findAuthentication(ref, registry, path.path, path.legacyFormat)
 			if err != nil {
 				return types.DockerAuthConfig{}, err
 			}
@@ -294,7 +316,7 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 // getAuthenticationWithHomeDir is an internal implementation detail of GetAuthentication,
 // it exists only to allow testing it with an artificial home directory.
 func getAuthenticationWithHomeDir(sys *types.SystemContext, registry, homeDir string) (string, string, error) {
-	auth, err := getCredentialsWithHomeDir(sys, registry, homeDir)
+	auth, err := getCredentialsWithHomeDir(sys, nil, registry, homeDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -575,8 +597,10 @@ func deleteAuthFromCredHelper(credHelper, registry string) error {
 	return helperclient.Erase(p, registry)
 }
 
-// findAuthentication looks for auth of registry in path
-func findAuthentication(registry, path string, legacyFormat bool) (types.DockerAuthConfig, error) {
+// findAuthentication looks for auth of registry in path. If ref is
+// not nil, then it will be taken into account when looking up the
+// authentication credentials.
+func findAuthentication(ref reference.Named, registry, path string, legacyFormat bool) (types.DockerAuthConfig, error) {
 	auths, err := readJSONFile(path, legacyFormat)
 	if err != nil {
 		return types.DockerAuthConfig{}, errors.Wrapf(err, "error reading JSON file %q", path)
@@ -587,12 +611,32 @@ func findAuthentication(registry, path string, legacyFormat bool) (types.DockerA
 		return getAuthFromCredHelper(ch, registry)
 	}
 
-	// I'm feeling lucky
-	if val, exists := auths.AuthConfigs[registry]; exists {
-		return decodeDockerAuth(val)
+	// Support for different paths in auth.
+	// (This is not a feature of ~/.docker/config.json; we support it even for
+	// those files as an extension.)
+	var keys []string
+	if !legacyFormat && ref != nil {
+		keys = authKeysForRef(ref)
+	} else {
+		keys = []string{registry}
+	}
+
+	// Repo or namespace keys are only supported as exact matches. For registry
+	// keys we prefer exact matches as well.
+	for _, key := range keys {
+		if val, exists := auths.AuthConfigs[key]; exists {
+			return decodeDockerAuth(val)
+		}
 	}
 
 	// bad luck; let's normalize the entries first
+	// This primarily happens for legacyFormat, which for a time used API URLs
+	// (http[s:]//…/v1/) as keys.
+	// Secondarily, (docker login) accepted URLs with no normalization for
+	// several years, and matched registry hostnames against that, so support
+	// those entries even in non-legacyFormat ~/.docker/config.json.
+	// The docker.io registry still uses the /v1/ key with a special host name,
+	// so account for that as well.
 	registry = normalizeRegistry(registry)
 	normalizedAuths := map[string]dockerAuthConfig{}
 	for k, v := range auths.AuthConfigs {
@@ -604,6 +648,28 @@ func findAuthentication(registry, path string, legacyFormat bool) (types.DockerA
 	}
 
 	return types.DockerAuthConfig{}, nil
+}
+
+// authKeysForRef returns the valid paths for a provided reference. For example,
+// when given a reference "quay.io/repo/ns/image:tag", then it would return
+// - quay.io/repo/ns/image
+// - quay.io/repo/ns
+// - quay.io/repo
+// - quay.io
+func authKeysForRef(ref reference.Named) (res []string) {
+	name := ref.Name()
+
+	for {
+		res = append(res, name)
+
+		lastSlash := strings.LastIndex(name, "/")
+		if lastSlash == -1 {
+			break
+		}
+		name = name[:lastSlash]
+	}
+
+	return res
 }
 
 // decodeDockerAuth decodes the username and password, which is

--- a/pkg/docker/config/testdata/refpath.json
+++ b/pkg/docker/config/testdata/refpath.json
@@ -1,0 +1,6 @@
+{
+  "auths": {
+    "example.org/repo": { "auth": "ZXhhbXBsZTpvcmc=" },
+    "example.org": { "auth": "bG9jYWw6aG9zdA==" }
+  }
+}


### PR DESCRIPTION
This patch adds support for `host[:port]/ns/…repo` to auth.json while keeping the backwards compatible behavior.

Refers to https://github.com/containers/image/issues/1276
