### PR TITLE
Use go env to fetch the go path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GOPROXY=https://proxy.golang.org
 
 GOBIN := $(shell go env GOBIN)
 ifeq ($(GOBIN),)
-GOBIN := $(GOPATH)/bin
+GOBIN := $(shell go env GOPATH)/bin
 endif
 
 # when cross compiling _for_ a Darwin or windows host, then we must use openpgp


### PR DESCRIPTION
If both GOBIN and GOPATH aren't set in the system environment then the
makefile will attempt to install to /bin. go env uses a sensible default
of $HOME/go if GOPATH isn't set.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>