### PR TITLE
`registry` alias for the `docker` transport

### DIFF
--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -14,6 +14,7 @@ import (
 
 func init() {
 	transports.Register(Transport)
+	transports.RegisterAlias(Transport, "registry")
 }
 
 // Transport is an ImageTransport for container registry-hosted images.

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -71,6 +71,11 @@ An image compliant with the "Open Container Image Layout Specification" stored a
 An image in the local ostree(1) repository.
 _/absolute/repo/path_ defaults to _/ostree/repo_.
 
+### **registry://**_docker-reference_
+
+The **registry** transport is an alias for the **docker** transport.  Once parsed, the transport of a reference will be returned as **docker**.
+
+
 ## Examples
 
 The following examples demonstrate how some of the containers transports can be used.
@@ -78,7 +83,7 @@ The examples use skopeo-copy(1) for copying container images.
 
 **Copying an image from one registry to another**:
 ```
-$ skopeo copy docker://docker.io/library/alpine:latest docker://localhost:5000/alpine:latest
+$ skopeo copy registry://docker.io/library/alpine:latest registry://localhost:5000/alpine:latest
 ```
 
 **Copying an image from a running Docker daemon to a directory in the OCI layout**:
@@ -100,7 +105,7 @@ test-oci/
 
 **Copying an image from a registry to the local storage**:
 ```
-$ skopeo copy docker://docker.io/library/alpine:latest containers-storage:alpine:latest
+$ skopeo copy registry://docker.io/library/alpine:latest containers-storage:alpine:latest
 ```
 
 ## SEE ALSO

--- a/signature/fixtures/policy-merge-overlap.json
+++ b/signature/fixtures/policy-merge-overlap.json
@@ -1,0 +1,44 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+       "registry": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ]
+        },
+        "docker": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy-merge-simple.json
+++ b/signature/fixtures/policy-merge-simple.json
@@ -1,0 +1,37 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "registry": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ]
+        },
+        "docker": {
+            "example.com/another/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy-simple-docker.json
+++ b/signature/fixtures/policy-simple-docker.json
@@ -1,0 +1,35 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ],
+            "example.com/another/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy-simple-merge.json
+++ b/signature/fixtures/policy-simple-merge.json
@@ -1,0 +1,37 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "registry": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ]
+        },
+        "docker": {
+            "example.com/another/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy-simple-registry.json
+++ b/signature/fixtures/policy-simple-registry.json
@@ -1,0 +1,35 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ],
+            "example.com/another/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy-unknown-transport.json
+++ b/signature/fixtures/policy-unknown-transport.json
@@ -1,0 +1,31 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "unknown-transport": {},
+        "registry": {
+            "example.com/playground": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ],
+            "example.com/production": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/keys/employee-gpg-keyring"
+                }
+            ]
+        }
+    }
+}

--- a/signature/fixtures/policy.json
+++ b/signature/fixtures/policy.json
@@ -12,7 +12,7 @@
                 }
             ]
         },
-        "docker": {
+        "registry": {
             "example.com/playground": [
                 {
                     "type": "insecureAcceptAnything"
@@ -24,7 +24,9 @@
                     "keyType": "GPGKeys",
                     "keyPath": "/keys/employee-gpg-keyring"
                 }
-            ],
+            ]
+        },
+        "docker": {
             "example.com/hardened": [
                 {
                     "type": "signedBy",

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -27,10 +27,13 @@ func (kt *knownTransports) Remove(k string) {
 	kt.mu.Unlock()
 }
 
-func (kt *knownTransports) Add(t types.ImageTransport) {
+func (kt *knownTransports) Add(t types.ImageTransport, alias string) {
 	kt.mu.Lock()
 	defer kt.mu.Unlock()
 	name := t.Name()
+	if alias != "" {
+		name = alias
+	}
 	if t := kt.transports[name]; t != nil {
 		panic(fmt.Sprintf("Duplicate image transport name %s", name))
 	}
@@ -57,7 +60,12 @@ func Delete(name string) {
 
 // Register registers a transport.
 func Register(t types.ImageTransport) {
-	kt.Add(t)
+	kt.Add(t, "")
+}
+
+// Register registers a transport with the specified alias.
+func RegisterAlias(t types.ImageTransport, alias string) {
+	kt.Add(t, alias)
 }
 
 // ImageName converts a types.ImageReference into an URL-like image name, which MUST be such that


### PR DESCRIPTION
Create a `registry` alias for the `docker` transport.
Parsing a `registry://` reference will hence return
the docker transport.

Support the alias in policy.json where `registry` scopes
are merged into `docker` scopes; both must not overlap.

Fixes: #1123
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@mtrmac @rhatdan PTAL

Once in, I will audit our tools (and the stack) for hard-coded "docker://" references. I recall some places doing that.