### PR TITLE
Use the default KeepAlive interval (15s) instead of 30s

### DIFF
--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -94,7 +94,6 @@ func hasFile(files []os.FileInfo, name string) bool {
 func NewTransport() *http.Transport {
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}
 	tr := &http.Transport{


### PR DESCRIPTION
Remove our overriding of the default KeepAlive interval.  We previously set it to 30 seconds, but now we'll leave it unset to get the default, which has been 15 seconds since Go 1.12.

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=2052672.