### PR TITLE
Release v5.21.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 20
+	VersionMinor = 21
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 21
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Mirrors defined in `registries.conf` can now be restricted for tag/digest references only, using the new `pull-from-mirror` option.

New option `copy.Options.SignIdentity`.

The library now formally requires Go 1.15 (which was, in practice, already the case).

- vendor: bump c/storage to main/d06b0f8
- storage: use race-free AddNames instead of SetNames
- build(deps): bump github.com/klauspost/compress from 1.14.4 to 1.15.0
- Update github.com/containerd/containerd
- build(deps): bump github.com/docker/distribution
- build(deps): bump github.com/sylabs/sif/v2 from 2.3.2 to 2.4.0
- build(deps): bump github.com/docker/docker
- build(deps): bump github.com/klauspost/compress from 1.15.0 to 1.15.1
- Silence go-staticcheck about openpgp use
- Try to make (make lint) pass with Go 1.18
- build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
- Use assert.ErrorContains
- build(deps): bump github.com/sylabs/sif/v2 from 2.4.0 to 2.4.1
- Update an obsolete comment
- Use Testing.T.Cleanup() to simplify tests
- Modify makeRequestToResolvedURL and makeRequestToResolvedURLOnce to accept an *url.URL
- Use url.Redacted() in log output
- Use testing.T.TempDir()
- Simplify blobifocache/internal/test.GenericCache
- build(deps): bump github.com/containers/ocicrypt from 1.1.2 to 1.1.3
- build(deps): bump github.com/docker/docker
- registries.conf: prefixes: subdomain matching
- registries.conf: fix typo in prefix
- toml decoding: report unknown keys
- build(deps): bump github.com/opencontainers/selinux
- Add option to specify the identity for signing
- Use only full named references for signing identity
- Add pull-from-mirror for adding per-mirror level restrictions
- build(deps): bump github.com/sylabs/sif/v2 from 2.4.1 to 2.4.2
