### PR TITLE
[RFC] oci: allow zstd for Docker images

### DIFF
--- a/image/oci.go
+++ b/image/oci.go
@@ -216,7 +216,7 @@ func (m *manifestOCI1) convertToManifestSchema2(_ context.Context, _ *types.Mani
 		case imgspecv1.MediaTypeImageLayerGzip:
 			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaType
 		case imgspecv1.MediaTypeImageLayerZstd:
-			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaTypeZstd
 		default:
 			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", layers[idx].MediaType)
 		}

--- a/image/oci_test.go
+++ b/image/oci_test.go
@@ -486,7 +486,7 @@ func TestConvertToManifestSchema2AllMediaTypes(t *testing.T) {
 	_, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
 	})
-	require.Error(t, err) // zstd compression is not supported for docker images
+	require.NoError(t, err)
 }
 
 func TestConvertToV2S2WithInvalidMIMEType(t *testing.T) {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -24,6 +24,8 @@ const (
 	DockerV2Schema2ConfigMediaType = "application/vnd.docker.container.image.v1+json"
 	// DockerV2Schema2LayerMediaType is the MIME type used for schema 2 layers.
 	DockerV2Schema2LayerMediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	// DockerV2Schema2LayerMediaTypeZstd is the MIME type used for schema 2 layers that use the zstd compression.
+	DockerV2Schema2LayerMediaTypeZstd = "application/vnd.docker.image.rootfs.diff.tar.zst"
 	// DockerV2SchemaLayerMediaTypeUncompressed is the mediaType used for uncompressed layers.
 	DockerV2SchemaLayerMediaTypeUncompressed = "application/vnd.docker.image.rootfs.diff.tar"
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list


### PR DESCRIPTION
Allow to use the zstd compression for docker images now that Docker
supports it: https://github.com/moby/moby/pull/41759

Marked as RFC as I am not completely sure about its implications.

Without this patch though I am not able to build any container that uses a zstd compressed image as base:

```
$ cat Dockerfile 
FROM docker.io/gscrivano/zstd-chunked:fedora
RUN dnf install -y nginx && dnf clean all -y

$ buildah bud --format oci --squash  .
STEP 1/2: FROM docker.io/gscrivano/zstd-chunked:fedora
error creating build container: error preparing image configuration: error converting image "containers-storage:[overlay@~/.local/share/containers/storage+/run/user/1000/containers]@c309a2d1ba2e8026019aa4c987684a1d8f84d6bc598ff88d6afe1b4cbde4d70d" from "application/vnd.oci.image.manifest.v1+json" to "application/vnd.docker.distribution.manifest.v2+json": Error during manifest conversion: "application/vnd.oci.image.layer.v1.tar+zstd": zstd compression is not supported for docker images 2
```

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>