### PR TITLE
Fix unpredictable outcome of compression.DetectCompression*

### DIFF
--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -29,7 +29,7 @@ var (
 	// Zstd compression.
 	Zstd = internal.NewAlgorithm("zstd", "zstd", []byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, zstdCompressor)
 	// Zstd:chunked compression.
-	ZstdChunked = internal.NewAlgorithm("zstd:chunked", "zstd", []byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, chunked.ZstdCompressor)
+	ZstdChunked = internal.NewAlgorithm("zstd:chunked", "zstd", nil, ZstdDecompressor, chunked.ZstdCompressor)
 
 	compressionAlgorithms = map[string]Algorithm{
 		Gzip.Name():        Gzip,
@@ -118,7 +118,8 @@ func DetectCompressionFormat(input io.Reader) (Algorithm, DecompressorFunc, io.R
 	var retAlgo Algorithm
 	var decompressor DecompressorFunc
 	for _, algo := range compressionAlgorithms {
-		if bytes.HasPrefix(buffer[:n], internal.AlgorithmPrefix(algo)) {
+		prefix := internal.AlgorithmPrefix(algo)
+		if len(prefix) > 0 && bytes.HasPrefix(buffer[:n], prefix) {
 			logrus.Debugf("Detected compression format %s", algo.Name())
 			retAlgo = algo
 			decompressor = internal.AlgorithmDecompressor(algo)

--- a/pkg/compression/internal/types.go
+++ b/pkg/compression/internal/types.go
@@ -14,7 +14,7 @@ type DecompressorFunc func(io.Reader) (io.ReadCloser, error)
 type Algorithm struct {
 	name         string
 	mime         string
-	prefix       []byte
+	prefix       []byte // Initial bytes of a stream compressed using this algorithm, or empty to disable detection.
 	decompressor DecompressorFunc
 	compressor   CompressorFunc
 }


### PR DESCRIPTION
Because `compressionAlgorithms` is a map, it is traversed in an unpredictable order, so using the same prefix for `zstd` and `zstd:chunked` meant that the caller could get either.

Define empty prefix as "opt out of detection", to always return `Zstd`.