### PR TITLE
Remove unused Makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@
 
 export GOPROXY=https://proxy.golang.org
 
-# Which github repository and branch to use for testing with skopeo
-SKOPEO_REPO = containers/skopeo
-SKOPEO_BRANCH ?= master
-# Set SUDO=sudo to run container integration tests using sudo.
-SUDO =
 
 GOBIN := $(shell go env GOBIN)
 ifeq ($(GOBIN),)


### PR DESCRIPTION
The Skopeo branch to test against is now driven by `SKOPEO_CI_TAG` in `.cirrus.yml`, these are not used by anything.