### PR TITLE
Release v5.20.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 19
+	VersionMinor = 20
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 20
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
- `docker/referece`: add `IsFullIdentifier`
- Changed oci layout transport to thread-safe destination
- add `pkg/blobcache` from Buildah
- blobcache: drop import on `buildah/docker`
- blobcache: drop history comment
- blobcache: make `ClearCache()` private
- blobcache: remove `CacheLookupReferenceFunc`
- blobcache: turn `BlobCache` into a struct
- blobcache: export `clearCache`
- Remove (unused and unreachable) keyring support
- Eliminate a goroutine
- Also introduces internal-only interfaces to allow extending the transport feature set in the future