### PR TITLE
bump main branch to v5.16.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,9 +6,9 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 15
+	VersionMinor = 16
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
Since we now have a release-5.15 branch, the v5.15.x series will be cut
from there.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mtrmac PTAL