### PR TITLE
Rename compression.Algorithm.MIME

### DIFF
--- a/manifest/common.go
+++ b/manifest/common.go
@@ -68,7 +68,7 @@ func compressionVariantMIMEType(variantTable []compressionMIMETypeSet, mimeType 
 			if mt == mimeType { // Found the variant
 				name := mtsUncompressed
 				if algorithm != nil {
-					name = algorithm.MIME()
+					name = algorithm.InternalUnstableUndocumentedMIMEQuestionMark()
 				}
 				if res, ok := variants[name]; ok {
 					if res != mtsUnsupportedMIMEType {

--- a/pkg/compression/internal/types.go
+++ b/pkg/compression/internal/types.go
@@ -37,8 +37,9 @@ func (c Algorithm) Name() string {
 	return c.name
 }
 
-// Name returns the MIME type to use for the compression algorithm.
-func (c Algorithm) MIME() string {
+// InternalUnstableUndocumentedMIMEQuestionMark ???
+// DO NOT USE THIS anywhere outside of c/image until it is properly documented.
+func (c Algorithm) InternalUnstableUndocumentedMIMEQuestionMark() string {
 	return c.mime
 }
 


### PR DESCRIPTION
... to `InternalUnstableUndocumentedMIMEQuestionMark` , as a minimal low-effort attempt to prevent this being a part of the API stability promise.

Hopefully this will actually be properly documented, or replaced with something maintainable, instead; this is a stupid stopgap to decrease the risk of the current state becoming a part of a release.

A follow-up to https://github.com/containers/image/pull/1084/files#r622268661 . Cc: @giuseppe @rhatdan  .