### PR TITLE
search: catalog: return full match as first item

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -423,7 +423,14 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 				res := SearchResult{
 					Name: repo,
 				}
-				searchRes = append(searchRes, res)
+				// bugzilla.redhat.com/show_bug.cgi?id=1976283
+				// If we have a full match, make sure it's listed as the first result.
+				// (Note there might be a full match we never see if we reach the result limit first.)
+				if repo == image {
+					searchRes = append([]SearchResult{res}, searchRes...)
+				} else {
+					searchRes = append(searchRes, res)
+				}
 			}
 		}
 


### PR DESCRIPTION
When searching via v2/catalog make sure that a full match is returned as
the first item.  The change is motivated by a conversation in a BZ [1]
on the rather undefined nature/semantics of searching images.

While this change does not fix the BZ, it may be a small improvement
when using the v2/catalog endpoint.

[1] bugzilla.redhat.com/show_bug.cgi?id=1976283

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>