### PR TITLE
HTTP cleanups

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -534,11 +534,10 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method, url
 // makeRequest should generally be preferred.
 // Note that no exponential back off is performed when receiving an http 429 status code.
 func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method, url string, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, stream)
+	req, err := http.NewRequestWithContext(ctx, method, url, stream)
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(ctx)
 	if streamLen != -1 { // Do not blindly overwrite if streamLen == -1, http.NewRequest above can figure out the length of bytes.Reader and similar objects without us having to compute it.
 		req.ContentLength = streamLen
 	}
@@ -631,12 +630,10 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 		return nil, errors.Errorf("missing realm in bearer auth challenge")
 	}
 
-	authReq, err := http.NewRequest(http.MethodPost, realm, nil)
+	authReq, err := http.NewRequestWithContext(ctx, http.MethodPost, realm, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	authReq = authReq.WithContext(ctx)
 
 	// Make the form data required against the oauth2 authentication
 	// More details here: https://docs.docker.com/registry/spec/auth/oauth/
@@ -681,12 +678,11 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 		return nil, errors.Errorf("missing realm in bearer auth challenge")
 	}
 
-	authReq, err := http.NewRequest(http.MethodGet, realm, nil)
+	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	authReq = authReq.WithContext(ctx)
 	params := authReq.URL.Query()
 	if c.auth.Username != "" {
 		params.Add("account", c.auth.Username)

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -304,7 +304,7 @@ func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password
 		Password: password,
 	}
 
-	resp, err := client.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth, nil)
+	resp, err := client.makeRequest(ctx, http.MethodGet, "/v2/", nil, nil, v2Auth, nil)
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		u.RawQuery = q.Encode()
 
 		logrus.Debugf("trying to talk to v1 search endpoint")
-		resp, err := client.makeRequest(ctx, "GET", u.String(), nil, nil, noAuth, nil)
+		resp, err := client.makeRequest(ctx, http.MethodGet, u.String(), nil, nil, noAuth, nil)
 		if err != nil {
 			logrus.Debugf("error getting search results from v1 endpoint %q: %v", registry, err)
 		} else {
@@ -400,7 +400,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	searchRes := []SearchResult{}
 	path := "/v2/_catalog"
 	for len(searchRes) < limit {
-		resp, err := client.makeRequest(ctx, "GET", path, nil, nil, v2Auth, nil)
+		resp, err := client.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
 		if err != nil {
 			logrus.Debugf("error getting search results from v2 endpoint %q: %v", registry, err)
 			return nil, errors.Wrapf(err, "couldn't search registry %q", registry)
@@ -736,7 +736,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 
 	ping := func(scheme string) error {
 		url := fmt.Sprintf(resolvedPingV2URL, scheme, c.registry)
-		resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth, nil)
+		resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
 		if err != nil {
 			logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 			return err
@@ -763,7 +763,7 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		// best effort to understand if we're talking to a V1 registry
 		pingV1 := func(scheme string) bool {
 			url := fmt.Sprintf(resolvedPingV1URL, scheme, c.registry)
-			resp, err := c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth, nil)
+			resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
 			if err != nil {
 				logrus.Debugf("Ping %s err %s (%#v)", url, err.Error(), err)
 				return false
@@ -797,7 +797,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 // using the original data structures.
 func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
 	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
-	res, err := c.makeRequest(ctx, "GET", path, nil, nil, v2Auth, nil)
+	res, err := c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -68,7 +68,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 	tags := make([]string, 0)
 
 	for {
-		res, err := client.makeRequest(ctx, "GET", path, nil, nil, v2Auth, nil)
+		res, err := client.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 		"Accept": manifest.DefaultRequestedManifestMIMETypes,
 	}
 
-	res, err := client.makeRequest(ctx, "HEAD", path, headers, nil, v2Auth, nil)
+	res, err := client.makeRequest(ctx, http.MethodHead, path, headers, nil, v2Auth, nil)
 	if err != nil {
 		return "", err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -192,7 +192,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	headers := map[string][]string{
 		"Accept": manifest.DefaultRequestedManifestMIMETypes,
 	}
-	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil, v2Auth, nil)
+	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -248,7 +248,7 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 		// NOTE: we must not authenticate on additional URLs as those
 		//       can be abused to leak credentials or tokens.  Please
 		//       refer to CVE-2020-15157 for more information.
-		resp, err = s.c.makeRequestToResolvedURL(ctx, "GET", url, nil, nil, -1, noAuth, nil)
+		resp, err = s.c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
 		if err == nil {
 			if resp.StatusCode != http.StatusOK {
 				err = errors.Errorf("error fetching external blob from %q: %d (%s)", url, resp.StatusCode, http.StatusText(resp.StatusCode))
@@ -295,7 +295,7 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 
 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
-	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil, v2Auth, nil)
+	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -364,7 +364,7 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 
 	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
-	res, err := s.c.makeRequest(ctx, "GET", path, nil, nil, v2Auth, nil)
+	res, err := s.c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -454,7 +454,7 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 
 	case "http", "https":
 		logrus.Debugf("GET %s", url)
-		req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 		if err != nil {
 			return nil, false, err
 		}
@@ -522,7 +522,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 	getPath := fmt.Sprintf(manifestPath, reference.Path(ref.ref), refTail)
-	get, err := c.makeRequest(ctx, "GET", getPath, headers, nil, v2Auth, nil)
+	get, err := c.makeRequest(ctx, http.MethodGet, getPath, headers, nil, v2Auth, nil)
 	if err != nil {
 		return err
 	}
@@ -544,7 +544,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 
 	// When retrieving the digest from a registry >= 2.3 use the following header:
 	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-	delete, err := c.makeRequest(ctx, "DELETE", deletePath, headers, nil, v2Auth, nil)
+	delete, err := c.makeRequest(ctx, http.MethodDelete, deletePath, headers, nil, v2Auth, nil)
 	if err != nil {
 		return err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -454,11 +454,10 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 
 	case "http", "https":
 		logrus.Debugf("GET %s", url)
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
 		if err != nil {
 			return nil, false, err
 		}
-		req = req.WithContext(ctx)
 		res, err := s.c.client.Do(req)
 		if err != nil {
 			return nil, false, err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/image/v5
 
-go 1.11
+go 1.13
 
 require (
 	github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 // indirect

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -148,13 +148,13 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 	errWrap := errors.New("failed fetching external blob from all urls")
 	for _, url := range urls {
 
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
 			continue
 		}
 
-		resp, err := s.client.Do(req.WithContext(ctx))
+		resp, err := s.client.Do(req)
 		if err != nil {
 			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
 			continue

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -148,7 +148,7 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 	errWrap := errors.New("failed fetching external blob from all urls")
 	for _, url := range urls {
 
-		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", url, err.Error())
 			continue

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -136,7 +136,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 func (c *openshiftClient) getImage(ctx context.Context, imageStreamImageName string) (*image, error) {
 	// FIXME: validate components per validation.IsValidPathSegmentName?
 	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreamimages/%s@%s", c.ref.namespace, c.ref.stream, imageStreamImageName)
-	body, err := c.doRequest(ctx, "GET", path, nil)
+	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 
 	// FIXME: validate components per validation.IsValidPathSegmentName?
 	path := fmt.Sprintf("/oapi/v1/namespaces/%s/imagestreams/%s", s.client.ref.namespace, s.client.ref.stream)
-	body, err := s.client.doRequest(ctx, "GET", path, nil)
+	body, err := s.client.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return err
 	}
@@ -495,7 +495,7 @@ sigExists:
 		if err != nil {
 			return err
 		}
-		_, err = d.client.doRequest(ctx, "POST", "/oapi/v1/imagesignatures", body)
+		_, err = d.client.doRequest(ctx, http.MethodPost, "/oapi/v1/imagesignatures", body)
 		if err != nil {
 			return err
 		}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -79,11 +79,10 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		logrus.Debugf("Will send body: %s", requestBody)
 		requestBodyReader = bytes.NewReader(requestBody)
 	}
-	req, err := http.NewRequest(method, url.String(), requestBodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), requestBodyReader)
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(ctx)
 
 	if len(c.bearerToken) != 0 {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken)


### PR DESCRIPTION
A few trivial cleanups of how we use `net/http`. Should not change behavior.

Fixes #1158.