### PR TITLE
blobcache: export clearCache

### DIFF
--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -139,7 +139,7 @@ func (b *BlobCache) Directory() string {
 	return b.directory
 }
 
-func (b *BlobCache) clearCache() error {
+func (b *BlobCache) ClearCache() error {
 	f, err := os.Open(b.directory)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -248,7 +248,7 @@ func TestBlobCache(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error copying the image using the cache: %v", err)
 				}
-				if err = cachedSrcRef.clearCache(); err != nil {
+				if err = cachedSrcRef.ClearCache(); err != nil {
 					t.Fatalf("error clearing cache: %v", err)
 				}
 			}


### PR DESCRIPTION
To allow for callers of Buildah's pkg/blobcache to continue building [1].

[1] https://github.com/containers/buildah/pull/3795#issuecomment-1047873727

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>