### PR TITLE
Update to benefit from Go 1.17

### DIFF
--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -3,7 +3,6 @@ package copy
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/containers/image/v5/directory"
@@ -36,8 +35,7 @@ func TestCreateSignature(t *testing.T) {
 		t.Skipf("Signing not supported: %v", err)
 	}
 
-	os.Setenv("GNUPGHOME", testGPGHomeDirectory)
-	defer os.Unsetenv("GNUPGHOME")
+	t.Setenv("GNUPGHOME", testGPGHomeDirectory)
 
 	// Signing a directory: reference, which does not have a DockerReference(), fails.
 	tempDir := t.TempDir()

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -163,9 +163,8 @@ func newBearerTokenFromJSONBlob(blob []byte) (*bearerToken, error) {
 func serverDefault() *tls.Config {
 	return &tls.Config{
 		// Avoid fallback to SSL protocols < TLS1.0
-		MinVersion:               tls.VersionTLS10,
-		PreferServerCipherSuites: true,
-		CipherSuites:             tlsconfig.DefaultServerAcceptedCiphers,
+		MinVersion:   tls.VersionTLS10,
+		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,9 @@
 module github.com/containers/image/v5
 
-go 1.16
+go 1.17
 
 require (
-	github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 // indirect
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.1.0
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/storage v1.41.0
@@ -15,41 +11,89 @@ require (
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/imdario/mergo v0.3.13
 	github.com/klauspost/compress v1.15.6
 	github.com/klauspost/pgzip v1.2.5
 	github.com/manifoldco/promptui v0.9.0
-	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84
-	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/opencontainers/selinux v1.10.1
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f
 	github.com/pkg/errors v0.9.1
 	github.com/proglottis/gpgme v0.1.2
-	github.com/prometheus/common v0.30.0 // indirect
-	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.2
 	github.com/sylabs/sif/v2 v2.7.1
 	github.com/ulikunitz/xz v0.5.10
 	github.com/vbatts/tar-split v0.11.2
 	github.com/vbauerster/mpb/v7 v7.4.2
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/bbolt v1.3.6
-	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+)
+
+require (
+	github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/Microsoft/hcsshim v0.9.2 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.11.4 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-intervals v0.0.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/mux v1.7.4 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
+	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
+	github.com/moby/sys/mountinfo v0.6.1 // indirect
+	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/opencontainers/runc v1.1.2 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.30.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
+	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/genproto v0.0.0-20220304144024-325a89244dc8 // indirect
+	google.golang.org/grpc v1.44.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/openshift/openshift-copies_test.go
+++ b/openshift/openshift-copies_test.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,20 +12,10 @@ const fixtureKubeConfigPath = "testdata/admin.kubeconfig"
 // These are only smoke tests based on the skopeo integration test cluster. Error handling, non-trivial configuration merging,
 // and any other situations are not currently covered.
 
-// Set up KUBECONFIG to point at the fixture, and return a handler to clean it up.
+// Set up KUBECONFIG to point at the fixture.
 // Callers MUST NOT call testing.T.Parallel().
 func setupKubeConfigForSerialTest(t *testing.T) {
-	// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
-	// run in parallel unless they opt in by calling t.Parallel().  So don’t do that.
-	oldKC, hasKC := os.LookupEnv("KUBECONFIG")
-	t.Cleanup(func() {
-		if hasKC {
-			os.Setenv("KUBECONFIG", oldKC)
-		} else {
-			os.Unsetenv("KUBECONFIG")
-		}
-	})
-	os.Setenv("KUBECONFIG", fixtureKubeConfigPath)
+	t.Setenv("KUBECONFIG", fixtureKubeConfigPath)
 }
 
 func TestClientConfigLoadingRules(t *testing.T) {

--- a/signature/mechanism_test.go
+++ b/signature/mechanism_test.go
@@ -97,9 +97,7 @@ func TestNewGPGSigningMechanismInDirectory(t *testing.T) {
 	}
 
 	// If we use the default directory mechanism, GNUPGHOME is respected.
-	origGNUPGHOME := os.Getenv("GNUPGHOME")
-	defer os.Setenv("GNUPGHOME", origGNUPGHOME)
-	os.Setenv("GNUPGHOME", testGPGHomeDirectory)
+	t.Setenv("GNUPGHOME", testGPGHomeDirectory)
 	mech, err = newGPGSigningMechanismInDirectory("")
 	require.NoError(t, err)
 	defer mech.Close()


### PR DESCRIPTION
Per https://github.com/containers/image/pull/1570#issuecomment-1149876963 , Go 1.17 will be required; so, update c/image to benefit from it.