### PR TITLE
 We should only look at Legacy path if DOCKER_CONFIG is not set. 

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -204,10 +204,10 @@ func getAuthFilePaths(sys *types.SystemContext, homeDir string) []authPath {
 		paths = append(paths,
 			authPath{path: filepath.Join(homeDir, dockerHomePath), legacyFormat: false},
 		)
+		paths = append(paths,
+			authPath{path: filepath.Join(homeDir, dockerLegacyHomePath), legacyFormat: true},
+		)
 	}
-	paths = append(paths,
-		authPath{path: filepath.Join(homeDir, dockerLegacyHomePath), legacyFormat: true},
-	)
 	return paths
 }
 


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>