### PR TITLE
Use strings.NewReader instead of bytes.NewBufferString

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -653,7 +652,7 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	params.Add("refresh_token", c.auth.IdentityToken)
 	params.Add("client_id", "containers/image")
 
-	authReq.Body = io.NopCloser(bytes.NewBufferString(params.Encode()))
+	authReq.Body = io.NopCloser(strings.NewReader(params.Encode()))
 	authReq.Header.Add("User-Agent", c.userAgent)
 	authReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	logrus.Debugf("%s %s", authReq.Method, authReq.URL.Redacted())

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/containers/image/v5/manifest"
@@ -29,7 +30,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		writer := NewWriter(&tarfileBuffer)
 		dest := NewDestination(nil, writer, nil)
 		// No layers
-		configInfo, err := dest.PutBlob(ctx, bytes.NewBufferString(c.config),
+		configInfo, err := dest.PutBlob(ctx, strings.NewReader(c.config),
 			types.BlobInfo{Size: -1}, cache, true)
 		require.NoError(t, err, c.config)
 		manifest, err := manifest.Schema2FromComponents(

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -389,7 +389,7 @@ func TestWriteRead(t *testing.T) {
 			t.Fatalf("Error saving randomly-generated layer to destination: %v", err)
 		}
 		t.Logf("Wrote randomly-generated layer %q (%d/%d bytes) to destination", digest, size, decompressedSize)
-		if _, err := dest.PutBlob(context.Background(), bytes.NewBufferString(config), configInfo, cache, false); err != nil {
+		if _, err := dest.PutBlob(context.Background(), strings.NewReader(config), configInfo, cache, false); err != nil {
 			t.Fatalf("Error saving config to destination: %v", err)
 		}
 		manifest := strings.Replace(manifestFmt, "%lh", digest.String(), -1)
@@ -908,7 +908,7 @@ func TestSize(t *testing.T) {
 	if dest == nil {
 		t.Fatalf("NewImageDestination(%q) returned no destination", ref.StringWithinTransport())
 	}
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBufferString(config), configInfo, cache, false); err != nil {
+	if _, err := dest.PutBlob(context.Background(), strings.NewReader(config), configInfo, cache, false); err != nil {
 		t.Fatalf("Error saving config to destination: %v", err)
 	}
 	digest1, usize1, size1, blob := makeLayer(t, archive.Gzip)


### PR DESCRIPTION
Just a micro-optimization: avoid maintaining state for a read/write buffer, and the allocation inherent in a `string` → `[]byte` conversion.