### PR TITLE
docker/reference: add IsFullIdentifier

### DIFF
--- a/docker/reference/regexp-additions.go
+++ b/docker/reference/regexp-additions.go
@@ -1,0 +1,6 @@
+package reference
+
+// Return true if the specified string fully matches `IdentifierRegexp`.
+func IsFullIdentifier(s string) bool {
+	return anchoredIdentifierRegexp.MatchString(s)
+}

--- a/docker/reference/regexp_test.go
+++ b/docker/reference/regexp_test.go
@@ -545,6 +545,9 @@ func TestIdentifierRegexp(t *testing.T) {
 
 	for i := range fullCases {
 		checkRegexp(t, anchoredIdentifierRegexp, fullCases[i])
+		if IsFullIdentifier(fullCases[i].input) != fullCases[i].match {
+			t.Errorf("Expected match for %q to be %v", fullCases[i].input, fullCases[i].match)
+		}
 	}
 
 	for i := range shortCases {


### PR DESCRIPTION
containers/common/libimage is in need to check whether a given input
looks like a full image ID (i.e., a 64-byte hex string).  Since
compiling regexes has a negative impact on init- and run-time, let's
expose a function to check whether a given string matches the already
compiled regex in docker/reference.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@mtrmac PTAL
I want it for optimizing the fixes for https://github.com/containers/podman/issues/12761.