### PR TITLE
Try to make (make lint) pass with Go 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ tools: .install.gitvalidation .install.golangci-lint .install.golint
 
 .install.golangci-lint:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.35.2; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.44.2; \
 	fi
 
 .install.golint:


### PR DESCRIPTION
This is an attempt to fix (make lint), which complains:
```
pkg/tlsclientconfig/tlsclientconfig_test.go:37:20: SA1019: tlsc.RootCAs.Subjects is deprecated: if s was returned by SystemCertPool, Subjects will not include the system roots. (staticcheck)
      for _, s := range tlsc.RootCAs.Subjects() {
                        ^
pkg/tlsclientconfig/tlsclientconfig_test.go:43:20: SA1019: systemCertPool.Subjects is deprecated: if s was returned by SystemCertPool, Subjects will not include the system roots. (staticcheck)
      for _, s := range systemCertPool.Subjects() {
                        ^
pkg/tlsclientconfig/tlsclientconfig_test.go:53:20: SA1019: tlsc.RootCAs.Subjects is deprecated: if s was returned by SystemCertPool, Subjects will not include the system roots. (staticcheck)
      for _, s := range tlsc.RootCAs.Subjects() {
```

... but the same `staticcheck` linter, for some reason, does NOT complain about these deprecated fields; the correct `//lint:ignore` comments are ineffective and actually cause extra warnings.

So, silence all of `staticcheck` via `//nolint` , hopefully temporarily.

(Also, note that `golangci-lint` itself, with this update, crashes with https://github.com/golangci/golangci-lint/issues/2374 ;
a local rebuild does not crash, but still fails per the above.)