### PR TITLE
docker: add workaround for CloudFront

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -367,6 +368,30 @@ func handle206Response(streams chan io.ReadCloser, errs chan error, body io.Read
 	}
 }
 
+var multipartByteRangesRe = regexp.MustCompile("multipart/byteranges; boundary=([A-Za-z-0-9:]+)")
+
+func parseMediaType(contentType string) (string, map[string]string, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		if err == mime.ErrInvalidMediaParameter {
+			// CloudFront returns an invalid MIME type, that contains an unquoted ":" in the boundary
+			// param, let's handle it here.
+			matches := multipartByteRangesRe.FindStringSubmatch(contentType)
+			if len(matches) == 2 {
+				mediaType = "multipart/byteranges"
+				params = map[string]string{
+					"boundary": matches[1],
+				}
+				err = nil
+			}
+		}
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	return mediaType, params, err
+}
+
 // GetBlobAt returns a sequential channel of readers that contain data for the requested
 // blob chunks, and a channel that might get a single error value.
 // The specified chunks must be not overlapping and sorted by their offset.
@@ -402,7 +427,7 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 		go splitHTTP200ResponseToPartial(streams, errs, res.Body, chunks)
 		return streams, errs, nil
 	case http.StatusPartialContent:
-		mediaType, params, err := mime.ParseMediaType(res.Header.Get("Content-Type"))
+		mediaType, params, err := parseMediaType(res.Header.Get("Content-Type"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -183,3 +183,30 @@ func TestHandle206Response(t *testing.T) {
 	}
 	verifyGetBlobAtOutput(t, streams, errs, expected)
 }
+
+func TestParseMediaType(t *testing.T) {
+	mediaType, params, err := parseMediaType("multipart/byteranges; boundary=CloudFront:3F750DE0752BEDE3882F7DBE80010D31")
+	require.NoError(t, err)
+	assert.Equal(t, mediaType, "multipart/byteranges")
+	assert.Equal(t, params["boundary"], "CloudFront:3F750DE0752BEDE3882F7DBE80010D31")
+
+	mediaType, params, err = parseMediaType("multipart/byteranges; boundary=00000000000061573284")
+	require.NoError(t, err)
+	assert.Equal(t, mediaType, "multipart/byteranges")
+	assert.Equal(t, params["boundary"], "00000000000061573284")
+
+	mediaType, params, err = parseMediaType("multipart/byteranges; foo=bar; bar=baz")
+	require.NoError(t, err)
+	assert.Equal(t, mediaType, "multipart/byteranges")
+	assert.Equal(t, params["foo"], "bar")
+	assert.Equal(t, params["bar"], "baz")
+
+	// quoted symbols '@'
+	_, params, err = parseMediaType("multipart/byteranges; boundary=\"@:\"")
+	require.NoError(t, err)
+	assert.Equal(t, params["boundary"], "@:")
+
+	// unquoted '@'
+	_, _, err = parseMediaType("multipart/byteranges; boundary=@")
+	require.Error(t, err)
+}


### PR DESCRIPTION
CloudFront returns an unquoted ':' in the boundary, special handle it.

It is needed for partial pulls from quay.io.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
