### PR TITLE
Fix “empty config file” detection

### DIFF
--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -49,6 +49,13 @@ type shortNameAliasConf struct {
 	// reference counter parts.
 	// Note that Aliases is niled after being loaded from a file.
 	Aliases map[string]string `toml:"aliases"`
+
+	// If you add any field, make sure to update nonempty() below.
+}
+
+// nonempty returns true if config contains at least one configuration entry.
+func (c *shortNameAliasConf) nonempty() bool {
+	return len(c.Aliases) != 0
 }
 
 // alias combines the parsed value of an alias with the config file it has been

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestShortNameAliasConfNonempty(t *testing.T) {
+	res := (&shortNameAliasConf{}).nonempty()
+	assert.False(t, res)
+	for _, c := range []shortNameAliasConf{
+		{Aliases: map[string]string{"a": "example.com/b"}},
+	} {
+		res := (&c).nonempty()
+		assert.True(t, res, c)
+	}
+}
+
 func TestParseShortNameValue(t *testing.T) {
 	tests := []struct {
 		input string

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -203,12 +203,17 @@ type V2RegistriesConf struct {
 	ShortNameMode string `toml:"short-name-mode"`
 
 	shortNameAliasConf
+
+	// If you add any field, make sure to update Nonempty() below.
 }
 
 // Nonempty returns true if config contains at least one configuration entry.
 func (config *V2RegistriesConf) Nonempty() bool {
 	return (len(config.Registries) != 0 ||
-		len(config.UnqualifiedSearchRegistries) != 0)
+		len(config.UnqualifiedSearchRegistries) != 0 ||
+		len(config.CredentialHelpers) != 0 ||
+		config.ShortNameMode != "" ||
+		config.shortNameAliasConf.nonempty())
 }
 
 // parsedConfig is the result of parsing, and possibly merging, configuration files;

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -427,7 +427,7 @@ func TestMixingV1andV2(t *testing.T) {
 		SystemRegistriesConfPath:    "testdata/mixing-v1-v2.conf",
 		SystemRegistriesConfDirPath: "testdata/this-does-not-exist",
 	})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mixing sysregistry v1/v2 is not supported")
 }
 

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -13,6 +13,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestV1RegistriesConfNonempty(t *testing.T) {
+	res := (&V1RegistriesConf{}).Nonempty()
+	assert.False(t, res)
+	for _, c := range []V1RegistriesConf{
+		{V1TOMLConfig: V1TOMLConfig{Search: V1TOMLregistries{Registries: []string{"example.com"}}}},
+		{V1TOMLConfig: V1TOMLConfig{Insecure: V1TOMLregistries{Registries: []string{"example.com"}}}},
+		{V1TOMLConfig: V1TOMLConfig{Block: V1TOMLregistries{Registries: []string{"example.com"}}}},
+	} {
+		res := (&c).Nonempty()
+		assert.True(t, res, c)
+	}
+}
+
+func TestV2RegistriesConfNonempty(t *testing.T) {
+	res := (&V2RegistriesConf{}).Nonempty()
+	assert.False(t, res)
+	for _, c := range []V2RegistriesConf{
+		{Registries: []Registry{{Prefix: "example.com"}}},
+		{UnqualifiedSearchRegistries: []string{"example.com"}},
+		{CredentialHelpers: []string{"a"}},
+		{ShortNameMode: "enforcing"},
+		{shortNameAliasConf: shortNameAliasConf{Aliases: map[string]string{"a": "example.com/b"}}},
+	} {
+		res := (&c).Nonempty()
+		assert.True(t, res, c)
+	}
+}
+
 func TestParseLocation(t *testing.T) {
 	var err error
 	var location string


### PR DESCRIPTION
primarily for v1/v2 mismatches.