### PR TITLE
release-5.5 Add DockerLogMirrirChoice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ lint:
 ifeq ($(TRAVIS),true)
 	$(GOBIN)/git-validation -q -run DCO,short-subject,dangling-whitespace
 else
-	git fetch -q "https://github.com/containers/image.git" "refs/heads/master"
+	git fetch -q "https://github.com/containers/image.git" "refs/heads/release-5.5"
 	upstream="$$(git rev-parse --verify FETCH_HEAD)" ; \
 		$(GOBIN)/git-validation -q -run DCO,short-subject,dangling-whitespace -range $$upstream..HEAD
 endif

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -65,7 +65,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	attempts := []attempt{}
 	for _, pullSource := range pullSources {
-		if sys.DockerLogMirrorChoice {
+		if sys != nil && sys.DockerLogMirrorChoice {
 			logrus.Infof("Trying to access %q", pullSource.Reference)
 		} else {
 			logrus.Debugf("Trying to access %q", pullSource.Reference)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -65,7 +65,11 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	attempts := []attempt{}
 	for _, pullSource := range pullSources {
-		logrus.Debugf("Trying to access %q", pullSource.Reference)
+		if sys.DockerLogMirrorChoice {
+			logrus.Infof("Trying to access %q", pullSource.Reference)
+		} else {
+			logrus.Debugf("Trying to access %q", pullSource.Reference)
+		}
 		s, err := newImageSourceAttempt(ctx, sys, ref, pullSource)
 		if err == nil {
 			return s, nil

--- a/types/types.go
+++ b/types/types.go
@@ -566,6 +566,8 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
 	DockerDisableDestSchema1MIMETypes bool
+	// If true, the physical pull source of docker transport images logged as info level
+	DockerLogMirrorChoice bool
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
 


### PR DESCRIPTION
Backport 6e02506 and a3a6d00 for crio 1.19.
Close: https://bugzilla.redhat.com/show_bug.cgi?id=1976293

Add DockerLogMirrorChoice to types.SystemContext for keeping log level of the physical pull source of images.
Crio could set it log the image source if it's from a mirror.

Signed-off-by: Qi Wang <qiwan@redhat.com>