### PR TITLE
docker, BlobInfoCache: try to reuse compressed blobs from `all known` compressed digests

### DIFF
--- a/docker/cache.go
+++ b/docker/cache.go
@@ -7,8 +7,9 @@ import (
 
 // bicTransportScope returns a BICTransportScope appropriate for ref.
 func bicTransportScope(ref dockerReference) types.BICTransportScope {
-	// Blobs can be reused across the whole registry.
-	return types.BICTransportScope{Opaque: reference.Domain(ref.ref)}
+	// Blobs can be reused across multiple registries
+	// therefore bucket all blobs in same scope
+	return types.BICTransportScope{Opaque: "all"}
 }
 
 // newBICLocationReference returns a BICLocationReference appropriate for ref.


### PR DESCRIPTION
It seems we try to reuse blobs only for the specified registry, however
we can have valid known compressed digests across registry as well
following pr attempts to use that by doing following steps.

* Move all known blobs into common data scope i.e `all` instead of
  storing them in seperate registry.

* Increase the sample set of potential blob reuse to all known
  compressed digests , also involving the one which do not belong to
current registry.

* If a blob is found match it against the registry where we are
  attempting to push. If blob is already there consider it a `CACHE
HIT!` and reply skipping blob, since its already there.

## How to verify this ?

#### Pre-steps

* Remove all images `buildah rmi --all` // needed so all new pulled blobs can
  be tagged again in common bucket
* Remove any previous `blob-info-cache` by

```console
rm /home/<user>/.local/share/containers/cache/blob-info-cache-v1.boltdb
```
### Actual use-case

```console
$ skopeo copy docker://registry.fedoraproject.org/fedora-minimal docker://quay.io/fl/test:some-tag
$ buildah pull registry.fedoraproject.org/fedora-minimal
$ buildah tag registry.fedoraproject.org/fedora-minimal quay.io/fl/test
$ buildah push quay.io/fl/test
```
#### Expected Output

```console
Getting image source signatures
Copying blob a3497ca15bbf skipped: already exists
Copying config f7e02de757 done
Writing manifest to image destination
Storing signatures
```
