### PR TITLE
Establish internal/private.ImageDestination

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1233,7 +1233,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// Note: the storage destination optimizes the committing of
 		// layers which requires passing the index of the layer.
 		// Hence, we need to special case and cast.
-		dest, ok := ic.c.dest.(private.ImageDestinationWithOptions)
+		dest, ok := ic.c.dest.(private.ImageDestination)
 		if ok {
 			options := private.TryReusingBlobOptions{
 				Cache:         ic.c.blobInfoCache,
@@ -1662,7 +1662,7 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	// Note: the storage destination optimizes the committing of layers
 	// which requires passing the index of the layer.  Hence, we need to
 	// special case and cast.
-	dest, ok := c.dest.(private.ImageDestinationWithOptions)
+	dest, ok := c.dest.(private.ImageDestination)
 	if ok {
 		options := private.PutBlobOptions{
 			Cache:      c.blobInfoCache,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/image/v5/image"
 	internalblobinfocache "github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/pkg/platform"
-	internalTypes "github.com/containers/image/v5/internal/types"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
@@ -1233,9 +1233,9 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// Note: the storage destination optimizes the committing of
 		// layers which requires passing the index of the layer.
 		// Hence, we need to special case and cast.
-		dest, ok := ic.c.dest.(internalTypes.ImageDestinationWithOptions)
+		dest, ok := ic.c.dest.(private.ImageDestinationWithOptions)
 		if ok {
-			options := internalTypes.TryReusingBlobOptions{
+			options := private.TryReusingBlobOptions{
 				Cache:         ic.c.blobInfoCache,
 				CanSubstitute: ic.canSubstituteBlobs,
 				SrcRef:        srcRef,
@@ -1286,8 +1286,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// of the source file are not known yet and must be fetched.
 	// Attempt a partial only when the source allows to retrieve a blob partially and
 	// the destination has support for it.
-	imgSource, okSource := ic.c.rawSource.(internalTypes.ImageSourceSeekable)
-	imgDest, okDest := ic.c.dest.(internalTypes.ImageDestinationPartial)
+	imgSource, okSource := ic.c.rawSource.(private.ImageSourceSeekable)
+	imgDest, okDest := ic.c.dest.(private.ImageDestinationPartial)
 	if okSource && okDest && !diffIDIsNeeded {
 		if reused, blobInfo := func() (bool, types.BlobInfo) { // A scope for defer
 			bar := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
@@ -1662,9 +1662,9 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 	// Note: the storage destination optimizes the committing of layers
 	// which requires passing the index of the layer.  Hence, we need to
 	// special case and cast.
-	dest, ok := c.dest.(internalTypes.ImageDestinationWithOptions)
+	dest, ok := c.dest.(private.ImageDestinationWithOptions)
 	if ok {
-		options := internalTypes.PutBlobOptions{
+		options := private.PutBlobOptions{
 			Cache:      c.blobInfoCache,
 			IsConfig:   isConfig,
 			EmptyLayer: emptyLayer,

--- a/copy/progress_reader.go
+++ b/copy/progress_reader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	internalTypes "github.com/containers/image/v5/internal/types"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 )
 
@@ -84,14 +84,14 @@ func (r *progressReader) Read(p []byte) (int, error) {
 // are received.
 type imageSourceSeekableProxy struct {
 	// source is the seekable input to read from.
-	source internalTypes.ImageSourceSeekable
+	source private.ImageSourceSeekable
 	// progress is the chan where the total number of bytes read so far are reported.
 	progress chan int64
 }
 
 // GetBlobAt reads from the ImageSourceSeekable and report how many bytes were received
 // to the progress chan.
-func (s imageSourceSeekableProxy) GetBlobAt(ctx context.Context, bInfo types.BlobInfo, chunks []internalTypes.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+func (s imageSourceSeekableProxy) GetBlobAt(ctx context.Context, bInfo types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
 	rc, errs, err := s.source.GetBlobAt(ctx, bInfo, chunks)
 	if err == nil {
 		total := int64(0)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/iolimits"
-	internalTypes "github.com/containers/image/v5/internal/types"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
@@ -288,7 +288,7 @@ func (s *dockerImageSource) HasThreadSafeGetBlob() bool {
 }
 
 // splitHTTP200ResponseToPartial splits a 200 response in multiple streams as specified by the chunks
-func splitHTTP200ResponseToPartial(streams chan io.ReadCloser, errs chan error, body io.ReadCloser, chunks []internalTypes.ImageSourceChunk) {
+func splitHTTP200ResponseToPartial(streams chan io.ReadCloser, errs chan error, body io.ReadCloser, chunks []private.ImageSourceChunk) {
 	defer close(streams)
 	defer close(errs)
 	currentOffset := uint64(0)
@@ -322,7 +322,7 @@ func splitHTTP200ResponseToPartial(streams chan io.ReadCloser, errs chan error, 
 }
 
 // handle206Response reads a 206 response and send each part as a separate ReadCloser to the streams chan.
-func handle206Response(streams chan io.ReadCloser, errs chan error, body io.ReadCloser, chunks []internalTypes.ImageSourceChunk, mediaType string, params map[string]string) {
+func handle206Response(streams chan io.ReadCloser, errs chan error, body io.ReadCloser, chunks []private.ImageSourceChunk, mediaType string, params map[string]string) {
 	defer close(streams)
 	defer close(errs)
 	if !strings.HasPrefix(mediaType, "multipart/") {
@@ -359,7 +359,7 @@ func handle206Response(streams chan io.ReadCloser, errs chan error, body io.Read
 
 // GetBlobAt returns a stream for the specified blob.
 // The specified chunks must be not overlapping and sorted by their offset.
-func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []internalTypes.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
 	headers := make(map[string][]string)
 
 	var rangeVals []string
@@ -401,7 +401,7 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 		return streams, errs, nil
 	case http.StatusBadRequest:
 		res.Body.Close()
-		return nil, nil, internalTypes.BadPartialRequestError{Status: res.Status}
+		return nil, nil, private.BadPartialRequestError{Status: res.Status}
 	default:
 		err := httpResponseToError(res, "Error fetching partial blob")
 		if err == nil {

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	internalTypes "github.com/containers/image/v5/internal/types"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,7 +130,7 @@ func TestSplitHTTP200ResponseToPartial(t *testing.T) {
 	defer body.Close()
 	streams := make(chan io.ReadCloser)
 	errs := make(chan error)
-	chunks := []internalTypes.ImageSourceChunk{
+	chunks := []private.ImageSourceChunk{
 		{Offset: 1, Length: 2},
 		{Offset: 4, Length: 1},
 	}
@@ -150,7 +150,7 @@ func TestHandle206Response(t *testing.T) {
 	defer body.Close()
 	streams := make(chan io.ReadCloser)
 	errs := make(chan error)
-	chunks := []internalTypes.ImageSourceChunk{
+	chunks := []private.ImageSourceChunk{
 		{Offset: 1, Length: 2},
 		{Offset: 4, Length: 1},
 	}
@@ -171,7 +171,7 @@ func TestHandle206Response(t *testing.T) {
 	defer body.Close()
 	streams = make(chan io.ReadCloser)
 	errs = make(chan error)
-	chunks = []internalTypes.ImageSourceChunk{{Offset: 100, Length: 5}}
+	chunks = []private.ImageSourceChunk{{Offset: 100, Length: 5}}
 	mediaType = "text/plain"
 	params = map[string]string{}
 	go handle206Response(streams, errs, body, chunks, mediaType, params)

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var _ private.ImageSourceSeekable = (*dockerImageSource)(nil)
+
 func TestDockerImageSourceReference(t *testing.T) {
 	manifestPathRegex := regexp.MustCompile("^/v2/.*/manifests/latest$")
 

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -8,9 +8,9 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
-// ImageDestinationWithOptions is an internal extension to the ImageDestination
+// ImageDestination is an internal extension to the types.ImageDestination
 // interface.
-type ImageDestinationWithOptions interface {
+type ImageDestination interface {
 	types.ImageDestination
 
 	// PutBlobWithOptions is a wrapper around PutBlob.  If

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -21,7 +21,7 @@ type ImageDestination interface {
 	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
 	// *must* be used the together.  Mixing the two with non "WithOptions"
 	// functions is not supported.
-	PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, options PutBlobOptions) (types.BlobInfo, error)
+	PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options PutBlobOptions) (types.BlobInfo, error)
 
 	// TryReusingBlobWithOptions is a wrapper around TryReusingBlob.  If
 	// options.LayerIndex is set, the reused blob will be recoreded as
@@ -30,7 +30,7 @@ type ImageDestination interface {
 	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
 	// *must* be used the together.  Mixing the two with non "WithOptions"
 	// functions is not supported.
-	TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options TryReusingBlobOptions) (bool, types.BlobInfo, error)
+	TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options TryReusingBlobOptions) (bool, types.BlobInfo, error)
 }
 
 // PutBlobOptions are used in PutBlobWithOptions.

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -13,23 +13,22 @@ import (
 type ImageDestination interface {
 	types.ImageDestination
 
-	// PutBlobWithOptions is a wrapper around PutBlob.  If
-	// options.LayerIndex is set, the blob will be committed directly.
-	// Either by the calling goroutine or by another goroutine already
-	// committing layers.
-	//
-	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
-	// *must* be used the together.  Mixing the two with non "WithOptions"
-	// functions is not supported.
+	// PutBlobWithOptions writes contents of stream and returns data representing the result.
+	// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
+	// inputInfo.Size is the expected length of stream, if known.
+	// inputInfo.MediaType describes the blob format, if known.
+	// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+	// to any other readers for download using the supplied digest.
+	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 	PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options PutBlobOptions) (types.BlobInfo, error)
 
-	// TryReusingBlobWithOptions is a wrapper around TryReusingBlob.  If
-	// options.LayerIndex is set, the reused blob will be recoreded as
-	// already pulled.
-	//
-	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
-	// *must* be used the together.  Mixing the two with non "WithOptions"
-	// functions is not supported.
+	// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+	// info.Digest must not be empty.
+	// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+	// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+	// reflected in the manifest that will be written.
+	// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 	TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options TryReusingBlobOptions) (bool, types.BlobInfo, error)
 }
 

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -1,17 +1,17 @@
-package types
+package private
 
 import (
 	"context"
 	"io"
 
 	"github.com/containers/image/v5/docker/reference"
-	publicTypes "github.com/containers/image/v5/types"
+	"github.com/containers/image/v5/types"
 )
 
 // ImageDestinationWithOptions is an internal extension to the ImageDestination
 // interface.
 type ImageDestinationWithOptions interface {
-	publicTypes.ImageDestination
+	types.ImageDestination
 
 	// PutBlobWithOptions is a wrapper around PutBlob.  If
 	// options.LayerIndex is set, the blob will be committed directly.
@@ -21,7 +21,7 @@ type ImageDestinationWithOptions interface {
 	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
 	// *must* be used the together.  Mixing the two with non "WithOptions"
 	// functions is not supported.
-	PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo publicTypes.BlobInfo, options PutBlobOptions) (publicTypes.BlobInfo, error)
+	PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, options PutBlobOptions) (types.BlobInfo, error)
 
 	// TryReusingBlobWithOptions is a wrapper around TryReusingBlob.  If
 	// options.LayerIndex is set, the reused blob will be recoreded as
@@ -30,13 +30,13 @@ type ImageDestinationWithOptions interface {
 	// Please note that TryReusingBlobWithOptions and PutBlobWithOptions
 	// *must* be used the together.  Mixing the two with non "WithOptions"
 	// functions is not supported.
-	TryReusingBlobWithOptions(ctx context.Context, blobinfo publicTypes.BlobInfo, options TryReusingBlobOptions) (bool, publicTypes.BlobInfo, error)
+	TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options TryReusingBlobOptions) (bool, types.BlobInfo, error)
 }
 
 // PutBlobOptions are used in PutBlobWithOptions.
 type PutBlobOptions struct {
 	// Cache to look up blob infos.
-	Cache publicTypes.BlobInfoCache
+	Cache types.BlobInfoCache
 	// Denotes whether the blob is a config or not.
 	IsConfig bool
 	// Indicates an empty layer.
@@ -48,7 +48,7 @@ type PutBlobOptions struct {
 // TryReusingBlobOptions are used in TryReusingBlobWithOptions.
 type TryReusingBlobOptions struct {
 	// Cache to look up blob infos.
-	Cache publicTypes.BlobInfoCache
+	Cache types.BlobInfoCache
 	// Use an equivalent of the desired blob.
 	CanSubstitute bool
 	// Indicates an empty layer.
@@ -71,14 +71,14 @@ type ImageSourceChunk struct {
 type ImageSourceSeekable interface {
 	// GetBlobAt returns a stream for the specified blob.
 	// The specified chunks must be not overlapping and sorted by their offset.
-	GetBlobAt(context.Context, publicTypes.BlobInfo, []ImageSourceChunk) (chan io.ReadCloser, chan error, error)
+	GetBlobAt(context.Context, types.BlobInfo, []ImageSourceChunk) (chan io.ReadCloser, chan error, error)
 }
 
 // ImageDestinationPartial is a service to store a blob by requesting the missing chunks to a ImageSourceSeekable.
 // This API is experimental and can be changed without bumping the major version number.
 type ImageDestinationPartial interface {
 	// PutBlobPartial writes contents of stream and returns data representing the result.
-	PutBlobPartial(ctx context.Context, stream ImageSourceSeekable, srcInfo publicTypes.BlobInfo, cache publicTypes.BlobInfoCache) (publicTypes.BlobInfo, error)
+	PutBlobPartial(ctx context.Context, stream ImageSourceSeekable, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error)
 }
 
 // BadPartialRequestError is returned by ImageSourceSeekable.GetBlobAt on an invalid request.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -446,13 +446,13 @@ func (s *storageImageDestination) computeNextBlobCacheFile() string {
 	return filepath.Join(s.directory, fmt.Sprintf("%d", atomic.AddInt32(&s.nextTempFileID, 1)))
 }
 
-// PutBlobWithOptions is a wrapper around PutBlob.  If options.LayerIndex is
-// set, the blob will be committed directly.  Either by the calling goroutine
-// or by another goroutine already committing layers.
-//
-// Please not that TryReusingBlobWithOptions and PutBlobWithOptions *must* be
-// used the together.  Mixing the two with non "WithOptions" functions is not
-// supported.
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
+// inputInfo.Size is the expected length of stream, if known.
+// inputInfo.MediaType describes the blob format, if known.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
 	info, err := s.PutBlob(ctx, stream, blobinfo, options.Cache, options.IsConfig)
 	if err != nil {
@@ -542,13 +542,13 @@ func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader,
 	}, nil
 }
 
-// TryReusingBlobWithOptions is a wrapper around TryReusingBlob.  If
-// options.LayerIndex is set, the reused blob will be recoreded as already
-// pulled.
-//
-// Please not that TryReusingBlobWithOptions and PutBlobWithOptions *must* be
-// used the together.  Mixing the two with the non "WithOptions" functions
-// is not supported.
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
 	reused, info, err := s.tryReusingBlobWithSrcRef(ctx, blobinfo, options.Cache, options.CanSubstitute, options.SrcRef)
 	if err != nil || !reused || options.LayerIndex == nil {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containers/image/v5/internal/private"
 	imanifest "github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/memory"
 	"github.com/containers/image/v5/types"
@@ -36,11 +37,13 @@ import (
 )
 
 var (
-	topwd                        = ""
-	_     types.ImageDestination = &storageImageDestination{}
-	_     types.ImageSource      = &storageImageSource{}
-	_     types.ImageReference   = &storageReference{}
-	_     types.ImageTransport   = &storageTransport{}
+	topwd                                     = ""
+	_     types.ImageDestination              = &storageImageDestination{}
+	_     private.ImageDestinationWithOptions = (*storageImageDestination)(nil)
+	_     private.ImageDestinationPartial     = (*storageImageDestination)(nil)
+	_     types.ImageSource                   = &storageImageSource{}
+	_     types.ImageReference                = &storageReference{}
+	_     types.ImageTransport                = &storageTransport{}
 )
 
 const (

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -37,13 +37,13 @@ import (
 )
 
 var (
-	topwd                                     = ""
-	_     types.ImageDestination              = &storageImageDestination{}
-	_     private.ImageDestinationWithOptions = (*storageImageDestination)(nil)
-	_     private.ImageDestinationPartial     = (*storageImageDestination)(nil)
-	_     types.ImageSource                   = &storageImageSource{}
-	_     types.ImageReference                = &storageReference{}
-	_     types.ImageTransport                = &storageTransport{}
+	topwd                                 = ""
+	_     types.ImageDestination          = &storageImageDestination{}
+	_     private.ImageDestination        = (*storageImageDestination)(nil)
+	_     private.ImageDestinationPartial = (*storageImageDestination)(nil)
+	_     types.ImageSource               = &storageImageSource{}
+	_     types.ImageReference            = &storageReference{}
+	_     types.ImageTransport            = &storageTransport{}
 )
 
 const (


### PR DESCRIPTION
Based on the #1439 experiment, this is trying to establish the common type, so that we can then separately work on the client-side wrapper, and the implementation-side compat/helper infrastructure.

This includes some commits from #1439; the new part is a proposal to, instead of using `publicTypes "…/v5/types" and `internalTypes "…/v5/internal/types`, with `internalTypes.ImageDestinationWithOptions`, to use `types "…/v5/types"` (as we used to) and `private "…/v5/internal/private"`, with `private.ImageDestination`.

The “private” name, as well as all other aspects, is certainly open for debate.

See individual commits for details.

@vrothberg WDYT?