### PR TITLE
Allow config authors to always use Prefix

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -82,8 +82,7 @@ location = "internal-registry-for-example.net/bar"
 requests for the image `example.com/foo/myimage:latest` will actually work with the
 `internal-registry-for-example.net/bar/myimage:latest` image.
 
-With a `prefix` containing a wildcard in the format: "*.example.com" for subdomain matching,
-the location can be empty. In such a case,
+With any valid `prefix`, the location can be emtpy. In such a case,
 prefix matching will occur, but no reference rewrite will occur. The
 original requested image string will be used as-is. But other settings like
 `insecure` / `blocked` / `mirrors` will be applied to matching images.
@@ -91,6 +90,10 @@ original requested image string will be used as-is. But other settings like
 Example: Given
 ```
 prefix = "*.example.com"
+```
+OR
+```
+prefix = "blah.example.com"
 ```
 requests for the image `blah.example.com/foo/myimage:latest` will be used
 as-is. But other settings like insecure/blocked/mirrors will be applied to matching images

--- a/pkg/sysregistriesv2/testdata/find-registry.conf
+++ b/pkg/sysregistriesv2/testdata/find-registry.conf
@@ -60,3 +60,6 @@ prefix="*.com"
 
 [[registry]]
 prefix="*.foobar.io"
+
+[[registry]]
+prefix="empty-location.set-prefix.example.com"


### PR DESCRIPTION
Previously an unset Location was only allowed for wildcarded Prefixes.
This commit will allow any valid Prefix.

Fixes: https://github.com/containers/image/pull/1191#discussion_r610622495

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@vrothberg @mtrmac @ashcrow  PTAL

