### PR TITLE
Run (gofmt -s -w)

### DIFF
--- a/internal/pkg/keyctl/key.go
+++ b/internal/pkg/keyctl/key.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package keyctl

--- a/internal/pkg/keyctl/keyring.go
+++ b/internal/pkg/keyctl/keyring.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 // Package keyctl is a Go interface to linux kernel keyrings (keyctl interface)

--- a/internal/pkg/keyctl/keyring_test.go
+++ b/internal/pkg/keyctl/keyring_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package keyctl

--- a/internal/pkg/keyctl/perm.go
+++ b/internal/pkg/keyctl/perm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package keyctl

--- a/internal/pkg/keyctl/sys_linux.go
+++ b/internal/pkg/keyctl/sys_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package keyctl

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree
 // +build containers_image_ostree
 
 package ostree

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree
 // +build containers_image_ostree
 
 package ostree

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree
 // +build containers_image_ostree
 
 package ostree

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree
 // +build containers_image_ostree
 
 package ostree

--- a/pkg/docker/config/config_unsupported.go
+++ b/pkg/docker/config/config_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && (!386 || !amd64)
 // +build !linux
 // +build !386 !amd64
 

--- a/signature/mechanism_gpgme.go
+++ b/signature/mechanism_gpgme.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_openpgp
 // +build !containers_image_openpgp
 
 package signature

--- a/signature/mechanism_gpgme_test.go
+++ b/signature/mechanism_gpgme_test.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_openpgp
 // +build !containers_image_openpgp
 
 package signature

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -1,3 +1,4 @@
+//go:build containers_image_openpgp
 // +build containers_image_openpgp
 
 package signature

--- a/signature/mechanism_openpgp_test.go
+++ b/signature/mechanism_openpgp_test.go
@@ -1,3 +1,4 @@
+//go:build containers_image_openpgp
 // +build containers_image_openpgp
 
 package signature

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/storage/storage_reference_test.go
+++ b/storage/storage_reference_test.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/storage/storage_transport_test.go
+++ b/storage/storage_transport_test.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package storage

--- a/transports/alltransports/docker_daemon.go
+++ b/transports/alltransports/docker_daemon.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_docker_daemon_stub
 // +build !containers_image_docker_daemon_stub
 
 package alltransports

--- a/transports/alltransports/docker_daemon_stub.go
+++ b/transports/alltransports/docker_daemon_stub.go
@@ -1,3 +1,4 @@
+//go:build containers_image_docker_daemon_stub
 // +build containers_image_docker_daemon_stub
 
 package alltransports

--- a/transports/alltransports/ostree.go
+++ b/transports/alltransports/ostree.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree && linux
 // +build containers_image_ostree,linux
 
 package alltransports

--- a/transports/alltransports/ostree_stub.go
+++ b/transports/alltransports/ostree_stub.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_ostree || !linux
 // +build !containers_image_ostree !linux
 
 package alltransports

--- a/transports/alltransports/storage.go
+++ b/transports/alltransports/storage.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_storage_stub
 // +build !containers_image_storage_stub
 
 package alltransports

--- a/transports/alltransports/storage_stub.go
+++ b/transports/alltransports/storage_stub.go
@@ -1,3 +1,4 @@
+//go:build containers_image_storage_stub
 // +build containers_image_storage_stub
 
 package alltransports


### PR DESCRIPTION
Go 1.17 introduces a much more reasonable build constraint format, and `gofmt` now fails without using it.

Sadly we still need the old format _as well_, to support <1.17 builds.