### PR TITLE
Fix error on parallel multiple image pullings with additionallayerstore

### DIFF
--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -941,7 +941,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 	s.lock.Unlock()
 	if ok {
 		layer, err := al.PutAs(id, lastLayer, nil)
-		if err != nil {
+		if err != nil && errors.Cause(err) != storage.ErrDuplicateID {
 			return errors.Wrapf(err, "failed to put layer from digest and labels")
 		}
 		lastLayer = layer.ID


### PR DESCRIPTION
Fixes https://github.com/containers/storage/issues/1263

Multiple parallel pullings of an image with additionallayerstore can occur the
following error:

```
Error: copying system image from manifest list: trying to reuse blob sha256:93ef9da9c5f3db2ac7fd52cab0e63c7e6fc9a722aec43d1b936a130e979ab8e8 at destination: failed to put layer from digest and labels: that ID is already in use
```

This commit fixes this issue by ignoring `ErrDuplicateID`. When the same layer
ID already exists in the storage, we can just reuse it instead of returning the
error. This is the same behaviour as when c/image uses `PutLayer`.
