### PR TITLE
Use a SourcedImage struct in c/image/copy

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -82,7 +82,7 @@ type copier struct {
 type imageCopier struct {
 	c                          *copier
 	manifestUpdates            *types.ManifestUpdateOptions
-	src                        types.Image
+	src                        *image.SourcedImage
 	diffIDsAreNeeded           bool
 	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
 	canSubstituteBlobs         bool
@@ -702,7 +702,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 
 	destRequiresOciEncryption := (isEncrypted(src) && ic.c.ociDecryptConfig != nil) || options.OciEncryptLayers != nil
 
-	manifestConversionPlan, err := ic.determineManifestConversion(ctx, c.dest.SupportedManifestMIMETypes(), options.ForceManifestMIMEType, destRequiresOciEncryption)
+	manifestConversionPlan, err := ic.determineManifestConversion(c.dest.SupportedManifestMIMETypes(), options.ForceManifestMIMEType, destRequiresOciEncryption)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -1027,7 +1027,7 @@ func layerDigestsDiffer(a, b []types.BlobInfo) bool {
 // stores the resulting config and manifest to the destination, and returns the stored manifest
 // and its digest.
 func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, digest.Digest, error) {
-	pendingImage := ic.src
+	var pendingImage types.Image = ic.src
 	if !ic.noPendingManifestUpdates() {
 		if ic.cannotModifyManifestReason != "" {
 			return nil, "", errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -706,6 +706,13 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	if err != nil {
 		return nil, "", "", err
 	}
+	// We set up this part of ic.manifestUpdates quite early, not just around the
+	// code that calls copyUpdatedConfigAndManifest, so that other parts of the copy code
+	// (e.g. the UpdatedImageNeedsLayerDiffIDs check just below) can make decisions based
+	// on the expected destination format.
+	if manifestConversionPlan.preferredMIMETypeNeedsConversion {
+		ic.manifestUpdates.ManifestMIMEType = manifestConversionPlan.preferredMIMEType
+	}
 
 	// If src.UpdatedImageNeedsLayerDiffIDs(ic.manifestUpdates) will be true, it needs to be true by the time we get here.
 	ic.diffIDsAreNeeded = src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -693,7 +693,13 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 
 	destRequiresOciEncryption := (isEncrypted(src) && ic.c.ociDecryptConfig != nil) || options.OciEncryptLayers != nil
 
-	manifestConversionPlan, err := ic.determineManifestConversion(c.dest.SupportedManifestMIMETypes(), options.ForceManifestMIMEType, destRequiresOciEncryption)
+	manifestConversionPlan, err := determineManifestConversion(determineManifestConversionInputs{
+		srcMIMEType:                    ic.src.ManifestMIMEType,
+		destSupportedManifestMIMETypes: ic.c.dest.SupportedManifestMIMETypes(),
+		forceManifestMIMEType:          options.ForceManifestMIMEType,
+		requiresOCIEncryption:          destRequiresOciEncryption,
+		cannotModifyManifestReason:     ic.cannotModifyManifestReason,
+	})
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -59,17 +59,6 @@ type manifestConversionPlan struct {
 	otherMIMETypeCandidates          []string // Other possible alternatives, in order
 }
 
-// determineManifestConversion returns a plan for what formats, and possibly conversions, to use for the manifest in ic.
-func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (manifestConversionPlan, error) {
-	return determineManifestConversion(determineManifestConversionInputs{
-		srcMIMEType:                    ic.src.ManifestMIMEType,
-		destSupportedManifestMIMETypes: destSupportedManifestMIMETypes,
-		forceManifestMIMEType:          forceManifestMIMEType,
-		requiresOCIEncryption:          requiresOciEncryption,
-		cannotModifyManifestReason:     ic.cannotModifyManifestReason,
-	})
-}
-
 // determineManifestConversion returns a plan for what formats, and possibly conversions, to use based on in.
 func determineManifestConversion(in determineManifestConversionInputs) (manifestConversionPlan, error) {
 	srcType := in.srcMIMEType

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -38,14 +38,22 @@ func (os *orderedSet) append(s string) {
 	}
 }
 
+// manifestConversionPlan contains the decisions made by determineManifestConversion.
+type manifestConversionPlan struct {
+	// The preferred manifest MIME type (whether we are converting to it or using it unmodified).
+	// We compute this only to show it in error messages; without having to add this context
+	// in an error message, we would be happy enough to know only that no conversion is needed.
+	preferredMIMEType       string
+	otherMIMETypeCandidates []string // Other possible alternatives, in order
+}
+
 // determineManifestConversion updates ic.manifestUpdates to convert manifest to a supported MIME type, if necessary and ic.canModifyManifest.
 // Note that the conversion will only happen later, through ic.src.UpdatedImage
-// Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
-// and a list of other possible alternatives, in order.
-func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (string, []string, error) {
+// Returns a plan for what formats, and possibly conversions, to use for the manifest in ic.
+func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (manifestConversionPlan, error) {
 	_, srcType, err := ic.src.Manifest(ctx)
 	if err != nil { // This should have been cached?!
-		return "", nil, errors.Wrap(err, "reading manifest")
+		return manifestConversionPlan{}, errors.Wrap(err, "reading manifest")
 	}
 	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
 	if srcType != normalizedSrcType {
@@ -58,7 +66,10 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 	}
 
 	if len(destSupportedManifestMIMETypes) == 0 && (!requiresOciEncryption || manifest.MIMETypeSupportsEncryption(srcType)) {
-		return srcType, []string{}, nil // Anything goes; just use the original as is, do not try any conversions.
+		return manifestConversionPlan{ // Anything goes; just use the original as is, do not try any conversions.
+			preferredMIMEType:       srcType,
+			otherMIMETypeCandidates: []string{},
+		}, nil
 	}
 	supportedByDest := map[string]struct{}{}
 	for _, t := range destSupportedManifestMIMETypes {
@@ -85,7 +96,10 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 		// messages.  But it is nice to hide the “if we can't modify, do no conversion”
 		// special case in here; the caller can then worry (or not) only about a good UI.
 		logrus.Debugf("We can't modify the manifest, hoping for the best...")
-		return srcType, []string{}, nil // Take our chances - FIXME? Or should we fail without trying?
+		return manifestConversionPlan{ // Take our chances - FIXME? Or should we fail without trying?
+			preferredMIMEType:       srcType,
+			otherMIMETypeCandidates: []string{},
+		}, nil
 	}
 
 	// Then use our list of preferred types.
@@ -102,15 +116,18 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 
 	logrus.Debugf("Manifest has MIME type %s, ordered candidate list [%s]", srcType, strings.Join(prioritizedTypes.list, ", "))
 	if len(prioritizedTypes.list) == 0 { // Coverage: destSupportedManifestMIMETypes is not empty (or we would have exited in the “Anything goes” case above), so this should never happen.
-		return "", nil, errors.New("Internal error: no candidate MIME types")
+		return manifestConversionPlan{}, errors.New("Internal error: no candidate MIME types")
 	}
-	preferredType := prioritizedTypes.list[0]
-	if preferredType != srcType {
-		ic.manifestUpdates.ManifestMIMEType = preferredType
+	res := manifestConversionPlan{
+		preferredMIMEType:       prioritizedTypes.list[0],
+		otherMIMETypeCandidates: prioritizedTypes.list[1:],
+	}
+	if res.preferredMIMEType != srcType {
+		ic.manifestUpdates.ManifestMIMEType = res.preferredMIMEType
 	} else {
 		logrus.Debugf("... will first try using the original manifest unmodified")
 	}
-	return preferredType, prioritizedTypes.list[1:], nil
+	return res, nil
 }
 
 // isMultiImage returns true if img is a list of images

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -60,13 +60,9 @@ type manifestConversionPlan struct {
 }
 
 // determineManifestConversion returns a plan for what formats, and possibly conversions, to use for the manifest in ic.
-func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (manifestConversionPlan, error) {
-	_, srcType, err := ic.src.Manifest(ctx)
-	if err != nil { // This should have been cached?!
-		return manifestConversionPlan{}, errors.Wrap(err, "reading manifest")
-	}
+func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMETypes []string, forceManifestMIMEType string, requiresOciEncryption bool) (manifestConversionPlan, error) {
 	return determineManifestConversion(determineManifestConversionInputs{
-		srcMIMEType:                    srcType,
+		srcMIMEType:                    ic.src.ManifestMIMEType,
 		destSupportedManifestMIMETypes: destSupportedManifestMIMETypes,
 		forceManifestMIMEType:          forceManifestMIMEType,
 		requiresOCIEncryption:          requiresOciEncryption,

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -38,6 +38,17 @@ func (os *orderedSet) append(s string) {
 	}
 }
 
+// determineManifestConversionInputs contains the inputs for determineManifestConversion.
+type determineManifestConversionInputs struct {
+	srcMIMEType string // MIME type of the input manifest
+
+	destSupportedManifestMIMETypes []string // MIME types supported by the destination, per types.ImageDestination.SupportedManifestMIMETypes()
+
+	forceManifestMIMEType      string // User’s choice of forced manifest MIME type
+	requiresOCIEncryption      bool   // Restrict to manifest formats that can support OCI encryption
+	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
+}
+
 // manifestConversionPlan contains the decisions made by determineManifestConversion.
 type manifestConversionPlan struct {
 	// The preferred manifest MIME type (whether we are converting to it or using it unmodified).
@@ -54,17 +65,30 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 	if err != nil { // This should have been cached?!
 		return manifestConversionPlan{}, errors.Wrap(err, "reading manifest")
 	}
+	return determineManifestConversion(determineManifestConversionInputs{
+		srcMIMEType:                    srcType,
+		destSupportedManifestMIMETypes: destSupportedManifestMIMETypes,
+		forceManifestMIMEType:          forceManifestMIMEType,
+		requiresOCIEncryption:          requiresOciEncryption,
+		cannotModifyManifestReason:     ic.cannotModifyManifestReason,
+	})
+}
+
+// determineManifestConversion returns a plan for what formats, and possibly conversions, to use based on in.
+func determineManifestConversion(in determineManifestConversionInputs) (manifestConversionPlan, error) {
+	srcType := in.srcMIMEType
 	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
 	if srcType != normalizedSrcType {
 		logrus.Debugf("Source manifest MIME type %s, treating it as %s", srcType, normalizedSrcType)
 		srcType = normalizedSrcType
 	}
 
-	if forceManifestMIMEType != "" {
-		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}
+	destSupportedManifestMIMETypes := in.destSupportedManifestMIMETypes
+	if in.forceManifestMIMEType != "" {
+		destSupportedManifestMIMETypes = []string{in.forceManifestMIMEType}
 	}
 
-	if len(destSupportedManifestMIMETypes) == 0 && (!requiresOciEncryption || manifest.MIMETypeSupportsEncryption(srcType)) {
+	if len(destSupportedManifestMIMETypes) == 0 && (!in.requiresOCIEncryption || manifest.MIMETypeSupportsEncryption(srcType)) {
 		return manifestConversionPlan{ // Anything goes; just use the original as is, do not try any conversions.
 			preferredMIMEType:       srcType,
 			otherMIMETypeCandidates: []string{},
@@ -72,7 +96,7 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 	}
 	supportedByDest := map[string]struct{}{}
 	for _, t := range destSupportedManifestMIMETypes {
-		if !requiresOciEncryption || manifest.MIMETypeSupportsEncryption(t) {
+		if !in.requiresOCIEncryption || manifest.MIMETypeSupportsEncryption(t) {
 			supportedByDest[t] = struct{}{}
 		}
 	}
@@ -89,7 +113,7 @@ func (ic *imageCopier) determineManifestConversion(ctx context.Context, destSupp
 	if _, ok := supportedByDest[srcType]; ok {
 		prioritizedTypes.append(srcType)
 	}
-	if ic.cannotModifyManifestReason != "" {
+	if in.cannotModifyManifestReason != "" {
 		// We could also drop this check and have the caller
 		// make the choice; it is already doing that to an extent, to improve error
 		// messages.  But it is nice to hide the “if we can't modify, do no conversion”

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -144,13 +144,12 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		ic := &imageCopier{
-			manifestUpdates:            &types.ManifestUpdateOptions{},
 			src:                        src,
 			cannotModifyManifestReason: "",
 		}
 		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
 		require.NoError(t, err, c.description)
-		assert.Equal(t, c.expectedUpdate, ic.manifestUpdates.ManifestMIMEType, c.description)
+		assert.Equal(t, c.expectedUpdate != "", res.preferredMIMETypeNeedsConversion, c.description)
 		if c.expectedUpdate == "" {
 			assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), res.preferredMIMEType, c.description)
 		} else {
@@ -163,13 +162,12 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		ic := &imageCopier{
-			manifestUpdates:            &types.ManifestUpdateOptions{},
 			src:                        src,
 			cannotModifyManifestReason: "Preserving digests",
 		}
 		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
 		require.NoError(t, err, c.description)
-		assert.Equal(t, "", ic.manifestUpdates.ManifestMIMEType, c.description)
+		assert.False(t, res.preferredMIMETypeNeedsConversion, c.description)
 		assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), res.preferredMIMEType, c.description)
 		assert.Equal(t, []string{}, res.otherMIMETypeCandidates, c.description)
 	}
@@ -178,20 +176,18 @@ func TestDetermineManifestConversion(t *testing.T) {
 	for _, c := range cases {
 		src := fakeImageSource(c.sourceType)
 		ic := &imageCopier{
-			manifestUpdates:            &types.ManifestUpdateOptions{},
 			src:                        src,
 			cannotModifyManifestReason: "",
 		}
 		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, v1.MediaTypeImageManifest, false)
 		require.NoError(t, err, c.description)
-		assert.Equal(t, v1.MediaTypeImageManifest, ic.manifestUpdates.ManifestMIMEType, c.description)
+		assert.True(t, res.preferredMIMETypeNeedsConversion, c.description)
 		assert.Equal(t, v1.MediaTypeImageManifest, res.preferredMIMEType, c.description)
 		assert.Equal(t, []string{}, res.otherMIMETypeCandidates, c.description)
 	}
 
 	// Error reading the manifest — smoke test only.
 	ic := imageCopier{
-		manifestUpdates:            &types.ManifestUpdateOptions{},
 		src:                        fakeImageSource(""),
 		cannotModifyManifestReason: "",
 	}

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/testing/mocks"
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/image/v5/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,56 +25,6 @@ func TestOrderedSet(t *testing.T) {
 		}
 		assert.Equal(t, c.expected, os.list, fmt.Sprintf("%#v", c.input))
 	}
-}
-
-// fakeImageSource is an implementation of types.Image which only returns itself as a MIME type in Manifest
-// except that "" means “reading the manifest should fail”
-type fakeImageSource string
-
-func (f fakeImageSource) Reference() types.ImageReference {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) Manifest(ctx context.Context) ([]byte, string, error) {
-	if string(f) == "" {
-		return nil, "", errors.New("Manifest() directed to fail")
-	}
-	return nil, string(f), nil
-}
-func (f fakeImageSource) Signatures(context.Context) ([][]byte, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) ConfigInfo() types.BlobInfo {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) ConfigBlob(context.Context) ([]byte, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) OCIConfig(context.Context) (*v1.Image, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) LayerInfos() []types.BlobInfo {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) EmbeddedDockerReferenceConflicts(ref reference.Named) bool {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) Inspect(context.Context) (*types.ImageInspectInfo, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) SupportsEncryption(ctx context.Context) bool {
-	panic("Unexpected call to a mock function")
-}
-func (f fakeImageSource) Size() (int64, error) {
-	panic("Unexpected call to a mock function")
 }
 
 func TestDetermineManifestConversion(t *testing.T) {
@@ -267,14 +215,6 @@ func TestDetermineManifestConversion(t *testing.T) {
 			otherMIMETypeCandidates:          []string{},
 		}, res, c.description)
 	}
-
-	// Error reading the manifest — smoke test only.
-	ic := imageCopier{
-		src:                        fakeImageSource(""),
-		cannotModifyManifestReason: "",
-	}
-	_, err := ic.determineManifestConversion(context.Background(), supportS1S2, "", false)
-	assert.Error(t, err)
 }
 
 // fakeUnparsedImage is an implementation of types.UnparsedImage which only returns itself as a MIME type in Manifest,

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -148,15 +148,15 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:                        src,
 			cannotModifyManifestReason: "",
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
+		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, c.expectedUpdate, ic.manifestUpdates.ManifestMIMEType, c.description)
 		if c.expectedUpdate == "" {
-			assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), preferredMIMEType, c.description)
+			assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), res.preferredMIMEType, c.description)
 		} else {
-			assert.Equal(t, c.expectedUpdate, preferredMIMEType, c.description)
+			assert.Equal(t, c.expectedUpdate, res.preferredMIMEType, c.description)
 		}
-		assert.Equal(t, c.expectedOtherCandidates, otherCandidates, c.description)
+		assert.Equal(t, c.expectedOtherCandidates, res.otherMIMETypeCandidates, c.description)
 	}
 
 	// Whatever the input is, with !canModifyManifest we return "keep the original as is"
@@ -167,11 +167,11 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:                        src,
 			cannotModifyManifestReason: "Preserving digests",
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
+		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, "", ic.manifestUpdates.ManifestMIMEType, c.description)
-		assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), preferredMIMEType, c.description)
-		assert.Equal(t, []string{}, otherCandidates, c.description)
+		assert.Equal(t, manifest.NormalizedMIMEType(c.sourceType), res.preferredMIMEType, c.description)
+		assert.Equal(t, []string{}, res.otherMIMETypeCandidates, c.description)
 	}
 
 	// With forceManifestMIMEType, the output is always the forced manifest type (in this case oci manifest)
@@ -182,11 +182,11 @@ func TestDetermineManifestConversion(t *testing.T) {
 			src:                        src,
 			cannotModifyManifestReason: "",
 		}
-		preferredMIMEType, otherCandidates, err := ic.determineManifestConversion(context.Background(), c.destTypes, v1.MediaTypeImageManifest, false)
+		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, v1.MediaTypeImageManifest, false)
 		require.NoError(t, err, c.description)
 		assert.Equal(t, v1.MediaTypeImageManifest, ic.manifestUpdates.ManifestMIMEType, c.description)
-		assert.Equal(t, v1.MediaTypeImageManifest, preferredMIMEType, c.description)
-		assert.Equal(t, []string{}, otherCandidates, c.description)
+		assert.Equal(t, v1.MediaTypeImageManifest, res.preferredMIMEType, c.description)
+		assert.Equal(t, []string{}, res.otherMIMETypeCandidates, c.description)
 	}
 
 	// Error reading the manifest — smoke test only.
@@ -195,7 +195,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 		src:                        fakeImageSource(""),
 		cannotModifyManifestReason: "",
 	}
-	_, _, err := ic.determineManifestConversion(context.Background(), supportS1S2, "", false)
+	_, err := ic.determineManifestConversion(context.Background(), supportS1S2, "", false)
 	assert.Error(t, err)
 }
 

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -223,24 +223,26 @@ func TestDetermineManifestConversion(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		src := fakeImageSource(c.sourceType)
-		ic := &imageCopier{
-			src:                        src,
-			cannotModifyManifestReason: "",
-		}
-		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
+		res, err := determineManifestConversion(determineManifestConversionInputs{
+			srcMIMEType:                    c.sourceType,
+			destSupportedManifestMIMETypes: c.destTypes,
+			forceManifestMIMEType:          "",
+			requiresOCIEncryption:          false,
+			cannotModifyManifestReason:     "",
+		})
 		require.NoError(t, err, c.description)
 		assert.Equal(t, c.expected, res, c.description)
 	}
 
-	// Whatever the input is, with !canModifyManifest we return "keep the original as is"
+	// Whatever the input is, with cannotModifyManifestReason we return "keep the original as is"
 	for _, c := range cases {
-		src := fakeImageSource(c.sourceType)
-		ic := &imageCopier{
-			src:                        src,
-			cannotModifyManifestReason: "Preserving digests",
-		}
-		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, "", false)
+		res, err := determineManifestConversion(determineManifestConversionInputs{
+			srcMIMEType:                    c.sourceType,
+			destSupportedManifestMIMETypes: c.destTypes,
+			forceManifestMIMEType:          "",
+			requiresOCIEncryption:          false,
+			cannotModifyManifestReason:     "Preserving digests",
+		})
 		require.NoError(t, err, c.description)
 		assert.Equal(t, manifestConversionPlan{
 			preferredMIMEType:                manifest.NormalizedMIMEType(c.sourceType),
@@ -251,12 +253,13 @@ func TestDetermineManifestConversion(t *testing.T) {
 
 	// With forceManifestMIMEType, the output is always the forced manifest type (in this case oci manifest)
 	for _, c := range cases {
-		src := fakeImageSource(c.sourceType)
-		ic := &imageCopier{
-			src:                        src,
-			cannotModifyManifestReason: "",
-		}
-		res, err := ic.determineManifestConversion(context.Background(), c.destTypes, v1.MediaTypeImageManifest, false)
+		res, err := determineManifestConversion(determineManifestConversionInputs{
+			srcMIMEType:                    c.sourceType,
+			destSupportedManifestMIMETypes: c.destTypes,
+			forceManifestMIMEType:          v1.MediaTypeImageManifest,
+			requiresOCIEncryption:          false,
+			cannotModifyManifestReason:     "",
+		})
 		require.NoError(t, err, c.description)
 		assert.Equal(t, manifestConversionPlan{
 			preferredMIMEType:                v1.MediaTypeImageManifest,

--- a/internal/image/sourced.go
+++ b/internal/image/sourced.go
@@ -80,8 +80,8 @@ func (ic *imageCloser) Close() error {
 // Internal users may depend on methods available in SourcedImage but not (yet?) in types.Image.
 type SourcedImage struct {
 	*UnparsedImage
-	manifestBlob     []byte
-	manifestMIMEType string
+	ManifestBlob     []byte // The manifest of the relevant instance
+	ManifestMIMEType string // MIME type of ManifestBlob
 	// genericManifest contains data corresponding to manifestBlob.
 	// NOTE: The manifest may have been modified in the process; DO NOT reserialize and store genericManifest
 	// if you want to preserve the original manifest; use manifestBlob directly.
@@ -113,8 +113,8 @@ func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *
 
 	return &SourcedImage{
 		UnparsedImage:    unparsed,
-		manifestBlob:     manifestBlob,
-		manifestMIMEType: manifestMIMEType,
+		ManifestBlob:     manifestBlob,
+		ManifestMIMEType: manifestMIMEType,
 		genericManifest:  parsedManifest,
 	}, nil
 }
@@ -126,7 +126,7 @@ func (i *SourcedImage) Size() (int64, error) {
 
 // Manifest overrides the UnparsedImage.Manifest to always use the fields which we have already fetched.
 func (i *SourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
-	return i.manifestBlob, i.manifestMIMEType, nil
+	return i.ManifestBlob, i.ManifestMIMEType, nil
 }
 
 func (i *SourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {

--- a/internal/image/sourced.go
+++ b/internal/image/sourced.go
@@ -70,12 +70,15 @@ func (ic *imageCloser) Close() error {
 	return ic.src.Close()
 }
 
-// sourcedImage is a general set of utilities for working with container images,
-// whatever is their underlying location (i.e. dockerImageSource-independent).
-// Note the existence of skopeo/docker.Image: some instances of a `types.Image`
-// may not be a `sourcedImage` directly. However, most users of `types.Image`
-// do not care, and those who care about `skopeo/docker.Image` know they do.
-type sourcedImage struct {
+// SourcedImage is a general set of utilities for working with container images,
+// whatever is their underlying transport (i.e. ImageSource-independent).
+// Note the existence of docker.Image and image.memoryImage: various instances
+// of a types.Image may not be a SourcedImage directly.
+//
+// Most external users of `types.Image` do not care, and those who care about `docker.Image` know they do.
+//
+// Internal users may depend on methods available in SourcedImage but not (yet?) in types.Image.
+type SourcedImage struct {
 	*UnparsedImage
 	manifestBlob     []byte
 	manifestMIMEType string
@@ -92,7 +95,7 @@ type sourcedImage struct {
 // The Image must not be used after the underlying ImageSource is Close()d.
 //
 // This is publicly visible as c/image/image.FromUnparsedImage.
-func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *UnparsedImage) (types.Image, error) {
+func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *UnparsedImage) (*SourcedImage, error) {
 	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
 	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
 	// this is the only UnparsedImage implementation around, anyway.
@@ -108,7 +111,7 @@ func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *
 		return nil, err
 	}
 
-	return &sourcedImage{
+	return &SourcedImage{
 		UnparsedImage:    unparsed,
 		manifestBlob:     manifestBlob,
 		manifestMIMEType: manifestMIMEType,
@@ -117,15 +120,15 @@ func FromUnparsedImage(ctx context.Context, sys *types.SystemContext, unparsed *
 }
 
 // Size returns the size of the image as stored, if it's known, or -1 if it isn't.
-func (i *sourcedImage) Size() (int64, error) {
+func (i *SourcedImage) Size() (int64, error) {
 	return -1, nil
 }
 
 // Manifest overrides the UnparsedImage.Manifest to always use the fields which we have already fetched.
-func (i *sourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
+func (i *SourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }
 
-func (i *sourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+func (i *SourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
 	return i.UnparsedImage.src.LayerInfosForCopy(ctx, i.UnparsedImage.instanceDigest)
 }


### PR DESCRIPTION
Another part of #1574 (but note that this approach is rather different from an earlier version):

Use an `internal/image.SourcedImage` directly instead of a `types.Image` interface for most of c/image/copy. The implementation/tests of `copy.determineManifestConversion` currently mock the `types.Image` interface; instead, turn `determineManifestConversion` into a ~pure function, with all inputs and outputs as fields in a struct.

Also add the first benefit of using the non-public `SourcedImage`: access the manifest and manifest’s MIME type directly without having to worry about (impossible) failures.

Should not change behavior overall. See individual commit messages for details.