### PR TITLE
Implement "non-empty configuration" using reflect.DeepEqual

### DIFF
--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -3,6 +3,7 @@ package sysregistriesv2
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -55,7 +56,11 @@ type shortNameAliasConf struct {
 
 // nonempty returns true if config contains at least one configuration entry.
 func (c *shortNameAliasConf) nonempty() bool {
-	return len(c.Aliases) != 0
+	copy := *c // A shallow copy
+	if copy.Aliases != nil && len(copy.Aliases) == 0 {
+		copy.Aliases = nil
+	}
+	return !reflect.DeepEqual(copy, shortNameAliasConf{})
 }
 
 // alias combines the parsed value of an alias with the config file it has been

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -11,13 +11,25 @@ import (
 )
 
 func TestShortNameAliasConfNonempty(t *testing.T) {
+	for _, c := range []shortNameAliasConf{
+		{},
+		{Aliases: map[string]string{}},
+	} {
+		copy := c // A shallow copy
+		res := copy.nonempty()
+		assert.False(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
+	}
+
 	res := (&shortNameAliasConf{}).nonempty()
 	assert.False(t, res)
 	for _, c := range []shortNameAliasConf{
 		{Aliases: map[string]string{"a": "example.com/b"}},
 	} {
-		res := (&c).nonempty()
+		copy := c // A shallow copy
+		res := copy.nonempty()
 		assert.True(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
 	}
 }
 

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -172,9 +173,17 @@ type V1RegistriesConf struct {
 
 // Nonempty returns true if config contains at least one configuration entry.
 func (config *V1RegistriesConf) Nonempty() bool {
-	return (len(config.V1TOMLConfig.Search.Registries) != 0 ||
-		len(config.V1TOMLConfig.Insecure.Registries) != 0 ||
-		len(config.V1TOMLConfig.Block.Registries) != 0)
+	copy := *config // A shallow copy
+	if copy.V1TOMLConfig.Search.Registries != nil && len(copy.V1TOMLConfig.Search.Registries) == 0 {
+		copy.V1TOMLConfig.Search.Registries = nil
+	}
+	if copy.V1TOMLConfig.Insecure.Registries != nil && len(copy.V1TOMLConfig.Insecure.Registries) == 0 {
+		copy.V1TOMLConfig.Insecure.Registries = nil
+	}
+	if copy.V1TOMLConfig.Block.Registries != nil && len(copy.V1TOMLConfig.Block.Registries) == 0 {
+		copy.V1TOMLConfig.Block.Registries = nil
+	}
+	return !reflect.DeepEqual(copy, V1RegistriesConf{})
 }
 
 // V2RegistriesConf is the sysregistries v2 configuration format.
@@ -209,11 +218,20 @@ type V2RegistriesConf struct {
 
 // Nonempty returns true if config contains at least one configuration entry.
 func (config *V2RegistriesConf) Nonempty() bool {
-	return (len(config.Registries) != 0 ||
-		len(config.UnqualifiedSearchRegistries) != 0 ||
-		len(config.CredentialHelpers) != 0 ||
-		config.ShortNameMode != "" ||
-		config.shortNameAliasConf.nonempty())
+	copy := *config // A shallow copy
+	if copy.Registries != nil && len(copy.Registries) == 0 {
+		copy.Registries = nil
+	}
+	if copy.UnqualifiedSearchRegistries != nil && len(copy.UnqualifiedSearchRegistries) == 0 {
+		copy.UnqualifiedSearchRegistries = nil
+	}
+	if copy.CredentialHelpers != nil && len(copy.CredentialHelpers) == 0 {
+		copy.CredentialHelpers = nil
+	}
+	if !copy.shortNameAliasConf.nonempty() {
+		copy.shortNameAliasConf = shortNameAliasConf{}
+	}
+	return !reflect.DeepEqual(copy, V2RegistriesConf{})
 }
 
 // parsedConfig is the result of parsing, and possibly merging, configuration files;

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -14,21 +14,42 @@ import (
 )
 
 func TestV1RegistriesConfNonempty(t *testing.T) {
-	res := (&V1RegistriesConf{}).Nonempty()
-	assert.False(t, res)
+	for _, c := range []V1RegistriesConf{
+		{},
+		{V1TOMLConfig: V1TOMLConfig{Search: V1TOMLregistries{Registries: []string{}}}},
+		{V1TOMLConfig: V1TOMLConfig{Insecure: V1TOMLregistries{Registries: []string{}}}},
+		{V1TOMLConfig: V1TOMLConfig{Block: V1TOMLregistries{Registries: []string{}}}},
+	} {
+		copy := c // A shallow copy
+		res := copy.Nonempty()
+		assert.False(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
+	}
 	for _, c := range []V1RegistriesConf{
 		{V1TOMLConfig: V1TOMLConfig{Search: V1TOMLregistries{Registries: []string{"example.com"}}}},
 		{V1TOMLConfig: V1TOMLConfig{Insecure: V1TOMLregistries{Registries: []string{"example.com"}}}},
 		{V1TOMLConfig: V1TOMLConfig{Block: V1TOMLregistries{Registries: []string{"example.com"}}}},
 	} {
-		res := (&c).Nonempty()
+		copy := c // A shallow copy
+		res := copy.Nonempty()
 		assert.True(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
 	}
 }
 
 func TestV2RegistriesConfNonempty(t *testing.T) {
-	res := (&V2RegistriesConf{}).Nonempty()
-	assert.False(t, res)
+	for _, c := range []V2RegistriesConf{
+		{},
+		{Registries: []Registry{}},
+		{UnqualifiedSearchRegistries: []string{}},
+		{CredentialHelpers: []string{}},
+		{shortNameAliasConf: shortNameAliasConf{Aliases: map[string]string{}}},
+	} {
+		copy := c // A shallow copy
+		res := copy.Nonempty()
+		assert.False(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
+	}
 	for _, c := range []V2RegistriesConf{
 		{Registries: []Registry{{Prefix: "example.com"}}},
 		{UnqualifiedSearchRegistries: []string{"example.com"}},
@@ -36,8 +57,10 @@ func TestV2RegistriesConfNonempty(t *testing.T) {
 		{ShortNameMode: "enforcing"},
 		{shortNameAliasConf: shortNameAliasConf{Aliases: map[string]string{"a": "example.com/b"}}},
 	} {
-		res := (&c).Nonempty()
+		copy := c // A shallow copy
+		res := copy.Nonempty()
 		assert.True(t, res, c)
+		assert.Equal(t, c, copy, c) // Ensure the method did not change the original value
 	}
 }
 


### PR DESCRIPTION
A RFC improvement on top of #1283 .

This is more expensive, but it automatically handles any future member additions.

Preserve the existing semantics of treating non-nil but empty slices and maps as “not non-empty”, just because the old implementation did so; I didn't check whether that actually ever happens and whether it matters for any existing callers.