### PR TITLE
Stop caching encrypted layers in docker destination

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1620,6 +1620,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 			finalizer = fin
 			inputInfo.Digest = ""
 			inputInfo.Size = -1
+			inputInfo.CryptoOperation = types.Encrypt
 			encrypted = true
 		}
 	}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -205,7 +205,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	}
 
 	logrus.Debugf("Upload of layer %s complete", computedDigest)
-	cache.RecordKnownLocation(d.ref.Transport(), bicTransportScope(d.ref), computedDigest, newBICLocationReference(d.ref))
+	if inputInfo.CryptoOperation != types.Encrypt {
+		cache.RecordKnownLocation(d.ref.Transport(), bicTransportScope(d.ref), computedDigest, newBICLocationReference(d.ref))
+	}
 	return types.BlobInfo{Digest: computedDigest, Size: sizeCounter.size}, nil
 }
 


### PR DESCRIPTION
In a case where a non-encrypted images is committed to a registry after
an encrypted image is committed, this library may try to reuse
encrypted layers for the non-encrypted images if the images have common
layers. When the non-encrypted image is committed, there is no
information to recognize that cached layers are encrypted. As a result,
the non-encrypted image has encrypted layers unexpectedly in the
registry. This causes an error when the non-encrypted image is pulled
from the registry.

To avoid reusing encrypted layers for another image, this change stops
caching a layer if it is encrypted.

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>