### PR TITLE
Don’t compute a digest of the compressed blob twice when pulling

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -532,9 +532,9 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 
 	// Record information about the blob.
 	s.lock.Lock()
-	s.blobDiffIDs[hasher.Digest()] = diffID.Digest()
-	s.fileSizes[hasher.Digest()] = counter.Count
-	s.filenames[hasher.Digest()] = filename
+	s.blobDiffIDs[blobDigest] = diffID.Digest()
+	s.fileSizes[blobDigest] = counter.Count
+	s.filenames[blobDigest] = filename
 	s.lock.Unlock()
 	// This is safe because we have just computed both values ourselves.
 	cache.RecordDigestUncompressedPair(blobDigest, diffID.Digest())

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -502,8 +502,9 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 		return errorBlobInfo, errors.Wrapf(err, "creating temporary file %q", filename)
 	}
 	defer file.Close()
-	counter := ioutils.NewWriteCounter(hasher.Hash())
-	reader := io.TeeReader(io.TeeReader(stream, counter), file)
+	counter := ioutils.NewWriteCounter(file)
+	reader := io.TeeReader(stream, counter)
+	reader = io.TeeReader(reader, hasher.Hash())
 	decompressed, err := archive.DecompressStream(reader)
 	if err != nil {
 		return errorBlobInfo, errors.Wrap(err, "setting up to decompress blob")

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -483,7 +483,7 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 		Size:   -1,
 	}
 	// Set up to digest the blob and count its size while saving it to a file.
-	hasher := digest.Canonical.Digester()
+	var hasher digest.Digester // = nil
 	if blobinfo.Digest != "" {
 		if err := blobinfo.Digest.Validate(); err != nil {
 			return errorBlobInfo, fmt.Errorf("invalid digest %#v: %w", blobinfo.Digest.String(), err)
@@ -491,6 +491,9 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 		if a := blobinfo.Digest.Algorithm(); a.Available() {
 			hasher = a.Digester()
 		}
+	}
+	if hasher == nil {
+		hasher = digest.Canonical.Digester()
 	}
 	diffID := digest.Canonical.Digester()
 	filename := s.computeNextBlobCacheFile()

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -514,6 +514,7 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 	if err != nil {
 		return errorBlobInfo, errors.Wrap(err, "setting up to decompress blob")
 	}
+
 	// Copy the data to the file.
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	_, err = io.Copy(diffID.Hash(), decompressed)


### PR DESCRIPTION
This is the smaller half of #1160.

Please see individual commit messages for details.

Cc:
- @nalind : Is there some subtlety about using `digest.Digest.Validate()`? Are there callers of `PutBlob()` that can’t be relied on to provide correct digests?
- @mrunalp 
