### PR TITLE
Added documentation for containers-storage transport.

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -110,6 +110,12 @@ The `tarball:` transport refers to tarred up container root filesystems.
 
 Scopes are ignored.
 
+### `containers-storage:`
+
+The `containers-storage` transport refers to the image location in a local containers storage.
+
+Supported scopes are for a specific image(s) or `""` for all images located in the containers-storage.
+
 ## Policy Requirements
 
 Using the mechanisms above, a set of policy requirements is looked up.  The policy requirements
@@ -305,6 +311,9 @@ selectively allow individual transports and scopes as desired.
                     }
                 }
             ]
+        },
+        "containers-storage": {
+            "": [{"type": "insecureAcceptAnything"}] /* Allow copy operations on any images stored in containers storage */
         }
     }
 }


### PR DESCRIPTION
It is important to mention it when the default policy is in restrictive
mode.
During push operation image is being copied from local storage to the
docker transport. This action should be allowed for a successfull push.