### PR TITLE
Silence go-staticcheck about openpgp use

### DIFF
--- a/signature/mechanism.go
+++ b/signature/mechanism.go
@@ -13,6 +13,7 @@ import (
 	// code path, where cryptography is not relevant. For now, continue to
 	// use this frozen deprecated implementation. When mechanism_openpgp.go
 	// migrates to another implementation, this should migrate as well.
+	//lint:ignore SA1019 See above
 	"golang.org/x/crypto/openpgp" //nolint:staticcheck
 )
 

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -20,6 +20,7 @@ import (
 	// For this verify-only fallback, we haven't reviewed any of the
 	// existing alternatives to choose; so, for now, continue to
 	// use this frozen deprecated implementation.
+	//lint:ignore SA1019 See above
 	"golang.org/x/crypto/openpgp" //nolint:staticcheck
 )
 


### PR DESCRIPTION
We already silence the CI linters, this silences warnings in the Visual Studio Code default configuration.