### PR TITLE
Only compute digests in PutBlob if truly necessary

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -171,9 +171,9 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	computedDigest := digester.Digest()
+	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", computedDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
@@ -189,7 +189,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		}
 	}
 
-	blobPath := d.ref.layerPath(computedDigest)
+	blobPath := d.ref.layerPath(blobDigest)
 	// need to explicitly close the file, since a rename won't otherwise not work on Windows
 	blobFile.Close()
 	explicitClosed = true
@@ -197,7 +197,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		return types.BlobInfo{}, err
 	}
 	succeeded = true
-	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
+	return types.BlobInfo{Digest: blobDigest, Size: size}, nil
 }
 
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -163,8 +164,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		}
 	}()
 
-	digester := digest.Canonical.Digester()
-	stream = io.TeeReader(stream, digester.Hash())
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	size, err := io.Copy(blobFile, stream)
 	if err != nil {

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -164,10 +164,9 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	}()
 
 	digester := digest.Canonical.Digester()
-	tee := io.TeeReader(stream, digester.Hash())
-
+	stream = io.TeeReader(stream, digester.Hash())
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-	size, err := io.Copy(blobFile, tee)
+	size, err := io.Copy(blobFile, stream)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -141,7 +141,7 @@ func (d *dirImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/internal/uploadreader"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
@@ -161,8 +162,7 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 		return types.BlobInfo{}, errors.Wrap(err, "determining upload URL")
 	}
 
-	digester := digest.Canonical.Digester()
-	stream = io.TeeReader(stream, digester.Hash())
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
 	sizeCounter := &sizeCounter{}
 	stream = io.TeeReader(stream, sizeCounter)
 

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -124,7 +124,7 @@ func (d *dockerImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
@@ -191,7 +191,6 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	// FIXME: DELETE uploadLocation on failure (does not really work in docker/distribution servers, which incorrectly require the "delete" action in the token's scope)
 
 	locationQuery := uploadLocation.Query()
-	// TODO: check inputInfo.Digest == computedDigest https://github.com/containers/image/pull/70#discussion_r77646717
 	locationQuery.Set("digest", computedDigest.String())
 	uploadLocation.RawQuery = locationQuery.Encode()
 	res, err = d.c.makeRequestToResolvedURL(ctx, http.MethodPut, uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, v2Auth, nil)

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -131,7 +131,7 @@ func (d *dockerImageDestination) HasThreadSafePutBlob() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
-	if inputInfo.Digest.String() != "" {
+	if inputInfo.Digest != "" {
 		// This should not really be necessary, at least the copy code calls TryReusingBlob automatically.
 		// Still, we need to check, if only because the "initiate upload" endpoint does not have a documented "blob already exists" return value.
 		// But we do that with NoCache, so that it _only_ checks the primary destination, instead of trying all mount candidates _again_.
@@ -484,7 +484,7 @@ func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [
 		return nil
 	}
 	if instanceDigest == nil {
-		if d.manifestDigest.String() == "" {
+		if d.manifestDigest == "" {
 			// This shouldn’t happen, ImageDestination users are required to call PutManifest before PutSignatures
 			return errors.Errorf("Unknown manifest digest, can't add signatures")
 		}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -186,12 +186,12 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	computedDigest := digester.Digest()
+	blobDigest := digester.Digest()
 
 	// FIXME: DELETE uploadLocation on failure (does not really work in docker/distribution servers, which incorrectly require the "delete" action in the token's scope)
 
 	locationQuery := uploadLocation.Query()
-	locationQuery.Set("digest", computedDigest.String())
+	locationQuery.Set("digest", blobDigest.String())
 	uploadLocation.RawQuery = locationQuery.Encode()
 	res, err = d.c.makeRequestToResolvedURL(ctx, http.MethodPut, uploadLocation.String(), map[string][]string{"Content-Type": {"application/octet-stream"}}, nil, -1, v2Auth, nil)
 	if err != nil {
@@ -203,9 +203,9 @@ func (d *dockerImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 		return types.BlobInfo{}, errors.Wrapf(registryHTTPResponseToError(res), "uploading layer to %s", uploadLocation)
 	}
 
-	logrus.Debugf("Upload of layer %s complete", computedDigest)
-	cache.RecordKnownLocation(d.ref.Transport(), bicTransportScope(d.ref), computedDigest, newBICLocationReference(d.ref))
-	return types.BlobInfo{Digest: computedDigest, Size: sizeCounter.size}, nil
+	logrus.Debugf("Upload of layer %s complete", blobDigest)
+	cache.RecordKnownLocation(d.ref.Transport(), bicTransportScope(d.ref), blobDigest, newBICLocationReference(d.ref))
+	return types.BlobInfo{Digest: blobDigest, Size: sizeCounter.size}, nil
 }
 
 // blobExists returns true iff repo contains a blob with digest, and if so, also its size.

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -105,9 +105,9 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 		defer streamCopy.Close()
 
 		digester := digest.Canonical.Digester()
-		tee := io.TeeReader(stream, digester.Hash())
+		stream2 := io.TeeReader(stream, digester.Hash())
 		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-		size, err := io.Copy(streamCopy, tee)
+		size, err := io.Copy(streamCopy, stream2)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -86,7 +86,7 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -95,7 +95,7 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed data.
-	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
+	if inputInfo.Size == -1 || inputInfo.Digest == "" {
 		logrus.Debugf("docker tarfile: input with unknown size, streaming to disk first ...")
 		streamCopy, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(d.sysCtx), "docker-tarfile-blob")
 		if err != nil {

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -72,7 +72,7 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available

--- a/image/docker_schema2_test.go
+++ b/image/docker_schema2_test.go
@@ -419,7 +419,7 @@ func (d *memoryImageDest) PutBlob(ctx context.Context, stream io.Reader, inputIn
 	if d.storedBlobs == nil {
 		d.storedBlobs = make(map[digest.Digest][]byte)
 	}
-	if inputInfo.Digest.String() == "" {
+	if inputInfo.Digest == "" {
 		panic("inputInfo.Digest unexpectedly empty")
 	}
 	contents, err := ioutil.ReadAll(stream)

--- a/internal/putblobdigest/put_blob_digest.go
+++ b/internal/putblobdigest/put_blob_digest.go
@@ -1,0 +1,57 @@
+package putblobdigest
+
+import (
+	"io"
+
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// Digester computes a digest of the provided stream, if not known yet.
+type Digester struct {
+	knownDigest digest.Digest   // Or ""
+	digester    digest.Digester // Or nil
+}
+
+// newDigester initiates computation of a digest.Canonical digest of stream,
+// if !validDigest; otherwise it just records knownDigest to be returned later.
+// The caller MUST use the returned stream instead of the original value.
+func newDigester(stream io.Reader, knownDigest digest.Digest, validDigest bool) (Digester, io.Reader) {
+	if validDigest {
+		return Digester{knownDigest: knownDigest}, stream
+	} else {
+		res := Digester{
+			digester: digest.Canonical.Digester(),
+		}
+		stream = io.TeeReader(stream, res.digester.Hash())
+		return res, stream
+	}
+}
+
+// DigestIfUnknown initiates computation of a digest.Canonical digest of stream,
+// if no digest is supplied in the provided blobInfo; otherwise blobInfo.Digest will
+// be used (accepting any algorithm).
+// The caller MUST use the returned stream instead of the original value.
+func DigestIfUnknown(stream io.Reader, blobInfo types.BlobInfo) (Digester, io.Reader) {
+	d := blobInfo.Digest
+	return newDigester(stream, d, d != "")
+}
+
+// DigestIfCanonicalUnknown initiates computation of a digest.Canonical digest of stream,
+// if a digest.Canonical digest is not supplied in the provided blobInfo;
+// otherwise blobInfo.Digest will be used.
+// The caller MUST use the returned stream instead of the original value.
+func DigestIfCanonicalUnknown(stream io.Reader, blobInfo types.BlobInfo) (Digester, io.Reader) {
+	d := blobInfo.Digest
+	return newDigester(stream, d, d != "" && d.Algorithm() == digest.Canonical)
+}
+
+// Digest() returns a digest value possibly computed by Digester.
+// This must be called only after all of the stream returned by a Digester constructor
+// has been successfully read.
+func (d Digester) Digest() digest.Digest {
+	if d.digester != nil {
+		return d.digester.Digest()
+	}
+	return d.knownDigest
+}

--- a/internal/putblobdigest/put_blob_digest_test.go
+++ b/internal/putblobdigest/put_blob_digest_test.go
@@ -1,0 +1,75 @@
+package putblobdigest
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testData = []byte("test data")
+
+type testCase struct {
+	inputDigest    digest.Digest
+	computesDigest bool
+	expectedDigest digest.Digest
+}
+
+func testDigester(t *testing.T, constructor func(io.Reader, types.BlobInfo) (Digester, io.Reader),
+	cases []testCase) {
+	for _, c := range cases {
+		stream := bytes.NewReader(testData)
+		digester, newStream := constructor(stream, types.BlobInfo{Digest: c.inputDigest})
+		assert.Equal(t, c.computesDigest, newStream != stream, c.inputDigest)
+		data, err := ioutil.ReadAll(newStream)
+		require.NoError(t, err, c.inputDigest)
+		assert.Equal(t, testData, data, c.inputDigest)
+		digest := digester.Digest()
+		assert.Equal(t, c.expectedDigest, digest, c.inputDigest)
+	}
+}
+
+func TestDigestIfUnknown(t *testing.T) {
+	testDigester(t, DigestIfUnknown, []testCase{
+		{
+			inputDigest:    digest.Digest("sha256:uninspected-value"),
+			computesDigest: false,
+			expectedDigest: digest.Digest("sha256:uninspected-value"),
+		},
+		{
+			inputDigest:    digest.Digest("unknown-algorithm:uninspected-value"),
+			computesDigest: false,
+			expectedDigest: digest.Digest("unknown-algorithm:uninspected-value"),
+		},
+		{
+			inputDigest:    "",
+			computesDigest: true,
+			expectedDigest: digest.Canonical.FromBytes(testData),
+		},
+	})
+}
+
+func TestDigestIfCanonicalUnknown(t *testing.T) {
+	testDigester(t, DigestIfCanonicalUnknown, []testCase{
+		{
+			inputDigest:    digest.Digest("sha256:uninspected-value"),
+			computesDigest: false,
+			expectedDigest: digest.Digest("sha256:uninspected-value"),
+		},
+		{
+			inputDigest:    digest.Digest("unknown-algorithm:uninspected-value"),
+			computesDigest: true,
+			expectedDigest: digest.Canonical.FromBytes(testData),
+		},
+		{
+			inputDigest:    "",
+			computesDigest: true,
+			expectedDigest: digest.Canonical.FromBytes(testData),
+		},
+	})
+}

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -88,7 +88,7 @@ func (d *ociArchiveImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result.
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
 // May update cache.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -139,10 +139,9 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	}()
 
 	digester := digest.Canonical.Digester()
-	tee := io.TeeReader(stream, digester.Hash())
-
+	stream = io.TeeReader(stream, digester.Hash())
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-	size, err := io.Copy(blobFile, tee)
+	size, err := io.Copy(blobFile, stream)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -146,9 +146,9 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	computedDigest := digester.Digest()
+	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", computedDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
@@ -164,7 +164,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		}
 	}
 
-	blobPath, err := d.ref.blobPath(computedDigest, d.sharedBlobDir)
+	blobPath, err := d.ref.blobPath(blobDigest, d.sharedBlobDir)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -179,7 +179,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		return types.BlobInfo{}, err
 	}
 	succeeded = true
-	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
+	return types.BlobInfo{Digest: blobDigest, Size: size}, nil
 }
 
 // TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -138,8 +139,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 		}
 	}()
 
-	digester := digest.Canonical.Digester()
-	stream = io.TeeReader(stream, digester.Hash())
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	size, err := io.Copy(blobFile, stream)
 	if err != nil {

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -115,7 +115,7 @@ func (d *ociImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result.
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
 // May update cache.

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -395,7 +395,7 @@ func (d *openshiftImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -160,10 +160,9 @@ func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	defer blobFile.Close()
 
 	digester := digest.Canonical.Digester()
-	tee := io.TeeReader(stream, digester.Hash())
-
+	stream = io.TeeReader(stream, digester.Hash())
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-	size, err := io.Copy(blobFile, tee)
+	size, err := io.Copy(blobFile, stream)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -139,7 +139,7 @@ func (d *ostreeImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result.
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
 // May update cache.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -167,17 +167,17 @@ func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	computedDigest := digester.Digest()
+	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", computedDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
 	}
 
-	hash := computedDigest.Hex()
-	d.blobs[hash] = &blobToImport{Size: size, Digest: computedDigest, BlobPath: blobPath}
-	return types.BlobInfo{Digest: computedDigest, Size: size}, nil
+	hash := blobDigest.Hex()
+	d.blobs[hash] = &blobToImport{Size: size, Digest: blobDigest, BlobPath: blobPath}
+	return types.BlobInfo{Digest: blobDigest, Size: size}, nil
 }
 
 func fixFiles(selinuxHnd *C.struct_selabel_handle, root string, dir string, usermode bool) error {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
@@ -159,8 +160,7 @@ func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	}
 	defer blobFile.Close()
 
-	digester := digest.Canonical.Digester()
-	stream = io.TeeReader(stream, digester.Hash())
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
 	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 	size, err := io.Copy(blobFile, stream)
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -471,7 +471,7 @@ func (s *storageImageDestination) HasThreadSafePutBlob() bool {
 }
 
 // PutBlob writes contents of stream and returns data representing the result.
-// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
 // May update cache.
@@ -492,9 +492,6 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 	}
 
 	// Set up to digest the blob if necessary, and count its size while saving it to a file.
-	// “It is not mandatory for the implementation to verify [blobinfo.Digest]”, so we rely
-	// on it being correct after we read all of stream. In most cases, the caller is
-	// copy.Image, which uses a digestingReader to validate the digest.
 	var hasher digest.Digester // = nil when we don't need to compute the blob digest
 	if blobinfo.Digest == "" {
 		hasher = digest.Canonical.Digester()

--- a/types/types.go
+++ b/types/types.go
@@ -299,7 +299,7 @@ type ImageDestination interface {
 	IgnoresEmbeddedDockerReference() bool
 
 	// PutBlob writes contents of stream and returns data representing the result.
-	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
+	// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 	// inputInfo.Size is the expected length of stream, if known.
 	// inputInfo.MediaType describes the blob format, if known.
 	// May update cache.


### PR DESCRIPTION
Document that `PutBlob` callers must only provide validated digests. This was always sort of implied, and we now rely on that explicitly to avoid computing the digests; it turns out the digest computation can consume a very noticeable amount of CPU time.

Then Introduce `internal/putblobdigest.Digester` and use it to let `PutBlob` use caller-provided digest values, if any.

See the individual commit messages for details.

Fixes #1160 (the last part).