### PR TITLE
Improve registry client error handling

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -1037,9 +1037,8 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 		return nil, err
 	}
 	defer res.Body.Close()
-
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("downloading signatures for %s in %s: %w", manifestDigest, ref.ref.Name(), handleErrorResponse(res))
+		return nil, fmt.Errorf("downloading signatures for %s in %s: %w", manifestDigest, ref.ref.Name(), registryHTTPResponseToError(res))
 	}
 
 	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureListBodySize)

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -982,13 +982,8 @@ func (c *dockerClient) getOCIDescriptorContents(ctx context.Context, ref dockerR
 
 // isManifestUnknownError returns true iff err from fetchManifest is a “manifest unknown” error.
 func isManifestUnknownError(err error) bool {
-	var errs errcode.Errors
-	if !errors.As(err, &errs) || len(errs) == 0 {
-		return false
-	}
-	err = errs[0]
-	ec, ok := err.(errcode.ErrorCoder)
-	if !ok {
+	var ec errcode.ErrorCoder
+	if !errors.As(err, &ec) {
 		return false
 	}
 	return ec.ErrorCode() == v2.ErrorCodeManifestUnknown

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -77,8 +77,8 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if err := httpResponseToError(res, "fetching tags list"); err != nil {
-			return nil, err
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("fetching tags list: %w", registryHTTPResponseToError(res))
 		}
 
 		var tagsHolder struct {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -244,7 +244,7 @@ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.
 		logrus.Debugf("... not present")
 		return false, -1, nil
 	default:
-		return false, -1, fmt.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
+		return false, -1, fmt.Errorf("checking whether a blob %s exists in %s: %w", digest, repo.Name(), registryHTTPResponseToError(res))
 	}
 }
 

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -487,13 +487,8 @@ func successStatus(status int) bool {
 	return status >= 200 && status <= 399
 }
 
-// isManifestInvalidError returns true iff err from client.HandleErrorResponse is a “manifest invalid” error.
+// isManifestInvalidError returns true iff err from registryHTTPResponseToError is a “manifest invalid” error.
 func isManifestInvalidError(err error) bool {
-	errors, ok := err.(errcode.Errors)
-	if !ok || len(errors) == 0 {
-		return false
-	}
-	err = errors[0]
 	ec, ok := err.(errcode.ErrorCoder)
 	if !ok {
 		return false

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -489,8 +489,8 @@ func successStatus(status int) bool {
 
 // isManifestInvalidError returns true iff err from registryHTTPResponseToError is a “manifest invalid” error.
 func isManifestInvalidError(err error) bool {
-	ec, ok := err.(errcode.ErrorCoder)
-	if !ok {
+	var ec errcode.ErrorCoder
+	if ok := errors.As(err, &ec); !ok {
 		return false
 	}
 

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -81,7 +81,8 @@ func registryHTTPResponseToError(res *http.Response) error {
 		if len(response) > 50 {
 			response = response[:50] + "..."
 		}
-		err = fmt.Errorf("StatusCode: %d, %s", e.StatusCode, response)
+		// %.0w makes e visible to error.Unwrap() without including any text
+		err = fmt.Errorf("StatusCode: %d, %s%.0w", e.StatusCode, response, e)
 	}
 	return err
 }

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -47,6 +50,32 @@ func httpResponseToError(res *http.Response, context string) error {
 // registry
 func registryHTTPResponseToError(res *http.Response) error {
 	err := handleErrorResponse(res)
+	// len(errs) == 0 should never be returned by handleErrorResponse; if it does, we don't modify it and let the caller report it as is.
+	if errs, ok := err.(errcode.Errors); ok && len(errs) > 0 {
+		// The docker/distribution registry implementation almost never returns
+		// more than one error in the HTTP body; it seems there is only one
+		// possible instance, where the second error reports a cleanup failure
+		// we don't really care about.
+		//
+		// The only _common_ case where a multi-element error is returned is
+		// created by the handleErrorResponse parser when OAuth authorization fails:
+		// the first element contains errors from a WWW-Authenticate header, the second
+		// element contains errors from the response body.
+		//
+		// In that case the first one is currently _slightly_ more informative (ErrorCodeUnauthorized
+		// for invalid tokens, ErrorCodeDenied for permission denied with a valid token
+		// for the first error, vs. ErrorCodeUnauthorized for both cases for the second error.)
+		//
+		// Also, docker/docker similarly only logs the other errors and returns the
+		// first one.
+		if len(errs) > 1 {
+			logrus.Debugf("Discarding non-primary errors:")
+			for _, err := range errs[1:] {
+				logrus.Debugf("  %s", err.Error())
+			}
+		}
+		err = errs[0]
+	}
 	if e, ok := err.(*unexpectedHTTPResponseError); ok {
 		response := string(e.Response)
 		if len(response) > 50 {

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -33,7 +33,7 @@ func httpResponseToError(res *http.Response, context string) error {
 	case http.StatusTooManyRequests:
 		return ErrTooManyRequests
 	case http.StatusUnauthorized:
-		err := handleErrorResponse(res)
+		err := registryHTTPResponseToError(res)
 		return ErrUnauthorizedForCredentials{Err: err}
 	default:
 		if context != "" {

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -110,6 +110,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				var e errcode.Error
 				ok := errors.As(err, &e)
 				require.True(t, ok)
+				// Note: (skopeo inspect) is checking for this errcode.Error value
 				assert.Equal(t, errcode.Error{
 					Code:    errcode.ErrorCodeUnknown, // The NOT_FOUND value is not defined, and turns into Unknown
 					Message: "404 page not found",

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -18,6 +18,7 @@ import (
 // they can change at any time for any reason.
 func TestRegistryHTTPResponseToError(t *testing.T) {
 	var unwrappedUnexpectedHTTPResponseError *unexpectedHTTPResponseError
+	var unwrappedErrcodeError errcode.Error
 	for _, c := range []struct {
 		name              string
 		response          string
@@ -52,9 +53,9 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"Header1: Value1\r\n" +
 				"\r\n" +
 				"<html><body>JSON? What JSON?</body></html>\r\n",
-			errorString:       "unauthorized: authentication required",
-			errorType:         errcode.Error{},
-			unwrappedErrorPtr: nil,
+			errorString:       "authentication required",
+			errorType:         nil,
+			unwrappedErrorPtr: &unwrappedErrcodeError,
 			errorCode:         &errcode.ErrorCodeUnauthorized,
 		},
 		{ // docker.io when an image is not found
@@ -69,9 +70,9 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"Www-Authenticate: Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/this-does-not-exist:pull\",error=\"insufficient_scope\"\r\n" +
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"authentication required\",\"detail\":[{\"Type\":\"repository\",\"Class\":\"\",\"Name\":\"library/this-does-not-exist\",\"Action\":\"pull\"}]}]}\n",
-			errorString:       "denied: requested access to the resource is denied",
-			errorType:         errcode.Error{},
-			unwrappedErrorPtr: nil,
+			errorString:       "requested access to the resource is denied",
+			errorType:         nil,
+			unwrappedErrorPtr: &unwrappedErrcodeError,
 			errorCode:         &errcode.ErrorCodeDenied,
 		},
 		{ // docker.io when a tag is not found
@@ -87,9 +88,9 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"Strict-Transport-Security: max-age=31536000\r\n" +
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"MANIFEST_UNKNOWN\",\"message\":\"manifest unknown\",\"detail\":{\"Tag\":\"this-does-not-exist\"}}]}\n",
-			errorString:       "manifest unknown: manifest unknown",
-			errorType:         errcode.Error{},
-			unwrappedErrorPtr: nil,
+			errorString:       "manifest unknown",
+			errorType:         nil,
+			unwrappedErrorPtr: &unwrappedErrcodeError,
 			errorCode:         &v2.ErrorCodeManifestUnknown,
 		},
 		{ // public.ecr.aws does not implement tag list
@@ -103,8 +104,8 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"NOT_FOUND\",\"message\":\"404 page not found\"}]}\r\n",
 			errorString:       "unknown: 404 page not found",
-			errorType:         errcode.Error{},
-			unwrappedErrorPtr: nil,
+			errorType:         nil,
+			unwrappedErrorPtr: &unwrappedErrcodeError,
 			errorCode:         &errcode.ErrorCodeUnknown,
 			fn: func(t *testing.T, err error) {
 				var e errcode.Error

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -64,8 +64,8 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"Www-Authenticate: Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/this-does-not-exist:pull\",error=\"insufficient_scope\"\r\n" +
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"authentication required\",\"detail\":[{\"Type\":\"repository\",\"Class\":\"\",\"Name\":\"library/this-does-not-exist\",\"Action\":\"pull\"}]}]}\n",
-			errorString:       "errors:\ndenied: requested access to the resource is denied\nunauthorized: authentication required\n",
-			errorType:         errcode.Errors{},
+			errorString:       "denied: requested access to the resource is denied",
+			errorType:         errcode.Error{},
 			unwrappedErrorPtr: nil,
 		},
 		{ // docker.io when a tag is not found
@@ -82,7 +82,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"MANIFEST_UNKNOWN\",\"message\":\"manifest unknown\",\"detail\":{\"Tag\":\"this-does-not-exist\"}}]}\n",
 			errorString:       "manifest unknown: manifest unknown",
-			errorType:         errcode.Errors{},
+			errorType:         errcode.Error{},
 			unwrappedErrorPtr: nil,
 		},
 		{ // public.ecr.aws does not implement tag list
@@ -96,7 +96,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"\r\n" +
 				"{\"errors\":[{\"code\":\"NOT_FOUND\",\"message\":\"404 page not found\"}]}\r\n",
 			errorString:       "unknown: 404 page not found",
-			errorType:         errcode.Errors{},
+			errorType:         errcode.Error{},
 			unwrappedErrorPtr: nil,
 		},
 	} {

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -17,6 +17,7 @@ import (
 // NOR the error texts are an API commitment subject to API stability expectations;
 // they can change at any time for any reason.
 func TestRegistryHTTPResponseToError(t *testing.T) {
+	var unwrappedUnexpectedHTTPResponseError *unexpectedHTTPResponseError
 	for _, c := range []struct {
 		name              string
 		response          string
@@ -43,7 +44,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"<html><body>JSON? What JSON?</body></html>\r\n",
 			errorString:       "StatusCode: 400, <html><body>JSON? What JSON?</body></html>\r\n",
 			errorType:         nil,
-			unwrappedErrorPtr: nil,
+			unwrappedErrorPtr: &unwrappedUnexpectedHTTPResponseError,
 		},
 		{
 			name: "401 body not in expected format",

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -89,15 +89,14 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			name: "GET https://public.ecr.aws/v2/nginx/nginx/tags/list",
 			response: "HTTP/1.1 404 Not Found\r\n" +
 				"Connection: close\r\n" +
-				"Content-Length: 19\r\n" +
-				"Content-Type: text/plain; charset=utf-8\r\n" +
-				"Date: Thu, 12 Aug 2021 19:54:58 GMT\r\n" +
+				"Content-Length: 65\r\n" +
+				"Content-Type: application/json; charset=utf-8\r\n" +
+				"Date: Tue, 06 Sep 2022 21:19:02 GMT\r\n" +
 				"Docker-Distribution-Api-Version: registry/2.0\r\n" +
-				"X-Content-Type-Options: nosniff\r\n" +
 				"\r\n" +
-				"404 page not found\n",
-			errorString:       "StatusCode: 404, 404 page not found\n",
-			errorType:         nil,
+				"{\"errors\":[{\"code\":\"NOT_FOUND\",\"message\":\"404 page not found\"}]}\r\n",
+			errorString:       "unknown: 404 page not found",
+			errorType:         errcode.Errors{},
 			unwrappedErrorPtr: nil,
 		},
 	} {


### PR DESCRIPTION
See https://github.com/containers/image/issues/1293#issuecomment-875791392 and the added comment.

The primary expected benefit is that this should turn
```
Error initializing source docker://foobar:latest: Error reading manifest latest in docker.io/library/foobar: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```
into
```
Error initializing source docker://foobar:latest: Error reading manifest latest in docker.io/library/foobar: denied: requested access to the resource is denied
```

⚠️ 
- <s>Currently absolutely untested. We should see what this changes in practice for a variety of registries and situations.</s>
- <s>This could potentially _silently_ break callers; notably https://github.com/containers/common/blob/a38eda676e2adea08a5138aa639f873537cac335/pkg/retry/retry.go#L60 almost certainly needs to add a case for `ErrorCodeDenied` because the second `ErrorCodeUnauthorized` will not be visible.</s>

@vrothberg PTAL.

---

Tests pass in https://github.com/containers/skopeo/pull/1522 .