### PR TITLE
Make compressionGoroutine panic-safe again

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1752,6 +1752,10 @@ func doCompression(dest io.Writer, src io.Reader, metadata map[string]string, co
 
 // compressGoroutine reads all input from src and writes its compressed equivalent to dest.
 func (c *copier) compressGoroutine(dest *io.PipeWriter, src io.Reader, metadata map[string]string, compressionFormat compression.Algorithm) {
-	err := doCompression(dest, src, metadata, compressionFormat, c.compressionLevel)
-	_ = dest.CloseWithError(err) // CloseWithError(nil) is equivalent to Close(), always returns nil
+	err := errors.New("Internal error: unexpected panic in compressGoroutine")
+	defer func() { // Note that this is not the same as {defer dest.CloseWithError(err)}; we need err to be evaluated lazily.
+		_ = dest.CloseWithError(err) // CloseWithError(nil) is equivalent to Close(), always returns nil
+	}()
+
+	err = doCompression(dest, src, metadata, compressionFormat, c.compressionLevel)
 }


### PR DESCRIPTION
Commit 3250f2da77d61931d38513846f2bb7fbf9352460 from #1084 removed the code that ensures the pipe is closed with error on a goroutine panic, i.e. that the caller does not hang indefinitely, for no clear reason; restore that.
