### PR TITLE
Use strings.ReplaceAll instead of strings.Replace(..., -1)

### DIFF
--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -39,7 +39,7 @@ func TestDockerImageSourceReference(t *testing.T) {
 	require.NoError(t, err)
 	registry := registryURL.Host
 
-	mirrorConfiguration := strings.Replace(
+	mirrorConfiguration := strings.ReplaceAll(
 		`[[registry]]
 prefix = "primary-override.example.com"
 location = "@REGISTRY@/primary-override"
@@ -49,7 +49,7 @@ location = "with-mirror.example.com"
 
 [[registry.mirror]]
 location = "@REGISTRY@/with-mirror"
-`, "@REGISTRY@", registry, -1)
+`, "@REGISTRY@", registry)
 	registriesConf, err := os.CreateTemp("", "docker-image-src")
 	require.NoError(t, err)
 	defer registriesConf.Close()

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -28,7 +28,7 @@ func TestTransportName(t *testing.T) {
 
 // A helper to replace $TMP in a repo path with a real temporary directory
 func withTmpDir(repo string, tmpDir string) string {
-	return strings.Replace(repo, "$TMP", tmpDir, -1)
+	return strings.ReplaceAll(repo, "$TMP", tmpDir)
 }
 
 // A common list of repo suffixes to test for the various ImageReference methods.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -392,13 +392,13 @@ func TestWriteRead(t *testing.T) {
 		if _, err := dest.PutBlob(context.Background(), strings.NewReader(config), configInfo, cache, false); err != nil {
 			t.Fatalf("Error saving config to destination: %v", err)
 		}
-		manifest := strings.Replace(manifestFmt, "%lh", digest.String(), -1)
-		manifest = strings.Replace(manifest, "%ch", configInfo.Digest.String(), -1)
-		manifest = strings.Replace(manifest, "%ls", fmt.Sprintf("%d", size), -1)
-		manifest = strings.Replace(manifest, "%cs", fmt.Sprintf("%d", configInfo.Size), -1)
+		manifest := strings.ReplaceAll(manifestFmt, "%lh", digest.String())
+		manifest = strings.ReplaceAll(manifest, "%ch", configInfo.Digest.String())
+		manifest = strings.ReplaceAll(manifest, "%ls", fmt.Sprintf("%d", size))
+		manifest = strings.ReplaceAll(manifest, "%cs", fmt.Sprintf("%d", configInfo.Size))
 		li := digest.Hex()
-		manifest = strings.Replace(manifest, "%li", li, -1)
-		manifest = strings.Replace(manifest, "%ci", sum.Hex(), -1)
+		manifest = strings.ReplaceAll(manifest, "%li", li)
+		manifest = strings.ReplaceAll(manifest, "%ci", sum.Hex())
 		t.Logf("this manifest is %q", manifest)
 		if err := dest.PutManifest(context.Background(), []byte(manifest), nil); err != nil {
 			t.Fatalf("Error saving manifest to destination: %v", err)


### PR DESCRIPTION
... for a trivial improvement in readability.

Should not change behavior.