### PR TITLE
backport + v5.14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -101,26 +101,22 @@ test_task:
               BUILDTAGS: 'btrfs_noversion libdm_no_deferred_remove'
         - name: "Test w/ opengpg"
           env:
-              BUILDTAGS: 'btrfs_noversion libdm_no_deferred_remove containers_image_openpgp'
+              BUILDTAGS: &withopengpg 'btrfs_noversion libdm_no_deferred_remove containers_image_openpgp'
     script: |
         make tools
         make test BUILDTAGS="$BUILDTAGS"
 
 
 #####
-###### NOTE: This task is subtantially duplicated in the containers/skopeo
-###### repository's `.cirrus.yml`.  Changes needed here should first be
-###### merged in that repository, before being manually duplicated here.
-######
-###### The *ONLY* exception is in "setup_script" which must initially
-###### clone the skopeo repository.
-######
+##### NOTE: This task is subtantially duplicated in the containers/skopeo
+##### repository's `.cirrus.yml`.  Changes made here should be fully merged
+##### prior to being manually duplicated and maintained in containers/skopeo.
+#####
 test_skopeo_task:
     alias: test_skopeo
+    only_if: *not_docs
     depends_on:
         - validate
-        - cross
-    only_if: *not_docs
     gce_instance:
         image_project: libpod-218412
         zone: "us-central1-f"
@@ -131,25 +127,23 @@ test_skopeo_task:
         disk: 200
         image_name: ${FEDORA_CACHE_IMAGE_NAME}
     matrix:
-        - name: "Skopeo"
+        - name: "Skopeo Test"
           env:
               BUILDTAGS: 'btrfs_noversion libdm_no_deferred_remove'
-        - name: "Skopeo w/ opengpg"
+        - name: "Skopeo Test w/ opengpg"
           env:
-              BUILDTAGS: 'btrfs_noversion libdm_no_deferred_remove containers_image_openpgp'
-    setup_script: |
+              BUILDTAGS: *withopengpg
+    setup_script: >-
         "${GOSRC}/${SCRIPT_BASE}/runner.sh" setup
     vendor_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" vendor
     build_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" build
-    validate_script: >-
-        "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" validate
     unit_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" unit
     integration_script: >-
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" integration
-    system_script: >-
+    system_script: >
         "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" system
 
 

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -21,13 +21,14 @@ const version = "Directory Transport Version: 1.1\n"
 var ErrNotContainerImageDir = errors.New("not a containers image directory, don't want to overwrite important data")
 
 type dirImageDestination struct {
-	ref      dirReference
-	compress bool
+	ref        dirReference
+	compress   bool
+	decompress bool
 }
 
 // newImageDestination returns an ImageDestination for writing to a directory.
-func newImageDestination(ref dirReference, compress bool) (types.ImageDestination, error) {
-	d := &dirImageDestination{ref: ref, compress: compress}
+func newImageDestination(ref dirReference, compress bool, decompress bool) (types.ImageDestination, error) {
+	d := &dirImageDestination{ref: ref, compress: compress, decompress: decompress}
 
 	// If directory exists check if it is empty
 	// if not empty, check whether the contents match that of a container image directory and overwrite the contents
@@ -103,6 +104,9 @@ func (d *dirImageDestination) SupportsSignatures(ctx context.Context) error {
 func (d *dirImageDestination) DesiredLayerCompression() types.LayerCompression {
 	if d.compress {
 		return types.Compress
+	}
+	if d.decompress {
+		return types.Decompress
 	}
 	return types.PreserveOriginal
 }

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -157,7 +157,11 @@ func (ref dirReference) NewImageDestination(ctx context.Context, sys *types.Syst
 	if sys != nil {
 		compress = sys.DirForceCompress
 	}
-	return newImageDestination(ref, compress)
+	decompress := false
+	if sys != nil {
+		decompress = sys.DirForceDecompress
+	}
+	return newImageDestination(ref, compress, decompress)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.

--- a/types/types.go
+++ b/types/types.go
@@ -636,6 +636,8 @@ type SystemContext struct {
 	// === dir.Transport overrides ===
 	// DirForceCompress compresses the image layers if set to true
 	DirForceCompress bool
+	// DirForceDecompress decompresses the image layers if set to true
+	DirForceDecompress bool
 
 	// CompressionFormat is the format to use for the compression of the blobs
 	CompressionFormat *compression.Algorithm

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 14
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 14
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Backport commit 3556c3159a5f237a57dc6c7c72355825e0e640c0 and cut a new v5.14.1.  This way we can easily cut a new Skopeo from main including the feature from 3556c3159a5f237a57dc6c7c72355825e0e640c0.

@mtrmac @TomSweeneyRedHat PTAL