### PR TITLE
Fix handling of missing data in GetAllCredentials

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -285,7 +285,7 @@ func getCredentialsWithHomeDir(sys *types.SystemContext, key, homeDir string) (t
 				return types.DockerAuthConfig{}, "", err
 			}
 
-			if (authConfig.Username != "" && authConfig.Password != "") || authConfig.IdentityToken != "" {
+			if authConfig != (types.DockerAuthConfig{}) {
 				return authConfig, path.path, nil
 			}
 		}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -190,14 +190,12 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 	for key := range allKeys {
 		authConf, err := GetCredentials(sys, key)
 		if err != nil {
-			if credentials.IsErrCredentialsNotFoundMessage(err.Error()) {
-				// Ignore if the credentials could not be found (anymore).
-				continue
-			}
 			// Note: we rely on the logging in `GetCredentials`.
 			return nil, err
 		}
-		authConfigs[key] = authConf
+		if authConf != (types.DockerAuthConfig{}) {
+			authConfigs[key] = authConf
+		}
 	}
 
 	return authConfigs, nil

--- a/pkg/docker/config/config_test.go
+++ b/pkg/docker/config/config_test.go
@@ -551,8 +551,7 @@ func TestGetAllCredentials(t *testing.T) {
 	os.Setenv("DOCKER_CONFIG", filepath.Join(path, "testdata"))
 	authConfigs, err := GetAllCredentials(nil)
 	require.NoError(t, err)
-	require.Len(t, authConfigs, 1)
-	require.Equal(t, authConfigs["registry-no-creds.com"], types.DockerAuthConfig{})
+	require.Empty(t, authConfigs)
 	os.Unsetenv("DOCKER_CONFIG")
 
 	for _, data := range [][]struct {


### PR DESCRIPTION
- Don't check for `credentials.IsErrCredentialsNotFoundMessage`, which is handled by `GetCredentials` and is not reachable here
- Do check for an empty struct, which is the outcome of that handling. Don't add that empty struct, meaning "nothing found", to the returned data.
- A somewhat-related cleanup.

This is a follow-up to https://github.com/containers/image/pull/1427#issuecomment-991109516 .