### PR TITLE
bug fix: handle CopySpecificImages correctly

### DIFF
--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -86,6 +86,30 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 	return nil
 }
 
+func (list *Schema2List) UpdateInstancesAndDiscardOthers(listUpdate []ListUpdate) error {
+	existingManifest := map[digest.Digest]Schema2ManifestDescriptor{}
+	for _, m := range list.Manifests {
+		for _, u := range listUpdate {
+			if m.Digest == u.Digest {
+				existingManifest[u.Digest] = m
+			}
+		}
+	}
+	list.Manifests = []Schema2ManifestDescriptor{}
+	for _, u := range listUpdate {
+		updatedManifest, ok := existingManifest[u.Digest]
+		if !ok {
+			return errors.New("digest needs to exist in manifest")
+		}
+		updatedManifest.MediaType = u.MediaType
+		updatedManifest.Digest = u.Digest
+		updatedManifest.Size = u.Size
+		list.Manifests = append(list.Manifests, updatedManifest)
+	}
+
+	return nil
+}
+
 // ChooseInstance parses blob as a schema2 manifest list, and returns the digest
 // of the image which is appropriate for the current environment.
 func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {

--- a/manifest/list.go
+++ b/manifest/list.go
@@ -33,6 +33,10 @@ type List interface {
 	// must be specified.
 	UpdateInstances([]ListUpdate) error
 
+	// UpdateInstancesAndDiscardOthers overrides the instances slice with information contained in the passed-in slice.
+	// All instances which do not have a matching digest in the passed-in slice will be discarded.
+	UpdateInstancesAndDiscardOthers([]ListUpdate) error
+
 	// Instance returns the size and MIME type of a particular instance in the list.
 	Instance(digest.Digest) (ListUpdate, error)
 


### PR DESCRIPTION
Currently the `ImageListSelection` setting `copy.CopySpecificImages` in `copy.Options` is useless since any digest slice passed to `Instances` must have the same length as the slice of manifests in the source list. 

Therefore, the only way to use `copy.CopySpecificImages` is to pass into `Instances` all digests which are present in the source list of manifests. Thus, `copy.CopySpecificImages` behaves like a really clunky version of `copy.CopyAllImages`.

This PR ensures that `copy.CopySpecificImages` is actually useful (again?) by removing any manifest from the list which cannot be matched with a digest listed in `Instances`.