### PR TITLE
Add reader/writer for oci-archive multi image support

### DIFF
--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -57,14 +57,19 @@ An image stored in the docker daemon's internal storage.
 The image must be specified as a _docker-reference_ or in an alternative _algo:digest_ format when being used as an image source.
 The _algo:digest_ refers to the image ID reported by docker-inspect(1).
 
-### **oci:**_path[:reference]_
+### **oci:**_path[:{reference|@source-index}]_
 
 An image compliant with the "Open Container Image Layout Specification" at _path_.
 Using a _reference_ is optional and allows for storing multiple images at the same _path_.
+For reading images, @_source-index_ is a zero-based index in manifest (to access untagged images).
+If neither reference nor @_source_index is specified when reading an image, the path must contain exactly one image.
 
-### **oci-archive:**_path[:reference]_
+### **oci-archive:**_path[:{reference|@source-index}]_
 
 An image compliant with the "Open Container Image Layout Specification" stored as a tar(1) archive at _path_.
+Using a _reference_ is optional and allows for storing multiple images at the same _path_.
+For reading archives, @_source-index_ is a zero-based index in archive manifest (to access untagged images).
+If neither reference nor @_source_index is specified when reading an archive, the archive must contain exactly one image.
 
 ### **ostree:**_docker-reference[@/absolute/repo/path]_
 

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -3,45 +3,62 @@ package archive
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/imagedestination"
 	"github.com/containers/image/v5/internal/imagedestination/impl"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/signature"
+	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/types"
-	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
 	perrors "github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type ociArchiveImageDestination struct {
 	impl.Compat
 
-	ref          ociArchiveReference
-	unpackedDest private.ImageDestination
-	tempDirRef   tempDirOCIRef
+	ref                   ociArchiveReference
+	individualWriterOrNil *Writer
+	unpackedDest          private.ImageDestination
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (private.ImageDestination, error) {
-	tempDirRef, err := createOCIRef(sys, ref.image)
-	if err != nil {
-		return nil, perrors.Wrapf(err, "creating oci reference")
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
+	var (
+		archive, individualWriterOrNil *Writer
+		err                            error
+	)
+
+	if ref.sourceIndex != -1 {
+		return nil, perrors.Wrapf(invalidOciArchiveErr, "destination reference must not contain a manifest index @%d", ref.sourceIndex)
 	}
-	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx, sys)
-	if err != nil {
-		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+
+	if ref.archiveWriter != nil {
+		archive = ref.archiveWriter
+		individualWriterOrNil = nil
+	} else {
+		archive, err = NewWriter(ctx, sys, ref.resolvedFile)
+		if err != nil {
+			return nil, err
 		}
+		individualWriterOrNil = archive
+	}
+	layoutRef, err := layout.NewReference(archive.tempDir, ref.image)
+	if err != nil {
+		archive.Close()
 		return nil, err
 	}
+	dst, err := layoutRef.NewImageDestination(ctx, sys)
+	if err != nil {
+		archive.Close()
+		return nil, err
+	}
+
 	d := &ociArchiveImageDestination{
-		ref:          ref,
-		unpackedDest: imagedestination.FromPublic(unpackedDest),
-		tempDirRef:   tempDirRef,
+		ref:                   ref,
+		individualWriterOrNil: individualWriterOrNil,
+		unpackedDest:          imagedestination.FromPublic(dst),
 	}
 	d.Compat = impl.AddCompat(d)
 	return d, nil
@@ -53,13 +70,14 @@ func (d *ociArchiveImageDestination) Reference() types.ImageReference {
 }
 
 // Close removes resources associated with an initialized ImageDestination, if any
-// Close deletes the temp directory of the oci-archive image
 func (d *ociArchiveImageDestination) Close() error {
-	defer func() {
-		err := d.tempDirRef.deleteTempDir()
-		logrus.Debugf("Error deleting temporary directory: %v", err)
-	}()
-	return d.unpackedDest.Close()
+	if err := d.unpackedDest.Close(); err != nil {
+		return err
+	}
+	if d.individualWriterOrNil == nil {
+		return nil
+	}
+	return d.individualWriterOrNil.Close()
 }
 
 func (d *ociArchiveImageDestination) SupportedManifestMIMETypes() []string {
@@ -160,32 +178,5 @@ func (d *ociArchiveImageDestination) Commit(ctx context.Context, unparsedTopleve
 	if err := d.unpackedDest.Commit(ctx, unparsedToplevel); err != nil {
 		return perrors.Wrapf(err, "storing image %q", d.ref.image)
 	}
-
-	// path of directory to tar up
-	src := d.tempDirRef.tempDirectory
-	// path to save tarred up file
-	dst := d.ref.resolvedFile
-	return tarDirectory(src, dst)
-}
-
-// tar converts the directory at src and saves it to dst
-func tarDirectory(src, dst string) error {
-	// input is a stream of bytes from the archive of the directory at path
-	input, err := archive.Tar(src, archive.Uncompressed)
-	if err != nil {
-		return perrors.Wrapf(err, "retrieving stream of bytes from %q", src)
-	}
-
-	// creates the tar file
-	outFile, err := os.Create(dst)
-	if err != nil {
-		return perrors.Wrapf(err, "creating tar file %q", dst)
-	}
-	defer outFile.Close()
-
-	// copies the contents of the directory to the tar file
-	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
-	_, err = io.Copy(outFile, input)
-
-	return err
+	return nil
 }

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/v5/internal/imagesource/impl"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/signature"
+	"github.com/containers/image/v5/oci/layout"
 	ocilayout "github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -20,30 +21,54 @@ import (
 type ociArchiveImageSource struct {
 	impl.Compat
 
-	ref         ociArchiveReference
-	unpackedSrc private.ImageSource
-	tempDirRef  tempDirOCIRef
+	ref                   ociArchiveReference
+	unpackedSrc           private.ImageSource
+	individualReaderOrNil *Reader
 }
 
 // newImageSource returns an ImageSource for reading from an existing directory.
-// newImageSource untars the file and saves it in a temp directory
-func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (private.ImageSource, error) {
-	tempDirRef, err := createUntarTempDir(sys, ref)
-	if err != nil {
-		return nil, perrors.Wrap(err, "creating temp directory")
+func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
+	var (
+		archive, individualReaderOrNil *Reader
+		layoutRef                      types.ImageReference
+		err                            error
+	)
+
+	if ref.archiveReader != nil {
+		archive = ref.archiveReader
+		individualReaderOrNil = nil
+	} else {
+		archive, _, err = NewReaderForReference(ctx, sys, ref)
+		if err != nil {
+			return nil, err
+		}
+		individualReaderOrNil = archive
 	}
 
-	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
-	if err != nil {
-		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+	if ref.sourceIndex != -1 {
+		layoutRef, err = layout.NewIndexReference(archive.tempDirectory, ref.sourceIndex)
+		if err != nil {
+			archive.Close()
+			return nil, err
 		}
+	} else {
+		layoutRef, err = layout.NewReference(archive.tempDirectory, ref.image)
+		if err != nil {
+			archive.Close()
+			return nil, err
+		}
+	}
+
+	src, err := layoutRef.NewImageSource(ctx, sys)
+	if err != nil {
+		archive.Close()
 		return nil, err
 	}
+
 	s := &ociArchiveImageSource{
-		ref:         ref,
-		unpackedSrc: imagesource.FromPublic(unpackedSrc),
-		tempDirRef:  tempDirRef,
+		ref:                   ref,
+		unpackedSrc:           imagesource.FromPublic(src),
+		individualReaderOrNil: individualReaderOrNil,
 	}
 	s.Compat = impl.AddCompat(s)
 	return s, nil
@@ -83,13 +108,14 @@ func (s *ociArchiveImageSource) Reference() types.ImageReference {
 }
 
 // Close removes resources associated with an initialized ImageSource, if any.
-// Close deletes the temporary directory at dst
 func (s *ociArchiveImageSource) Close() error {
-	defer func() {
-		err := s.tempDirRef.deleteTempDir()
-		logrus.Debugf("error deleting tmp dir: %v", err)
-	}()
-	return s.unpackedSrc.Close()
+	if err := s.unpackedSrc.Close(); err != nil {
+		return err
+	}
+	if s.individualReaderOrNil == nil {
+		return nil
+	}
+	return s.individualReaderOrNil.Close()
 }
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).

--- a/oci/archive/reader.go
+++ b/oci/archive/reader.go
@@ -1,0 +1,197 @@
+package archive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/image/v5/internal/tmpdir"
+	"github.com/containers/image/v5/oci/internal"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage/pkg/archive"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	perrors "github.com/pkg/errors"
+)
+
+// Reader manages the temp directory that the oci archive is untarred to and the
+// manifest of the images. It allows listing its contents and accessing
+// individual images with less overhead than creating image references individually
+// (because the archive is, if necessary, copied or decompressed only once)
+type Reader struct {
+	manifest      *imgspecv1.Index
+	tempDirectory string
+	path          string // The original, user-specified path
+}
+
+// NewReader creates the temp directory that keeps the untarred archive from src.
+// // The caller should call .Close() on the returned object.
+// func NewReader(ctx context.Context, sys *types.SystemContext, src string) (*Reader, error) {
+// 	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
+// 	arch, err := os.Open(src)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	defer arch.Close()
+
+// 	dst, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+// 	if err != nil {
+// 		return nil, errors.Wrap(err, "error creating temp directory")
+// 	}
+
+// 	reader := Reader{
+// 		tempDirectory: dst,
+// 		path:          src,
+// 	}
+
+// 	succeeded := false
+// 	defer func() {
+// 		if !succeeded {
+// 			reader.Close()
+// 		}
+// 	}()
+// 	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
+// 		return nil, errors.Wrapf(err, "error untarring file %q", dst)
+// 	}
+
+// 	indexJSON, err := os.Open(filepath.Join(dst, "index.json"))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	defer indexJSON.Close()
+// 	reader.manifest = &imgspecv1.Index{}
+// 	if err := json.NewDecoder(indexJSON).Decode(reader.manifest); err != nil {
+// 		return nil, err
+// 	}
+// 	succeeded = true
+// 	return &reader, nil
+// }
+
+func NewReader(ctx context.Context, sys *types.SystemContext, src string) (*Reader, error) {
+	arch, err := os.Open(src)
+	if err != nil {
+		return nil, err
+	}
+	defer arch.Close()
+
+	dst, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+	if err != nil {
+		return nil, perrors.Wrap(err, "error creating temp directory")
+	}
+
+	reader := Reader{
+		tempDirectory: dst,
+		path:          src,
+	}
+
+	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
+		return nil, perrors.Wrapf(err, "error untarring file %q", dst)
+	}
+
+	indexJSON, err := os.Open(filepath.Join(dst, "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer indexJSON.Close()
+	reader.manifest = &imgspecv1.Index{}
+	if err := json.NewDecoder(indexJSON).Decode(reader.manifest); err != nil {
+		return nil, err
+	}
+
+	return &reader, nil
+}
+
+// NewReader returns a Reader for src. The caller should call Close() on the returned object
+func NewReaderForReference(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) (*Reader, types.ImageReference, error) {
+	standalone, ok := ref.(ociArchiveReference)
+	if !ok {
+		return nil, nil, perrors.Errorf("Internal error: NewReader called for a non-oci/archive ImageReference %s", transports.ImageName(ref))
+	}
+	if standalone.archiveReader != nil {
+		return nil, nil, perrors.Errorf("Internal error: NewReader called for a reader-bound reference %s", standalone.StringWithinTransport())
+	}
+
+	reader, err := NewReader(ctx, sys, standalone.resolvedFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	// src := standalone.resolvedFile
+	// arch, err := os.Open(src)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// defer arch.Close()
+
+	// dst, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+	// if err != nil {
+	// 	return nil, fmt.Errorf("error creating temp directory: %w", err)
+	// }
+
+	// reader := Reader{
+	// 	tempDirectory: dst,
+	// 	path:          src,
+	// }
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			reader.Close()
+		}
+	}()
+	// if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
+	// 	return nil, fmt.Errorf("error untarring file %q: %w", dst, err)
+	// }
+
+	// indexJSON, err := os.Open(filepath.Join(dst, "index.json"))
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// defer indexJSON.Close()
+	// reader.manifest = &imgspecv1.Index{}
+	// if err := json.NewDecoder(indexJSON).Decode(reader.manifest); err != nil {
+	// 	return nil, err
+	// }
+	readerRef, err := newReference(standalone.resolvedFile, standalone.image, -1, reader, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	succeeded = true
+	return reader, readerRef, nil
+}
+
+// ListResult wraps the image reference and the manifest for loading
+type ListResult struct {
+	ImageRef           types.ImageReference
+	ManifestDescriptor imgspecv1.Descriptor
+}
+
+// List returns a slice of manifests included in the archive
+func (r *Reader) List() ([]ListResult, error) {
+	var res []ListResult
+
+	for _, md := range r.manifest.Manifests {
+		refName := internal.NameFromAnnotations(md.Annotations)
+		index := -1
+		if refName != "" {
+			index = 1
+		}
+		ref, err := newReference(r.path, refName, index, r, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error creating image reference: %w", err)
+		}
+		reference := ListResult{
+			ImageRef:           ref,
+			ManifestDescriptor: md,
+		}
+		res = append(res, reference)
+	}
+	return res, nil
+}
+
+// Close deletes temporary files associated with the Reader, if any.
+func (r *Reader) Close() error {
+	return os.RemoveAll(r.tempDirectory)
+}

--- a/oci/archive/writer.go
+++ b/oci/archive/writer.go
@@ -1,0 +1,79 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/image/v5/internal/tmpdir"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage/pkg/archive"
+)
+
+// Writer manages an in-progress OCI archive and allows adding images to it
+type Writer struct {
+	// tempDir will be tarred to oci archive
+	tempDir string
+	// user-specified path
+	path string
+}
+
+// NewWriter creates a temp directory will be tarred to oci-archive.
+// The caller should call .Close() on the returned object.
+func NewWriter(ctx context.Context, sys *types.SystemContext, file string) (*Writer, error) {
+	dir, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
+	if err != nil {
+		return nil, fmt.Errorf("error creating temp directory: %w", err)
+	}
+	ociWriter := &Writer{
+		tempDir: dir,
+		path:    file,
+	}
+	return ociWriter, nil
+}
+
+// NewReference returns an ImageReference that allows adding an image to Writer,
+// with an optional image name
+func (w *Writer) NewReference(name string) (types.ImageReference, error) {
+	ref, err := newReference(w.path, name, -1, nil, w)
+	if err != nil {
+		return nil, fmt.Errorf("error creating image reference: %w", err)
+	}
+	return ref, nil
+}
+
+// Close writes all outstanding data about images to the archive, and
+// releases state associated with the Writer, if any.
+// It deletes any temporary files associated with the Writer.
+// No more images can be added after this is called.
+func (w *Writer) Close() error {
+	err := tarDirectory(w.tempDir, w.path)
+	if err2 := os.RemoveAll(w.tempDir); err2 != nil && err == nil {
+		err = err2
+	}
+	return err
+}
+
+// tar converts the directory at src and saves it to dst
+func tarDirectory(src, dst string) error {
+	// input is a stream of bytes from the archive of the directory at path
+	input, err := archive.Tar(src, archive.Uncompressed)
+	if err != nil {
+		return fmt.Errorf("retrieving stream of bytes from %q: %w", src, err)
+	}
+
+	// creates the tar file
+	outFile, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("creating tar file %q: %w", dst, err)
+	}
+	defer outFile.Close()
+
+	// copies the contents of the directory to the tar file
+	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
+	_, err = io.Copy(outFile, input)
+
+	return err
+}

--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
+
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -33,9 +36,9 @@ func ValidateImageName(image string) error {
 	return err
 }
 
-// SplitPathAndImage tries to split the provided OCI reference into the OCI path and image.
+// splitPathAndImage tries to split the provided OCI reference into the OCI path and image.
 // Neither path nor image parts are validated at this stage.
-func SplitPathAndImage(reference string) (string, string) {
+func splitPathAndImage(reference string) (string, string) {
 	if runtime.GOOS == "windows" {
 		return splitPathAndImageWindows(reference)
 	}
@@ -124,4 +127,46 @@ func validateScopeNonWindows(scope string) error {
 	}
 
 	return nil
+}
+
+// parseOCIReferenceName parses the image from the oci reference.
+func parseOCIReferenceName(image string) (img string, index int, err error) {
+	index = -1
+	if strings.HasPrefix(image, "@") {
+		idx, err := strconv.Atoi(image[1:])
+		if err != nil {
+			return "", index, fmt.Errorf("Invalid source index @%s: not an integer: %w", image[1:], err)
+		}
+		if idx < 0 {
+			return "", index, fmt.Errorf("Invalid source index @%d: must not be negative", idx)
+		}
+		index = idx
+	} else {
+		img = image
+	}
+	return img, index, nil
+}
+
+// ParseReferenceIntoElements splits the oci reference into location, image name and source index if exists
+func ParseReferenceIntoElements(reference string) (string, string, int, error) {
+	dir, image := splitPathAndImage(reference)
+	image, index, err := parseOCIReferenceName(image)
+	if err != nil {
+		return "", "", -1, err
+	}
+	return dir, image, index, nil
+}
+
+// NameFromAnnotations returns a reference string to be used as an image name,
+// or an empty string.  The annotations map may be nil.
+func NameFromAnnotations(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+	// buildkit/containerd are using a custom annotation see
+	// containers/podman/issues/12560.
+	if annotations["io.containerd.image.name"] != "" {
+		return annotations["io.containerd.image.name"]
+	}
+	return annotations[imgspecv1.AnnotationRefName]
 }

--- a/oci/internal/oci_util_test.go
+++ b/oci/internal/oci_util_test.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testDataSplitReference struct {
@@ -15,6 +16,12 @@ type testDataSplitReference struct {
 type testDataScopeValidation struct {
 	scope      string
 	errMessage string
+}
+
+type testOCIReference struct {
+	ref   string
+	image string
+	index int
 }
 
 func TestSplitReferenceIntoDirAndImageWindows(t *testing.T) {
@@ -58,5 +65,27 @@ func TestValidateScopeWindows(t *testing.T) {
 		} else {
 			assert.EqualError(t, err, test.errMessage, fmt.Sprintf("No error for scope '%s'", test.scope))
 		}
+	}
+}
+
+func TestParseOCIReferenceName(t *testing.T) {
+	validTests := []testOCIReference{
+		{"@0", "", 0},
+		{"notlatest@1", "notlatest@1", -1},
+	}
+	for _, test := range validTests {
+		img, idx, err := parseOCIReferenceName(test.ref)
+		assert.NoError(t, err)
+		assert.Equal(t, img, test.image)
+		assert.Equal(t, idx, test.index)
+	}
+
+	invalidTests := []string{
+		"@-5",
+		"@invalidIndex",
+	}
+	for _, test := range invalidTests {
+		_, _, err := parseOCIReferenceName(test)
+		assert.Error(t, err)
 	}
 }

--- a/oci/layout/fixtures/two_names_manifest/index.json
+++ b/oci/layout/fixtures/two_names_manifest/index.json
@@ -1,0 +1,25 @@
+{
+    "schemaVersion": 2,
+    "manifests": [
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "size": 7143,
+            "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+            "platform": {
+                "architecture": "ppc64le",
+                "os": "linux"
+            },
+            "annotations": {
+                "org.opencontainers.image.ref.name": "imageValue0"
+            }
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:62ae1939cdb49e93f32cdb29d61ad276552532c6ae7fd543de7bf22511e4965e",
+            "size": 348,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "imageValue1"
+            }
+        }
+    ]
+}

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -33,7 +33,10 @@ type ociImageDestination struct {
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(sys *types.SystemContext, ref ociReference) (private.ImageDestination, error) {
+func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
+	if ref.sourceIndex != -1 {
+		return nil, fmt.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
+	}
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -32,7 +32,8 @@ func TestPutBlobDigestFailure(t *testing.T) {
 	const digestErrorString = "Simulated digest error"
 	const blobDigest = "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
 
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	dirRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	blobPath, err := dirRef.blobPath(blobDigest, "")
@@ -71,7 +72,8 @@ func TestPutBlobDigestFailure(t *testing.T) {
 
 // TestPutManifestAppendsToExistingManifest tests that new manifests are getting added to existing index.
 func TestPutManifestAppendsToExistingManifest(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
@@ -94,7 +96,8 @@ func TestPutManifestAppendsToExistingManifest(t *testing.T) {
 
 // TestPutManifestTwice tests that existing manifest gets updated and not appended.
 func TestPutManifestTwice(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
@@ -109,7 +112,8 @@ func TestPutManifestTwice(t *testing.T) {
 }
 
 func TestPutTwoDifferentTags(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,16 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGetManifestDescriptor is testing a regression issue where a nil error was being wrapped,
-// this causes the returned error to be nil as well and the user wasn't getting a proper error output.
-//
-// More info: https://github.com/containers/skopeo/issues/496
 func TestGetManifestDescriptor(t *testing.T) {
 	imageRef, err := NewReference("fixtures/two_images_manifest", "")
 	require.NoError(t, err)
 
+	// test a regression issue where a nil error was being wrapped,
+	// this causes the returned error to be nil as well and the user wasn't getting a proper error output.
+	//
+	// More info: https://github.com/containers/skopeo/issues/496
 	_, err = imageRef.(ociReference).getManifestDescriptor()
 	assert.EqualError(t, err, ErrMoreThanOneImage.Error())
+
+	imageRef, err = NewReference("fixtures/two_names_manifest", "imageValue0")
+	require.NoError(t, err)
+	manDescriptor, err := imageRef.(ociReference).getManifestDescriptor()
+	require.NoError(t, err)
+	assert.Equal(t, manDescriptor.Annotations["org.opencontainers.image.ref.name"], "imageValue0")
+
+	imageRef, err = NewIndexReference("fixtures/two_names_manifest", 1)
+	require.NoError(t, err)
+	manDescriptor, err = imageRef.(ociReference).getManifestDescriptor()
+	require.NoError(t, err)
+	assert.Equal(t, manDescriptor.Annotations["org.opencontainers.image.ref.name"], "imageValue1")
 }
 
 func TestTransportName(t *testing.T) {
@@ -69,11 +82,17 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 		"relativepath",
 		tmpDir + "/thisdoesnotexist",
 	} {
-		for _, image := range []struct{ suffix, image string }{
-			{":notlatest:image", "notlatest:image"},
-			{":latestimage", "latestimage"},
-			{":", ""},
-			{"", ""},
+		for _, image := range []struct {
+			suffix, image string
+			sourceIndex   int
+		}{
+			{":notlatest:image", "notlatest:image", -1},
+			{":latestimage", "latestimage", -1},
+			{":", "", -1},
+			{"", "", -1},
+			{":@0", "", 0},
+			{":@10", "", 10},
+			{":@999999", "", 999999},
 		} {
 			input := path + image.suffix
 			ref, err := fn(input)
@@ -82,11 +101,16 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 			require.True(t, ok)
 			assert.Equal(t, path, ociRef.dir, input)
 			assert.Equal(t, image.image, ociRef.image, input)
+			assert.Equal(t, image.sourceIndex, ociRef.sourceIndex, input)
 		}
 	}
 
 	_, err := fn(tmpDir + ":invalid'image!value@")
 	assert.Error(t, err)
+
+	_, err = fn(tmpDir + ":@-3")
+	assert.Error(t, err)
+
 }
 
 func TestNewReference(t *testing.T) {
@@ -103,6 +127,7 @@ func TestNewReference(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, tmpDir, ociRef.dir)
 	assert.Equal(t, imageValue, ociRef.image)
+	assert.Equal(t, -1, ociRef.sourceIndex)
 
 	ref, err = NewReference(tmpDir, noImageValue)
 	require.NoError(t, err)
@@ -110,6 +135,7 @@ func TestNewReference(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, tmpDir, ociRef.dir)
 	assert.Equal(t, noImageValue, ociRef.image)
+	assert.Equal(t, -1, ociRef.sourceIndex)
 
 	_, err = NewReference(tmpDir+"/thisparentdoesnotexist/something", imageValue)
 	assert.Error(t, err)
@@ -119,11 +145,57 @@ func TestNewReference(t *testing.T) {
 
 	_, err = NewReference(tmpDir+"/has:colon", imageValue)
 	assert.Error(t, err)
+
+	// Test private newReference
+	_, err = newReference(tmpDir, imageValue, 1)
+	assert.Error(t, err)
+}
+
+func TestNewIndexReference(t *testing.T) {
+	const imageValue = "imageValue"
+
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	ref, err := NewIndexReference(tmpDir, 10)
+	require.NoError(t, err)
+	ociRef, ok := ref.(ociReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir, ociRef.dir)
+	assert.Equal(t, "", ociRef.image)
+	assert.Equal(t, 10, ociRef.sourceIndex)
+
+	ref, err = NewIndexReference(tmpDir, 9999)
+	require.NoError(t, err)
+	ociRef, ok = ref.(ociReference)
+	require.True(t, ok)
+	assert.Equal(t, tmpDir, ociRef.dir)
+	assert.Equal(t, "", ociRef.image)
+	assert.Equal(t, 9999, ociRef.sourceIndex)
+
+	_, err = NewIndexReference(tmpDir+"/thisparentdoesnotexist/something", 10)
+	assert.Error(t, err)
+
+	// sourceIndex cannot be less than -1
+	_, err = NewIndexReference(tmpDir, -3)
+	assert.Error(t, err)
+
+	_, err = NewIndexReference(tmpDir+"/has:colon", 99)
+	assert.Error(t, err)
+
+	// Test private newReference
+	_, err = newReference(tmpDir, imageValue, 1)
+	assert.Error(t, err)
 }
 
 // refToTempOCI creates a temporary directory and returns an reference to it.
-func refToTempOCI(t *testing.T) (types.ImageReference, string) {
-	tmpDir := t.TempDir()
+// The caller should
+//   defer os.RemoveAll(tmpDir)
+func refToTempOCI(t *testing.T, sourceIndex bool) (ref types.ImageReference, tmpDir string) {
+	tmpDir, err := ioutil.TempDir("", "oci-transport-test")
+	require.NoError(t, err)
+
 	m := `{
 		"schemaVersion": 2,
 		"manifests": [
@@ -142,15 +214,40 @@ func refToTempOCI(t *testing.T) (types.ImageReference, string) {
 		]
 	}
 `
-	err := os.WriteFile(filepath.Join(tmpDir, "index.json"), []byte(m), 0644)
+	if sourceIndex {
+		m = `{
+			"schemaVersion": 2,
+			"manifests": [
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"size": 7143,
+				"digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+				"platform": {
+					"architecture": "ppc64le",
+					"os": "linux"
+				},
+			}
+			]
+		}
+	`
+	}
+
+	err = os.WriteFile(filepath.Join(tmpDir, "index.json"), []byte(m), 0644)
 	require.NoError(t, err)
-	ref, err := NewReference(tmpDir, "imageValue")
-	require.NoError(t, err)
+
+	if sourceIndex {
+		ref, err = NewIndexReference(tmpDir, 1)
+		require.NoError(t, err)
+	} else {
+		ref, err = NewReference(tmpDir, "imageValue")
+		require.NoError(t, err)
+	}
 	return ref, tmpDir
 }
 
 func TestReferenceTransport(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	assert.Equal(t, Transport, ref.Transport())
 }
 
@@ -159,7 +256,8 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 
 	for _, c := range []struct{ input, result string }{
 		{"/dir1:notlatest:notlatest", "/dir1:notlatest:notlatest"}, // Explicit image
-		{"/dir3:", "/dir3:"}, // No image
+		{"/dir3:", "/dir3:"},     // No image
+		{"/dir1:@1", "/dir1:@1"}, // Explicit sourceIndex of image
 	} {
 		ref, err := ParseReference(tmpDir + c.input)
 		require.NoError(t, err, c.input)
@@ -174,12 +272,14 @@ func TestReferenceStringWithinTransport(t *testing.T) {
 }
 
 func TestReferenceDockerReference(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	assert.Nil(t, ref.DockerReference())
 }
 
 func TestReferencePolicyConfigurationIdentity(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 
 	assert.Equal(t, tmpDir, ref.PolicyConfigurationIdentity())
 	// A non-canonical path.  Test just one, the various other cases are
@@ -192,10 +292,27 @@ func TestReferencePolicyConfigurationIdentity(t *testing.T) {
 	ref, err = NewReference("/", "image3")
 	require.NoError(t, err)
 	assert.Equal(t, "/", ref.PolicyConfigurationIdentity())
+
+	// Test the sourceIndex case
+	ref, tmpDir = refToTempOCI(t, true)
+	defer os.RemoveAll(tmpDir)
+
+	assert.Equal(t, tmpDir, ref.PolicyConfigurationIdentity())
+	// A non-canonical path.  Test just one, the various other cases are
+	// tested in explicitfilepath.ResolvePathToFullyExplicit.
+	ref, err = NewIndexReference(tmpDir+"/.", 1)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir, ref.PolicyConfigurationIdentity())
+
+	// "/" as a corner case.
+	ref, err = NewIndexReference("/", 2)
+	require.NoError(t, err)
+	assert.Equal(t, "/", ref.PolicyConfigurationIdentity())
 }
 
 func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	// We don't really know enough to make a full equality test here.
 	ns := ref.PolicyConfigurationNamespaces()
 	require.NotNil(t, ns)
@@ -223,42 +340,79 @@ func TestReferencePolicyConfigurationNamespaces(t *testing.T) {
 	ref, err := NewReference("/", "image3")
 	require.NoError(t, err)
 	assert.Equal(t, []string{}, ref.PolicyConfigurationNamespaces())
+
+	// Test the sourceIndex case
+	ref, tmpDir = refToTempOCI(t, true)
+	defer os.RemoveAll(tmpDir)
+	// We don't really know enough to make a full equality test here.
+	ns = ref.PolicyConfigurationNamespaces()
+	require.NotNil(t, ns)
+	assert.True(t, len(ns) >= 2)
+	assert.Equal(t, tmpDir, ns[0])
+	assert.Equal(t, filepath.Dir(tmpDir), ns[1])
+
+	// Test with a known path which should exist. Test just one non-canonical
+	// path, the various other cases are tested in explicitfilepath.ResolvePathToFullyExplicit.
+	//
+	// It would be nice to test a deeper hierarchy, but it is not obvious what
+	// deeper path is always available in the various distros, AND is not likely
+	// to contains a symbolic link.
+	for _, path := range []string{"/usr/share", "/usr/share/./."} {
+		_, err := os.Lstat(path)
+		require.NoError(t, err)
+		ref, err := NewIndexReference(path, 1)
+		require.NoError(t, err)
+		ns := ref.PolicyConfigurationNamespaces()
+		require.NotNil(t, ns)
+		assert.Equal(t, []string{"/usr/share", "/usr"}, ns)
+	}
+
+	// "/" as a corner case.
+	ref, err = NewIndexReference("/", 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, ref.PolicyConfigurationNamespaces())
 }
 
 func TestReferenceNewImage(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	_, err := ref.NewImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceNewImageSource(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	_, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	dest, err := ref.NewImageDestination(context.Background(), nil)
 	assert.NoError(t, err)
 	defer dest.Close()
 }
 
 func TestReferenceDeleteImage(t *testing.T) {
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	err := ref.DeleteImage(context.Background(), nil)
 	assert.Error(t, err)
 }
 
 func TestReferenceOCILayoutPath(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	assert.Equal(t, tmpDir+"/oci-layout", ociRef.ociLayoutPath())
 }
 
 func TestReferenceIndexPath(t *testing.T) {
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	assert.Equal(t, tmpDir+"/index.json", ociRef.indexPath())
@@ -267,7 +421,8 @@ func TestReferenceIndexPath(t *testing.T) {
 func TestReferenceBlobPath(t *testing.T) {
 	const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-	ref, tmpDir := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	bp, err := ociRef.blobPath("sha256:"+hex, "")
@@ -278,7 +433,8 @@ func TestReferenceBlobPath(t *testing.T) {
 func TestReferenceSharedBlobPathShared(t *testing.T) {
 	const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	bp, err := ociRef.blobPath("sha256:"+hex, "/external/path")
@@ -289,7 +445,8 @@ func TestReferenceSharedBlobPathShared(t *testing.T) {
 func TestReferenceBlobPathInvalid(t *testing.T) {
 	const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-	ref, _ := refToTempOCI(t)
+	ref, tmpDir := refToTempOCI(t, false)
+	defer os.RemoveAll(tmpDir)
 	ociRef, ok := ref.(ociReference)
 	require.True(t, ok)
 	_, err := ociRef.blobPath(hex, "")


### PR DESCRIPTION
Add reader/writer with helpers to allow podman save/load multi oci-archive images.
Allow read oci-archive using source_index to point to the index from oci-archive manifest.
Also reimplement ociArchiveImage{Source,Destination} to support this.

Taking over https://github.com/containers/image/pull/1072
Fixes https://github.com/containers/image/issues/1116

Signed-off-by: Qi Wang <qiwan@redhat.com>
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>