### PR TITLE
Stop calling gpgme-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,10 @@ MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 export PATH := $(PATH):${GOBIN}
 
-# On macOS, (brew install gpgme) installs it within /usr/local, but /usr/local/include is not in the default search path.
-# Rather than hard-code this directory, use gpgme-config. Sadly that must be done at the top-level user
-# instead of locally in the gpgme subpackage, because cgo supports only pkg-config, not general shell scripts,
-# and gpgme does not install a pkg-config file.
-# If gpgme is not installed or gpgme-config can’t be found for other reasons, the error is silently ignored
-# (and the user will probably find out because the cgo compilation will fail).
-GPGME_ENV = CGO_CFLAGS="$(shell gpgme-config --cflags 2>/dev/null)" CGO_LDFLAGS="$(shell gpgme-config --libs 2>/dev/null)"
-
 all: tools test validate .gitvalidation
 
 build:
-	$(GPGME_ENV) GO111MODULE="on" go build $(BUILDFLAGS) ./...
+	GO111MODULE="on" go build $(BUILDFLAGS) ./...
 
 $(MANPAGES): %: %.md
 	$(GOMD2MAN) -in $< -out $@
@@ -76,7 +68,7 @@ clean:
 	rm -rf $(MANPAGES)
 
 test:
-	@$(GPGME_ENV) GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
+	@GO111MODULE="on" go test $(BUILDFLAGS) -cover ./...
 
 fmt:
 	@gofmt -l -s -w $(SOURCE_DIRS)


### PR DESCRIPTION
As of the just-updated `github.com/proglottis/gpgme` 0.1.2, the `gpgme` subpackage uses CGo’s native `#cgo pkg-config` support to find the relevant libraries, and we no longer need to manually set `CGO_CFLAGS` and `CGO_LDFLAGS`. So stop doing that.

Note that the `proglottis/gpgme` update (already before this commit) means the minimal supported version of GPGME is 1.13.0.