### PR TITLE
v5.17.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 16
+	VersionMinor = 17
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 17
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Includes a fix for CVE-2021-41190 / GHSA-77vh-xpmg-72qh .

* [CI:DOCS] Misc manpage fixups
* Log credentials helper path if available
* Record locations of blobs discovered by PutBlob but not TryReusingBlob
* Fix possible out-of-bounds accesses in string indexing
* Precompute digests option prior to registry upload
* Add simple documentation how to use c/image with podman's rootless mode
* Fix c/image fails to pull OCI image with non-`http(s)://` urls
* Reject ambiguous manifest formats