### PR TITLE
Change OCI layout transport to thread-safe destination

### DIFF
--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -112,7 +112,7 @@ func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
 
 // HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
 func (d *ociImageDestination) HasThreadSafePutBlob() bool {
-	return false
+	return true
 }
 
 // PutBlob writes contents of stream and returns data representing the result.


### PR DESCRIPTION
This PR follows up the discussion in #1466.

I did another round of practical tests with Skopeo 1.6.1 built on top of this change.
I was able to successfully copy to OCI layout format the following images: 

| Image reference                                                        | Number of blobs | Size on registry |
|------------------------------------------------------------------------|-----------------|------------------|
| `quay.io/madeeks/pyfr:1.10.0-cuda11.2-openmpi4.1.0-ubuntu20.04`          |        18       |       2.3GB      |
| `quay.io/madeeks/horovod:0.22.0-tf2.5.0-cuda11.2-mpich3.1.4-ubuntu18.04` |        23       |       4.1GB      |
| `quay.io/madeeks/gromacs:2020.4-cuda11.2.0-mpich3.1.4-centos7`           |        15       |       2.3GB      |
| `nvcr.io/nvidia/tensorflow:22.01-tf2-py3`                                |        44       |      6.66GB      |
| `nvcr.io/nvidia/nvhpc:22.1-devel-cuda_multi-ubuntu20.04`                 |        13       |      8.14GB      |


Closes #1466 