### PR TITLE
Remove `GetCredentials` deprecation

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -343,8 +343,8 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	v1Res := &V1Results{}
 
 	// Get credentials from authfile for the underlying hostname
-	// lint:ignore SA1019 We can't use GetCredentialsForRef because we want to search the whole registry.
-	auth, err := config.GetCredentials(sys, registry) // nolint:staticcheck // https://github.com/golangci/golangci-lint/issues/741
+	// We can't use GetCredentialsForRef here because we want to search the whole registry.
+	auth, err := config.GetCredentials(sys, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting username and password")
 	}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -236,9 +236,8 @@ func getAuthFilePaths(sys *types.SystemContext, homeDir string) []authPath {
 // file or .docker/config.json, including support for OAuth2 and IdentityToken.
 // If an entry is not found, an empty struct is returned.
 //
-// Deprecated: GetCredentialsForRef should be used in favor of this API
-// because it allows different credentials for different repositories on the
-// same registry.
+// GetCredentialsForRef should almost always be used in favor of this API to
+// allow different credentials for different repositories on the same registry.
 func GetCredentials(sys *types.SystemContext, registry string) (types.DockerAuthConfig, error) {
 	return getCredentialsWithHomeDir(sys, nil, registry, homedir.Get())
 }


### PR DESCRIPTION
We cannot use `GetCredentialsForRef` if we want to retrieve the
credentials for a single registry. This use case is still valid which
makes the deprecation of the API obsolete.

Refers to https://github.com/containers/common/pull/659#discussion_r672568675