### PR TITLE
Simplify credential normalization, fix tests

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -665,13 +665,10 @@ func findAuthentication(ref reference.Named, registry, path string, legacyFormat
 	// The docker.io registry still uses the /v1/ key with a special host name,
 	// so account for that as well.
 	registry = normalizeAuthFileKey(registry, legacyFormat)
-	normalizedAuths := map[string]dockerAuthConfig{}
 	for k, v := range auths.AuthConfigs {
-		normalizedAuths[normalizeAuthFileKey(k, legacyFormat)] = v
-	}
-
-	if val, exists := normalizedAuths[registry]; exists {
-		return decodeDockerAuth(val)
+		if normalizeAuthFileKey(k, legacyFormat) == registry {
+			return decodeDockerAuth(v)
+		}
 	}
 
 	return types.DockerAuthConfig{}, nil

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -664,7 +664,7 @@ func findAuthentication(ref reference.Named, registry, path string, legacyFormat
 	// those entries even in non-legacyFormat ~/.docker/config.json.
 	// The docker.io registry still uses the /v1/ key with a special host name,
 	// so account for that as well.
-	registry = normalizeAuthFileKey(registry, legacyFormat)
+	registry = normalizeRegistry(registry)
 	for k, v := range auths.AuthConfigs {
 		if normalizeAuthFileKey(k, legacyFormat) == registry {
 			return decodeDockerAuth(v)

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -192,17 +192,17 @@ func TestGetAuth(t *testing.T) {
 			},
 			{
 				name:     "normalize registry",
-				hostname: "https://example.org/v1",
+				hostname: "normalize.example.org",
 				path:     filepath.Join("testdata", "full.json"),
 				expected: types.DockerAuthConfig{
-					Username: "example",
-					Password: "org",
+					Username: "normalize",
+					Password: "example",
 				},
 				testPreviousAPI: true,
 			},
 			{
 				name:     "match localhost",
-				hostname: "http://localhost",
+				hostname: "localhost",
 				path:     filepath.Join("testdata", "full.json"),
 				expected: types.DockerAuthConfig{
 					Username: "local",
@@ -222,7 +222,7 @@ func TestGetAuth(t *testing.T) {
 			},
 			{
 				name:     "match port",
-				hostname: "https://localhost:5000",
+				hostname: "localhost:5000",
 				path:     filepath.Join("testdata", "abnormal.json"),
 				expected: types.DockerAuthConfig{
 					Username: "local",
@@ -387,16 +387,16 @@ func TestGetAuthFromLegacyFile(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:     "normalize registry",
-			hostname: "https://docker.io/v1",
+			name:     "ignore schema and path",
+			hostname: "localhost",
 			expected: types.DockerAuthConfig{
-				Username: "docker",
-				Password: "io-legacy",
+				Username: "local",
+				Password: "host-legacy",
 			},
 		},
 		{
-			name:     "ignore schema and path",
-			hostname: "http://index.docker.io/v1",
+			name:     "normalize registry",
+			hostname: "docker.io",
 			expected: types.DockerAuthConfig{
 				Username: "docker",
 				Password: "io-legacy",

--- a/pkg/docker/config/testdata/full.json
+++ b/pkg/docker/config/testdata/full.json
@@ -20,6 +20,9 @@
     },
     "10.10.30.45:5000": {
       "auth": "MTAuMTA6MzAuNDUtNTAwMA=="
+    },
+    "https://normalize.example.org/v1": {
+      "auth": "bm9ybWFsaXplOmV4YW1wbGU="
     }
   }
 }

--- a/pkg/docker/config/testdata/legacy.json
+++ b/pkg/docker/config/testdata/legacy.json
@@ -1,5 +1,5 @@
 {
-  "docker.io/v2": {
+  "http://index.docker.io/v1": {
     "auth": "ZG9ja2VyOmlvLWxlZ2FjeQ=="
   },
   "https://localhost/v1": {


### PR DESCRIPTION
- Don't build a map just to access one element. NOTE: This might change behavior with ambiguous files, we now use the first matching entry, not the last one.
- Don't unnecessarily strip schema:// and /path from registry on search, and adjust tests

See the individual commit messages for details.