### PR TITLE
docker/config: handle credentials not found errors

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -620,6 +620,10 @@ func getAuthFromCredHelper(credHelper, registry string) (types.DockerAuthConfig,
 	p := helperclient.NewShellProgramFunc(helperName)
 	creds, err := helperclient.Get(p, registry)
 	if err != nil {
+		if credentials.IsErrCredentialsNotFoundMessage(err.Error()) {
+			logrus.Debugf("Not logged in to %s with credential helper %s", registry, credHelper)
+			err = nil
+		}
 		return types.DockerAuthConfig{}, err
 	}
 

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -547,6 +547,14 @@ func TestGetAllCredentials(t *testing.T) {
 		SystemRegistriesConfDirPath: filepath.Join("testdata", "IdoNotExist"),
 	}
 
+	// Make sure that we can handle no-creds-found errors.
+	os.Setenv("DOCKER_CONFIG", filepath.Join(path, "testdata"))
+	authConfigs, err := GetAllCredentials(nil)
+	require.NoError(t, err)
+	require.Len(t, authConfigs, 1)
+	require.Equal(t, authConfigs["registry-no-creds.com"], types.DockerAuthConfig{})
+	os.Unsetenv("DOCKER_CONFIG")
+
 	for _, data := range [][]struct {
 		writeKey    string
 		expectedKey string

--- a/pkg/docker/config/testdata/config.json
+++ b/pkg/docker/config/testdata/config.json
@@ -1,0 +1,5 @@
+{
+	"credHelpers" : {
+		"registry-no-creds.com" : "helper-registry"
+	}
+}

--- a/pkg/docker/config/testdata/docker-credential-helper-registry
+++ b/pkg/docker/config/testdata/docker-credential-helper-registry
@@ -6,6 +6,7 @@ case "${1}" in
         case "${REGISTRY}" in
             ("registry-a.com") echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"foo\",\"Secret\":\"bar\"}" ;;
             ("registry-b.com") echo "{\"ServerURL\":\"${REGISTRY}\",\"Username\":\"<token>\",\"Secret\":\"fizzbuzz\"}" ;;
+            ("registry-no-creds.com") echo "credentials not found in native keychain" && exit 1 ;;
             (*) echo "{}" ;;
         esac
         exit 0


### PR DESCRIPTION
A credential helper may not have the credentials we are looking for and
exits with 1 (and specific error).  Make sure we're treating this case
correctly and don't error but return empty credentials.

Fixes: containers/podman/issues/11636
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @giuseppe @umohnani8 PTAL