### PR TITLE
Change all references to docker registry to container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 containers' images and container image registries.
 
 The containers/image library allows application to pull and push images from
-container image registries, like the upstream docker registry. It also
+container image registries, like the docker.io and quay.io registries. It also
 implements "simple image signing".
 
 The containers/image library also allows you to inspect a repository on a

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -92,7 +92,7 @@ type bearerToken struct {
 	expirationTime time.Time
 }
 
-// dockerClient is configuration for dealing with a single Docker registry.
+// dockerClient is configuration for dealing with a single container registry.
 type dockerClient struct {
 	// The following members are set by newDockerClient and do not change afterwards.
 	sys       *types.SystemContext
@@ -752,7 +752,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		err = ping("http")
 	}
 	if err != nil {
-		err = errors.Wrapf(err, "error pinging docker registry %s", c.registry)
+		err = errors.Wrapf(err, "error pinging container registry %s", c.registry)
 		if c.sys != nil && c.sys.DockerDisableV1Ping {
 			return err
 		}

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -16,7 +16,7 @@ func init() {
 	transports.Register(Transport)
 }
 
-// Transport is an ImageTransport for Docker registry-hosted images.
+// Transport is an ImageTransport for container registry-hosted images.
 var Transport = dockerTransport{}
 
 type dockerTransport struct{}

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -12,7 +12,7 @@ import (
 var (
 	// ErrV1NotSupported is returned when we're trying to talk to a
 	// docker V1 registry.
-	ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
+	ErrV1NotSupported = errors.New("can't talk to a V1 container registry")
 	// ErrTooManyRequests is returned when the status code returned is 429
 	ErrTooManyRequests = errors.New("too many requests to registry")
 )

--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -68,7 +68,7 @@ i.e. either specifying a complete name of a tagged image, or prefix denoting
 a host/namespace/image stream or a wildcarded expression for matching all
 subdomains. For wildcarded subdomain matching, `*.example.com` is a valid case, but `example*.*.com` is not.
 
-*Note:* The _hostname_ and _port_ refer to the Docker registry host and port (the one used
+*Note:* The _hostname_ and _port_ refer to the container registry host and port (the one used
 e.g. for `docker pull`), _not_ to the OpenShift API host and port.
 
 ### `dir:`

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -195,7 +195,7 @@ func MatchesDigest(manifest []byte, expectedDigest digest.Digest) (bool, error) 
 }
 
 // AddDummyV2S1Signature adds an JWS signature with a temporary key (i.e. useless) to a v2s1 manifest.
-// This is useful to make the manifest acceptable to a Docker Registry (even though nothing needs or wants the JWS signature).
+// This is useful to make the manifest acceptable to a docker/distribution registry (even though nothing needs or wants the JWS signature).
 func AddDummyV2S1Signature(manifest []byte) ([]byte, error) {
 	key, err := libtrust.GenerateECP256PrivateKey()
 	if err != nil {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -164,7 +164,7 @@ type openshiftImageSource struct {
 	// Values specific to this image
 	sys *types.SystemContext
 	// State
-	docker               types.ImageSource // The Docker Registry endpoint, or nil if not resolved yet
+	docker               types.ImageSource // The docker/distribution API endpoint, or nil if not resolved yet
 	imageStreamImageName string            // Resolved image identifier, or "" if not known yet
 }
 
@@ -316,7 +316,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 
 type openshiftImageDestination struct {
 	client *openshiftClient
-	docker types.ImageDestination // The Docker Registry endpoint
+	docker types.ImageDestination // The docker/distribution API endpoint
 	// State
 	imageStreamImageName string // "" if not yet known
 }

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -306,7 +306,7 @@ func getCredentialsWithHomeDir(sys *types.SystemContext, ref reference.Named, re
 // .docker/config.json
 //
 // Deprecated: This API only has support for username and password. To get the
-// support for oauth2 in docker registry authentication, we added the new
+// support for oauth2 in container registry authentication, we added the new
 // GetCredentials API. The new API should be used and this API is kept to
 // maintain backward compatibility.
 func GetAuthentication(sys *types.SystemContext, registry string) (string, string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -598,12 +598,12 @@ type SystemContext struct {
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
 	// a client certificate (ending with ".cert") and a client certificate key
-	// (ending with ".key") used when talking to a Docker Registry.
+	// (ending with ".key") used when talking to a container registry.
 	DockerCertPath string
 	// If not "", overrides the system’s default path for a directory containing host[:port] subdirectories with the same structure as DockerCertPath above.
 	// Ignored if DockerCertPath is non-empty.
 	DockerPerHostCertDirPath string
-	// Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
+	// Allow contacting container registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	DockerInsecureSkipTLSVerify OptionalBool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	// Ignored if DockerBearerRegistryToken is non-empty.


### PR DESCRIPTION
Will leave references to distribution spec until there is an OCI Spec we
can point at.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>