### PR TITLE
Wrap public transport implementations to consistently use a private API

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1272,8 +1272,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// of the source file are not known yet and must be fetched.
 	// Attempt a partial only when the source allows to retrieve a blob partially and
 	// the destination has support for it.
-	imgSource, okSource := ic.c.rawSource.(private.BlobChunkAccessor)
-	if okSource && ic.c.dest.SupportsPutBlobPartial() && !diffIDIsNeeded {
+	sourceChunkAccessor, hasChunkAccessor := ic.c.rawSource.(private.BlobChunkAccessor)
+	if hasChunkAccessor && ic.c.dest.SupportsPutBlobPartial() && !diffIDIsNeeded {
 		if reused, blobInfo := func() (bool, types.BlobInfo) { // A scope for defer
 			bar := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
 			hideProgressBar := true
@@ -1288,7 +1288,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			defer close(progress)
 
 			proxy := blobChunkAccessorProxy{
-				source:   imgSource,
+				wrapped:  sourceChunkAccessor,
 				progress: progress,
 			}
 			go func() {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1235,14 +1235,13 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// Hence, we need to special case and cast.
 		dest, ok := ic.c.dest.(private.ImageDestination)
 		if ok {
-			options := private.TryReusingBlobOptions{
+			reused, blobInfo, err = dest.TryReusingBlobWithOptions(ctx, srcInfo, private.TryReusingBlobOptions{
 				Cache:         ic.c.blobInfoCache,
 				CanSubstitute: ic.canSubstituteBlobs,
 				EmptyLayer:    emptyLayer,
 				LayerIndex:    &layerIndex,
 				SrcRef:        srcRef,
-			}
-			reused, blobInfo, err = dest.TryReusingBlobWithOptions(ctx, srcInfo, options)
+			})
 		} else {
 			reused, blobInfo, err = ic.c.dest.TryReusingBlob(ctx, srcInfo, ic.c.blobInfoCache, ic.canSubstituteBlobs)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1273,8 +1273,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// Attempt a partial only when the source allows to retrieve a blob partially and
 	// the destination has support for it.
 	imgSource, okSource := ic.c.rawSource.(private.ImageSourceSeekable)
-	imgDest, okDest := ic.c.dest.(private.ImageDestinationPartial)
-	if okSource && okDest && !diffIDIsNeeded {
+	if okSource && ic.c.dest.SupportsPutBlobPartial() && !diffIDIsNeeded {
 		if reused, blobInfo := func() (bool, types.BlobInfo) { // A scope for defer
 			bar := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
 			hideProgressBar := true
@@ -1304,7 +1303,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			bar.SetTotal(srcInfo.Size, false)
-			info, err := imgDest.PutBlobPartial(ctx, proxy, srcInfo, ic.c.blobInfoCache)
+			info, err := ic.c.dest.PutBlobPartial(ctx, proxy, srcInfo, ic.c.blobInfoCache)
 			if err == nil {
 				bar.SetRefill(srcInfo.Size - bar.Current())
 				bar.SetCurrent(srcInfo.Size)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1272,7 +1272,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// of the source file are not known yet and must be fetched.
 	// Attempt a partial only when the source allows to retrieve a blob partially and
 	// the destination has support for it.
-	imgSource, okSource := ic.c.rawSource.(private.ImageSourceSeekable)
+	imgSource, okSource := ic.c.rawSource.(private.BlobChunkAccessor)
 	if okSource && ic.c.dest.SupportsPutBlobPartial() && !diffIDIsNeeded {
 		if reused, blobInfo := func() (bool, types.BlobInfo) { // A scope for defer
 			bar := ic.c.createProgressBar(pool, true, srcInfo, "blob", "done")
@@ -1287,7 +1287,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			defer close(terminate)
 			defer close(progress)
 
-			proxy := imageSourceSeekableProxy{
+			proxy := blobChunkAccessorProxy{
 				source:   imgSource,
 				progress: progress,
 			}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -204,20 +204,22 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		reportWriter = options.ReportWriter
 	}
 
-	dest, err := destRef.NewImageDestination(ctx, options.DestinationCtx)
+	publicDest, err := destRef.NewImageDestination(ctx, options.DestinationCtx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing destination %s", transports.ImageName(destRef))
 	}
+	dest := imagedestination.FromPublic(publicDest)
 	defer func() {
 		if err := dest.Close(); err != nil {
 			retErr = errors.Wrapf(retErr, " (dest: %v)", err)
 		}
 	}()
 
-	rawSource, err := srcRef.NewImageSource(ctx, options.SourceCtx)
+	publicRawSource, err := srcRef.NewImageSource(ctx, options.SourceCtx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing source %s", transports.ImageName(srcRef))
 	}
+	rawSource := imagesource.FromPublic(publicRawSource)
 	defer func() {
 		if err := rawSource.Close(); err != nil {
 			retErr = errors.Wrapf(retErr, " (src: %v)", err)
@@ -233,8 +235,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:             imagedestination.FromPublic(dest),
-		rawSource:        imagesource.FromPublic(rawSource),
+		dest:             dest,
+		rawSource:        rawSource,
 		reportWriter:     reportWriter,
 		progressOutput:   progressOutput,
 		progressInterval: options.ProgressInterval,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1238,10 +1238,10 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			options := private.TryReusingBlobOptions{
 				Cache:         ic.c.blobInfoCache,
 				CanSubstitute: ic.canSubstituteBlobs,
-				SrcRef:        srcRef,
 				EmptyLayer:    emptyLayer,
+				LayerIndex:    &layerIndex,
+				SrcRef:        srcRef,
 			}
-			options.LayerIndex = &layerIndex
 			reused, blobInfo, err = dest.TryReusingBlobWithOptions(ctx, srcInfo, options)
 		} else {
 			reused, blobInfo, err = ic.c.dest.TryReusingBlob(ctx, srcInfo, ic.c.blobInfoCache, ic.canSubstituteBlobs)

--- a/copy/progress_reader.go
+++ b/copy/progress_reader.go
@@ -83,8 +83,8 @@ func (r *progressReader) Read(p []byte) (int, error) {
 // blobChunkAccessorProxy wraps a BlobChunkAccessor and keeps track of how many bytes
 // are received.
 type blobChunkAccessorProxy struct {
-	// source is the underlying BlobChunkAccessor
-	source private.BlobChunkAccessor
+	// wrapped is the underlying BlobChunkAccessor
+	wrapped private.BlobChunkAccessor
 	// progress is the chan where the total number of bytes read so far are reported.
 	progress chan int64
 }
@@ -94,8 +94,8 @@ type blobChunkAccessorProxy struct {
 // The specified chunks must be not overlapping and sorted by their offset.
 // The readers must be fully consumed, in the order they are returned, before blocking
 // to read the next chunk.
-func (s blobChunkAccessorProxy) GetBlobAt(ctx context.Context, bInfo types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
-	rc, errs, err := s.source.GetBlobAt(ctx, bInfo, chunks)
+func (s blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+	rc, errs, err := s.wrapped.GetBlobAt(ctx, info, chunks)
 	if err == nil {
 		total := int64(0)
 		for _, c := range chunks {

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/image/v5/directory"
 	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/internal/imagedestination"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
@@ -47,7 +48,7 @@ func TestCreateSignature(t *testing.T) {
 	require.NoError(t, err)
 	defer dirDest.Close()
 	c := &copier{
-		dest:         dirDest,
+		dest:         imagedestination.FromPublic(dirDest),
 		reportWriter: ioutil.Discard,
 	}
 	_, err = c.createSignature(manifestBlob, testKeyFingerprint, "")
@@ -61,7 +62,7 @@ func TestCreateSignature(t *testing.T) {
 	require.NoError(t, err)
 	defer dockerDest.Close()
 	c = &copier{
-		dest:         dockerDest,
+		dest:         imagedestination.FromPublic(dockerDest),
 		reportWriter: ioutil.Discard,
 	}
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -357,8 +357,11 @@ func handle206Response(streams chan io.ReadCloser, errs chan error, body io.Read
 	}
 }
 
-// GetBlobAt returns a stream for the specified blob.
+// GetBlobAt returns a sequential channel of readers that contain data for the requested
+// blob chunks, and a channel that might get a single error value.
 // The specified chunks must be not overlapping and sorted by their offset.
+// The readers must be fully consumed, in the order they are returned, before blocking
+// to read the next chunk.
 func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
 	headers := make(map[string][]string)
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -147,6 +147,11 @@ func (s *dockerImageSource) Close() error {
 	return nil
 }
 
+// SupportsGetBlobAt() returns true if GetBlobAt (BlobChunkAccessor) is supported.
+func (s *dockerImageSource) SupportsGetBlobAt() bool {
+	return true
+}
+
 // LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
 // blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
 // to read the image's layers.

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ private.BlobChunkAccessor = (*dockerImageSource)(nil)
+var _ private.ImageSource = (*dockerImageSource)(nil)
 
 func TestDockerImageSourceReference(t *testing.T) {
 	manifestPathRegex := regexp.MustCompile("^/v2/.*/manifests/latest$")

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ private.ImageSourceSeekable = (*dockerImageSource)(nil)
+var _ private.BlobChunkAccessor = (*dockerImageSource)(nil)
 
 func TestDockerImageSourceReference(t *testing.T) {
 	manifestPathRegex := regexp.MustCompile("^/v2/.*/manifests/latest$")

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -53,7 +53,7 @@ func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inpu
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (w *wrapped) PutBlobPartial(ctx context.Context, stream private.ImageSourceSeekable, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+func (w *wrapped) PutBlobPartial(ctx context.Context, stream private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
 	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", w.Reference().Transport().Name())
 }
 

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -49,11 +49,11 @@ func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inpu
 }
 
 // PutBlobPartial attempts to create a blob using the data that is already present
-// at the destination. stream is accessed in a non-sequential way to retrieve the missing chunks.
+// at the destination. chunkAccessor is accessed in a non-sequential way to retrieve the missing chunks.
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (w *wrapped) PutBlobPartial(ctx context.Context, stream private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+func (w *wrapped) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
 	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", w.Reference().Transport().Name())
 }
 

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -1,0 +1,54 @@
+package imagedestination
+
+import (
+	"context"
+	"io"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/types"
+)
+
+// FromPublic(dest) returns an object that provides the private.ImageDestination API
+//
+// Eventually, we might want to expose this function, and methods of the returned object,
+// as a public API (or rather, a variant that does not include the already-superseded
+// methods of types.ImageDestination, and has added more future-proofing), and more strongly
+// deprecate direct use of types.ImageDestination.
+//
+// NOTE: The returned API MUST NOT be a public interface (it can be either just a struct
+// with public methods, or perhaps a private interface), so that we can add methods
+// without breaking any external implementors of a public interface.
+func FromPublic(dest types.ImageDestination) private.ImageDestination {
+	if dest2, ok := dest.(private.ImageDestination); ok {
+		return dest2
+	}
+	return &wrapped{ImageDestination: dest}
+}
+
+// wrapped provides the private.ImageDestination operations
+// for a destination that only implements types.ImageDestination
+type wrapped struct {
+	types.ImageDestination
+}
+
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
+// inputInfo.Size is the expected length of stream, if known.
+// inputInfo.MediaType describes the blob format, if known.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
+	return w.PutBlob(ctx, stream, inputInfo, options.Cache, options.IsConfig)
+}
+
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+func (w *wrapped) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
+	return w.TryReusingBlob(ctx, info, options.Cache, options.CanSubstitute)
+}

--- a/internal/imagesource/wrapper.go
+++ b/internal/imagesource/wrapper.go
@@ -1,0 +1,47 @@
+package imagesource
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/types"
+)
+
+// FromPublic(src) returns an object that provides the private.ImageSource API
+//
+// Eventually, we might want to expose this function, and methods of the returned object,
+// as a public API (or rather, a variant that does not include the already-superseded
+// methods of types.ImageSource, and has added more future-proofing), and more strongly
+// deprecate direct use of types.ImageSource.
+//
+// NOTE: The returned API MUST NOT be a public interface (it can be either just a struct
+// with public methods, or perhaps a private interface), so that we can add methods
+// without breaking any external implementors of a public interface.
+func FromPublic(src types.ImageSource) private.ImageSource {
+	if src2, ok := src.(private.ImageSource); ok {
+		return src2
+	}
+	return &wrapped{ImageSource: src}
+}
+
+// wrapped provides the private.ImageSource operations
+// for a source that only implements types.ImageSource
+type wrapped struct {
+	types.ImageSource
+}
+
+// SupportsGetBlobAt() returns true if GetBlobAt (BlobChunkAccessor) is supported.
+func (w *wrapped) SupportsGetBlobAt() bool {
+	return false
+}
+
+// GetBlobAt returns a sequential channel of readers that contain data for the requested
+// blob chunks, and a channel that might get a single error value.
+// The specified chunks must be not overlapping and sorted by their offset.
+// The readers must be fully consumed, in the order they are returned, before blocking
+// to read the next chunk.
+func (w *wrapped) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+	return nil, nil, fmt.Errorf("internal error: GetBlobAt is not supported by the %q transport", w.Reference().Transport().Name())
+}

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -8,6 +8,16 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
+// ImageSource is an internal extension to the types.ImageSource interface.
+type ImageSource interface {
+	types.ImageSource
+
+	// SupportsGetBlobAt() returns true if GetBlobAt (BlobChunkAccessor) is supported.
+	SupportsGetBlobAt() bool
+	// BlobChunkAccessor.GetBlobAt is available only if SupportsGetBlobAt().
+	BlobChunkAccessor
+}
+
 // ImageDestination is an internal extension to the types.ImageDestination
 // interface.
 type ImageDestination interface {

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -34,28 +34,29 @@ type ImageDestination interface {
 
 // PutBlobOptions are used in PutBlobWithOptions.
 type PutBlobOptions struct {
-	// Cache to look up blob infos.
-	Cache types.BlobInfoCache
-	// Denotes whether the blob is a config or not.
-	IsConfig bool
-	// Indicates an empty layer.
-	EmptyLayer bool
-	// The corresponding index in the layer slice.
-	LayerIndex *int
+	Cache    types.BlobInfoCache // Cache to optionally update with the uploaded bloblook up blob infos.
+	IsConfig bool                // True if the blob is a config
+
+	// The following fields are new to internal/private.  Users of internal/private MUST fill them in,
+	// but they also must expect that they will be ignored by types.ImageDestination transports.
+
+	EmptyLayer bool // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
+	LayerIndex *int // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
 }
 
 // TryReusingBlobOptions are used in TryReusingBlobWithOptions.
 type TryReusingBlobOptions struct {
-	// Cache to look up blob infos.
-	Cache types.BlobInfoCache
-	// Use an equivalent of the desired blob.
+	Cache types.BlobInfoCache // Cache to use and/or update.
+	// If true, it is allowed to use an equivalent of the desired blob;
+	// in that case the returned info may not match the input.
 	CanSubstitute bool
-	// Indicates an empty layer.
-	EmptyLayer bool
-	// The corresponding index in the layer slice.
-	LayerIndex *int
-	// The reference of the image that contains the target blob.
-	SrcRef reference.Named
+
+	// The following fields are new to internal/private.  Users of internal/private MUST fill them in,
+	// but they also must expect that they will be ignored by types.ImageDestination transports.
+
+	EmptyLayer bool            // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
+	LayerIndex *int            // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
+	SrcRef     reference.Named // A reference to the source image that contains the input blob.
 }
 
 // ImageSourceChunk is a portion of a blob.

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -26,11 +26,11 @@ type ImageDestination interface {
 	PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options PutBlobOptions) (types.BlobInfo, error)
 
 	// PutBlobPartial attempts to create a blob using the data that is already present
-	// at the destination. stream is accessed in a non-sequential way to retrieve the missing chunks.
+	// at the destination. chunkAccessor is accessed in a non-sequential way to retrieve the missing chunks.
 	// It is available only if SupportsPutBlobPartial().
 	// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 	// should fall back to PutBlobWithOptions.
-	PutBlobPartial(ctx context.Context, stream BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error)
+	PutBlobPartial(ctx context.Context, chunkAccessor BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error)
 
 	// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
@@ -83,7 +83,7 @@ type BlobChunkAccessor interface {
 	// The specified chunks must be not overlapping and sorted by their offset.
 	// The readers must be fully consumed, in the order they are returned, before blocking
 	// to read the next chunk.
-	GetBlobAt(context.Context, types.BlobInfo, []ImageSourceChunk) (chan io.ReadCloser, chan error, error)
+	GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []ImageSourceChunk) (chan io.ReadCloser, chan error, error)
 }
 
 // BadPartialRequestError is returned by BlobChunkAccessor.GetBlobAt on an invalid request.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -609,8 +609,11 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 
 }
 
-// PutBlobPartial attempts to create a blob using the data that is already present at the destination storage.  stream is accessed
-// in a non-sequential way to retrieve the missing chunks.
+// PutBlobPartial attempts to create a blob using the data that is already present
+// at the destination. stream is accessed in a non-sequential way to retrieve the missing chunks.
+// It is available only if SupportsPutBlobPartial().
+// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
+// should fall back to PutBlobWithOptions.
 func (s *storageImageDestination) PutBlobPartial(ctx context.Context, stream private.ImageSourceSeekable, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
 	fetcher := zstdFetcher{
 		stream:   stream,
@@ -1259,6 +1262,11 @@ func (s *storageImageDestination) MustMatchRuntimeOS() bool {
 // Does not make a difference if Reference().DockerReference() is nil.
 func (s *storageImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return true // Yes, we want the unmodified manifest
+}
+
+// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
+func (s *storageImageDestination) SupportsPutBlobPartial() bool {
+	return true
 }
 
 // PutSignatures records the image's signatures for committing as a single data blob.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -586,12 +586,12 @@ func (s *storageImageDestination) tryReusingBlobWithSrcRef(ctx context.Context, 
 }
 
 type zstdFetcher struct {
-	stream   private.ImageSourceSeekable
+	stream   private.BlobChunkAccessor
 	ctx      context.Context
 	blobInfo types.BlobInfo
 }
 
-// GetBlobAt converts from chunked.GetBlobAt to ImageSourceSeekable.GetBlobAt.
+// GetBlobAt converts from chunked.GetBlobAt to BlobChunkAccessor.GetBlobAt.
 func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
 	var newChunks []private.ImageSourceChunk
 	for _, v := range chunks {
@@ -614,7 +614,7 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (s *storageImageDestination) PutBlobPartial(ctx context.Context, stream private.ImageSourceSeekable, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+func (s *storageImageDestination) PutBlobPartial(ctx context.Context, stream private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
 	fetcher := zstdFetcher{
 		stream:   stream,
 		ctx:      ctx,

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -37,13 +37,12 @@ import (
 )
 
 var (
-	topwd                                 = ""
-	_     types.ImageDestination          = &storageImageDestination{}
-	_     private.ImageDestination        = (*storageImageDestination)(nil)
-	_     private.ImageDestinationPartial = (*storageImageDestination)(nil)
-	_     types.ImageSource               = &storageImageSource{}
-	_     types.ImageReference            = &storageReference{}
-	_     types.ImageTransport            = &storageTransport{}
+	topwd                          = ""
+	_     types.ImageDestination   = &storageImageDestination{}
+	_     private.ImageDestination = (*storageImageDestination)(nil)
+	_     types.ImageSource        = &storageImageSource{}
+	_     types.ImageReference     = &storageReference{}
+	_     types.ImageTransport     = &storageTransport{}
 )
 
 const (


### PR DESCRIPTION
Another part of the #1439 concept.

- Add `private.ImageSource`, similar to the existing `private.ImageDestination`.
- Introduce `internal/imagesource.FromPublic` and `internal/imagedestination.FromPublic`; the copy pipeline can now always use the private API without cluttering the code with compatibility paths.
- Replace the use of optional `ImageSourceSeekable` and `PutBlobPartial` interfaces with mandatory methods on the private interfaces, along with "Supports…” methods. For now, this is more wordy and risks inconsistency between the supports flags and actual implementations, but we’ll eventually make it cleaner and type-safe again, by providing mix-ins (so that a transport that doesn’t support a feature, or does support a feature, needs just to add a mix-in).

See individual commit messages for details.