### PR TITLE
Reorganize storageImageDestination to prioritize the private …WithOptions methods

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -665,12 +665,6 @@ func (s *storageImageDestination) tryReusingBlobAsPending(ctx context.Context, b
 		}
 	}
 
-	return s.tryReusingBlobLocked(ctx, blobinfo, options)
-}
-
-// tryReusingBlobLocked implements a core functionality of TryReusingBlob.
-// This must be called with a lock being held on storageImageDestination.
-func (s *storageImageDestination) tryReusingBlobLocked(ctx context.Context, blobinfo types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
 	if blobinfo.Digest == "" {
 		return false, types.BlobInfo{}, errors.Errorf(`Can not check for a blob with unknown digest`)
 	}

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -446,6 +446,11 @@ func (s *storageImageDestination) computeNextBlobCacheFile() string {
 	return filepath.Join(s.directory, fmt.Sprintf("%d", atomic.AddInt32(&s.nextTempFileID, 1)))
 }
 
+// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
+func (s *storageImageDestination) HasThreadSafePutBlob() bool {
+	return true
+}
+
 // PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
@@ -464,11 +469,6 @@ func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream
 	}
 
 	return info, s.queueOrCommit(ctx, info, *options.LayerIndex, options.EmptyLayer)
-}
-
-// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
-func (s *storageImageDestination) HasThreadSafePutBlob() bool {
-	return true
 }
 
 // PutBlob writes contents of stream and returns data representing the result.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -459,7 +459,7 @@ func (s *storageImageDestination) HasThreadSafePutBlob() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
-	info, err := s.PutBlob(ctx, stream, blobinfo, options.Cache, options.IsConfig)
+	info, err := s.putBlobToPendingFile(ctx, stream, blobinfo, options.Cache, options.IsConfig)
 	if err != nil {
 		return info, err
 	}
@@ -480,6 +480,12 @@ func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	return s.putBlobToPendingFile(ctx, stream, blobinfo, cache, isConfig)
+}
+
+// putBlobToPendingFile implements ImageDestination.PutBlob, storing stream into an on-disk file.
+// The caller must arrange the blob to be eventually commited using s.commitLayer().
+func (s *storageImageDestination) putBlobToPendingFile(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	// Stores a layer or data blob in our temporary directory, checking that any information
 	// in the blobinfo matches the incoming data.
 	errorBlobInfo := types.BlobInfo{

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -480,7 +480,7 @@ func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
-	return s.putBlobToPendingFile(ctx, stream, blobinfo, private.PutBlobOptions{
+	return s.PutBlobWithOptions(ctx, stream, blobinfo, private.PutBlobOptions{
 		Cache:    cache,
 		IsConfig: isConfig,
 	})

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -635,11 +635,7 @@ func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context,
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 // May use and/or update cache.
 func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
-	// lock the entire method as it executes fairly quickly
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.tryReusingBlobLocked(ctx, blobinfo, private.TryReusingBlobOptions{
+	return s.TryReusingBlobWithOptions(ctx, blobinfo, private.TryReusingBlobOptions{
 		Cache:         cache,
 		CanSubstitute: canSubstitute,
 	})


### PR DESCRIPTION
Another part of #1439 : modify `storageImageDestination` so that `PutBlob` is just a trivial wrapper over `PutBlobWithOptions`, and `TryReusingBlob` is just a trivial wrapper over `TryReusingBlobWithOptions`.

Later we’ll replace those wrappers with uses of universally-usable adapters.