### PR TITLE
Don't run skopeo's runner.sh validate

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,8 +143,6 @@ test_skopeo_task:
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" vendor
     build_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" build
-    validate_script: >-
-        "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" validate
     unit_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" unit
     integration_script: >-


### PR DESCRIPTION
It was removed in https://github.com/containers/skopeo/pull/1374 .

Fixes a failure visible in https://github.com/containers/image/pull/1307 .