### PR TITLE
Remove a direct dependency on golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,6 @@ require (
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )


### PR DESCRIPTION
After https://github.com/containers/image/pull/1477 has removed the last direct user of the package, update also the dependency.

Don't completely remove it so that updating c/image can't cause a downgrade of `golang.org/x/sys` in consumers;
eventually some dependency will start requiring a newer version of `golang.org/x/sys` and the entry will completely
drop out (or we eventually update to the newer `go.mod` format that lists indirect dependencies as well).