### PR TITLE
Don't include full manifest contents in error messages

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1058,7 +1058,8 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 		instanceDigest = &manifestDigest
 	}
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
-		return nil, "", errors.Wrapf(err, "writing manifest %q", string(man))
+		logrus.Debugf("Error %v while writing manifest %q", err, string(man))
+		return nil, "", errors.Wrapf(err, "writing manifest")
 	}
 	return man, manifestDigest, nil
 }


### PR DESCRIPTION
The content may be useful in principle, but most of the time
it primarily obscures the returned error message, e.g.

```
FATA[0006] writing manifest "{\n   \"schemaVersion\": 2,\n   \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n   \"config\": {\n      \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n      \"size\": 1493,\n      \"digest\": \"sha256:f0b02e9d092d905d0d87a8455a1ae3e9bb47b4aa3dc125125ca5cd10d6441c9f\"\n   },\n   \"layers\": [\n      {\n         \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\n         \"size\": 764619,\n         \"digest\": \"sha256:9758c28807f21c13d05c704821fdd56c0b9574912f9b916c65e1df3e6b8bc572\"\n      }\n   ]\n}": server didn't return a Docker-Content-Digest header, it probably isn’t a container registry
```

Preserve the contents in a debug log, that should be enough at least for failures that are readily reproducible.
