### PR TITLE
Eliminate a goroutine

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1283,27 +1283,10 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 				bar.Abort(hideProgressBar)
 			}()
 
-			progress := make(chan int64)
-			terminate := make(chan interface{})
-
-			defer close(terminate)
-			defer close(progress)
-
 			proxy := blobChunkAccessorProxy{
-				wrapped:  ic.c.rawSource,
-				progress: progress,
+				wrapped: ic.c.rawSource,
+				bar:     bar,
 			}
-			go func() {
-				for {
-					select {
-					case written := <-progress:
-						bar.IncrInt64(written)
-					case <-terminate:
-						return
-					}
-				}
-			}()
-
 			bar.SetTotal(srcInfo.Size, false)
 			info, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, ic.c.blobInfoCache)
 			if err == nil {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -1305,7 +1305,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			bar.SetTotal(srcInfo.Size, false)
-			info, err := ic.c.dest.PutBlobPartial(ctx, proxy, srcInfo, ic.c.blobInfoCache)
+			info, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, ic.c.blobInfoCache)
 			if err == nil {
 				bar.SetRefill(srcInfo.Size - bar.Current())
 				bar.SetCurrent(srcInfo.Size)

--- a/copy/progress_reader.go
+++ b/copy/progress_reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
+	"github.com/vbauerster/mpb/v7"
 )
 
 // progressReader is a reader that reports its progress on an interval.
@@ -83,10 +84,8 @@ func (r *progressReader) Read(p []byte) (int, error) {
 // blobChunkAccessorProxy wraps a BlobChunkAccessor and keeps track of how many bytes
 // are received.
 type blobChunkAccessorProxy struct {
-	// wrapped is the underlying BlobChunkAccessor
-	wrapped private.BlobChunkAccessor
-	// progress is the chan where the total number of bytes read so far are reported.
-	progress chan int64
+	wrapped private.BlobChunkAccessor // The underlying BlobChunkAccessor
+	bar     *mpb.Bar                  // A progress bar updated with the number of bytes read so far
 }
 
 // GetBlobAt returns a sequential channel of readers that contain data for the requested
@@ -101,7 +100,7 @@ func (s *blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobI
 		for _, c := range chunks {
 			total += int64(c.Length)
 		}
-		s.progress <- total
+		s.bar.IncrInt64(total)
 	}
 	return rc, errs, err
 }

--- a/copy/progress_reader.go
+++ b/copy/progress_reader.go
@@ -94,7 +94,7 @@ type blobChunkAccessorProxy struct {
 // The specified chunks must be not overlapping and sorted by their offset.
 // The readers must be fully consumed, in the order they are returned, before blocking
 // to read the next chunk.
-func (s blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+func (s *blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
 	rc, errs, err := s.wrapped.GetBlobAt(ctx, info, chunks)
 	if err == nil {
 		total := int64(0)


### PR DESCRIPTION
Have `imageSourceSeekableProxy` directly update the progress bar, instead of sending the data to a channel and updating the progress bar in a separate goroutine.

In theory, this might slow down `GetBlobAt` a bit, because it will block on a progress bar update (but not on a repaint IIRC). We already pay the same price for `bar.ProxyReader()` on ordinary copies, so it's almost certainly not worth worrying about, and worth the simplification.
