### PR TITLE
accept identity tokens from credential helpers

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -601,10 +601,18 @@ func getAuthFromCredHelper(credHelper, registry string) (types.DockerAuthConfig,
 	if err != nil {
 		return types.DockerAuthConfig{}, err
 	}
-	return types.DockerAuthConfig{
-		Username: creds.Username,
-		Password: creds.Secret,
-	}, nil
+
+	switch creds.Username {
+	case "<token>":
+		return types.DockerAuthConfig{
+			IdentityToken: creds.Secret,
+		}, nil
+	default:
+		return types.DockerAuthConfig{
+			Username: creds.Username,
+			Password: creds.Secret,
+		}, nil
+	}
 }
 
 func setAuthToCredHelper(credHelper, registry, username, password string) error {

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -277,6 +277,18 @@ func TestGetAuth(t *testing.T) {
 				testPreviousAPI: true,
 			},
 			{
+				name:     "identity token credhelper from registries.conf",
+				hostname: "registry-b.com",
+				sys: &types.SystemContext{
+					SystemRegistriesConfPath:    filepath.Join("testdata", "cred-helper.conf"),
+					SystemRegistriesConfDirPath: filepath.Join("testdata", "IdoNotExist"),
+				},
+				expected: types.DockerAuthConfig{
+					IdentityToken: "fizzbuzz",
+				},
+				testPreviousAPI: true,
+			},
+			{
 				name:     "match ref image",
 				hostname: "example.org",
 				ref:      "example.org/repo/image:latest",

--- a/pkg/docker/config/testdata/docker-credential-helper-registry
+++ b/pkg/docker/config/testdata/docker-credential-helper-registry
@@ -3,11 +3,11 @@
 case "${1}" in
     get)
         read REGISTRY
-        if [[ "${REGISTRY}" = "registry-a.com" ]]; then
-	        echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}"
-	else
-		echo "{}"
-	fi
+        case "${REGISTRY}" in
+            ("registry-a.com") echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}" ;;
+            ("registry-b.com") echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"<token>\",\"Secret\":\"fizzbuzz\"}" ;;
+            (*) echo "{}" ;;
+        esac
         exit 0
     ;;
     store)


### PR DESCRIPTION
When calling a credential helper, there are two types of credentials
that may be returned: a username and password pair, or an identity
token. The credential helper uses the same struct for returning both
types of credentials. From the `docker login` [documentation]:

> If the secret being stored is an identity token, the Username should
> be set to `<token>`.

When an identity token is provided, the Docker client should
authenticate using OAuth2 rather than the standard bearer challenge
response.

This changeset modifies the credential helper code to recognize this
special username, and sets the IdentityToken field of DockerAuthConfig
instead of Username and Password.

[documentation]: https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol

Signed-off-by: Terin Stock <terinjokes@gmail.com>