### PR TITLE
Remove users of pkg/errors.WithStack, pkg/errors.Cause

### DIFF
--- a/copy/blob.go
+++ b/copy/blob.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/internal/private"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,7 +35,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	// read stream to the end, and validation does not happen.
 	digestingReader, err := newDigestingReader(stream.reader, srcInfo.Digest)
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrapf(err, "preparing to verify blob %s", srcInfo.Digest)
+		return types.BlobInfo{}, perrors.Wrapf(err, "preparing to verify blob %s", srcInfo.Digest)
 	}
 	stream.reader = digestingReader
 
@@ -76,7 +76,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	if decryptionStep.decrypting && toEncrypt {
 		// If nothing else, we can only set uploadedInfo.CryptoOperation to a single value.
 		// Before relaxing this, see the original pull request’s review if there are other reasons to reject this.
-		return types.BlobInfo{}, errors.New("Unable to support both decryption and encryption in the same copy")
+		return types.BlobInfo{}, perrors.New("Unable to support both decryption and encryption in the same copy")
 	}
 	encryptionStep, err := ic.c.blobPipelineEncryptionStep(&stream, toEncrypt, srcInfo, decryptionStep)
 	if err != nil {
@@ -106,7 +106,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	}
 	uploadedInfo, err := ic.c.dest.PutBlobWithOptions(ctx, &errorAnnotationReader{stream.reader}, stream.info, options)
 	if err != nil {
-		return types.BlobInfo{}, errors.Wrap(err, "writing blob")
+		return types.BlobInfo{}, perrors.Wrap(err, "writing blob")
 	}
 
 	uploadedInfo.Annotations = stream.info.Annotations
@@ -125,7 +125,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		logrus.Debugf("Consuming rest of the original blob to satisfy getOriginalLayerCopyWriter")
 		_, err := io.Copy(io.Discard, originalLayerReader)
 		if err != nil {
-			return types.BlobInfo{}, errors.Wrapf(err, "reading input blob %s", srcInfo.Digest)
+			return types.BlobInfo{}, perrors.Wrapf(err, "reading input blob %s", srcInfo.Digest)
 		}
 	}
 
@@ -165,7 +165,7 @@ type errorAnnotationReader struct {
 func (r errorAnnotationReader) Read(b []byte) (n int, err error) {
 	n, err = r.reader.Read(b)
 	if err != io.EOF {
-		return n, errors.Wrapf(err, "happened during read")
+		return n, perrors.Wrapf(err, "happened during read")
 	}
 	return n, err
 }

--- a/copy/blob.go
+++ b/copy/blob.go
@@ -2,6 +2,7 @@ package copy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -76,7 +77,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	if decryptionStep.decrypting && toEncrypt {
 		// If nothing else, we can only set uploadedInfo.CryptoOperation to a single value.
 		// Before relaxing this, see the original pull request’s review if there are other reasons to reject this.
-		return types.BlobInfo{}, perrors.New("Unable to support both decryption and encryption in the same copy")
+		return types.BlobInfo{}, errors.New("Unable to support both decryption and encryption in the same copy")
 	}
 	encryptionStep, err := ic.c.blobPipelineEncryptionStep(&stream, toEncrypt, srcInfo, decryptionStep)
 	if err != nil {

--- a/copy/blob.go
+++ b/copy/blob.go
@@ -2,6 +2,7 @@ package copy
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containers/image/v5/internal/private"
@@ -129,10 +130,10 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	}
 
 	if digestingReader.validationFailed { // Coverage: This should never happen.
-		return types.BlobInfo{}, errors.Errorf("Internal error writing blob %s, digest verification failed but was ignored", srcInfo.Digest)
+		return types.BlobInfo{}, fmt.Errorf("Internal error writing blob %s, digest verification failed but was ignored", srcInfo.Digest)
 	}
 	if stream.info.Digest != "" && uploadedInfo.Digest != stream.info.Digest {
-		return types.BlobInfo{}, errors.Errorf("Internal error writing blob %s, blob with digest %s saved with digest %s", srcInfo.Digest, stream.info.Digest, uploadedInfo.Digest)
+		return types.BlobInfo{}, fmt.Errorf("Internal error writing blob %s, blob with digest %s saved with digest %s", srcInfo.Digest, stream.info.Digest, uploadedInfo.Digest)
 	}
 	if digestingReader.validationSucceeded {
 		if err := compressionStep.recordValidatedDigestData(ic.c, uploadedInfo, srcInfo, encryptionStep, decryptionStep); err != nil {

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,7 +27,7 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 	// This requires us to “peek ahead” into the stream to read the initial part, which requires us to chain through another io.Reader returned by DetectCompression.
 	format, decompressor, reader, err := compression.DetectCompressionFormat(stream.reader) // We could skip this in some cases, but let's keep the code path uniform
 	if err != nil {
-		return bpDetectCompressionStepData{}, errors.Wrapf(err, "reading blob %s", srcInfo.Digest)
+		return bpDetectCompressionStepData{}, perrors.Wrapf(err, "reading blob %s", srcInfo.Digest)
 	}
 	stream.reader = reader
 
@@ -299,7 +299,7 @@ func doCompression(dest io.Writer, src io.Reader, metadata map[string]string, co
 
 // compressGoroutine reads all input from src and writes its compressed equivalent to dest.
 func (c *copier) compressGoroutine(dest *io.PipeWriter, src io.Reader, metadata map[string]string, compressionFormat compressiontypes.Algorithm) {
-	err := errors.New("Internal error: unexpected panic in compressGoroutine")
+	err := perrors.New("Internal error: unexpected panic in compressGoroutine")
 	defer func() { // Note that this is not the same as {defer dest.CloseWithError(err)}; we need err to be evaluated lazily.
 		_ = dest.CloseWithError(err) // CloseWithError(nil) is equivalent to Close(), always returns nil
 	}()

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -299,7 +300,7 @@ func doCompression(dest io.Writer, src io.Reader, metadata map[string]string, co
 
 // compressGoroutine reads all input from src and writes its compressed equivalent to dest.
 func (c *copier) compressGoroutine(dest *io.PipeWriter, src io.Reader, metadata map[string]string, compressionFormat compressiontypes.Algorithm) {
-	err := perrors.New("Internal error: unexpected panic in compressGoroutine")
+	err := errors.New("Internal error: unexpected panic in compressGoroutine")
 	defer func() { // Note that this is not the same as {defer dest.CloseWithError(err)}; we need err to be evaluated lazily.
 		_ = dest.CloseWithError(err) // CloseWithError(nil) is equivalent to Close(), always returns nil
 	}()

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"fmt"
 	"io"
 
 	internalblobinfocache "github.com/containers/image/v5/internal/blobinfocache"
@@ -259,7 +260,7 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 		case types.Decompress:
 			c.blobInfoCache.RecordDigestUncompressedPair(srcInfo.Digest, uploadedInfo.Digest)
 		default:
-			return errors.Errorf("Internal error: Unexpected d.operation value %#v", d.operation)
+			return fmt.Errorf("Internal error: Unexpected d.operation value %#v", d.operation)
 		}
 	}
 	if d.uploadedCompressorName != "" && d.uploadedCompressorName != internalblobinfocache.UnknownCompression {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -753,8 +753,10 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		// because we failed to create a manifest of the specified type because the specific manifest type
 		// doesn't support the type of compression we're trying to use (e.g. docker v2s2 and zstd), we may
 		// have other options available that could still succeed.
-		_, isManifestRejected := perrors.Cause(err).(types.ManifestTypeRejectedError)
-		_, isCompressionIncompatible := perrors.Cause(err).(manifest.ManifestLayerCompressionIncompatibilityError)
+		var manifestTypeRejectedError types.ManifestTypeRejectedError
+		var manifestLayerCompressionIncompatibilityError manifest.ManifestLayerCompressionIncompatibilityError
+		isManifestRejected := errors.As(err, &manifestTypeRejectedError)
+		isCompressionIncompatible := errors.As(err, &manifestLayerCompressionIncompatibilityError)
 		if (!isManifestRejected && !isCompressionIncompatible) || len(manifestConversionPlan.otherMIMETypeCandidates) == 0 {
 			// We don’t have other options.
 			// In principle the code below would handle this as well, but the resulting  error message is fairly ugly.

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,7 +38,7 @@ import (
 
 var (
 	// ErrDecryptParamsMissing is returned if there is missing decryption parameters
-	ErrDecryptParamsMissing = perrors.New("Necessary DecryptParameters not present")
+	ErrDecryptParamsMissing = errors.New("Necessary DecryptParameters not present")
 
 	// maxParallelDownloads is used to limit the maximum number of parallel
 	// downloads.  Let's follow Firefox by limiting it to 6.
@@ -424,7 +425,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 				return nil, perrors.Wrapf(err, "computing digest of source image's manifest")
 			}
 			if !matches {
-				return nil, perrors.New("Digest of source image's manifest would not match destination reference")
+				return nil, errors.New("Digest of source image's manifest would not match destination reference")
 			}
 		}
 	}
@@ -628,7 +629,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 					return nil, "", "", perrors.Wrapf(err, "computing digest of source image's manifest")
 				}
 				if !matches {
-					return nil, "", "", perrors.New("Digest of source image's manifest would not match destination reference")
+					return nil, "", "", errors.New("Digest of source image's manifest would not match destination reference")
 				}
 			}
 		}
@@ -930,7 +931,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.
 			if ic.diffIDsAreNeeded {
-				cld.err = perrors.New("getting DiffID for foreign layers is unimplemented")
+				cld.err = errors.New("getting DiffID for foreign layers is unimplemented")
 			} else {
 				cld.destInfo = srcLayer
 				logrus.Debugf("Skipping foreign layer %q copy to %s", cld.destInfo.Digest, ic.c.dest.Reference().Transport().Name())
@@ -1285,7 +1286,7 @@ func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Rea
 	var getDiffIDRecorder func(compressiontypes.DecompressorFunc) io.Writer // = nil
 	var diffIDChan chan diffIDResult
 
-	err := perrors.New("Internal error: unexpected panic in copyLayer") // For pipeWriter.CloseWithbelow
+	err := errors.New("Internal error: unexpected panic in copyLayer") // For pipeWriter.CloseWithbelow
 	if diffIDIsNeeded {
 		diffIDChan = make(chan diffIDResult, 1) // Buffered, so that sending a value after this or our caller has failed and exited does not block.
 		pipeReader, pipeWriter := io.Pipe()
@@ -1315,7 +1316,7 @@ func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Rea
 func diffIDComputationGoroutine(dest chan<- diffIDResult, layerStream io.ReadCloser, decompressor compressiontypes.DecompressorFunc) {
 	result := diffIDResult{
 		digest: "",
-		err:    perrors.New("Internal error: unexpected panic in diffIDComputationGoroutine"),
+		err:    errors.New("Internal error: unexpected panic in diffIDComputationGoroutine"),
 	}
 	defer func() { dest <- result }()
 	defer layerStream.Close() // We do not care to bother the other end of the pipe with other failures; we send them to dest instead.

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -175,7 +175,7 @@ func validateImageListSelection(selection ImageListSelection) error {
 	case CopySystemImage, CopyAllImages, CopySpecificImages:
 		return nil
 	default:
-		return errors.Errorf("Invalid value for options.ImageListSelection: %d", selection)
+		return fmt.Errorf("Invalid value for options.ImageListSelection: %d", selection)
 	}
 }
 
@@ -309,7 +309,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {
-			return nil, errors.Errorf("copying multiple images: destination transport %q does not support copying multiple images as a group", destRef.Transport().Name())
+			return nil, fmt.Errorf("copying multiple images: destination transport %q does not support copying multiple images as a group", destRef.Transport().Name())
 		}
 		// Copy some or all of the images.
 		switch options.ImageListSelection {
@@ -457,7 +457,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	if selectedListType != originalList.MIMEType() {
 		if cannotModifyManifestListReason != "" {
-			return nil, errors.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", selectedListType, cannotModifyManifestListReason)
+			return nil, fmt.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", selectedListType, cannotModifyManifestListReason)
 		}
 	}
 
@@ -542,7 +542,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		// If we can't just use the original value, but we have to change it, flag an error.
 		if !bytes.Equal(attemptedManifestList, originalManifestList) {
 			if cannotModifyManifestListReason != "" {
-				return nil, errors.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", thisListType, cannotModifyManifestListReason)
+				return nil, fmt.Errorf("Manifest list must be converted to type %q to be written to destination, but we cannot modify it: %q", thisListType, cannotModifyManifestListReason)
 			}
 			logrus.Debugf("Manifest list has been updated")
 		} else {
@@ -866,7 +866,7 @@ func (ic *imageCopier) updateEmbeddedDockerReference() error {
 	}
 
 	if ic.cannotModifyManifestReason != "" {
-		return errors.Errorf("Copying a schema1 image with an embedded Docker reference to %s (Docker reference %s) would change the manifest, which we cannot do: %q",
+		return fmt.Errorf("Copying a schema1 image with an embedded Docker reference to %s (Docker reference %s) would change the manifest, which we cannot do: %q",
 			transports.ImageName(ic.c.dest.Reference()), destRef.String(), ic.cannotModifyManifestReason)
 	}
 	ic.manifestUpdates.EmbeddedDockerReference = destRef
@@ -897,7 +897,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// If we only need to check authorization, no updates required.
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if ic.cannotModifyManifestReason != "" {
-			return errors.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
+			return fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
 		}
 		srcInfos = updatedSrcInfos
 		srcInfosUpdated = true
@@ -1024,7 +1024,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 	var pendingImage types.Image = ic.src
 	if !ic.noPendingManifestUpdates() {
 		if ic.cannotModifyManifestReason != "" {
-			return nil, "", errors.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)
+			return nil, "", fmt.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)
 		}
 		if !ic.diffIDsAreNeeded && ic.src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates) {
 			// We have set ic.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
@@ -1033,7 +1033,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 			// when ic.c.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
 			// Supposedly s2-only registries do not exist or are extremely rare, so failing with this error message is good enough for now.
 			// If handling such registries turns out to be necessary, we could compute ic.diffIDsAreNeeded based on the full list of manifest MIME type candidates.
-			return nil, "", errors.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
+			return nil, "", fmt.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
 		}
 		pi, err := ic.src.UpdatedImage(ctx, *ic.manifestUpdates)
 		if err != nil {
@@ -1098,7 +1098,7 @@ func (ic *imageCopier) copyConfig(ctx context.Context, src types.Image) error {
 			return err
 		}
 		if destInfo.Digest != srcInfo.Digest {
-			return errors.Errorf("Internal error: copying uncompressed config blob %s changed digest to %s", srcInfo.Digest, destInfo.Digest)
+			return fmt.Errorf("Internal error: copying uncompressed config blob %s changed digest to %s", srcInfo.Digest, destInfo.Digest)
 		}
 	}
 	return nil

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -2,6 +2,7 @@ package copy
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/copy/digesting_reader.go
+++ b/copy/digesting_reader.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 type digestingReader struct {
@@ -48,7 +48,7 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 			// Coverage: This should not happen, the hash.Hash interface requires
 			// d.digest.Write to never return an error, and the io.Writer interface
 			// requires n2 == len(input) if no error is returned.
-			return 0, errors.Wrapf(err, "updating digest during verification: %d vs. %d", n2, n)
+			return 0, perrors.Wrapf(err, "updating digest during verification: %d vs. %d", n2, n)
 		}
 	}
 	if err == io.EOF {

--- a/copy/digesting_reader.go
+++ b/copy/digesting_reader.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"fmt"
 	"hash"
 	"io"
 
@@ -23,11 +24,11 @@ type digestingReader struct {
 func newDigestingReader(source io.Reader, expectedDigest digest.Digest) (*digestingReader, error) {
 	var digester digest.Digester
 	if err := expectedDigest.Validate(); err != nil {
-		return nil, errors.Errorf("Invalid digest specification %s", expectedDigest)
+		return nil, fmt.Errorf("Invalid digest specification %s", expectedDigest)
 	}
 	digestAlgorithm := expectedDigest.Algorithm()
 	if !digestAlgorithm.Available() {
-		return nil, errors.Errorf("Invalid digest specification %s: unsupported digest algorithm %s", expectedDigest, digestAlgorithm)
+		return nil, fmt.Errorf("Invalid digest specification %s: unsupported digest algorithm %s", expectedDigest, digestAlgorithm)
 	}
 	digester = digestAlgorithm.Digester()
 
@@ -54,7 +55,7 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 		actualDigest := d.digester.Digest()
 		if actualDigest != d.expectedDigest {
 			d.validationFailed = true
-			return 0, errors.Errorf("Digest did not match, expected %s, got %s", d.expectedDigest, actualDigest)
+			return 0, fmt.Errorf("Digest did not match, expected %s, got %s", d.expectedDigest, actualDigest)
 		}
 		d.validationSucceeded = true
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -6,7 +6,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/ocicrypt"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // isOciEncrypted returns a bool indicating if a mediatype is encrypted
@@ -41,7 +41,7 @@ func (c *copier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo types.
 		}
 		reader, decryptedDigest, err := ocicrypt.DecryptLayer(c.ociDecryptConfig, stream.reader, desc, false)
 		if err != nil {
-			return nil, errors.Wrapf(err, "decrypting layer %s", srcInfo.Digest)
+			return nil, perrors.Wrapf(err, "decrypting layer %s", srcInfo.Digest)
 		}
 
 		stream.reader = reader
@@ -92,7 +92,7 @@ func (c *copier) blobPipelineEncryptionStep(stream *sourceStream, toEncrypt bool
 		}
 		reader, finalizer, err := ocicrypt.EncryptLayer(c.ociEncryptConfig, stream.reader, desc)
 		if err != nil {
-			return nil, errors.Wrapf(err, "encrypting blob %s", srcInfo.Digest)
+			return nil, perrors.Wrapf(err, "encrypting blob %s", srcInfo.Digest)
 		}
 
 		stream.reader = reader
@@ -116,7 +116,7 @@ func (d *bpEncryptionStepData) updateCryptoOperationAndAnnotations(operation *ty
 
 	encryptAnnotations, err := d.finalizer()
 	if err != nil {
-		return errors.Wrap(err, "Unable to finalize encryption")
+		return perrors.Wrap(err, "Unable to finalize encryption")
 	}
 	*operation = types.Encrypt
 	if *annotations == nil {

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -2,6 +2,7 @@ package copy
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/manifest"
@@ -180,7 +181,7 @@ func (c *copier) determineListConversion(currentListMIMEType string, destSupport
 
 	logrus.Debugf("Manifest list has MIME type %s, ordered candidate list [%s]", currentListMIMEType, strings.Join(destSupportedMIMETypes, ", "))
 	if len(prioritizedTypes.list) == 0 {
-		return "", nil, errors.Errorf("destination does not support any supported manifest list types (%v)", manifest.SupportedListMIMETypes)
+		return "", nil, fmt.Errorf("destination does not support any supported manifest list types (%v)", manifest.SupportedListMIMETypes)
 	}
 	selectedType := prioritizedTypes.list[0]
 	otherSupportedTypes := prioritizedTypes.list[1:]

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -2,12 +2,12 @@ package copy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -1,6 +1,8 @@
 package copy
 
 import (
+	"fmt"
+
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
@@ -20,12 +22,12 @@ func (c *copier) createSignature(manifest []byte, keyIdentity string, passphrase
 
 	if identity != nil {
 		if reference.IsNameOnly(identity) {
-			return nil, errors.Errorf("Sign identity must be a fully specified reference %s", identity)
+			return nil, fmt.Errorf("Sign identity must be a fully specified reference %s", identity)
 		}
 	} else {
 		identity = c.dest.Reference().DockerReference()
 		if identity == nil {
-			return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(c.dest.Reference()))
+			return nil, fmt.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(c.dest.Reference()))
 		}
 	}
 

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -6,18 +6,18 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // createSignature creates a new signature of manifest using keyIdentity.
 func (c *copier) createSignature(manifest []byte, keyIdentity string, passphrase string, identity reference.Named) ([]byte, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing GPG")
+		return nil, perrors.Wrap(err, "initializing GPG")
 	}
 	defer mech.Close()
 	if err := mech.SupportsSigning(); err != nil {
-		return nil, errors.Wrap(err, "Signing not supported")
+		return nil, perrors.Wrap(err, "Signing not supported")
 	}
 
 	if identity != nil {
@@ -34,7 +34,7 @@ func (c *copier) createSignature(manifest []byte, keyIdentity string, passphrase
 	c.Printf("Signing manifest\n")
 	newSig, err := signature.SignDockerManifestWithOptions(manifest, identity.String(), mech, keyIdentity, &signature.SignOptions{Passphrase: passphrase})
 	if err != nil {
-		return nil, errors.Wrap(err, "creating signature")
+		return nil, perrors.Wrap(err, "creating signature")
 	}
 	return newSig, nil
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (types.Imag
 			desiredLayerCompression = types.Compress
 
 			if sys.DirForceDecompress {
-				return nil, errors.Errorf("Cannot compress and decompress at the same time")
+				return nil, fmt.Errorf("Cannot compress and decompress at the same time")
 			}
 		}
 		if sys.DirForceDecompress {
@@ -171,7 +172,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	}
 	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
@@ -209,7 +210,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // May use and/or update cache.
 func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, fmt.Errorf(`"Can not check for a blob with unknown digest`)
 	}
 	blobPath := d.ref.layerPath(info.Digest)
 	finfo, err := os.Stat(blobPath)

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -210,7 +210,7 @@ func (d *dirImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // May use and/or update cache.
 func (d *dirImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, fmt.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, fmt.Errorf("Can not check for a blob with unknown digest")
 	}
 	blobPath := d.ref.layerPath(info.Digest)
 	finfo, err := os.Stat(blobPath)

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,7 +19,7 @@ const version = "Directory Transport Version: 1.1\n"
 
 // ErrNotContainerImageDir indicates that the directory doesn't match the expected contents of a directory created
 // using the 'dir' transport
-var ErrNotContainerImageDir = errors.New("not a containers image directory, don't want to overwrite important data")
+var ErrNotContainerImageDir = perrors.New("not a containers image directory, don't want to overwrite important data")
 
 type dirImageDestination struct {
 	ref                     dirReference
@@ -48,7 +48,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (types.Imag
 	// if the contents don't match throw an error
 	dirExists, err := pathExists(d.ref.resolvedPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "checking for path %q", d.ref.resolvedPath)
+		return nil, perrors.Wrapf(err, "checking for path %q", d.ref.resolvedPath)
 	}
 	if dirExists {
 		isEmpty, err := isDirEmpty(d.ref.resolvedPath)
@@ -59,7 +59,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (types.Imag
 		if !isEmpty {
 			versionExists, err := pathExists(d.ref.versionPath())
 			if err != nil {
-				return nil, errors.Wrapf(err, "checking if path exists %q", d.ref.versionPath())
+				return nil, perrors.Wrapf(err, "checking if path exists %q", d.ref.versionPath())
 			}
 			if versionExists {
 				contents, err := os.ReadFile(d.ref.versionPath())
@@ -75,20 +75,20 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (types.Imag
 			}
 			// delete directory contents so that only one image is in the directory at a time
 			if err = removeDirContents(d.ref.resolvedPath); err != nil {
-				return nil, errors.Wrapf(err, "erasing contents in %q", d.ref.resolvedPath)
+				return nil, perrors.Wrapf(err, "erasing contents in %q", d.ref.resolvedPath)
 			}
 			logrus.Debugf("overwriting existing container image directory %q", d.ref.resolvedPath)
 		}
 	} else {
 		// create directory if it doesn't exist
 		if err := os.MkdirAll(d.ref.resolvedPath, 0755); err != nil {
-			return nil, errors.Wrapf(err, "unable to create directory %q", d.ref.resolvedPath)
+			return nil, perrors.Wrapf(err, "unable to create directory %q", d.ref.resolvedPath)
 		}
 	}
 	// create version file
 	err = os.WriteFile(d.ref.versionPath(), []byte(version), 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating version file %q", d.ref.versionPath())
+		return nil, perrors.Wrapf(err, "creating version file %q", d.ref.versionPath())
 	}
 	return d, nil
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,7 +20,7 @@ const version = "Directory Transport Version: 1.1\n"
 
 // ErrNotContainerImageDir indicates that the directory doesn't match the expected contents of a directory created
 // using the 'dir' transport
-var ErrNotContainerImageDir = perrors.New("not a containers image directory, don't want to overwrite important data")
+var ErrNotContainerImageDir = errors.New("not a containers image directory, don't want to overwrite important data")
 
 type dirImageDestination struct {
 	ref                     dirReference

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -3,6 +3,7 @@ package directory
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/image/v5/pkg/blobinfocache/memory"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +131,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 			}
 			return len(p), nil
 		}
-		return 0, errors.Errorf(digestErrorString)
+		return 0, errors.New(digestErrorString)
 	})
 
 	dest, err := ref.NewImageDestination(context.Background(), nil)

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -2,6 +2,7 @@ package directory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -39,7 +39,7 @@ func (t dirTransport) ParseReference(reference string) (types.ImageReference, er
 // scope passed to this function will not be "", that value is always allowed.
 func (t dirTransport) ValidatePolicyConfigurationScope(scope string) error {
 	if !strings.HasPrefix(scope, "/") {
-		return errors.Errorf("Invalid scope %s: Must be an absolute path", scope)
+		return fmt.Errorf("Invalid scope %s: Must be an absolute path", scope)
 	}
 	// Refuse also "/", otherwise "/" and "" would have the same semantics,
 	// and "" could be unexpectedly shadowed by the "/" entry.
@@ -48,7 +48,7 @@ func (t dirTransport) ValidatePolicyConfigurationScope(scope string) error {
 	}
 	cleaned := filepath.Clean(scope)
 	if cleaned != scope {
-		return errors.Errorf(`Invalid scope %s: Uses non-canonical format, perhaps try %s`, scope, cleaned)
+		return fmt.Errorf(`Invalid scope %s: Uses non-canonical format, perhaps try %s`, scope, cleaned)
 	}
 	return nil
 }
@@ -157,7 +157,7 @@ func (ref dirReference) NewImageDestination(ctx context.Context, sys *types.Syst
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.Errorf("Deleting images not implemented for dir: images")
+	return errors.New("Deleting images not implemented for dir: images")
 }
 
 // manifestPath returns a path for the manifest within a directory using our conventions.

--- a/directory/explicitfilepath/path.go
+++ b/directory/explicitfilepath/path.go
@@ -1,10 +1,9 @@
 package explicitfilepath
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // ResolvePathToFullyExplicit returns the input path converted to an absolute, no-symlinks, cleaned up path.
@@ -26,14 +25,14 @@ func ResolvePathToFullyExplicit(path string) (string, error) {
 			// This can still happen if there is a filesystem race condition, causing the Lstat() above to fail but the later resolution to succeed.
 			// We do not care to promise anything if such filesystem race conditions can happen, but we definitely don't want to return "."/".." components
 			// in the resulting path, and especially not at the end.
-			return "", errors.Errorf("Unexpectedly missing special filename component in %s", path)
+			return "", fmt.Errorf("Unexpectedly missing special filename component in %s", path)
 		}
 		resolvedPath := filepath.Join(resolvedParent, file)
 		// As a sanity check, ensure that there are no "." or ".." components.
 		cleanedResolvedPath := filepath.Clean(resolvedPath)
 		if cleanedResolvedPath != resolvedPath {
 			// Coverage: This should never happen.
-			return "", errors.Errorf("Internal inconsistency: Path %s resolved to %s still cleaned up to %s", path, resolvedPath, cleanedResolvedPath)
+			return "", fmt.Errorf("Internal inconsistency: Path %s resolved to %s still cleaned up to %s", path, resolvedPath, cleanedResolvedPath)
 		}
 		return resolvedPath, nil
 	default: // err != nil, unrecognized

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -2,11 +2,11 @@ package archive
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 type archiveImageDestination struct {
@@ -18,7 +18,7 @@ type archiveImageDestination struct {
 
 func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
 	if ref.sourceIndex != -1 {
-		return nil, errors.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
+		return nil, fmt.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
 	}
 
 	var archive *tarfile.Writer

--- a/docker/archive/reader.go
+++ b/docker/archive/reader.go
@@ -7,7 +7,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // Reader manages a single Docker archive, allows listing its contents and accessing
@@ -75,7 +75,7 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 		for _, tag := range image.RepoTags {
 			parsedTag, err := reference.ParseNormalizedNamed(tag)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Invalid tag %#v in manifest item @%d", tag, imageIndex)
+				return nil, perrors.Wrapf(err, "Invalid tag %#v in manifest item @%d", tag, imageIndex)
 			}
 			nt, ok := parsedTag.(reference.NamedTagged)
 			if !ok {
@@ -83,14 +83,14 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 			}
 			ref, err := newReference(r.path, nt, -1, r.archive, nil)
 			if err != nil {
-				return nil, errors.Wrapf(err, "creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
+				return nil, perrors.Wrapf(err, "creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
 			}
 			refs = append(refs, ref)
 		}
 		if len(refs) == 0 {
 			ref, err := newReference(r.path, nil, imageIndex, r.archive, nil)
 			if err != nil {
-				return nil, errors.Wrapf(err, "creating a reference for manifest item @%d", imageIndex)
+				return nil, perrors.Wrapf(err, "creating a reference for manifest item @%d", imageIndex)
 			}
 			refs = append(refs, ref)
 		}

--- a/docker/archive/reader.go
+++ b/docker/archive/reader.go
@@ -1,6 +1,8 @@
 package archive
 
 import (
+	"fmt"
+
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports"
@@ -40,10 +42,10 @@ func (r *Reader) Close() error {
 func NewReaderForReference(sys *types.SystemContext, ref types.ImageReference) (*Reader, types.ImageReference, error) {
 	standalone, ok := ref.(archiveReference)
 	if !ok {
-		return nil, nil, errors.Errorf("Internal error: NewReaderForReference called for a non-docker/archive ImageReference %s", transports.ImageName(ref))
+		return nil, nil, fmt.Errorf("Internal error: NewReaderForReference called for a non-docker/archive ImageReference %s", transports.ImageName(ref))
 	}
 	if standalone.archiveReader != nil {
-		return nil, nil, errors.Errorf("Internal error: NewReaderForReference called for a reader-bound reference %s", standalone.StringWithinTransport())
+		return nil, nil, fmt.Errorf("Internal error: NewReaderForReference called for a reader-bound reference %s", standalone.StringWithinTransport())
 	}
 	reader, err := NewReader(sys, standalone.path)
 	if err != nil {
@@ -77,7 +79,7 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 			}
 			nt, ok := parsedTag.(reference.NamedTagged)
 			if !ok {
-				return nil, errors.Errorf("Invalid tag %s (%s): does not contain a tag", tag, parsedTag.String())
+				return nil, fmt.Errorf("Invalid tag %s (%s): does not contain a tag", tag, parsedTag.String())
 			}
 			ref, err := newReference(r.path, nt, -1, r.archive, nil)
 			if err != nil {
@@ -107,7 +109,7 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 func (r *Reader) ManifestTagsForReference(ref types.ImageReference) ([]string, error) {
 	archiveRef, ok := ref.(archiveReference)
 	if !ok {
-		return nil, errors.Errorf("Internal error: ManifestTagsForReference called for a non-docker/archive ImageReference %s", transports.ImageName(ref))
+		return nil, fmt.Errorf("Internal error: ManifestTagsForReference called for a non-docker/archive ImageReference %s", transports.ImageName(ref))
 	}
 	manifestItem, tagIndex, err := r.archive.ChooseManifestItem(archiveRef.ref, archiveRef.sourceIndex)
 	if err != nil {

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -59,7 +59,7 @@ type archiveReference struct {
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.
 func ParseReference(refString string) (types.ImageReference, error) {
 	if refString == "" {
-		return nil, errors.Errorf("docker-archive reference %s isn't of the form <path>[:<reference>]", refString)
+		return nil, fmt.Errorf("docker-archive reference %s isn't of the form <path>[:<reference>]", refString)
 	}
 
 	parts := strings.SplitN(refString, ":", 2)
@@ -75,7 +75,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 				return nil, errors.Wrapf(err, "Invalid source index %s", parts[1])
 			}
 			if i < 0 {
-				return nil, errors.Errorf("Invalid source index @%d: must not be negative", i)
+				return nil, fmt.Errorf("Invalid source index @%d: must not be negative", i)
 			}
 			sourceIndex = i
 		} else {
@@ -86,7 +86,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 			ref = reference.TagNameOnly(ref)
 			refTagged, isTagged := ref.(reference.NamedTagged)
 			if !isTagged { // If ref contains a digest, TagNameOnly does not change it
-				return nil, errors.Errorf("reference does not include a tag: %s", ref.String())
+				return nil, fmt.Errorf("reference does not include a tag: %s", ref.String())
 			}
 			nt = refTagged
 		}
@@ -110,16 +110,16 @@ func NewIndexReference(path string, sourceIndex int) (types.ImageReference, erro
 func newReference(path string, ref reference.NamedTagged, sourceIndex int,
 	archiveReader *tarfile.Reader, archiveWriter *tarfile.Writer) (types.ImageReference, error) {
 	if strings.Contains(path, ":") {
-		return nil, errors.Errorf("Invalid docker-archive: reference: colon in path %q is not supported", path)
+		return nil, fmt.Errorf("Invalid docker-archive: reference: colon in path %q is not supported", path)
 	}
 	if ref != nil && sourceIndex != -1 {
-		return nil, errors.Errorf("Invalid docker-archive: reference: cannot use both a tag and a source index")
+		return nil, fmt.Errorf("Invalid docker-archive: reference: cannot use both a tag and a source index")
 	}
 	if _, isDigest := ref.(reference.Canonical); isDigest {
-		return nil, errors.Errorf("docker-archive doesn't support digest references: %s", ref.String())
+		return nil, fmt.Errorf("docker-archive doesn't support digest references: %s", ref.String())
 	}
 	if sourceIndex != -1 && sourceIndex < 0 {
-		return nil, errors.Errorf("Invalid docker-archive: reference: index @%d must not be negative", sourceIndex)
+		return nil, fmt.Errorf("Invalid docker-archive: reference: index @%d must not be negative", sourceIndex)
 	}
 	return archiveReference{
 		path:          path,

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,7 +39,7 @@ func (t archiveTransport) ParseReference(reference string) (types.ImageReference
 // scope passed to this function will not be "", that value is always allowed.
 func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 	// See the explanation in archiveReference.PolicyConfigurationIdentity.
-	return perrors.New(`docker-archive: does not support any scopes except the default "" one`)
+	return errors.New(`docker-archive: does not support any scopes except the default "" one`)
 }
 
 // archiveReference is an ImageReference for Docker images.
@@ -203,5 +204,5 @@ func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref archiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	// Not really supported, for safety reasons.
-	return perrors.New("Deleting images not implemented for docker-archive: images")
+	return errors.New("Deleting images not implemented for docker-archive: images")
 }

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -11,7 +11,7 @@ import (
 	ctrImage "github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -38,7 +38,7 @@ func (t archiveTransport) ParseReference(reference string) (types.ImageReference
 // scope passed to this function will not be "", that value is always allowed.
 func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 	// See the explanation in archiveReference.PolicyConfigurationIdentity.
-	return errors.New(`docker-archive: does not support any scopes except the default "" one`)
+	return perrors.New(`docker-archive: does not support any scopes except the default "" one`)
 }
 
 // archiveReference is an ImageReference for Docker images.
@@ -72,7 +72,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		if len(parts[1]) > 0 && parts[1][0] == '@' {
 			i, err := strconv.Atoi(parts[1][1:])
 			if err != nil {
-				return nil, errors.Wrapf(err, "Invalid source index %s", parts[1])
+				return nil, perrors.Wrapf(err, "Invalid source index %s", parts[1])
 			}
 			if i < 0 {
 				return nil, fmt.Errorf("Invalid source index @%d: must not be negative", i)
@@ -81,7 +81,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		} else {
 			ref, err := reference.ParseNormalizedNamed(parts[1])
 			if err != nil {
-				return nil, errors.Wrapf(err, "docker-archive parsing reference")
+				return nil, perrors.Wrapf(err, "docker-archive parsing reference")
 			}
 			ref = reference.TagNameOnly(ref)
 			refTagged, isTagged := ref.(reference.NamedTagged)
@@ -203,5 +203,5 @@ func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref archiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
 	// Not really supported, for safety reasons.
-	return errors.New("Deleting images not implemented for docker-archive: images")
+	return perrors.New("Deleting images not implemented for docker-archive: images")
 }

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"errors"
 	"io"
 	"os"
 
@@ -74,7 +75,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	}
 
 	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {
-		return nil, perrors.New("docker-archive doesn't support modifying existing images")
+		return nil, errors.New("docker-archive doesn't support modifying existing images")
 	}
 
 	succeeded = true

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // Writer manages a single in-progress Docker archive and allows adding images to it.
@@ -60,7 +60,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	// only in a different way. Either way, it’s up to the user to not have two writers to the same path.)
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "opening file %q", path)
+		return nil, perrors.Wrapf(err, "opening file %q", path)
 	}
 	succeeded := false
 	defer func() {
@@ -70,11 +70,11 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	}()
 	fhStat, err := fh.Stat()
 	if err != nil {
-		return nil, errors.Wrapf(err, "statting file %q", path)
+		return nil, perrors.Wrapf(err, "statting file %q", path)
 	}
 
 	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {
-		return nil, errors.New("docker-archive doesn't support modifying existing images")
+		return nil, perrors.New("docker-archive doesn't support modifying existing images")
 	}
 
 	succeeded = true

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
@@ -28,11 +29,11 @@ type daemonImageDestination struct {
 // newImageDestination returns a types.ImageDestination for the specified image reference.
 func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daemonReference) (types.ImageDestination, error) {
 	if ref.ref == nil {
-		return nil, errors.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
+		return nil, fmt.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
 	}
 	namedTaggedRef, ok := ref.ref.(reference.NamedTagged)
 	if !ok {
-		return nil, errors.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
+		return nil, fmt.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
 	}
 
 	var mustMatchRuntimeOS = true

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -68,7 +69,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 
 // imageLoadGoroutine accepts tar stream on reader, sends it to c, and reports error or success by writing to statusChannel
 func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeReader, statusChannel chan<- error) {
-	err := perrors.New("Internal error: unexpected panic in imageLoadGoroutine")
+	err := errors.New("Internal error: unexpected panic in imageLoadGoroutine")
 	defer func() {
 		logrus.Debugf("docker-daemon: sending done, status %v", err)
 		statusChannel <- err
@@ -115,7 +116,7 @@ func (d *daemonImageDestination) Close() error {
 		// immediately, and hopefully, through terminating the sending which uses "Transfer-Encoding: chunked"" without sending
 		// the terminating zero-length chunk, prevent the docker daemon from processing the tar stream at all.
 		// Whether that works or not, closing the PipeWriter seems desirable in any case.
-		if err := d.writer.CloseWithError(perrors.New("Aborting upload, daemonImageDestination closed without a previous .Commit()")); err != nil {
+		if err := d.writer.CloseWithError(errors.New("Aborting upload, daemonImageDestination closed without a previous .Commit()")); err != nil {
 			return err
 		}
 	}

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,7 +43,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing docker engine client")
+		return nil, perrors.Wrap(err, "initializing docker engine client")
 	}
 
 	reader, writer := io.Pipe()
@@ -68,7 +68,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 
 // imageLoadGoroutine accepts tar stream on reader, sends it to c, and reports error or success by writing to statusChannel
 func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeReader, statusChannel chan<- error) {
-	err := errors.New("Internal error: unexpected panic in imageLoadGoroutine")
+	err := perrors.New("Internal error: unexpected panic in imageLoadGoroutine")
 	defer func() {
 		logrus.Debugf("docker-daemon: sending done, status %v", err)
 		statusChannel <- err
@@ -85,7 +85,7 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 
 	resp, err := c.ImageLoad(ctx, reader, true)
 	if err != nil {
-		err = errors.Wrap(err, "saving image to docker engine")
+		err = perrors.Wrap(err, "saving image to docker engine")
 		return
 	}
 	defer resp.Body.Close()
@@ -115,7 +115,7 @@ func (d *daemonImageDestination) Close() error {
 		// immediately, and hopefully, through terminating the sending which uses "Transfer-Encoding: chunked"" without sending
 		// the terminating zero-length chunk, prevent the docker daemon from processing the tar stream at all.
 		// Whether that works or not, closing the PipeWriter seems desirable in any case.
-		if err := d.writer.CloseWithError(errors.New("Aborting upload, daemonImageDestination closed without a previous .Commit()")); err != nil {
+		if err := d.writer.CloseWithError(perrors.New("Aborting upload, daemonImageDestination closed without a previous .Commit()")); err != nil {
 			return err
 		}
 	}

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 type daemonImageSource struct {
@@ -25,13 +25,13 @@ type daemonImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonReference) (types.ImageSource, error) {
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing docker engine client")
+		return nil, perrors.Wrap(err, "initializing docker engine client")
 	}
 	// Per NewReference(), ref.StringWithinTransport() is either an image ID (config digest), or a !reference.NameOnly() reference.
 	// Either way ImageSave should create a tarball with exactly one image.
 	inputStream, err := c.ImageSave(ctx, []string{ref.StringWithinTransport()})
 	if err != nil {
-		return nil, errors.Wrap(err, "loading image from docker engine")
+		return nil, perrors.Wrap(err, "loading image from docker engine")
 	}
 	defer inputStream.Close()
 

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/image/v5/docker/policyconfiguration"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -39,7 +39,7 @@ func (t daemonTransport) ParseReference(reference string) (types.ImageReference,
 func (t daemonTransport) ValidatePolicyConfigurationScope(scope string) error {
 	// ID values cannot be effectively namespaced, and are clearly invalid host:port values.
 	if _, err := digest.Parse(scope); err == nil {
-		return errors.Errorf(`docker-daemon: can not use algo:digest value %s as a namespace`, scope)
+		return fmt.Errorf(`docker-daemon: can not use algo:digest value %s as a namespace`, scope)
 	}
 
 	// FIXME? We could be verifying the various character set and length restrictions
@@ -70,7 +70,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		// The daemon explicitly refuses to tag images with a reponame equal to digest.Canonical - but _only_ this digest name.
 		// Other digest references are ambiguous, so refuse them.
 		if dgst.Algorithm() != digest.Canonical {
-			return nil, errors.Errorf("Invalid docker-daemon: reference %s: only digest algorithm %s accepted", refString, digest.Canonical)
+			return nil, fmt.Errorf("Invalid docker-daemon: reference %s: only digest algorithm %s accepted", refString, digest.Canonical)
 		}
 		return NewReference(dgst, nil)
 	}
@@ -80,7 +80,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		return nil, err
 	}
 	if reference.FamiliarName(ref) == digest.Canonical.String() {
-		return nil, errors.Errorf("Invalid docker-daemon: reference %s: The %s repository name is reserved for (non-shortened) digest references", refString, digest.Canonical)
+		return nil, fmt.Errorf("Invalid docker-daemon: reference %s: The %s repository name is reserved for (non-shortened) digest references", refString, digest.Canonical)
 	}
 	return NewReference("", ref)
 }
@@ -92,7 +92,7 @@ func NewReference(id digest.Digest, ref reference.Named) (types.ImageReference, 
 	}
 	if ref != nil {
 		if reference.IsNameOnly(ref) {
-			return nil, errors.Errorf("docker-daemon: reference %s has neither a tag nor a digest", reference.FamiliarString(ref))
+			return nil, fmt.Errorf("docker-daemon: reference %s has neither a tag nor a digest", reference.FamiliarString(ref))
 		}
 		// A github.com/distribution/reference value can have a tag and a digest at the same time!
 		// Most versions of docker/reference do not handle that (ignoring the tag), so reject such input.
@@ -102,7 +102,7 @@ func NewReference(id digest.Digest, ref reference.Named) (types.ImageReference, 
 		_, isTagged := ref.(reference.NamedTagged)
 		_, isDigested := ref.(reference.Canonical)
 		if isTagged && isDigested {
-			return nil, errors.Errorf("docker-daemon: references with both a tag and digest are currently not supported")
+			return nil, fmt.Errorf("docker-daemon: references with both a tag and digest are currently not supported")
 		}
 	}
 	return daemonReference{
@@ -215,5 +215,5 @@ func (ref daemonReference) DeleteImage(ctx context.Context, sys *types.SystemCon
 	// Should this just untag the image? Should this stop running containers?
 	// The semantics is not quite as clear as for remote repositories.
 	// The user can run (docker rmi) directly anyway, so, for now(?), punt instead of trying to guess what the user meant.
-	return errors.Errorf("Deleting images not implemented for docker-daemon: images")
+	return errors.New("Deleting images not implemented for docker-daemon: images")
 }

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -628,7 +628,7 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	scopes []authScope) (*bearerToken, error) {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, errors.Errorf("missing realm in bearer auth challenge")
+		return nil, errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodPost, realm, nil)
@@ -676,7 +676,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 	scopes []authScope) (*bearerToken, error) {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, errors.Errorf("missing realm in bearer auth challenge")
+		return nil, errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -628,7 +629,7 @@ func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge chall
 	scopes []authScope) (*bearerToken, error) {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, perrors.New("missing realm in bearer auth challenge")
+		return nil, errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodPost, realm, nil)
@@ -676,7 +677,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, challenge challenge,
 	scopes []authScope) (*bearerToken, error) {
 	realm, ok := challenge.Parameters["realm"]
 	if !ok {
-		return nil, perrors.New("missing realm in bearer auth challenge")
+		return nil, errors.New("missing realm in bearer auth challenge")
 	}
 
 	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -56,7 +56,7 @@ func (i *Image) GetRepositoryTags(ctx context.Context) ([]string, error) {
 func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) ([]string, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, errors.Errorf("ref must be a dockerReference")
+		return nil, errors.New("ref must be a dockerReference")
 	}
 
 	path := fmt.Sprintf(tagsPath, reference.Path(dr.ref))
@@ -116,7 +116,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) (digest.Digest, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return "", errors.Errorf("ref must be a dockerReference")
+		return "", errors.New("ref must be a dockerReference")
 	}
 
 	tagOrDigest, err := dr.tagOrDigest()

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // Image is a Docker-specific implementation of types.ImageCloser with a few extra methods
@@ -56,13 +56,13 @@ func (i *Image) GetRepositoryTags(ctx context.Context) ([]string, error) {
 func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) ([]string, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, errors.New("ref must be a dockerReference")
+		return nil, perrors.New("ref must be a dockerReference")
 	}
 
 	path := fmt.Sprintf(tagsPath, reference.Path(dr.ref))
 	client, err := newDockerClientFromRef(sys, dr, false, "pull")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create client")
+		return nil, perrors.Wrap(err, "failed to create client")
 	}
 
 	tags := make([]string, 0)
@@ -116,7 +116,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) (digest.Digest, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return "", errors.New("ref must be a dockerReference")
+		return "", perrors.New("ref must be a dockerReference")
 	}
 
 	tagOrDigest, err := dr.tagOrDigest()
@@ -126,7 +126,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 
 	client, err := newDockerClientFromRef(sys, dr, false, "pull")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create client")
+		return "", perrors.Wrap(err, "failed to create client")
 	}
 
 	path := fmt.Sprintf(manifestPath, reference.Path(dr.ref), tagOrDigest)
@@ -141,7 +141,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", errors.Wrapf(registryHTTPResponseToError(res), "reading digest %s in %s", tagOrDigest, dr.ref.Name())
+		return "", perrors.Wrapf(registryHTTPResponseToError(res), "reading digest %s in %s", tagOrDigest, dr.ref.Name())
 	}
 
 	dig, err := digest.Parse(res.Header.Get("Docker-Content-Digest"))

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -56,7 +57,7 @@ func (i *Image) GetRepositoryTags(ctx context.Context) ([]string, error) {
 func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) ([]string, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, perrors.New("ref must be a dockerReference")
+		return nil, errors.New("ref must be a dockerReference")
 	}
 
 	path := fmt.Sprintf(tagsPath, reference.Path(dr.ref))
@@ -116,7 +117,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) (digest.Digest, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return "", perrors.New("ref must be a dockerReference")
+		return "", errors.New("ref must be a dockerReference")
 	}
 
 	tagOrDigest, err := dr.tagOrDigest()

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -318,7 +318,7 @@ func (d *dockerImageDestination) tryReusingExactBlob(ctx context.Context, info t
 // May use and/or update cache.
 func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.New(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
 	}
 
 	// First, check whether the blob happens to already exist at the destination.

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -83,7 +83,7 @@ func (d *dockerImageDestination) SupportsSignatures(ctx context.Context) error {
 	case d.c.signatureBase != nil:
 		return nil
 	default:
-		return errors.Errorf("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
+		return errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
 }
 
@@ -243,7 +243,7 @@ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.
 		logrus.Debugf("... not present")
 		return false, -1, nil
 	default:
-		return false, -1, errors.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
+		return false, -1, fmt.Errorf("failed to read from destination repository %s: %d (%s)", reference.Path(d.ref.ref), res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }
 
@@ -318,7 +318,7 @@ func (d *dockerImageDestination) tryReusingExactBlob(ctx context.Context, info t
 // May use and/or update cache.
 func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.New(`"Can not check for a blob with unknown digest`)
 	}
 
 	// First, check whether the blob happens to already exist at the destination.
@@ -424,7 +424,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 			if merr != nil {
 				return errors.Wrapf(err, "Attempted to PutManifest using an explicitly specified digest (%q) that didn't match the manifest's digest (%v attempting to compute it)", instanceDigest.String(), merr)
 			}
-			return errors.Errorf("Attempted to PutManifest using an explicitly specified digest (%q) that didn't match the manifest's digest (%q)", instanceDigest.String(), manifestDigest.String())
+			return fmt.Errorf("Attempted to PutManifest using an explicitly specified digest (%q) that didn't match the manifest's digest (%q)", instanceDigest.String(), manifestDigest.String())
 		}
 	} else {
 		// Compute the digest of the main manifest, or the list if it's a list, so that we
@@ -525,7 +525,7 @@ func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [
 	if instanceDigest == nil {
 		if d.manifestDigest == "" {
 			// This shouldn’t happen, ImageDestination users are required to call PutManifest before PutSignatures
-			return errors.Errorf("Unknown manifest digest, can't add signatures")
+			return errors.New("Unknown manifest digest, can't add signatures")
 		}
 		instanceDigest = &d.manifestDigest
 	}
@@ -539,7 +539,7 @@ func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [
 	case d.c.signatureBase != nil:
 		return d.putSignaturesToLookaside(signatures, *instanceDigest)
 	default:
-		return errors.Errorf("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
+		return errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
 }
 
@@ -598,9 +598,9 @@ func (d *dockerImageDestination) putOneSignature(url *url.URL, signature []byte)
 		return nil
 
 	case "http", "https":
-		return errors.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.Redacted())
+		return fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.Redacted())
 	default:
-		return errors.Errorf("Unsupported scheme when writing signature to %s", url.Redacted())
+		return fmt.Errorf("Unsupported scheme when writing signature to %s", url.Redacted())
 	}
 }
 
@@ -618,9 +618,9 @@ func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error
 		return false, err
 
 	case "http", "https":
-		return false, errors.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.Redacted())
+		return false, fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.Redacted())
 	default:
-		return false, errors.Errorf("Unsupported scheme when deleting signature from %s", url.Redacted())
+		return false, fmt.Errorf("Unsupported scheme when deleting signature from %s", url.Redacted())
 	}
 }
 

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -84,7 +85,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	switch len(attempts) {
 	case 0:
-		return nil, perrors.New("Internal error: newImageSource returned without trying any endpoint")
+		return nil, errors.New("Internal error: newImageSource returned without trying any endpoint")
 	case 1:
 		return nil, attempts[0].err // If no mirrors are used, perfectly preserve the error type and add no noise.
 	default:
@@ -250,7 +251,7 @@ func (s *dockerImageSource) getExternalBlob(ctx context.Context, urls []string) 
 		err  error
 	)
 	if len(urls) == 0 {
-		return nil, 0, perrors.New("internal error: getExternalBlob called with no URLs")
+		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
 	}
 	for _, u := range urls {
 		url, err := url.Parse(u)
@@ -337,7 +338,7 @@ func handle206Response(streams chan io.ReadCloser, errs chan error, body io.Read
 	}
 	boundary, found := params["boundary"]
 	if !found {
-		errs <- perrors.New("could not find boundary")
+		errs <- errors.New("could not find boundary")
 		body.Close()
 		return
 	}
@@ -352,7 +353,7 @@ func handle206Response(streams chan io.ReadCloser, errs chan error, body io.Read
 				errs <- err
 			}
 			if parts != len(chunks) {
-				errs <- perrors.New("invalid number of chunks returned by the server")
+				errs <- errors.New("invalid number of chunks returned by the server")
 			}
 			return
 		}
@@ -491,7 +492,7 @@ func (s *dockerImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 	case s.c.signatureBase != nil:
 		return s.getSignaturesFromLookaside(ctx, instanceDigest)
 	default:
-		return nil, perrors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
+		return nil, errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
 }
 

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -49,7 +49,7 @@ type dockerReference struct {
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.
 func ParseReference(refString string) (types.ImageReference, error) {
 	if !strings.HasPrefix(refString, "//") {
-		return nil, errors.Errorf("docker: image reference %s does not start with //", refString)
+		return nil, fmt.Errorf("docker: image reference %s does not start with //", refString)
 	}
 	ref, err := reference.ParseNormalizedNamed(strings.TrimPrefix(refString, "//"))
 	if err != nil {
@@ -67,7 +67,7 @@ func NewReference(ref reference.Named) (types.ImageReference, error) {
 // newReference returns a dockerReference for a named reference.
 func newReference(ref reference.Named) (dockerReference, error) {
 	if reference.IsNameOnly(ref) {
-		return dockerReference{}, errors.Errorf("Docker reference %s has neither a tag nor a digest", reference.FamiliarString(ref))
+		return dockerReference{}, fmt.Errorf("Docker reference %s has neither a tag nor a digest", reference.FamiliarString(ref))
 	}
 	// A github.com/distribution/reference value can have a tag and a digest at the same time!
 	// The docker/distribution API does not really support that (we can’t ask for an image with a specific
@@ -77,7 +77,7 @@ func newReference(ref reference.Named) (dockerReference, error) {
 	_, isTagged := ref.(reference.NamedTagged)
 	_, isDigested := ref.(reference.Canonical)
 	if isTagged && isDigested {
-		return dockerReference{}, errors.Errorf("Docker references with both a tag and digest are currently not supported")
+		return dockerReference{}, errors.New("Docker references with both a tag and digest are currently not supported")
 	}
 
 	return dockerReference{
@@ -164,5 +164,5 @@ func (ref dockerReference) tagOrDigest() (string, error) {
 		return ref.Tag(), nil
 	}
 	// This should not happen, NewReference above refuses reference.IsNameOnly values.
-	return "", errors.Errorf("Internal inconsistency: Reference %s unexpectedly has neither a digest nor a tag", reference.FamiliarString(ref.ref))
+	return "", fmt.Errorf("Internal inconsistency: Reference %s unexpectedly has neither a digest nor a tag", reference.FamiliarString(ref.ref))
 }

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution/registry/client"
-	perrors "github.com/pkg/errors"
 )
 
 var (
@@ -42,7 +41,7 @@ func httpResponseToError(res *http.Response, context string) error {
 		if context != "" {
 			context = context + ": "
 		}
-		return perrors.Errorf("%sinvalid status code from registry %d (%s)", context, res.StatusCode, http.StatusText(res.StatusCode))
+		return fmt.Errorf("%sinvalid status code from registry %d (%s)", context, res.StatusCode, http.StatusText(res.StatusCode))
 	}
 }
 

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -54,7 +55,7 @@ func (d *Destination) SupportedManifestMIMETypes() []string {
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 func (d *Destination) SupportsSignatures(ctx context.Context) error {
-	return perrors.New("Storing signatures for docker tar files is not supported")
+	return errors.New("Storing signatures for docker tar files is not supported")
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -162,7 +163,7 @@ func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, c
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
 	if instanceDigest != nil {
-		return perrors.New(`Manifest lists are not supported for docker tar files`)
+		return errors.New(`Manifest lists are not supported for docker tar files`)
 	}
 	// We do not bother with types.ManifestTypeRejectedError; our .SupportedManifestMIMETypes() above is already providing only one alternative,
 	// so the caller trying a different manifest kind would be pointless.
@@ -171,7 +172,7 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest 
 		return perrors.Wrap(err, "parsing manifest")
 	}
 	if man.SchemaVersion != 2 || man.MediaType != manifest.DockerV2Schema2MediaType {
-		return perrors.New("Unsupported manifest type, need a Docker schema 2 manifest")
+		return errors.New("Unsupported manifest type, need a Docker schema 2 manifest")
 	}
 
 	if err := d.archive.lock(); err != nil {
@@ -191,10 +192,10 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest 
 // there can be no secondary manifests.  MUST be called after PutManifest (signatures reference manifest contents).
 func (d *Destination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	if instanceDigest != nil {
-		return perrors.New(`Manifest lists are not supported for docker tar files`)
+		return errors.New(`Manifest lists are not supported for docker tar files`)
 	}
 	if len(signatures) != 0 {
-		return perrors.New("Storing signatures for docker tar files is not supported")
+		return errors.New("Storing signatures for docker tar files is not supported")
 	}
 	return nil
 }

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -54,7 +54,7 @@ func (d *Destination) SupportedManifestMIMETypes() []string {
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 func (d *Destination) SupportsSignatures(ctx context.Context) error {
-	return errors.Errorf("Storing signatures for docker tar files is not supported")
+	return errors.New("Storing signatures for docker tar files is not supported")
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -171,7 +171,7 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest 
 		return errors.Wrap(err, "parsing manifest")
 	}
 	if man.SchemaVersion != 2 || man.MediaType != manifest.DockerV2Schema2MediaType {
-		return errors.Errorf("Unsupported manifest type, need a Docker schema 2 manifest")
+		return errors.New("Unsupported manifest type, need a Docker schema 2 manifest")
 	}
 
 	if err := d.archive.lock(); err != nil {
@@ -191,10 +191,10 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte, instanceDigest 
 // there can be no secondary manifests.  MUST be called after PutManifest (signatures reference manifest contents).
 func (d *Destination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	if instanceDigest != nil {
-		return errors.Errorf(`Manifest lists are not supported for docker tar files`)
+		return errors.New(`Manifest lists are not supported for docker tar files`)
 	}
 	if len(signatures) != 0 {
-		return errors.Errorf("Storing signatures for docker tar files is not supported")
+		return errors.New("Storing signatures for docker tar files is not supported")
 	}
 	return nil
 }

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -3,6 +3,7 @@ package tarfile
 import (
 	"archive/tar"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -189,7 +190,7 @@ func (r *Reader) openTarComponent(componentPath string) (io.ReadCloser, error) {
 	// This is only a sanity check; if anyone did concurrently close ra, this access is technically
 	// racy against the write in .Close().
 	if r.path == "" {
-		return nil, perrors.New("Internal error: trying to read an already closed tarfile.Reader")
+		return nil, errors.New("Internal error: trying to read an already closed tarfile.Reader")
 	}
 
 	f, err := os.Open(r.path)

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -3,6 +3,7 @@ package tarfile
 import (
 	"archive/tar"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -136,7 +137,7 @@ func (r *Reader) Close() error {
 func (r *Reader) ChooseManifestItem(ref reference.NamedTagged, sourceIndex int) (*ManifestItem, int, error) {
 	switch {
 	case ref != nil && sourceIndex != -1:
-		return nil, -1, errors.Errorf("Internal error: Cannot have both ref %s and source index @%d",
+		return nil, -1, fmt.Errorf("Internal error: Cannot have both ref %s and source index @%d",
 			ref.String(), sourceIndex)
 
 	case ref != nil:
@@ -152,18 +153,18 @@ func (r *Reader) ChooseManifestItem(ref reference.NamedTagged, sourceIndex int) 
 				}
 			}
 		}
-		return nil, -1, errors.Errorf("Tag %#v not found", refString)
+		return nil, -1, fmt.Errorf("Tag %#v not found", refString)
 
 	case sourceIndex != -1:
 		if sourceIndex >= len(r.Manifest) {
-			return nil, -1, errors.Errorf("Invalid source index @%d, only %d manifest items available",
+			return nil, -1, fmt.Errorf("Invalid source index @%d, only %d manifest items available",
 				sourceIndex, len(r.Manifest))
 		}
 		return &r.Manifest[sourceIndex], -1, nil
 
 	default:
 		if len(r.Manifest) != 1 {
-			return nil, -1, errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(r.Manifest))
+			return nil, -1, fmt.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(r.Manifest))
 		}
 		return &r.Manifest[0], -1, nil
 	}
@@ -226,7 +227,7 @@ func (r *Reader) openTarComponent(componentPath string) (io.ReadCloser, error) {
 	}
 
 	if !header.FileInfo().Mode().IsRegular() {
-		return nil, errors.Errorf("Error reading tar archive component %s: not a regular file", header.Name)
+		return nil, fmt.Errorf("Error reading tar archive component %s: not a regular file", header.Name)
 	}
 	succeeded = true
 	return &tarReadCloser{Reader: tarReader, backingFile: f}, nil

--- a/docker/internal/tarfile/src.go
+++ b/docker/internal/tarfile/src.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -180,7 +181,7 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 		}
 	}
 	if len(unknownLayerSizes) != 0 {
-		return nil, perrors.New("Some layer tarfiles are missing in the tarball") // This could do with a better error reporting, if this ever happened in practice.
+		return nil, errors.New("Some layer tarfiles are missing in the tarball") // This could do with a better error reporting, if this ever happened in practice.
 	}
 
 	return knownLayers, nil
@@ -195,7 +196,7 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 func (s *Source) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
 	if instanceDigest != nil {
 		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
-		return nil, "", perrors.New(`Manifest lists are not supported by "docker-daemon:"`)
+		return nil, "", errors.New(`Manifest lists are not supported by "docker-daemon:"`)
 	}
 	if s.generatedManifest == nil {
 		if err := s.ensureCachedDataIsPresent(); err != nil {
@@ -314,7 +315,7 @@ func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo, cache types.B
 func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	if instanceDigest != nil {
 		// How did we even get here? GetManifest(ctx, nil) has returned a manifest.DockerV2Schema2MediaType.
-		return nil, perrors.New(`Manifest lists are not supported by "docker-daemon:"`)
+		return nil, errors.New(`Manifest lists are not supported by "docker-daemon:"`)
 	}
 	return [][]byte{}, nil
 }

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,7 +54,7 @@ func (w *Writer) lock() error {
 	w.mutex.Lock()
 	if w.tar == nil {
 		w.mutex.Unlock()
-		return errors.New("Internal error: trying to use an already closed tarfile.Writer")
+		return perrors.New("Internal error: trying to use an already closed tarfile.Writer")
 	}
 	return nil
 }
@@ -72,7 +72,7 @@ func (w *Writer) unlock() {
 // The caller must have locked the Writer.
 func (w *Writer) tryReusingBlobLocked(info types.BlobInfo) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
+		return false, types.BlobInfo{}, perrors.New("Can not check for a blob with unknown digest")
 	}
 	if blob, ok := w.blobs[info.Digest]; ok {
 		return true, types.BlobInfo{Digest: info.Digest, Size: blob.Size}, nil
@@ -94,16 +94,16 @@ func (w *Writer) ensureSingleLegacyLayerLocked(layerID string, layerDigest diges
 		// See also the comment in physicalLayerPath.
 		physicalLayerPath := w.physicalLayerPath(layerDigest)
 		if err := w.sendSymlinkLocked(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
-			return errors.Wrap(err, "creating layer symbolic link")
+			return perrors.Wrap(err, "creating layer symbolic link")
 		}
 
 		b := []byte("1.0")
 		if err := w.sendBytesLocked(filepath.Join(layerID, legacyVersionFileName), b); err != nil {
-			return errors.Wrap(err, "writing VERSION file")
+			return perrors.Wrap(err, "writing VERSION file")
 		}
 
 		if err := w.sendBytesLocked(filepath.Join(layerID, legacyConfigFileName), configBytes); err != nil {
-			return errors.Wrap(err, "writing config json file")
+			return perrors.Wrap(err, "writing config json file")
 		}
 
 		w.legacyLayers[layerID] = struct{}{}
@@ -128,7 +128,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 			var config map[string]*json.RawMessage
 			err := json.Unmarshal(configBytes, &config)
 			if err != nil {
-				return errors.Wrap(err, "unmarshaling config")
+				return perrors.Wrap(err, "unmarshaling config")
 			}
 			for _, attr := range [7]string{"architecture", "config", "container", "container_config", "created", "docker_version", "os"} {
 				layerConfig[attr] = config[attr]
@@ -152,7 +152,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 		layerConfig["layer_id"] = chainID
 		b, err := json.Marshal(layerConfig) // Note that layerConfig["id"] is not set yet at this point.
 		if err != nil {
-			return errors.Wrap(err, "marshaling layer config")
+			return perrors.Wrap(err, "marshaling layer config")
 		}
 		delete(layerConfig, "layer_id")
 		layerID := digest.Canonical.FromBytes(b).Hex()
@@ -160,7 +160,7 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 
 		configBytes, err := json.Marshal(layerConfig)
 		if err != nil {
-			return errors.Wrap(err, "marshaling layer config")
+			return perrors.Wrap(err, "marshaling layer config")
 		}
 
 		if err := w.ensureSingleLegacyLayerLocked(layerID, l.Digest, configBytes); err != nil {
@@ -280,10 +280,10 @@ func (w *Writer) Close() error {
 
 	b, err = json.Marshal(w.repositories)
 	if err != nil {
-		return errors.Wrap(err, "marshaling repositories")
+		return perrors.Wrap(err, "marshaling repositories")
 	}
 	if err := w.sendBytesLocked(legacyRepositoriesFileName, b); err != nil {
-		return errors.Wrap(err, "writing config json file")
+		return perrors.Wrap(err, "writing config json file")
 	}
 
 	if err := w.tar.Close(); err != nil {

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -72,7 +72,7 @@ func (w *Writer) unlock() {
 // The caller must have locked the Writer.
 func (w *Writer) tryReusingBlobLocked(info types.BlobInfo) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.Errorf("Can not check for a blob with unknown digest")
+		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
 	}
 	if blob, ok := w.blobs[info.Digest]; ok {
 		return true, types.BlobInfo{Digest: info.Digest, Size: blob.Size}, nil
@@ -375,7 +375,7 @@ func (w *Writer) sendFileLocked(path string, expectedSize int64, stream io.Reade
 		return err
 	}
 	if size != expectedSize {
-		return errors.Errorf("Size mismatch when copying %s, expected %d, got %d", path, expectedSize, size)
+		return fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", path, expectedSize, size)
 	}
 	return nil
 }

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -54,7 +55,7 @@ func (w *Writer) lock() error {
 	w.mutex.Lock()
 	if w.tar == nil {
 		w.mutex.Unlock()
-		return perrors.New("Internal error: trying to use an already closed tarfile.Writer")
+		return errors.New("Internal error: trying to use an already closed tarfile.Writer")
 	}
 	return nil
 }
@@ -72,7 +73,7 @@ func (w *Writer) unlock() {
 // The caller must have locked the Writer.
 func (w *Writer) tryReusingBlobLocked(info types.BlobInfo) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, perrors.New("Can not check for a blob with unknown digest")
+		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
 	}
 	if blob, ok := w.blobs[info.Digest]; ok {
 		return true, types.BlobInfo{Digest: info.Digest, Size: blob.Size}, nil

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -61,7 +61,7 @@ type signatureStorageBase *url.URL
 func SignatureStorageBaseURL(sys *types.SystemContext, ref types.ImageReference, write bool) (*url.URL, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, errors.Errorf("ref must be a dockerReference")
+		return nil, errors.New("ref must be a dockerReference")
 	}
 	// FIXME? Loading and parsing the config could be cached across calls.
 	dirPath := registriesDirPath(sys)
@@ -87,7 +87,7 @@ func SignatureStorageBaseURL(sys *types.SystemContext, ref types.ImageReference,
 	// FIXME? Restrict to explicitly supported schemes?
 	repo := reference.Path(dr.ref) // Note that this is without a tag or digest.
 	if path.Clean(repo) != repo {  // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
-		return nil, errors.Errorf("Unexpected path elements in Docker reference %s for signature storage", dr.ref.String())
+		return nil, fmt.Errorf("Unexpected path elements in Docker reference %s for signature storage", dr.ref.String())
 	}
 	url.Path = url.Path + "/" + repo
 	return url, nil
@@ -158,7 +158,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 
 		if config.DefaultDocker != nil {
 			if mergedConfig.DefaultDocker != nil {
-				return nil, errors.Errorf(`Error parsing signature storage configuration: "default-docker" defined both in "%s" and "%s"`,
+				return nil, fmt.Errorf(`Error parsing signature storage configuration: "default-docker" defined both in "%s" and "%s"`,
 					dockerDefaultMergedFrom, configPath)
 			}
 			mergedConfig.DefaultDocker = config.DefaultDocker
@@ -167,7 +167,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 
 		for nsName, nsConfig := range config.Docker { // includes config.Docker == nil
 			if _, ok := mergedConfig.Docker[nsName]; ok {
-				return nil, errors.Errorf(`Error parsing signature storage configuration: "docker" namespace "%s" defined both in "%s" and "%s"`,
+				return nil, fmt.Errorf(`Error parsing signature storage configuration: "docker" namespace "%s" defined both in "%s" and "%s"`,
 					nsName, nsMergedFrom[nsName], configPath)
 			}
 			mergedConfig.Docker[nsName] = nsConfig

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -61,7 +62,7 @@ type signatureStorageBase *url.URL
 func SignatureStorageBaseURL(sys *types.SystemContext, ref types.ImageReference, write bool) (*url.URL, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, perrors.New("ref must be a dockerReference")
+		return nil, errors.New("ref must be a dockerReference")
 	}
 	// FIXME? Loading and parsing the config could be cached across calls.
 	dirPath := registriesDirPath(sys)

--- a/docker/lookaside.go
+++ b/docker/lookaside.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -61,7 +61,7 @@ type signatureStorageBase *url.URL
 func SignatureStorageBaseURL(sys *types.SystemContext, ref types.ImageReference, write bool) (*url.URL, error) {
 	dr, ok := ref.(dockerReference)
 	if !ok {
-		return nil, errors.New("ref must be a dockerReference")
+		return nil, perrors.New("ref must be a dockerReference")
 	}
 	// FIXME? Loading and parsing the config could be cached across calls.
 	dirPath := registriesDirPath(sys)
@@ -76,7 +76,7 @@ func SignatureStorageBaseURL(sys *types.SystemContext, ref types.ImageReference,
 	if topLevel != "" {
 		url, err = url.Parse(topLevel)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Invalid signature storage URL %s", topLevel)
+			return nil, perrors.Wrapf(err, "Invalid signature storage URL %s", topLevel)
 		}
 	} else {
 		// returns default directory if no sigstore specified in configuration file
@@ -153,7 +153,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 		var config registryConfiguration
 		err = yaml.Unmarshal(configBytes, &config)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing %s", configPath)
+			return nil, perrors.Wrapf(err, "parsing %s", configPath)
 		}
 
 		if config.DefaultDocker != nil {

--- a/docker/policyconfiguration/naming.go
+++ b/docker/policyconfiguration/naming.go
@@ -1,6 +1,7 @@
 package policyconfiguration
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -16,9 +17,9 @@ func DockerReferenceIdentity(ref reference.Named) (string, error) {
 	digested, isDigested := ref.(reference.Canonical)
 	switch {
 	case isTagged && isDigested: // Note that this CAN actually happen.
-		return "", errors.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
+		return "", fmt.Errorf("Unexpected Docker reference %s with both a name and a digest", reference.FamiliarString(ref))
 	case !isTagged && !isDigested: // This should not happen, the caller is expected to ensure !reference.IsNameOnly()
-		return "", errors.Errorf("Internal inconsistency: Docker reference %s with neither a tag nor a digest", reference.FamiliarString(ref))
+		return "", fmt.Errorf("Internal inconsistency: Docker reference %s with neither a tag nor a digest", reference.FamiliarString(ref))
 	case isTagged:
 		res = res + ":" + tagged.Tag()
 	case isDigested:

--- a/docker/policyconfiguration/naming.go
+++ b/docker/policyconfiguration/naming.go
@@ -1,11 +1,11 @@
 package policyconfiguration
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/pkg/errors"
 )
 
 // DockerReferenceIdentity returns a string representation of the reference, suitable for policy lookup,

--- a/internal/image/docker_list.go
+++ b/internal/image/docker_list.go
@@ -6,26 +6,26 @@ import (
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	list, err := manifest.Schema2ListFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing schema2 manifest list")
+		return nil, perrors.Wrapf(err, "parsing schema2 manifest list")
 	}
 	targetManifestDigest, err := list.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "choosing image instance")
+		return nil, perrors.Wrapf(err, "choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fetching target platform image selected from manifest list")
+		return nil, perrors.Wrapf(err, "fetching target platform image selected from manifest list")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrap(err, "computing manifest digest")
+		return nil, perrors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
 		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/internal/image/docker_list.go
+++ b/internal/image/docker_list.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -27,7 +28,7 @@ func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemConte
 		return nil, errors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
-		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
+		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
 	}
 
 	return manifestInstanceFromBlob(ctx, sys, src, manblob, mt)

--- a/internal/image/docker_schema1.go
+++ b/internal/image/docker_schema1.go
@@ -2,13 +2,13 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 type manifestSchema1 struct {
@@ -165,22 +165,22 @@ func (m *manifestSchema1) convertToManifestSchema2(_ context.Context, options *t
 
 	if len(m.m.ExtractedV1Compatibility) == 0 {
 		// What would this even mean?! Anyhow, the rest of the code depends on FSLayers[0] and ExtractedV1Compatibility[0] existing.
-		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
+		return nil, fmt.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
 	}
 	if len(m.m.ExtractedV1Compatibility) != len(m.m.FSLayers) {
-		return nil, errors.Errorf("Inconsistent schema 1 manifest: %d history entries, %d fsLayers entries", len(m.m.ExtractedV1Compatibility), len(m.m.FSLayers))
+		return nil, fmt.Errorf("Inconsistent schema 1 manifest: %d history entries, %d fsLayers entries", len(m.m.ExtractedV1Compatibility), len(m.m.FSLayers))
 	}
 	if uploadedLayerInfos != nil && len(uploadedLayerInfos) != len(m.m.FSLayers) {
-		return nil, errors.Errorf("Internal error: uploaded %d blobs, but schema1 manifest has %d fsLayers", len(uploadedLayerInfos), len(m.m.FSLayers))
+		return nil, fmt.Errorf("Internal error: uploaded %d blobs, but schema1 manifest has %d fsLayers", len(uploadedLayerInfos), len(m.m.FSLayers))
 	}
 	if layerDiffIDs != nil && len(layerDiffIDs) != len(m.m.FSLayers) {
-		return nil, errors.Errorf("Internal error: collected %d DiffID values, but schema1 manifest has %d fsLayers", len(layerDiffIDs), len(m.m.FSLayers))
+		return nil, fmt.Errorf("Internal error: collected %d DiffID values, but schema1 manifest has %d fsLayers", len(layerDiffIDs), len(m.m.FSLayers))
 	}
 
 	var convertedLayerUpdates []types.BlobInfo // Only used if options.LayerInfos != nil
 	if options.LayerInfos != nil {
 		if len(options.LayerInfos) != len(m.m.FSLayers) {
-			return nil, errors.Errorf("Error converting image: layer edits for %d layers vs %d existing layers",
+			return nil, fmt.Errorf("Error converting image: layer edits for %d layers vs %d existing layers",
 				len(options.LayerInfos), len(m.m.FSLayers))
 		}
 		convertedLayerUpdates = []types.BlobInfo{}

--- a/internal/image/docker_schema2.go
+++ b/internal/image/docker_schema2.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -138,7 +139,7 @@ func (m *manifestSchema2) Inspect(ctx context.Context) (*types.ImageInspectInfo,
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen
-			return nil, perrors.New("asked for a different config blob")
+			return nil, errors.New("asked for a different config blob")
 		}
 		config, err := m.ConfigBlob(ctx)
 		if err != nil {

--- a/internal/image/docker_schema2.go
+++ b/internal/image/docker_schema2.go
@@ -99,7 +99,7 @@ func (m *manifestSchema2) OCIConfig(ctx context.Context) (*imgspecv1.Image, erro
 func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 	if m.configBlob == nil {
 		if m.src == nil {
-			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestSchema2")
+			return nil, fmt.Errorf("Internal error: neither src nor configBlob set in manifestSchema2")
 		}
 		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromSchema2Descriptor(m.m.ConfigDescriptor), none.NoCache)
 		if err != nil {
@@ -112,7 +112,7 @@ func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 		}
 		computedDigest := digest.FromBytes(blob)
 		if computedDigest != m.m.ConfigDescriptor.Digest {
-			return nil, errors.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.ConfigDescriptor.Digest)
+			return nil, fmt.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.ConfigDescriptor.Digest)
 		}
 		m.configBlob = blob
 	}
@@ -277,7 +277,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 	haveGzippedEmptyLayer := false
 	if len(imageConfig.History) == 0 {
 		// What would this even mean?! Anyhow, the rest of the code depends on fsLayers[0] and history[0] existing.
-		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema1SignedMediaType)
+		return nil, fmt.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema1SignedMediaType)
 	}
 	for v2Index, historyEntry := range imageConfig.History {
 		parentV1ID = v1ID
@@ -296,7 +296,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 					return nil, errors.Wrap(err, "uploading empty layer")
 				}
 				if info.Digest != emptyLayerBlobInfo.Digest {
-					return nil, errors.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)
+					return nil, fmt.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)
 				}
 				haveGzippedEmptyLayer = true
 			}
@@ -306,7 +306,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 			blobDigest = emptyLayerBlobInfo.Digest
 		} else {
 			if nonemptyLayerIndex >= len(m.m.LayersDescriptors) {
-				return nil, errors.Errorf("Invalid image configuration, needs more than the %d distributed layers", len(m.m.LayersDescriptors))
+				return nil, fmt.Errorf("Invalid image configuration, needs more than the %d distributed layers", len(m.m.LayersDescriptors))
 			}
 			if options.LayerInfos != nil {
 				convertedLayerUpdates = append(convertedLayerUpdates, options.LayerInfos[nonemptyLayerIndex])
@@ -333,7 +333,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 		fakeImage.ContainerConfig.Cmd = []string{historyEntry.CreatedBy}
 		v1CompatibilityBytes, err := json.Marshal(&fakeImage)
 		if err != nil {
-			return nil, errors.Errorf("Internal error: Error creating v1compatibility for %#v", fakeImage)
+			return nil, fmt.Errorf("Internal error: Error creating v1compatibility for %#v", fakeImage)
 		}
 
 		fsLayers[v1Index] = manifest.Schema1FSLayers{BlobSum: blobDigest}

--- a/internal/image/docker_schema2.go
+++ b/internal/image/docker_schema2.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -138,7 +138,7 @@ func (m *manifestSchema2) Inspect(ctx context.Context) (*types.ImageInspectInfo,
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen
-			return nil, errors.New("asked for a different config blob")
+			return nil, perrors.New("asked for a different config blob")
 		}
 		config, err := m.ConfigBlob(ctx)
 		if err != nil {
@@ -293,7 +293,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 				// and anyway this blob is so small that it’s easier to just copy it than to worry about figuring out another location where to get it.
 				info, err := dest.PutBlob(ctx, bytes.NewReader(GzippedEmptyLayer), emptyLayerBlobInfo, none.NoCache, false)
 				if err != nil {
-					return nil, errors.Wrap(err, "uploading empty layer")
+					return nil, perrors.Wrap(err, "uploading empty layer")
 				}
 				if info.Digest != emptyLayerBlobInfo.Digest {
 					return nil, fmt.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)

--- a/internal/image/docker_schema2_test.go
+++ b/internal/image/docker_schema2_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/image/manifest.go
+++ b/internal/image/manifest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // genericManifest is an interface for parsing, modifying image manifests and related data.
@@ -107,7 +106,7 @@ func convertManifestIfRequiredWithUpdate(ctx context.Context, options types.Mani
 
 	converter, ok := converters[options.ManifestMIMEType]
 	if !ok {
-		return nil, errors.Errorf("Unsupported conversion type: %v", options.ManifestMIMEType)
+		return nil, fmt.Errorf("Unsupported conversion type: %v", options.ManifestMIMEType)
 	}
 
 	optionsCopy := options

--- a/internal/image/memory.go
+++ b/internal/image/memory.go
@@ -2,9 +2,9 @@ package image
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 // memoryImage is a mostly-implementation of types.Image assembled from data

--- a/internal/image/oci.go
+++ b/internal/image/oci.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 type manifestOCI1 struct {

--- a/internal/image/oci.go
+++ b/internal/image/oci.go
@@ -61,7 +61,7 @@ func (m *manifestOCI1) ConfigInfo() types.BlobInfo {
 func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 	if m.configBlob == nil {
 		if m.src == nil {
-			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestOCI1")
+			return nil, errors.New("Internal error: neither src nor configBlob set in manifestOCI1")
 		}
 		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromOCI1Descriptor(m.m.Config), none.NoCache)
 		if err != nil {
@@ -74,7 +74,7 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 		}
 		computedDigest := digest.FromBytes(blob)
 		if computedDigest != m.m.Config.Digest {
-			return nil, errors.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.Config.Digest)
+			return nil, fmt.Errorf("Download config.json digest %s does not match expected %s", computedDigest, m.m.Config.Digest)
 		}
 		m.configBlob = blob
 	}

--- a/internal/image/oci_index.go
+++ b/internal/image/oci_index.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -27,7 +28,7 @@ func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, s
 		return nil, errors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
-		return nil, errors.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
+		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)
 	}
 
 	return manifestInstanceFromBlob(ctx, sys, src, manblob, mt)

--- a/internal/image/oci_index.go
+++ b/internal/image/oci_index.go
@@ -6,26 +6,26 @@ import (
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	index, err := manifest.OCI1IndexFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing OCI1 index")
+		return nil, perrors.Wrapf(err, "parsing OCI1 index")
 	}
 	targetManifestDigest, err := index.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "choosing image instance")
+		return nil, perrors.Wrapf(err, "choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fetching target platform image selected from image index")
+		return nil, perrors.Wrapf(err, "fetching target platform image selected from image index")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrap(err, "computing manifest digest")
+		return nil, perrors.Wrap(err, "computing manifest digest")
 	}
 	if !matches {
 		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/internal/image/oci_test.go
+++ b/internal/image/oci_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,7 +17,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/image/unparsed.go
+++ b/internal/image/unparsed.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
@@ -60,7 +61,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 				return nil, "", errors.Wrap(err, "computing manifest digest")
 			}
 			if !matches {
-				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
+				return nil, "", fmt.Errorf("Manifest does not match provided manifest digest %s", digest)
 			}
 		}
 

--- a/internal/image/unparsed.go
+++ b/internal/image/unparsed.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // UnparsedImage implements types.UnparsedImage .
@@ -58,7 +58,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
 			matches, err := manifest.MatchesDigest(m, digest)
 			if err != nil {
-				return nil, "", errors.Wrap(err, "computing manifest digest")
+				return nil, "", perrors.Wrap(err, "computing manifest digest")
 			}
 			if !matches {
 				return nil, "", fmt.Errorf("Manifest does not match provided manifest digest %s", digest)

--- a/internal/iolimits/iolimits.go
+++ b/internal/iolimits/iolimits.go
@@ -1,9 +1,8 @@
 package iolimits
 
 import (
+	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 // All constants below are intended to be used as limits for `ReadAtMost`. The
@@ -52,7 +51,7 @@ func ReadAtMost(reader io.Reader, limit int) ([]byte, error) {
 	}
 
 	if len(res) > limit {
-		return nil, errors.Errorf("exceeded maximum allowed size of %d bytes", limit)
+		return nil, fmt.Errorf("exceeded maximum allowed size of %d bytes", limit)
 	}
 
 	return res, nil

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -106,10 +107,10 @@ func Schema1Clone(src *Schema1) *Schema1 {
 // initialize initializes ExtractedV1Compatibility and verifies invariants, so that the rest of this code can assume a minimally healthy manifest.
 func (m *Schema1) initialize() error {
 	if len(m.FSLayers) != len(m.History) {
-		return perrors.New("length of history not equal to number of layers")
+		return errors.New("length of history not equal to number of layers")
 	}
 	if len(m.FSLayers) == 0 {
-		return perrors.New("no FSLayers in manifest")
+		return errors.New("no FSLayers in manifest")
 	}
 	m.ExtractedV1Compatibility = make([]Schema1V1Compatibility, len(m.History))
 	for i, h := range m.History {
@@ -180,7 +181,7 @@ func (m *Schema1) fixManifestLayers() error {
 		}
 	}
 	if m.ExtractedV1Compatibility[len(m.ExtractedV1Compatibility)-1].Parent != "" {
-		return perrors.New("Invalid parent ID in the base layer of the image")
+		return errors.New("Invalid parent ID in the base layer of the image")
 	}
 	// check general duplicates to error instead of a deadlock
 	idmap := make(map[string]struct{})
@@ -241,7 +242,7 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	// Convert the schema 1 compat info into a schema 2 config, constructing some of the fields
 	// that aren't directly comparable using info from the manifest.
 	if len(m.History) == 0 {
-		return nil, perrors.New("image has no layers")
+		return nil, errors.New("image has no layers")
 	}
 	s1 := Schema2V1Image{}
 	config := []byte(m.History[0].V1Compatibility)

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -58,7 +59,7 @@ func Schema1FromManifest(manifest []byte) (*Schema1, error) {
 		return nil, err
 	}
 	if s1.SchemaVersion != 1 {
-		return nil, errors.Errorf("unsupported schema version %d", s1.SchemaVersion)
+		return nil, fmt.Errorf("unsupported schema version %d", s1.SchemaVersion)
 	}
 	if err := validateUnambiguousManifestFormat(manifest, DockerV2Schema1SignedMediaType,
 		allowedFieldFSLayers|allowedFieldHistory); err != nil {
@@ -142,7 +143,7 @@ func (m *Schema1) LayerInfos() []LayerInfo {
 func (m *Schema1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	// Our LayerInfos includes empty layers (where m.ExtractedV1Compatibility[].ThrowAway), so expect them to be included here as well.
 	if len(m.FSLayers) != len(layerInfos) {
-		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.FSLayers), len(layerInfos))
+		return fmt.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.FSLayers), len(layerInfos))
 	}
 	m.FSLayers = make([]Schema1FSLayers, len(layerInfos))
 	for i, info := range layerInfos {
@@ -187,7 +188,7 @@ func (m *Schema1) fixManifestLayers() error {
 	for _, img := range m.ExtractedV1Compatibility {
 		// skip IDs that appear after each other, we handle those later
 		if _, exists := idmap[img.ID]; img.ID != lastID && exists {
-			return errors.Errorf("ID %+v appears multiple times in manifest", img.ID)
+			return fmt.Errorf("ID %+v appears multiple times in manifest", img.ID)
 		}
 		lastID = img.ID
 		idmap[lastID] = struct{}{}
@@ -199,7 +200,7 @@ func (m *Schema1) fixManifestLayers() error {
 			m.History = append(m.History[:i], m.History[i+1:]...)
 			m.ExtractedV1Compatibility = append(m.ExtractedV1Compatibility[:i], m.ExtractedV1Compatibility[i+1:]...)
 		} else if m.ExtractedV1Compatibility[i].Parent != m.ExtractedV1Compatibility[i+1].ID {
-			return errors.Errorf("Invalid parent ID. Expected %v, got %v", m.ExtractedV1Compatibility[i+1].ID, m.ExtractedV1Compatibility[i].Parent)
+			return fmt.Errorf("Invalid parent ID. Expected %v, got %v", m.ExtractedV1Compatibility[i+1].ID, m.ExtractedV1Compatibility[i].Parent)
 		}
 	}
 	return nil
@@ -209,7 +210,7 @@ var validHex = regexp.MustCompile(`^([a-f0-9]{64})$`)
 
 func validateV1ID(id string) error {
 	if ok := validHex.MatchString(id); !ok {
-		return errors.Errorf("image ID %q is invalid", id)
+		return fmt.Errorf("image ID %q is invalid", id)
 	}
 	return nil
 }
@@ -292,20 +293,20 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	// Add the history and rootfs information.
 	rootfs, err := json.Marshal(rootFS)
 	if err != nil {
-		return nil, errors.Errorf("error encoding rootfs information %#v: %v", rootFS, err)
+		return nil, fmt.Errorf("error encoding rootfs information %#v: %v", rootFS, err)
 	}
 	rawRootfs := json.RawMessage(rootfs)
 	raw["rootfs"] = &rawRootfs
 	history, err := json.Marshal(convertedHistory)
 	if err != nil {
-		return nil, errors.Errorf("error encoding history information %#v: %v", convertedHistory, err)
+		return nil, fmt.Errorf("error encoding history information %#v: %v", convertedHistory, err)
 	}
 	rawHistory := json.RawMessage(history)
 	raw["history"] = &rawHistory
 	// Encode the result.
 	config, err = json.Marshal(raw)
 	if err != nil {
-		return nil, errors.Errorf("error re-encoding compat image config %#v: %v", s1, err)
+		return nil, fmt.Errorf("error re-encoding compat image config %#v: %v", s1, err)
 	}
 	return config, nil
 }

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/image/v5/pkg/strslice"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // Schema2Descriptor is a “descriptor” in docker/distribution schema 2.
@@ -246,7 +246,7 @@ func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(schema2CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return errors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
+			return perrors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
 		}
 		m.LayersDescriptors[i].MediaType = mimeType
 		m.LayersDescriptors[i].Digest = info.Digest

--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -234,7 +234,7 @@ var schema2CompressionMIMETypeSets = []compressionMIMETypeSet{
 // CompressionAlgorithm that would result in anything other than gzip compression.
 func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.LayersDescriptors) != len(layerInfos) {
-		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.LayersDescriptors), len(layerInfos))
+		return fmt.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.LayersDescriptors), len(layerInfos))
 	}
 	original := m.LayersDescriptors
 	m.LayersDescriptors = make([]Schema2Descriptor, len(layerInfos))

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -60,14 +60,14 @@ func (list *Schema2List) Instance(instanceDigest digest.Digest) (ListUpdate, err
 			}, nil
 		}
 	}
-	return ListUpdate{}, errors.Errorf("unable to find instance %s passed to Schema2List.Instances", instanceDigest)
+	return ListUpdate{}, fmt.Errorf("unable to find instance %s passed to Schema2List.Instances", instanceDigest)
 }
 
 // UpdateInstances updates the sizes, digests, and media types of the manifests
 // which the list catalogs.
 func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 	if len(updates) != len(list.Manifests) {
-		return errors.Errorf("incorrect number of update entries passed to Schema2List.UpdateInstances: expected %d, got %d", len(list.Manifests), len(updates))
+		return fmt.Errorf("incorrect number of update entries passed to Schema2List.UpdateInstances: expected %d, got %d", len(list.Manifests), len(updates))
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
@@ -75,11 +75,11 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 		}
 		list.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
-			return errors.Errorf("update %d of %d passed to Schema2List.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
+			return fmt.Errorf("update %d of %d passed to Schema2List.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
 		}
 		list.Manifests[i].Size = updates[i].Size
 		if updates[i].MediaType == "" {
-			return errors.Errorf("update %d of %d passed to Schema2List.UpdateInstances had no media type (was %q)", i+1, len(updates), list.Manifests[i].MediaType)
+			return fmt.Errorf("update %d of %d passed to Schema2List.UpdateInstances had no media type (was %q)", i+1, len(updates), list.Manifests[i].MediaType)
 		}
 		list.Manifests[i].MediaType = updates[i].MediaType
 	}

--- a/manifest/docker_schema2_list.go
+++ b/manifest/docker_schema2_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // Schema2PlatformSpec describes the platform which a particular manifest is
@@ -71,7 +71,7 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
-			return errors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances contained an invalid digest", i+1, len(updates))
+			return perrors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances contained an invalid digest", i+1, len(updates))
 		}
 		list.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
@@ -91,7 +91,7 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "getting platform information %#v", ctx)
+		return "", perrors.Wrapf(err, "getting platform information %#v", ctx)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range list.Manifests {
@@ -115,7 +115,7 @@ func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest
 func (list *Schema2List) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(list)
 	if err != nil {
-		return nil, errors.Wrapf(err, "marshaling Schema2List %#v", list)
+		return nil, perrors.Wrapf(err, "marshaling Schema2List %#v", list)
 	}
 	return buf, nil
 }
@@ -190,7 +190,7 @@ func Schema2ListFromManifest(manifest []byte) (*Schema2List, error) {
 		Manifests: []Schema2ManifestDescriptor{},
 	}
 	if err := json.Unmarshal(manifest, &list); err != nil {
-		return nil, errors.Wrapf(err, "unmarshaling Schema2List %q", string(manifest))
+		return nil, perrors.Wrapf(err, "unmarshaling Schema2List %q", string(manifest))
 	}
 	if err := validateUnambiguousManifestFormat(manifest, DockerV2ListMediaType,
 		allowedFieldManifests); err != nil {

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // BlobInfoFromOCI1Descriptor returns a types.BlobInfo based on the input OCI1 descriptor.
@@ -139,7 +139,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(oci1CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return errors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
+			return perrors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
 		}
 		if info.CryptoOperation == types.Encrypt {
 			encMediaType, err := getEncryptedMediaType(mimeType)

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -163,7 +163,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 func getEncryptedMediaType(mediatype string) (string, error) {
 	for _, s := range strings.Split(mediatype, "+")[1:] {
 		if s == "encrypted" {
-			return "", fmt.Errorf("unsupportedmediatype: %v already encrypted", mediatype)
+			return "", fmt.Errorf("unsupported mediaType: %v already encrypted", mediatype)
 		}
 	}
 	unsuffixedMediatype := strings.Split(mediatype, "+")[0]
@@ -172,14 +172,14 @@ func getEncryptedMediaType(mediatype string) (string, error) {
 		return mediatype + "+encrypted", nil
 	}
 
-	return "", fmt.Errorf("unsupported mediatype to encrypt: %v", mediatype)
+	return "", fmt.Errorf("unsupported mediaType to encrypt: %v", mediatype)
 }
 
 // getEncryptedMediaType will return the mediatype to its encrypted counterpart and return
 // an error if the mediatype does not support decryption
 func getDecryptedMediaType(mediatype string) (string, error) {
 	if !strings.HasSuffix(mediatype, "+encrypted") {
-		return "", fmt.Errorf("unsupported mediatype to decrypt %v:", mediatype)
+		return "", fmt.Errorf("unsupported mediaType to decrypt %v:", mediatype)
 	}
 
 	return strings.TrimSuffix(mediatype, "+encrypted"), nil

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -124,7 +124,7 @@ var oci1CompressionMIMETypeSets = []compressionMIMETypeSet{
 // handled — that logic should eventually also be provided as OCI1 methods, not hard-coded in callers.
 func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 	if len(m.Layers) != len(layerInfos) {
-		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.Layers), len(layerInfos))
+		return fmt.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.Layers), len(layerInfos))
 	}
 	original := m.Layers
 	m.Layers = make([]imgspecv1.Descriptor, len(layerInfos))
@@ -163,7 +163,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 func getEncryptedMediaType(mediatype string) (string, error) {
 	for _, s := range strings.Split(mediatype, "+")[1:] {
 		if s == "encrypted" {
-			return "", errors.Errorf("unsupportedmediatype: %v already encrypted", mediatype)
+			return "", fmt.Errorf("unsupportedmediatype: %v already encrypted", mediatype)
 		}
 	}
 	unsuffixedMediatype := strings.Split(mediatype, "+")[0]
@@ -172,14 +172,14 @@ func getEncryptedMediaType(mediatype string) (string, error) {
 		return mediatype + "+encrypted", nil
 	}
 
-	return "", errors.Errorf("unsupported mediatype to encrypt: %v", mediatype)
+	return "", fmt.Errorf("unsupported mediatype to encrypt: %v", mediatype)
 }
 
 // getEncryptedMediaType will return the mediatype to its encrypted counterpart and return
 // an error if the mediatype does not support decryption
 func getDecryptedMediaType(mediatype string) (string, error) {
 	if !strings.HasSuffix(mediatype, "+encrypted") {
-		return "", errors.Errorf("unsupported mediatype to decrypt %v:", mediatype)
+		return "", fmt.Errorf("unsupported mediatype to decrypt %v:", mediatype)
 	}
 
 	return strings.TrimSuffix(mediatype, "+encrypted"), nil

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -44,14 +44,14 @@ func (index *OCI1Index) Instance(instanceDigest digest.Digest) (ListUpdate, erro
 			}, nil
 		}
 	}
-	return ListUpdate{}, errors.Errorf("unable to find instance %s in OCI1Index", instanceDigest)
+	return ListUpdate{}, fmt.Errorf("unable to find instance %s in OCI1Index", instanceDigest)
 }
 
 // UpdateInstances updates the sizes, digests, and media types of the manifests
 // which the list catalogs.
 func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 	if len(updates) != len(index.Manifests) {
-		return errors.Errorf("incorrect number of update entries passed to OCI1Index.UpdateInstances: expected %d, got %d", len(index.Manifests), len(updates))
+		return fmt.Errorf("incorrect number of update entries passed to OCI1Index.UpdateInstances: expected %d, got %d", len(index.Manifests), len(updates))
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
@@ -59,11 +59,11 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 		}
 		index.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
-			return errors.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
+			return fmt.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
 		}
 		index.Manifests[i].Size = updates[i].Size
 		if updates[i].MediaType == "" {
-			return errors.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had no media type (was %q)", i+1, len(updates), index.Manifests[i].MediaType)
+			return fmt.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had no media type (was %q)", i+1, len(updates), index.Manifests[i].MediaType)
 		}
 		index.Manifests[i].MediaType = updates[i].MediaType
 	}

--- a/manifest/oci_index.go
+++ b/manifest/oci_index.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // OCI1Index is just an alias for the OCI index type, but one which we can
@@ -55,7 +55,7 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
-			return errors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances contained an invalid digest", i+1, len(updates))
+			return perrors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances contained an invalid digest", i+1, len(updates))
 		}
 		index.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
@@ -75,7 +75,7 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "getting platform information %#v", ctx)
+		return "", perrors.Wrapf(err, "getting platform information %#v", ctx)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range index.Manifests {
@@ -108,7 +108,7 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 func (index *OCI1Index) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(index)
 	if err != nil {
-		return nil, errors.Wrapf(err, "marshaling OCI1Index %#v", index)
+		return nil, perrors.Wrapf(err, "marshaling OCI1Index %#v", index)
 	}
 	return buf, nil
 }
@@ -202,7 +202,7 @@ func OCI1IndexFromManifest(manifest []byte) (*OCI1Index, error) {
 		},
 	}
 	if err := json.Unmarshal(manifest, &index); err != nil {
-		return nil, errors.Wrapf(err, "unmarshaling OCI1Index %q", string(manifest))
+		return nil, perrors.Wrapf(err, "unmarshaling OCI1Index %q", string(manifest))
 	}
 	if err := validateUnambiguousManifestFormat(manifest, imgspecv1.MediaTypeImageIndex,
 		allowedFieldManifests); err != nil {

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,12 +22,12 @@ type ociArchiveImageDestination struct {
 func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating oci reference")
+		return nil, perrors.Wrapf(err, "creating oci reference")
 	}
 	unpackedDest, err := tempDirRef.ociRefExtracted.NewImageDestination(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+			return nil, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (d *ociArchiveImageDestination) PutSignatures(ctx context.Context, signatur
 // after the directory is made, it is tarred up into a file and the directory is deleted
 func (d *ociArchiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if err := d.unpackedDest.Commit(ctx, unparsedToplevel); err != nil {
-		return errors.Wrapf(err, "storing image %q", d.ref.image)
+		return perrors.Wrapf(err, "storing image %q", d.ref.image)
 	}
 
 	// path of directory to tar up
@@ -150,13 +150,13 @@ func tarDirectory(src, dst string) error {
 	// input is a stream of bytes from the archive of the directory at path
 	input, err := archive.Tar(src, archive.Uncompressed)
 	if err != nil {
-		return errors.Wrapf(err, "retrieving stream of bytes from %q", src)
+		return perrors.Wrapf(err, "retrieving stream of bytes from %q", src)
 	}
 
 	// creates the tar file
 	outFile, err := os.Create(dst)
 	if err != nil {
-		return errors.Wrapf(err, "creating tar file %q", dst)
+		return perrors.Wrapf(err, "creating tar file %q", dst)
 	}
 	defer outFile.Close()
 

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -48,7 +48,7 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociArchRef, ok := imgRef.(ociArchiveReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociArchiveReference")
+		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociArchiveReference")
 	}
 	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,13 +23,13 @@ type ociArchiveImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(sys, ref)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating temp directory")
+		return nil, perrors.Wrap(err, "creating temp directory")
 	}
 
 	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+			return nil, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
 		return nil, err
 	}
@@ -48,11 +48,11 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociArchRef, ok := imgRef.(ociArchiveReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociArchiveReference")
+		return imgspecv1.Descriptor{}, perrors.New("error typecasting, need type ociArchiveReference")
 	}
 	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {
-		return imgspecv1.Descriptor{}, errors.Wrap(err, "creating temp directory")
+		return imgspecv1.Descriptor{}, perrors.Wrap(err, "creating temp directory")
 	}
 	defer func() {
 		err := tempDirRef.deleteTempDir()
@@ -61,7 +61,7 @@ func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.Im
 
 	descriptor, err := ocilayout.LoadManifestDescriptor(tempDirRef.ociRefExtracted)
 	if err != nil {
-		return imgspecv1.Descriptor{}, errors.Wrap(err, "loading index")
+		return imgspecv1.Descriptor{}, perrors.Wrap(err, "loading index")
 	}
 	return descriptor, nil
 }

--- a/oci/archive/oci_src.go
+++ b/oci/archive/oci_src.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	ocilayout "github.com/containers/image/v5/oci/layout"
@@ -48,7 +49,7 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociArchRef, ok := imgRef.(ociArchiveReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, perrors.New("error typecasting, need type ociArchiveReference")
+		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociArchiveReference")
 	}
 	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -139,7 +139,7 @@ func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *typ
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociArchiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.New("Deleting images not implemented for oci: images")
+	return perrors.New("Deleting images not implemented for oci: images")
 }
 
 // struct to store the ociReference and temporary directory returned by createOCIRef
@@ -158,7 +158,7 @@ func (t *tempDirOCIRef) deleteTempDir() error {
 func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error) {
 	dir, err := os.MkdirTemp(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
 	if err != nil {
-		return tempDirOCIRef{}, errors.Wrapf(err, "creating temp directory")
+		return tempDirOCIRef{}, perrors.Wrapf(err, "creating temp directory")
 	}
 	ociRef, err := ocilayout.NewReference(dir, image)
 	if err != nil {
@@ -173,7 +173,7 @@ func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error)
 func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (tempDirOCIRef, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
-		return tempDirOCIRef{}, errors.Wrap(err, "creating oci reference")
+		return tempDirOCIRef{}, perrors.Wrap(err, "creating oci reference")
 	}
 	src := ref.resolvedFile
 	dst := tempDirRef.tempDirectory
@@ -185,9 +185,9 @@ func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (temp
 	defer arch.Close()
 	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return tempDirOCIRef{}, errors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+			return tempDirOCIRef{}, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
 		}
-		return tempDirOCIRef{}, errors.Wrapf(err, "untarring file %q", tempDirRef.tempDirectory)
+		return tempDirOCIRef{}, perrors.Wrapf(err, "untarring file %q", tempDirRef.tempDirectory)
 	}
 	return tempDirRef, nil
 }

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -139,7 +140,7 @@ func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *typ
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociArchiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return perrors.New("Deleting images not implemented for oci: images")
+	return errors.New("Deleting images not implemented for oci: images")
 }
 
 // struct to store the ociReference and temporary directory returned by createOCIRef

--- a/oci/archive/oci_transport.go
+++ b/oci/archive/oci_transport.go
@@ -139,7 +139,7 @@ func (ref ociArchiveReference) NewImageDestination(ctx context.Context, sys *typ
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociArchiveReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.Errorf("Deleting images not implemented for oci: images")
+	return errors.New("Deleting images not implemented for oci: images")
 }
 
 // struct to store the ociReference and temporary directory returned by createOCIRef

--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -1,11 +1,13 @@
 package internal
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -27,7 +29,7 @@ func ValidateImageName(image string) error {
 
 	var err error
 	if !refRegexp.MatchString(image) {
-		err = errors.Errorf("Invalid image %s", image)
+		err = fmt.Errorf("Invalid image %s", image)
 	}
 	return err
 }
@@ -72,11 +74,11 @@ func ValidateOCIPath(path string) error {
 	if runtime.GOOS == "windows" {
 		// On Windows we must allow for a ':' as part of the path
 		if strings.Count(path, ":") > 1 {
-			return errors.Errorf("Invalid OCI reference: path %s contains more than one colon", path)
+			return fmt.Errorf("Invalid OCI reference: path %s contains more than one colon", path)
 		}
 	} else {
 		if strings.Contains(path, ":") {
-			return errors.Errorf("Invalid OCI reference: path %s contains a colon", path)
+			return fmt.Errorf("Invalid OCI reference: path %s contains a colon", path)
 		}
 	}
 	return nil
@@ -96,7 +98,7 @@ func ValidateScope(scope string) error {
 
 	cleaned := filepath.Clean(scope)
 	if cleaned != scope {
-		return errors.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+		return fmt.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
 	}
 
 	return nil
@@ -105,7 +107,7 @@ func ValidateScope(scope string) error {
 func validateScopeWindows(scope string) error {
 	matched, _ := regexp.Match(`^[a-zA-Z]:\\`, []byte(scope))
 	if !matched {
-		return errors.Errorf("Invalid scope '%s'. Must be an absolute path", scope)
+		return fmt.Errorf("Invalid scope '%s'. Must be an absolute path", scope)
 	}
 
 	return nil
@@ -113,7 +115,7 @@ func validateScopeWindows(scope string) error {
 
 func validateScopeNonWindows(scope string) error {
 	if !strings.HasPrefix(scope, "/") {
-		return errors.Errorf("Invalid scope %s: must be an absolute path", scope)
+		return fmt.Errorf("Invalid scope %s: must be an absolute path", scope)
 	}
 
 	// Refuse also "/", otherwise "/" and "" would have the same semantics,

--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -1,13 +1,12 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -192,7 +192,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // May use and/or update cache.
 func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.New(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
 	}
 	blobPath, err := d.ref.blobPath(info.Digest, d.sharedBlobDir)
 	if err != nil {

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -81,7 +82,7 @@ func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 func (d *ociImageDestination) SupportsSignatures(ctx context.Context) error {
-	return errors.Errorf("Pushing signatures for OCI images is not supported")
+	return errors.New("Pushing signatures for OCI images is not supported")
 }
 
 func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
@@ -146,7 +147,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	}
 	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
@@ -191,7 +192,7 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 // May use and/or update cache.
 func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
-		return false, types.BlobInfo{}, errors.Errorf(`"Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.New(`"Can not check for a blob with unknown digest`)
 	}
 	blobPath, err := d.ref.blobPath(info.Digest, d.sharedBlobDir)
 	if err != nil {
@@ -295,7 +296,7 @@ func (d *ociImageDestination) addManifest(desc *imgspecv1.Descriptor) {
 // (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
 func (d *ociImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	if len(signatures) != 0 {
-		return errors.Errorf("Pushing signatures for OCI images is not supported")
+		return errors.New("Pushing signatures for OCI images is not supported")
 	}
 	return nil
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 type ociImageDestination struct {

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -50,7 +50,7 @@ func TestPutBlobDigestFailure(t *testing.T) {
 			}
 			return len(p), nil
 		}
-		return 0, errors.Errorf(digestErrorString)
+		return 0, errors.New(digestErrorString)
 	})
 
 	dest, err := ref.NewImageDestination(context.Background(), nil)

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -150,10 +151,10 @@ func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 // should fallback to fetch the non-external blob (i.e. pull from the registry).
 func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
 	if len(urls) == 0 {
-		return nil, 0, perrors.New("internal error: getExternalBlob called with no URLs")
+		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
 	}
 
-	errWrap := perrors.New("failed fetching external blob from all urls")
+	errWrap := errors.New("failed fetching external blob from all urls")
 	hasSupportedURL := false
 	for _, u := range urls {
 		if u, err := url.Parse(u); err != nil || (u.Scheme != "http" && u.Scheme != "https") {

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 type ociImageSource struct {
@@ -150,10 +150,10 @@ func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *dige
 // should fallback to fetch the non-external blob (i.e. pull from the registry).
 func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
 	if len(urls) == 0 {
-		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
+		return nil, 0, perrors.New("internal error: getExternalBlob called with no URLs")
 	}
 
-	errWrap := errors.New("failed fetching external blob from all urls")
+	errWrap := perrors.New("failed fetching external blob from all urls")
 	hasSupportedURL := false
 	for _, u := range urls {
 		if u, err := url.Parse(u); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
@@ -162,19 +162,19 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 		hasSupportedURL = true
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 		if err != nil {
-			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
+			errWrap = perrors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
 			continue
 		}
 
 		resp, err := s.client.Do(req)
 		if err != nil {
-			errWrap = errors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
+			errWrap = perrors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
 			continue
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
-			errWrap = errors.Wrapf(errWrap, "fetching %s failed, response code not 200", u)
+			errWrap = perrors.Wrapf(errWrap, "fetching %s failed, response code not 200", u)
 			continue
 		}
 

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ var (
 
 	// ErrMoreThanOneImage is an error returned when the manifest includes
 	// more than one image and the user should choose which one to use.
-	ErrMoreThanOneImage = perrors.New("more than one image in oci, choose an image")
+	ErrMoreThanOneImage = errors.New("more than one image in oci, choose an image")
 )
 
 type ociTransport struct{}
@@ -215,7 +216,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociRef, ok := imgRef.(ociReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, perrors.New("error typecasting, need type ociRef")
+		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociRef")
 	}
 	return ociRef.getManifestDescriptor()
 }
@@ -234,7 +235,7 @@ func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.Syst
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return perrors.New("Deleting images not implemented for oci: images")
+	return errors.New("Deleting images not implemented for oci: images")
 }
 
 // ociLayoutPath returns a path for the oci-layout within a directory using OCI conventions.

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -29,7 +29,7 @@ var (
 
 	// ErrMoreThanOneImage is an error returned when the manifest includes
 	// more than one image and the user should choose which one to use.
-	ErrMoreThanOneImage = errors.New("more than one image in oci, choose an image")
+	ErrMoreThanOneImage = perrors.New("more than one image in oci, choose an image")
 )
 
 type ociTransport struct{}
@@ -215,7 +215,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociRef, ok := imgRef.(ociReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociRef")
+		return imgspecv1.Descriptor{}, perrors.New("error typecasting, need type ociRef")
 	}
 	return ociRef.getManifestDescriptor()
 }
@@ -234,7 +234,7 @@ func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.Syst
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.New("Deleting images not implemented for oci: images")
+	return perrors.New("Deleting images not implemented for oci: images")
 }
 
 // ociLayoutPath returns a path for the oci-layout within a directory using OCI conventions.
@@ -250,7 +250,7 @@ func (ref ociReference) indexPath() string {
 // blobPath returns a path for a blob within a directory using OCI image-layout conventions.
 func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
 	if err := digest.Validate(); err != nil {
-		return "", errors.Wrapf(err, "unexpected digest reference %s", digest)
+		return "", perrors.Wrapf(err, "unexpected digest reference %s", digest)
 	}
 	blobDir := filepath.Join(ref.dir, "blobs")
 	if sharedBlobDir != "" {

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -215,7 +215,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, error) {
 	ociRef, ok := imgRef.(ociReference)
 	if !ok {
-		return imgspecv1.Descriptor{}, errors.Errorf("error typecasting, need type ociRef")
+		return imgspecv1.Descriptor{}, errors.New("error typecasting, need type ociRef")
 	}
 	return ociRef.getManifestDescriptor()
 }
@@ -234,7 +234,7 @@ func (ref ociReference) NewImageDestination(ctx context.Context, sys *types.Syst
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ociReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.Errorf("Deleting images not implemented for oci: images")
+	return errors.New("Deleting images not implemented for oci: images")
 }
 
 // ociLayoutPath returns a path for the oci-layout within a directory using OCI conventions.

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -354,19 +354,19 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdCluster) []err
 
 	if len(clusterInfo.Server) == 0 {
 		if len(clusterName) == 0 {
-			validationErrors = append(validationErrors, errors.Errorf("default cluster has no server defined"))
+			validationErrors = append(validationErrors, errors.New("default cluster has no server defined"))
 		} else {
-			validationErrors = append(validationErrors, errors.Errorf("no server found for cluster %q", clusterName))
+			validationErrors = append(validationErrors, fmt.Errorf("no server found for cluster %q", clusterName))
 		}
 	}
 	// Make sure CA data and CA file aren't both specified
 	if len(clusterInfo.CertificateAuthority) != 0 && len(clusterInfo.CertificateAuthorityData) != 0 {
-		validationErrors = append(validationErrors, errors.Errorf("certificate-authority-data and certificate-authority are both specified for %v. certificate-authority-data will override", clusterName))
+		validationErrors = append(validationErrors, fmt.Errorf("certificate-authority-data and certificate-authority are both specified for %v. certificate-authority-data will override", clusterName))
 	}
 	if len(clusterInfo.CertificateAuthority) != 0 {
 		err := validateFileIsReadable(clusterInfo.CertificateAuthority)
 		if err != nil {
-			validationErrors = append(validationErrors, errors.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
+			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
 		}
 	}
 
@@ -390,34 +390,34 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdAuthInfo) []error {
 	if len(authInfo.ClientCertificate) != 0 || len(authInfo.ClientCertificateData) != 0 {
 		// Make sure cert data and file aren't both specified
 		if len(authInfo.ClientCertificate) != 0 && len(authInfo.ClientCertificateData) != 0 {
-			validationErrors = append(validationErrors, errors.Errorf("client-cert-data and client-cert are both specified for %v. client-cert-data will override", authInfoName))
+			validationErrors = append(validationErrors, fmt.Errorf("client-cert-data and client-cert are both specified for %v. client-cert-data will override", authInfoName))
 		}
 		// Make sure key data and file aren't both specified
 		if len(authInfo.ClientKey) != 0 && len(authInfo.ClientKeyData) != 0 {
-			validationErrors = append(validationErrors, errors.Errorf("client-key-data and client-key are both specified for %v; client-key-data will override", authInfoName))
+			validationErrors = append(validationErrors, fmt.Errorf("client-key-data and client-key are both specified for %v; client-key-data will override", authInfoName))
 		}
 		// Make sure a key is specified
 		if len(authInfo.ClientKey) == 0 && len(authInfo.ClientKeyData) == 0 {
-			validationErrors = append(validationErrors, errors.Errorf("client-key-data or client-key must be specified for %v to use the clientCert authentication method", authInfoName))
+			validationErrors = append(validationErrors, fmt.Errorf("client-key-data or client-key must be specified for %v to use the clientCert authentication method", authInfoName))
 		}
 
 		if len(authInfo.ClientCertificate) != 0 {
 			err := validateFileIsReadable(authInfo.ClientCertificate)
 			if err != nil {
-				validationErrors = append(validationErrors, errors.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
 			}
 		}
 		if len(authInfo.ClientKey) != 0 {
 			err := validateFileIsReadable(authInfo.ClientKey)
 			if err != nil {
-				validationErrors = append(validationErrors, errors.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
 			}
 		}
 	}
 
 	// authPath also provides information for the client to identify the server, so allow multiple auth methods in that case
 	if (len(methods) > 1) && (!usingAuthPath) {
-		validationErrors = append(validationErrors, errors.Errorf("more than one authentication method found for %v; found %v, only one is allowed", authInfoName, methods))
+		validationErrors = append(validationErrors, fmt.Errorf("more than one authentication method found for %v; found %v, only one is allowed", authInfoName, methods))
 	}
 
 	return validationErrors
@@ -774,7 +774,7 @@ func restClientFor(config *restConfig) (*url.URL, *http.Client, error) {
 // Kubernetes API.
 func defaultServerURL(host string, defaultTLS bool) (*url.URL, error) {
 	if host == "" {
-		return nil, errors.Errorf("host must be a URL or a host:port pair")
+		return nil, errors.New("host must be a URL or a host:port pair")
 	}
 	base := host
 	hostURL, err := url.Parse(base)
@@ -791,7 +791,7 @@ func defaultServerURL(host string, defaultTLS bool) (*url.URL, error) {
 			return nil, err
 		}
 		if hostURL.Path != "" && hostURL.Path != "/" {
-			return nil, errors.Errorf("host must be a URL or a host:port pair: %q", base)
+			return nil, fmt.Errorf("host must be a URL or a host:port pair: %q", base)
 		}
 	}
 
@@ -861,7 +861,7 @@ func transportNew(config *restConfig) (http.RoundTripper, error) {
 
 	// REMOVED: HTTPWrappersForConfig(config, rt) in favor of the caller setting HTTP headers itself based on restConfig. Only this inlined check remains.
 	if len(config.Username) != 0 && len(config.BearerToken) != 0 {
-		return nil, errors.Errorf("username/password or bearer token may be set, but not both")
+		return nil, errors.New("username/password or bearer token may be set, but not both")
 	}
 
 	return rt, nil
@@ -954,7 +954,7 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 		return nil, nil
 	}
 	if c.HasCA() && c.Insecure {
-		return nil, errors.Errorf("specifying a root certificates file with the insecure flag is not allowed")
+		return nil, errors.New("specifying a root certificates file with the insecure flag is not allowed")
 	}
 	if err := loadTLSFiles(c); err != nil {
 		return nil, err

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -327,9 +328,9 @@ func (config *directClientConfig) getContext() clientcmdContext {
 }
 
 var (
-	errEmptyConfig = perrors.New("no configuration has been provided")
+	errEmptyConfig = errors.New("no configuration has been provided")
 	// message is for consistency with old behavior
-	errEmptyCluster = perrors.New("cluster has no server defined")
+	errEmptyCluster = errors.New("cluster has no server defined")
 )
 
 //helper for checking certificate/key/CA
@@ -354,7 +355,7 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdCluster) []err
 
 	if len(clusterInfo.Server) == 0 {
 		if len(clusterName) == 0 {
-			validationErrors = append(validationErrors, perrors.New("default cluster has no server defined"))
+			validationErrors = append(validationErrors, errors.New("default cluster has no server defined"))
 		} else {
 			validationErrors = append(validationErrors, fmt.Errorf("no server found for cluster %q", clusterName))
 		}
@@ -774,7 +775,7 @@ func restClientFor(config *restConfig) (*url.URL, *http.Client, error) {
 // Kubernetes API.
 func defaultServerURL(host string, defaultTLS bool) (*url.URL, error) {
 	if host == "" {
-		return nil, perrors.New("host must be a URL or a host:port pair")
+		return nil, errors.New("host must be a URL or a host:port pair")
 	}
 	base := host
 	hostURL, err := url.Parse(base)
@@ -861,7 +862,7 @@ func transportNew(config *restConfig) (http.RoundTripper, error) {
 
 	// REMOVED: HTTPWrappersForConfig(config, rt) in favor of the caller setting HTTP headers itself based on restConfig. Only this inlined check remains.
 	if len(config.Username) != 0 && len(config.BearerToken) != 0 {
-		return nil, perrors.New("username/password or bearer token may be set, but not both")
+		return nil, errors.New("username/password or bearer token may be set, but not both")
 	}
 
 	return rt, nil
@@ -954,7 +955,7 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 		return nil, nil
 	}
 	if c.HasCA() && c.Insecure {
-		return nil, perrors.New("specifying a root certificates file with the insecure flag is not allowed")
+		return nil, errors.New("specifying a root certificates file with the insecure flag is not allowed")
 	}
 	if err := loadTLSFiles(c); err != nil {
 		return nil, err

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 )
@@ -327,9 +327,9 @@ func (config *directClientConfig) getContext() clientcmdContext {
 }
 
 var (
-	errEmptyConfig = errors.New("no configuration has been provided")
+	errEmptyConfig = perrors.New("no configuration has been provided")
 	// message is for consistency with old behavior
-	errEmptyCluster = errors.New("cluster has no server defined")
+	errEmptyCluster = perrors.New("cluster has no server defined")
 )
 
 //helper for checking certificate/key/CA
@@ -354,7 +354,7 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdCluster) []err
 
 	if len(clusterInfo.Server) == 0 {
 		if len(clusterName) == 0 {
-			validationErrors = append(validationErrors, errors.New("default cluster has no server defined"))
+			validationErrors = append(validationErrors, perrors.New("default cluster has no server defined"))
 		} else {
 			validationErrors = append(validationErrors, fmt.Errorf("no server found for cluster %q", clusterName))
 		}
@@ -578,7 +578,7 @@ func (rules *clientConfigLoadingRules) Load() (*clientcmdConfig, error) {
 			continue
 		}
 		if err != nil {
-			errlist = append(errlist, errors.Wrapf(err, "loading config file \"%s\"", filename))
+			errlist = append(errlist, perrors.Wrapf(err, "loading config file \"%s\"", filename))
 			continue
 		}
 
@@ -691,7 +691,7 @@ func resolveLocalPaths(config *clientcmdConfig) error {
 		}
 		base, err := filepath.Abs(filepath.Dir(cluster.LocationOfOrigin))
 		if err != nil {
-			return errors.Wrapf(err, "Could not determine the absolute path of config file %s", cluster.LocationOfOrigin)
+			return perrors.Wrapf(err, "Could not determine the absolute path of config file %s", cluster.LocationOfOrigin)
 		}
 
 		if err := resolvePaths(getClusterFileReferences(cluster), base); err != nil {
@@ -704,7 +704,7 @@ func resolveLocalPaths(config *clientcmdConfig) error {
 		}
 		base, err := filepath.Abs(filepath.Dir(authInfo.LocationOfOrigin))
 		if err != nil {
-			return errors.Wrapf(err, "Could not determine the absolute path of config file %s", authInfo.LocationOfOrigin)
+			return perrors.Wrapf(err, "Could not determine the absolute path of config file %s", authInfo.LocationOfOrigin)
 		}
 
 		if err := resolvePaths(getAuthInfoFileReferences(authInfo), base); err != nil {
@@ -774,7 +774,7 @@ func restClientFor(config *restConfig) (*url.URL, *http.Client, error) {
 // Kubernetes API.
 func defaultServerURL(host string, defaultTLS bool) (*url.URL, error) {
 	if host == "" {
-		return nil, errors.New("host must be a URL or a host:port pair")
+		return nil, perrors.New("host must be a URL or a host:port pair")
 	}
 	base := host
 	hostURL, err := url.Parse(base)
@@ -861,7 +861,7 @@ func transportNew(config *restConfig) (http.RoundTripper, error) {
 
 	// REMOVED: HTTPWrappersForConfig(config, rt) in favor of the caller setting HTTP headers itself based on restConfig. Only this inlined check remains.
 	if len(config.Username) != 0 && len(config.BearerToken) != 0 {
-		return nil, errors.New("username/password or bearer token may be set, but not both")
+		return nil, perrors.New("username/password or bearer token may be set, but not both")
 	}
 
 	return rt, nil
@@ -954,7 +954,7 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 		return nil, nil
 	}
 	if c.HasCA() && c.Insecure {
-		return nil, errors.New("specifying a root certificates file with the insecure flag is not allowed")
+		return nil, perrors.New("specifying a root certificates file with the insecure flag is not allowed")
 	}
 	if err := loadTLSFiles(c); err != nil {
 		return nil, err

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/image/v5/version"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -118,13 +118,13 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 	switch {
 	case res.StatusCode == http.StatusSwitchingProtocols: // FIXME?! No idea why this weird case exists in k8s.io/kubernetes/pkg/client/restclient.
 		if statusValid && status.Status != "Success" {
-			return nil, errors.New(status.Message)
+			return nil, perrors.New(status.Message)
 		}
 	case res.StatusCode >= http.StatusOK && res.StatusCode <= http.StatusPartialContent:
 		// OK.
 	default:
 		if statusValid {
-			return nil, errors.New(status.Message)
+			return nil, perrors.New(status.Message)
 		}
 		return nil, fmt.Errorf("HTTP error: status code: %d (%s), body: %s", res.StatusCode, http.StatusText(res.StatusCode), string(body))
 	}
@@ -292,7 +292,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 		}
 	}
 	if te == nil {
-		return errors.New("No matching tag found")
+		return perrors.New("No matching tag found")
 	}
 	logrus.Debugf("tag event %#v", te)
 	dockerRefString, err := s.client.convertDockerImageReference(te.DockerImageReference)
@@ -437,7 +437,7 @@ func (d *openshiftImageDestination) PutSignatures(ctx context.Context, signature
 	var imageStreamImageName string
 	if instanceDigest == nil {
 		if d.imageStreamImageName == "" {
-			return errors.New("Internal error: Unknown manifest digest, can't add signatures")
+			return perrors.New("Internal error: Unknown manifest digest, can't add signatures")
 		}
 		imageStreamImageName = d.imageStreamImageName
 	} else {
@@ -474,7 +474,7 @@ sigExists:
 			randBytes := make([]byte, 16)
 			n, err := rand.Read(randBytes)
 			if err != nil || n != 16 {
-				return errors.Wrapf(err, "generating random signature len %d", n)
+				return perrors.Wrapf(err, "generating random signature len %d", n)
 			}
 			signatureName = fmt.Sprintf("%s@%032x", imageStreamImageName, randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -126,7 +126,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		if statusValid {
 			return nil, errors.New(status.Message)
 		}
-		return nil, errors.Errorf("HTTP error: status code: %d (%s), body: %s", res.StatusCode, http.StatusText(res.StatusCode), string(body))
+		return nil, fmt.Errorf("HTTP error: status code: %d (%s), body: %s", res.StatusCode, http.StatusText(res.StatusCode), string(body))
 	}
 
 	return body, nil
@@ -153,7 +153,7 @@ func (c *openshiftClient) getImage(ctx context.Context, imageStreamImageName str
 func (c *openshiftClient) convertDockerImageReference(ref string) (string, error) {
 	parts := strings.SplitN(ref, "/", 2)
 	if len(parts) != 2 {
-		return "", errors.Errorf("Invalid format of docker reference %s: missing '/'", ref)
+		return "", fmt.Errorf("Invalid format of docker reference %s: missing '/'", ref)
 	}
 	return reference.Domain(c.ref.dockerReference) + "/" + parts[1], nil
 }
@@ -292,7 +292,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 		}
 	}
 	if te == nil {
-		return errors.Errorf("No matching tag found")
+		return errors.New("No matching tag found")
 	}
 	logrus.Debugf("tag event %#v", te)
 	dockerRefString, err := s.client.convertDockerImageReference(te.DockerImageReference)
@@ -437,7 +437,7 @@ func (d *openshiftImageDestination) PutSignatures(ctx context.Context, signature
 	var imageStreamImageName string
 	if instanceDigest == nil {
 		if d.imageStreamImageName == "" {
-			return errors.Errorf("Internal error: Unknown manifest digest, can't add signatures")
+			return errors.New("Internal error: Unknown manifest digest, can't add signatures")
 		}
 		imageStreamImageName = d.imageStreamImageName
 	} else {

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -11,7 +11,7 @@ import (
 	genericImage "github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -59,7 +59,7 @@ type openshiftReference struct {
 func ParseReference(ref string) (types.ImageReference, error) {
 	r, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse image reference %q", ref)
+		return nil, perrors.Wrapf(err, "failed to parse image reference %q", ref)
 	}
 	tagged, ok := r.(reference.NamedTagged)
 	if !ok {
@@ -149,5 +149,5 @@ func (ref openshiftReference) NewImageDestination(ctx context.Context, sys *type
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref openshiftReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.New("Deleting images not implemented for atomic: images")
+	return perrors.New("Deleting images not implemented for atomic: images")
 }

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -43,7 +43,7 @@ var scopeRegexp = regexp.MustCompile("^[^/]*(/[^:/]*(/[^:/]*(:[^:/]*)?)?)?$")
 // scope passed to this function will not be "", that value is always allowed.
 func (t openshiftTransport) ValidatePolicyConfigurationScope(scope string) error {
 	if scopeRegexp.FindStringIndex(scope) == nil {
-		return errors.Errorf("Invalid scope name %s", scope)
+		return fmt.Errorf("Invalid scope name %s", scope)
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func ParseReference(ref string) (types.ImageReference, error) {
 	}
 	tagged, ok := r.(reference.NamedTagged)
 	if !ok {
-		return nil, errors.Errorf("invalid image reference %s, expected format: 'hostname/namespace/stream:tag'", ref)
+		return nil, fmt.Errorf("invalid image reference %s, expected format: 'hostname/namespace/stream:tag'", ref)
 	}
 	return NewReference(tagged)
 }
@@ -72,7 +72,7 @@ func ParseReference(ref string) (types.ImageReference, error) {
 func NewReference(dockerRef reference.NamedTagged) (types.ImageReference, error) {
 	r := strings.SplitN(reference.Path(dockerRef), "/", 3)
 	if len(r) != 2 {
-		return nil, errors.Errorf("invalid image reference: %s, expected format: 'hostname/namespace/stream:tag'",
+		return nil, fmt.Errorf("invalid image reference: %s, expected format: 'hostname/namespace/stream:tag'",
 			reference.FamiliarString(dockerRef))
 	}
 	return openshiftReference{
@@ -149,5 +149,5 @@ func (ref openshiftReference) NewImageDestination(ctx context.Context, sys *type
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref openshiftReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.Errorf("Deleting images not implemented for atomic: images")
+	return errors.New("Deleting images not implemented for atomic: images")
 }

--- a/openshift/openshift_transport.go
+++ b/openshift/openshift_transport.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -149,5 +150,5 @@ func (ref openshiftReference) NewImageDestination(ctx context.Context, sys *type
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref openshiftReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return perrors.New("Deleting images not implemented for atomic: images")
+	return errors.New("Deleting images not implemented for atomic: images")
 }

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -167,7 +167,7 @@ func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, 
 	}
 	blobDigest := digester.Digest()
 	if inputInfo.Size != -1 && size != inputInfo.Size {
-		return types.BlobInfo{}, errors.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
+		return types.BlobInfo{}, fmt.Errorf("Size mismatch when copying %s, expected %d, got %d", blobDigest, inputInfo.Size, size)
 	}
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -388,7 +389,7 @@ func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *ostreeImageDestination) PutManifest(ctx context.Context, manifestBlob []byte, instanceDigest *digest.Digest) error {
 	if instanceDigest != nil {
-		return perrors.New(`Manifest lists are not supported by "ostree:"`)
+		return errors.New(`Manifest lists are not supported by "ostree:"`)
 	}
 
 	d.manifest = string(manifestBlob)
@@ -416,7 +417,7 @@ func (d *ostreeImageDestination) PutManifest(ctx context.Context, manifestBlob [
 // there can be no secondary manifests.
 func (d *ostreeImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	if instanceDigest != nil {
-		return perrors.New(`Manifest lists are not supported by "ostree:"`)
+		return errors.New(`Manifest lists are not supported by "ostree:"`)
 	}
 
 	path := filepath.Join(d.tmpDirPath, d.ref.signaturePath(0))

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -19,7 +20,6 @@ import (
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
 	glib "github.com/ostreedev/ostree-go/pkg/glibobject"
-	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"
 )

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -42,16 +42,16 @@ func init() {
 func (t ostreeTransport) ValidatePolicyConfigurationScope(scope string) error {
 	sep := strings.Index(scope, ":")
 	if sep < 0 {
-		return errors.Errorf("Invalid ostree: scope %s: Must include a repo", scope)
+		return fmt.Errorf("Invalid ostree: scope %s: Must include a repo", scope)
 	}
 	repo := scope[:sep]
 
 	if !strings.HasPrefix(repo, "/") {
-		return errors.Errorf("Invalid ostree: scope %s: repository must be an absolute path", scope)
+		return fmt.Errorf("Invalid ostree: scope %s: repository must be an absolute path", scope)
 	}
 	cleaned := filepath.Clean(repo)
 	if cleaned != repo {
-		return errors.Errorf(`Invalid ostree: scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+		return fmt.Errorf(`Invalid ostree: scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
 	}
 
 	// FIXME? In the namespaces within a repo,
@@ -117,7 +117,7 @@ func NewReference(image string, repo string) (types.ImageReference, error) {
 	// This is necessary to prevent directory paths returned by PolicyConfigurationNamespaces
 	// from being ambiguous with values of PolicyConfigurationIdentity.
 	if strings.Contains(resolved, ":") {
-		return nil, errors.Errorf("Invalid OSTree reference %s@%s: path %s contains a colon", image, repo, resolved)
+		return nil, fmt.Errorf("Invalid OSTree reference %s@%s: path %s contains a colon", image, repo, resolved)
 	}
 
 	return ostreeReference{
@@ -213,7 +213,7 @@ func (ref ostreeReference) NewImageDestination(ctx context.Context, sys *types.S
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref ostreeReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
-	return errors.Errorf("Deleting images not implemented for ostree: images")
+	return errors.New("Deleting images not implemented for ostree: images")
 }
 
 var ostreeRefRegexp = regexp.MustCompile(`^[A-Za-z0-9.-]$`)

--- a/ostree/ostree_transport.go
+++ b/ostree/ostree_transport.go
@@ -6,6 +6,7 @@ package ostree
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 const defaultOSTreeRepo = "/ostree/repo"

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -3,6 +3,7 @@ package blobcache
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -76,13 +77,13 @@ func makeFilename(blobSum digest.Digest, isConfig bool) string {
 // or different version of a blob when preparing the list of layers when reading an image.
 func NewBlobCache(ref types.ImageReference, directory string, compress types.LayerCompression) (*BlobCache, error) {
 	if directory == "" {
-		return nil, errors.Errorf("error creating cache around reference %q: no directory specified", transports.ImageName(ref))
+		return nil, fmt.Errorf("error creating cache around reference %q: no directory specified", transports.ImageName(ref))
 	}
 	switch compress {
 	case types.Compress, types.Decompress, types.PreserveOriginal:
 		// valid value, accept it
 	default:
-		return nil, errors.Errorf("unhandled LayerCompression value %v", compress)
+		return nil, fmt.Errorf("unhandled LayerCompression value %v", compress)
 	}
 	return &BlobCache{
 		reference: ref,

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -141,7 +141,7 @@ func (b *BlobCache) Directory() string {
 func (b *BlobCache) ClearCache() error {
 	f, err := os.Open(b.directory)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer f.Close()
 	names, err := f.Readdirnames(-1)

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -22,7 +22,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -221,7 +221,7 @@ func TestBlobCache(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected an error copying the image, but got success")
 				} else {
-					if os.IsNotExist(errors.Cause(err)) {
+					if os.IsNotExist(perrors.Cause(err)) {
 						t.Logf("ok: got expected does-not-exist error copying the image with blobs missing: %v", err)
 					} else {
 						t.Logf("got an error copying the image with missing blobs, but not sure which error: %v", err)

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +24,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -221,7 +222,7 @@ func TestBlobCache(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected an error copying the image, but got success")
 				} else {
-					if os.IsNotExist(perrors.Cause(err)) {
+					if errors.Is(err, fs.ErrNotExist) {
 						t.Logf("ok: got expected does-not-exist error copying the image with blobs missing: %v", err)
 					} else {
 						t.Logf("got an error copying the image with missing blobs, but not sure which error: %v", err)

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/storage/pkg/chunked/compressor"
 	"github.com/klauspost/pgzip"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/ulikunitz/xz"
 )
@@ -151,13 +151,13 @@ func DetectCompression(input io.Reader) (DecompressorFunc, io.Reader, error) {
 func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
 	decompressor, stream, err := DetectCompression(stream)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "detecting compression")
+		return nil, false, perrors.Wrapf(err, "detecting compression")
 	}
 	var res io.ReadCloser
 	if decompressor != nil {
 		res, err = decompressor(stream)
 		if err != nil {
-			return nil, false, errors.Wrapf(err, "initializing decompression")
+			return nil, false, perrors.Wrapf(err, "initializing decompression")
 		}
 	} else {
 		res = io.NopCloser(stream)

--- a/pkg/compression/compression_test.go
+++ b/pkg/compression/compression_test.go
@@ -2,11 +2,10 @@ package compression
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -465,11 +465,10 @@ func RemoveAllAuthentication(sys *types.SystemContext) error {
 			var creds map[string]string
 			creds, err = listAuthsFromCredHelper(helper)
 			if err != nil {
-				switch perrors.Cause(err) {
-				case exec.ErrNotFound:
+				if errors.Is(err, exec.ErrNotFound) {
 					// It's okay if the helper doesn't exist.
 					continue
-				default:
+				} else {
 					// fall through
 				}
 			} else {

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -47,9 +48,9 @@ var (
 
 	// ErrNotLoggedIn is returned for users not logged into a registry
 	// that they are trying to logout of
-	ErrNotLoggedIn = perrors.New("not logged in")
+	ErrNotLoggedIn = errors.New("not logged in")
 	// ErrNotSupported is returned for unsupported methods
-	ErrNotSupported = perrors.New("not supported")
+	ErrNotSupported = errors.New("not supported")
 )
 
 // SetCredentials stores the username and password in a location

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -111,7 +111,7 @@ func SetCredentials(sys *types.SystemContext, key, username, password string) (s
 }
 
 func unsupportedNamespaceErr(helper string) error {
-	return errors.Errorf("namespaced key is not supported for credential helper %s", helper)
+	return fmt.Errorf("namespaced key is not supported for credential helper %s", helper)
 }
 
 // SetAuthentication stores the username and password in the credential helper or file
@@ -781,7 +781,7 @@ func normalizeRegistry(registry string) string {
 // allowed and returns an indicator if the key is namespaced.
 func validateKey(key string) (bool, error) {
 	if strings.HasPrefix(key, "http://") || strings.HasPrefix(key, "https://") {
-		return false, errors.Errorf("key %s contains http[s]:// prefix", key)
+		return false, fmt.Errorf("key %s contains http[s]:// prefix", key)
 	}
 
 	// Ideally this should only accept explicitly valid keys, compare

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -18,7 +18,7 @@ import (
 	helperclient "github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -47,9 +47,9 @@ var (
 
 	// ErrNotLoggedIn is returned for users not logged into a registry
 	// that they are trying to logout of
-	ErrNotLoggedIn = errors.New("not logged in")
+	ErrNotLoggedIn = perrors.New("not logged in")
 	// ErrNotSupported is returned for unsupported methods
-	ErrNotSupported = errors.New("not supported")
+	ErrNotSupported = perrors.New("not supported")
 )
 
 // SetCredentials stores the username and password in a location
@@ -149,7 +149,7 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 				// readJSONFile returns an empty map in case the path doesn't exist.
 				auths, err := readJSONFile(path.path, path.legacyFormat)
 				if err != nil {
-					return nil, errors.Wrapf(err, "reading JSON file %q", path.path)
+					return nil, perrors.Wrapf(err, "reading JSON file %q", path.path)
 				}
 				// Credential helpers in the auth file have a
 				// direct mapping to a registry, so we can just
@@ -171,7 +171,7 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 			if err != nil {
 				logrus.Debugf("Error listing credentials stored in credential helper %s: %v", helper, err)
 			}
-			switch errors.Cause(err) {
+			switch perrors.Cause(err) {
 			case nil:
 				for registry := range creds {
 					addKey(registry)
@@ -358,7 +358,7 @@ func getAuthenticationWithHomeDir(sys *types.SystemContext, key, homeDir string)
 		return "", "", err
 	}
 	if auth.IdentityToken != "" {
-		return "", "", errors.Wrap(ErrNotSupported, "non-empty identity token found and this API doesn't support it")
+		return "", "", perrors.Wrap(ErrNotSupported, "non-empty identity token found and this API doesn't support it")
 	}
 	return auth.Username, auth.Password, nil
 }
@@ -397,7 +397,7 @@ func RemoveAuthentication(sys *types.SystemContext, key string) error {
 				return
 			}
 		}
-		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "removing credentials for %s from credential helper %s", key, helper))
+		multiErr = multierror.Append(multiErr, perrors.Wrapf(err, "removing credentials for %s from credential helper %s", key, helper))
 	}
 
 	for _, helper := range helpers {
@@ -465,7 +465,7 @@ func RemoveAllAuthentication(sys *types.SystemContext) error {
 		default:
 			var creds map[string]string
 			creds, err = listAuthsFromCredHelper(helper)
-			switch errors.Cause(err) {
+			switch perrors.Cause(err) {
 			case nil:
 				for registry := range creds {
 					err = deleteAuthFromCredHelper(helper, registry)
@@ -530,7 +530,7 @@ func getPathToAuthWithOS(sys *types.SystemContext, goOS string) (string, bool, e
 			// This means the user set the XDG_RUNTIME_DIR variable and either forgot to create the directory
 			// or made a typo while setting the environment variable,
 			// so return an error referring to $XDG_RUNTIME_DIR instead of xdgRuntimeDirPath inside.
-			return "", false, errors.Wrapf(err, "%q directory set by $XDG_RUNTIME_DIR does not exist. Either create the directory or unset $XDG_RUNTIME_DIR.", runtimeDir)
+			return "", false, perrors.Wrapf(err, "%q directory set by $XDG_RUNTIME_DIR does not exist. Either create the directory or unset $XDG_RUNTIME_DIR.", runtimeDir)
 		} // else ignore err and let the caller fail accessing xdgRuntimeDirPath.
 		return filepath.Join(runtimeDir, xdgRuntimeDirPath), false, nil
 	}
@@ -554,13 +554,13 @@ func readJSONFile(path string, legacyFormat bool) (dockerConfigFile, error) {
 
 	if legacyFormat {
 		if err = json.Unmarshal(raw, &auths.AuthConfigs); err != nil {
-			return dockerConfigFile{}, errors.Wrapf(err, "unmarshaling JSON at %q", path)
+			return dockerConfigFile{}, perrors.Wrapf(err, "unmarshaling JSON at %q", path)
 		}
 		return auths, nil
 	}
 
 	if err = json.Unmarshal(raw, &auths); err != nil {
-		return dockerConfigFile{}, errors.Wrapf(err, "unmarshaling JSON at %q", path)
+		return dockerConfigFile{}, perrors.Wrapf(err, "unmarshaling JSON at %q", path)
 	}
 
 	if auths.AuthConfigs == nil {
@@ -592,21 +592,21 @@ func modifyJSON(sys *types.SystemContext, editor func(auths *dockerConfigFile) (
 
 	auths, err := readJSONFile(path, false)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading JSON file %q", path)
+		return "", perrors.Wrapf(err, "reading JSON file %q", path)
 	}
 
 	updated, err := editor(&auths)
 	if err != nil {
-		return "", errors.Wrapf(err, "updating %q", path)
+		return "", perrors.Wrapf(err, "updating %q", path)
 	}
 	if updated {
 		newData, err := json.MarshalIndent(auths, "", "\t")
 		if err != nil {
-			return "", errors.Wrapf(err, "marshaling JSON %q", path)
+			return "", perrors.Wrapf(err, "marshaling JSON %q", path)
 		}
 
 		if err = ioutils.AtomicWriteFile(path, newData, 0600); err != nil {
-			return "", errors.Wrapf(err, "writing to file %q", path)
+			return "", perrors.Wrapf(err, "writing to file %q", path)
 		}
 	}
 
@@ -660,7 +660,7 @@ func deleteAuthFromCredHelper(credHelper, registry string) error {
 func findCredentialsInFile(key, registry, path string, legacyFormat bool) (types.DockerAuthConfig, error) {
 	auths, err := readJSONFile(path, legacyFormat)
 	if err != nil {
-		return types.DockerAuthConfig{}, errors.Wrapf(err, "reading JSON file %q", path)
+		return types.DockerAuthConfig{}, perrors.Wrapf(err, "reading JSON file %q", path)
 	}
 
 	// First try cred helpers. They should always be normalized.

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -171,17 +171,14 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 			creds, err := listAuthsFromCredHelper(helper)
 			if err != nil {
 				logrus.Debugf("Error listing credentials stored in credential helper %s: %v", helper, err)
-			}
-			if err != nil {
 				if errors.Is(err, exec.ErrNotFound) {
-					// It's okay if the helper doesn't exist.
+					creds = nil // It's okay if the helper doesn't exist.
 				} else {
 					return nil, err
 				}
-			} else {
-				for registry := range creds {
-					addKey(registry)
-				}
+			}
+			for registry := range creds {
+				addKey(registry)
 			}
 		}
 	}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -469,14 +469,13 @@ func RemoveAllAuthentication(sys *types.SystemContext) error {
 					// It's okay if the helper doesn't exist.
 					continue
 				} else {
-					// fall through
+					break
 				}
-			} else {
-				for registry := range creds {
-					err = deleteAuthFromCredHelper(helper, registry)
-					if err != nil {
-						break
-					}
+			}
+			for registry := range creds {
+				err = deleteAuthFromCredHelper(helper, registry)
+				if err != nil {
+					break
 				}
 			}
 		}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -173,10 +173,9 @@ func GetAllCredentials(sys *types.SystemContext) (map[string]types.DockerAuthCon
 				logrus.Debugf("Error listing credentials stored in credential helper %s: %v", helper, err)
 			}
 			if err != nil {
-				switch perrors.Cause(err) {
-				case exec.ErrNotFound:
+				if errors.Is(err, exec.ErrNotFound) {
 					// It's okay if the helper doesn't exist.
-				default:
+				} else {
 					return nil, err
 				}
 			} else {

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/manifoldco/promptui"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"golang.org/x/term"
 )
 
@@ -33,7 +33,7 @@ func IsShortName(input string) bool {
 func parseUnnormalizedShortName(input string) (bool, reference.Named, error) {
 	ref, err := reference.Parse(input)
 	if err != nil {
-		return false, nil, errors.Wrapf(err, "cannot parse input: %q", input)
+		return false, nil, perrors.Wrapf(err, "cannot parse input: %q", input)
 	}
 
 	named, ok := ref.(reference.Named)
@@ -47,7 +47,7 @@ func parseUnnormalizedShortName(input string) (bool, reference.Named, error) {
 		// normalized (e.g., docker.io/alpine to docker.io/library/alpine.
 		named, err = reference.ParseNormalizedNamed(input)
 		if err != nil {
-			return false, nil, errors.Wrapf(err, "cannot normalize input: %q", input)
+			return false, nil, perrors.Wrapf(err, "cannot normalize input: %q", input)
 		}
 		return false, named, nil
 	}
@@ -188,7 +188,7 @@ func (r *Resolved) FormatPullErrors(pullErrors []error) error {
 			sb.WriteString("\n * ")
 			sb.WriteString(e.Error())
 		}
-		return errors.New(sb.String())
+		return perrors.New(sb.String())
 	}
 }
 
@@ -216,7 +216,7 @@ func (c *PullCandidate) Record() error {
 	value := reference.TrimNamed(c.Value)
 
 	if err := Add(c.resolved.systemContext, name.String(), value); err != nil {
-		return errors.Wrapf(err, "recording short-name alias (%q=%q)", c.resolved.userInput, c.Value)
+		return perrors.Wrapf(err, "recording short-name alias (%q=%q)", c.resolved.userInput, c.Value)
 	}
 	return nil
 }
@@ -279,7 +279,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	if ctx != nil && ctx.PodmanOnlyShortNamesIgnoreRegistriesConfAndForceDockerHub {
 		named, err := reference.ParseNormalizedNamed(name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot normalize input: %q", name)
+			return nil, perrors.Wrapf(err, "cannot normalize input: %q", name)
 		}
 		resolved.addCandidate(named)
 		resolved.rationale = rationaleEnforcedDockerHub
@@ -337,7 +337,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	for _, reg := range unqualifiedSearchRegistries {
 		named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
+			return nil, perrors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
 		}
 		resolved.addCandidate(named)
 	}
@@ -361,7 +361,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 			return resolved, nil
 		case types.ShortNameModeEnforcing:
 			// Enforcing errors out without a prompt.
-			return nil, errors.New("short-name resolution enforced but cannot prompt without a TTY")
+			return nil, perrors.New("short-name resolution enforced but cannot prompt without a TTY")
 		default:
 			// We should not end up here.
 			return nil, fmt.Errorf("unexpected short-name mode (%v) during resolution", mode)
@@ -387,7 +387,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 
 	named, err := reference.ParseNormalizedNamed(selection)
 	if err != nil {
-		return nil, errors.Wrapf(err, "selection %q is not a valid reference", selection)
+		return nil, perrors.Wrapf(err, "selection %q is not a valid reference", selection)
 	}
 
 	resolved.PullCandidates = nil
@@ -428,7 +428,7 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 		for _, reg := range registries {
 			named, err := reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", reg, name))
 			if err != nil {
-				return nil, errors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
+				return nil, perrors.Wrapf(err, "creating reference with unqualified-search registry %q", reg)
 			}
 			named = reference.TagNameOnly(named) // Make sure to add ":latest" if needed
 			candidates = append(candidates, named)

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -38,7 +38,7 @@ func parseUnnormalizedShortName(input string) (bool, reference.Named, error) {
 
 	named, ok := ref.(reference.Named)
 	if !ok {
-		return true, nil, errors.Errorf("%q is not a named reference", input)
+		return true, nil, fmt.Errorf("%q is not a named reference", input)
 	}
 
 	registry := reference.Domain(named)
@@ -87,7 +87,7 @@ func Add(ctx *types.SystemContext, name string, value reference.Named) error {
 		return err
 	}
 	if !isShort {
-		return errors.Errorf("%q is not a short name", name)
+		return fmt.Errorf("%q is not a short name", name)
 	}
 	return sysregistriesv2.AddShortNameAlias(ctx, name, value.String())
 }
@@ -102,7 +102,7 @@ func Remove(ctx *types.SystemContext, name string) error {
 		return err
 	}
 	if !isShort {
-		return errors.Errorf("%q is not a short name", name)
+		return fmt.Errorf("%q is not a short name", name)
 	}
 	return sysregistriesv2.RemoveShortNameAlias(ctx, name)
 }
@@ -172,7 +172,7 @@ func (r *Resolved) Description() string {
 func (r *Resolved) FormatPullErrors(pullErrors []error) error {
 	if len(pullErrors) >= 0 && len(pullErrors) != len(r.PullCandidates) {
 		pullErrors = append(pullErrors,
-			errors.Errorf("internal error: expected %d instead of %d errors for %d pull candidates",
+			fmt.Errorf("internal error: expected %d instead of %d errors for %d pull candidates",
 				len(r.PullCandidates), len(pullErrors), len(r.PullCandidates)))
 	}
 
@@ -262,7 +262,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	case types.ShortNameModeDisabled, types.ShortNameModePermissive, types.ShortNameModeEnforcing:
 		// We're good.
 	default:
-		return nil, errors.Errorf("unsupported short-name mode (%v)", mode)
+		return nil, fmt.Errorf("unsupported short-name mode (%v)", mode)
 	}
 
 	isShort, shortRef, err := parseUnnormalizedShortName(name)
@@ -328,9 +328,9 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 	// Error out if there's no matching alias and no search registries.
 	if len(unqualifiedSearchRegistries) == 0 {
 		if usrConfig != "" {
-			return nil, errors.Errorf("short-name %q did not resolve to an alias and no unqualified-search registries are defined in %q", name, usrConfig)
+			return nil, fmt.Errorf("short-name %q did not resolve to an alias and no unqualified-search registries are defined in %q", name, usrConfig)
 		}
-		return nil, errors.Errorf("short-name %q did not resolve to an alias and no containers-registries.conf(5) was found", name)
+		return nil, fmt.Errorf("short-name %q did not resolve to an alias and no containers-registries.conf(5) was found", name)
 	}
 	resolved.originDescription = usrConfig
 
@@ -364,7 +364,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 			return nil, errors.New("short-name resolution enforced but cannot prompt without a TTY")
 		default:
 			// We should not end up here.
-			return nil, errors.Errorf("unexpected short-name mode (%v) during resolution", mode)
+			return nil, fmt.Errorf("unexpected short-name mode (%v) during resolution", mode)
 		}
 	}
 

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -1,6 +1,7 @@
 package shortnames
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -188,7 +189,7 @@ func (r *Resolved) FormatPullErrors(pullErrors []error) error {
 			sb.WriteString("\n * ")
 			sb.WriteString(e.Error())
 		}
-		return perrors.New(sb.String())
+		return errors.New(sb.String())
 	}
 }
 
@@ -361,7 +362,7 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 			return resolved, nil
 		case types.ShortNameModeEnforcing:
 			// Enforcing errors out without a prompt.
-			return nil, perrors.New("short-name resolution enforced but cannot prompt without a TTY")
+			return nil, errors.New("short-name resolution enforced but cannot prompt without a TTY")
 		default:
 			// We should not end up here.
 			return nil, fmt.Errorf("unexpected short-name mode (%v) during resolution", mode)

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -1,6 +1,7 @@
 package sysregistriesv2
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -166,7 +167,7 @@ func editShortNameAlias(ctx *types.SystemContext, name string, value *string) er
 	} else {
 		// If the name does not exist, throw an error.
 		if _, exists := conf.Aliases[name]; !exists {
-			return errors.Errorf("short-name alias %q not found in %q: please check registries.conf files", name, confPath)
+			return fmt.Errorf("short-name alias %q not found in %q: please check registries.conf files", name, confPath)
 		}
 
 		delete(conf.Aliases, name)
@@ -214,21 +215,21 @@ func parseShortNameValue(alias string) (reference.Named, error) {
 	}
 
 	if _, ok := ref.(reference.Digested); ok {
-		return nil, errors.Errorf("invalid alias %q: must not contain digest", alias)
+		return nil, fmt.Errorf("invalid alias %q: must not contain digest", alias)
 	}
 
 	if _, ok := ref.(reference.Tagged); ok {
-		return nil, errors.Errorf("invalid alias %q: must not contain tag", alias)
+		return nil, fmt.Errorf("invalid alias %q: must not contain tag", alias)
 	}
 
 	named, ok := ref.(reference.Named)
 	if !ok {
-		return nil, errors.Errorf("invalid alias %q: must contain registry and repository", alias)
+		return nil, fmt.Errorf("invalid alias %q: must contain registry and repository", alias)
 	}
 
 	registry := reference.Domain(named)
 	if !(strings.ContainsAny(registry, ".:") || registry == "localhost") {
-		return nil, errors.Errorf("invalid alias %q: must contain registry and repository", alias)
+		return nil, fmt.Errorf("invalid alias %q: must contain registry and repository", alias)
 	}
 
 	// A final parse to make sure that docker.io references are correctly
@@ -246,21 +247,21 @@ func validateShortName(name string) error {
 	}
 
 	if _, ok := repo.(reference.Digested); ok {
-		return errors.Errorf("invalid short name %q: must not contain digest", name)
+		return fmt.Errorf("invalid short name %q: must not contain digest", name)
 	}
 
 	if _, ok := repo.(reference.Tagged); ok {
-		return errors.Errorf("invalid short name %q: must not contain tag", name)
+		return fmt.Errorf("invalid short name %q: must not contain tag", name)
 	}
 
 	named, ok := repo.(reference.Named)
 	if !ok {
-		return errors.Errorf("invalid short name %q: no name", name)
+		return fmt.Errorf("invalid short name %q: no name", name)
 	}
 
 	registry := reference.Domain(named)
 	if strings.ContainsAny(registry, ".:") || registry == "localhost" {
-		return errors.Errorf("invalid short name %q: must not contain registry", name)
+		return fmt.Errorf("invalid short name %q: must not contain registry", name)
 	}
 	return nil
 }

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/lockfile"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -211,7 +211,7 @@ func RemoveShortNameAlias(ctx *types.SystemContext, name string) error {
 func parseShortNameValue(alias string) (reference.Named, error) {
 	ref, err := reference.Parse(alias)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing alias %q", alias)
+		return nil, perrors.Wrapf(err, "parsing alias %q", alias)
 	}
 
 	if _, ok := ref.(reference.Digested); ok {
@@ -243,7 +243,7 @@ func parseShortNameValue(alias string) (reference.Named, error) {
 func validateShortName(name string) error {
 	repo, err := reference.Parse(name)
 	if err != nil {
-		return errors.Wrapf(err, "cannot parse short name: %q", name)
+		return perrors.Wrapf(err, "cannot parse short name: %q", name)
 	}
 
 	if _, ok := repo.(reference.Digested); ok {
@@ -299,7 +299,7 @@ func newShortNameAliasCache(path string, conf *shortNameAliasConf) (*shortNameAl
 	if len(errs) > 0 {
 		err := errs[0]
 		for i := 1; i < len(errs); i++ {
-			err = errors.Wrapf(err, "%v\n", errs[i])
+			err = perrors.Wrapf(err, "%v\n", errs[i])
 		}
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, *shortNameAli
 	meta, err := toml.DecodeFile(confPath, &conf)
 	if err != nil && !os.IsNotExist(err) {
 		// It's okay if the config doesn't exist.  Other errors are not.
-		return nil, nil, errors.Wrapf(err, "loading short-name aliases config file %q", confPath)
+		return nil, nil, perrors.Wrapf(err, "loading short-name aliases config file %q", confPath)
 	}
 	if keys := meta.Undecoded(); len(keys) > 0 {
 		logrus.Debugf("Failed to decode keys %q from %q", keys, confPath)
@@ -330,7 +330,7 @@ func loadShortNameAliasConf(confPath string) (*shortNameAliasConf, *shortNameAli
 	// file could still be corrupted by another process or user.
 	cache, err := newShortNameAliasCache(confPath, &conf)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "loading short-name aliases config file %q", confPath)
+		return nil, nil, perrors.Wrapf(err, "loading short-name aliases config file %q", confPath)
 	}
 
 	return &conf, cache, nil

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -782,7 +782,7 @@ func parseShortNameMode(mode string) (types.ShortNameMode, error) {
 	case "permissive":
 		return types.ShortNameModePermissive, nil
 	default:
-		return types.ShortNameModeInvalid, errors.Errorf("invalid short-name mode: %q", mode)
+		return types.ShortNameModeInvalid, fmt.Errorf("invalid short-name mode: %q", mode)
 	}
 }
 

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -103,7 +103,7 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 	newNamedRef = e.Location + refString[prefixLen:]
 	newParsedRef, err := reference.ParseNamed(newNamedRef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "rewriting reference")
+		return nil, perrors.Wrapf(err, "rewriting reference")
 	}
 
 	return newParsedRef, nil
@@ -666,7 +666,7 @@ func dropInConfigs(wrapper configWrapper) ([]string, error) {
 		if err != nil && !os.IsNotExist(err) {
 			// Ignore IsNotExist errors: most systems won't have a registries.conf.d
 			// directory.
-			return nil, errors.Wrapf(err, "reading registries.conf.d")
+			return nil, perrors.Wrapf(err, "reading registries.conf.d")
 		}
 	}
 
@@ -708,7 +708,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 				return nil, err // Should never happen
 			}
 		} else {
-			return nil, errors.Wrapf(err, "loading registries configuration %q", wrapper.configPath)
+			return nil, perrors.Wrapf(err, "loading registries configuration %q", wrapper.configPath)
 		}
 	}
 
@@ -721,7 +721,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 		// Enforce v2 format for drop-in-configs.
 		dropIn, err := loadConfigFile(path, true)
 		if err != nil {
-			return nil, errors.Wrapf(err, "loading drop-in registries configuration %q", path)
+			return nil, perrors.Wrapf(err, "loading drop-in registries configuration %q", path)
 		}
 		config.updateWithConfigurationFrom(dropIn)
 	}
@@ -975,7 +975,7 @@ func loadConfigFile(path string, forceV2 bool) (*parsedConfig, error) {
 	// Parse and validate short-name aliases.
 	cache, err := newShortNameAliasCache(path, &res.partialV2.shortNameAliasConf)
 	if err != nil {
-		return nil, errors.Wrap(err, "validating short-name aliases")
+		return nil, perrors.Wrap(err, "validating short-name aliases")
 	}
 	res.aliasCache = cache
 	// Clear conf.partialV2.shortNameAliasConf to make it available for garbage collection and

--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			if tlsc.RootCAs == nil {
 				systemPool, err := tlsconfig.SystemCertPool()
 				if err != nil {
-					return errors.Wrap(err, "unable to get system cert pool")
+					return perrors.Wrap(err, "unable to get system cert pool")
 				}
 				tlsc.RootCAs = systemPool
 			}

--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -2,6 +2,7 @@ package tlsclientconfig
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -60,7 +61,7 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			keyName := certName[:len(certName)-5] + ".key"
 			logrus.Debugf(" cert: %s", fullPath)
 			if !hasFile(fs, keyName) {
-				return errors.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
+				return fmt.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
 			}
 			cert, err := tls.LoadX509KeyPair(filepath.Join(dir, certName), filepath.Join(dir, keyName))
 			if err != nil {
@@ -73,7 +74,7 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			certName := keyName[:len(keyName)-4] + ".cert"
 			logrus.Debugf(" key: %s", fullPath)
 			if !hasFile(fs, certName) {
-				return errors.Errorf("missing client certificate %s for key %s", certName, keyName)
+				return fmt.Errorf("missing client certificate %s for key %s", certName, keyName)
 			}
 		}
 	}

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -406,7 +406,7 @@ func (pr *prSignedBy) UnmarshalJSON(data []byte) error {
 	case !gotKeyPath && !gotKeyData:
 		return InvalidPolicyFormatError("At least one of keyPath and keyData mus be specified")
 	default: // Coverage: This should never happen
-		return errors.Errorf("Impossible keyPath/keyData presence combination!?")
+		return fmt.Errorf("Impossible keyPath/keyData presence combination!?")
 	}
 	if err != nil {
 		return err

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -15,6 +15,7 @@ package signature
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -162,7 +163,7 @@ var _ json.Unmarshaler = (*PolicyTransportScopes)(nil)
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (m *PolicyTransportScopes) UnmarshalJSON(data []byte) error {
-	return perrors.New("Do not try to unmarshal PolicyTransportScopes directly")
+	return errors.New("Do not try to unmarshal PolicyTransportScopes directly")
 }
 
 // policyTransportScopesWithTransport is a way to unmarshal a PolicyTransportScopes

--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 )
 
 // systemDefaultPolicyPath is the policy path used for DefaultPolicy().
@@ -81,7 +81,7 @@ func NewPolicyFromFile(fileName string) (*Policy, error) {
 	}
 	policy, err := NewPolicyFromBytes(contents)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid policy in %q", fileName)
+		return nil, perrors.Wrapf(err, "invalid policy in %q", fileName)
 	}
 	return policy, nil
 }
@@ -162,7 +162,7 @@ var _ json.Unmarshaler = (*PolicyTransportScopes)(nil)
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (m *PolicyTransportScopes) UnmarshalJSON(data []byte) error {
-	return errors.New("Do not try to unmarshal PolicyTransportScopes directly")
+	return perrors.New("Do not try to unmarshal PolicyTransportScopes directly")
 }
 
 // policyTransportScopesWithTransport is a way to unmarshal a PolicyTransportScopes

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containers/image/v5/directory"
 	"github.com/containers/image/v5/docker"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 
 	// this import is needed  where we use the "atomic" transport in TestPolicyUnmarshalJSON
 	_ "github.com/containers/image/v5/openshift"
@@ -207,7 +207,7 @@ func TestNewPolicyFromFile(t *testing.T) {
 	// A failure case; most are tested in the individual method unit tests.
 	_, err = NewPolicyFromFile("/dev/null")
 	require.Error(t, err)
-	assert.IsType(t, InvalidPolicyFormatError(""), errors.Cause(err))
+	assert.IsType(t, InvalidPolicyFormatError(""), perrors.Cause(err))
 }
 
 func TestNewPolicyFromBytes(t *testing.T) {

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -95,7 +95,7 @@ const (
 // changeContextState changes pc.state, or fails if the state is unexpected
 func (pc *PolicyContext) changeState(expected, new policyContextState) error {
 	if pc.state != expected {
-		return fmt.Errorf(`"Invalid PolicyContext state, expected "%s", found "%s"`, expected, pc.state)
+		return fmt.Errorf(`Invalid PolicyContext state, expected "%s", found "%s"`, expected, pc.state)
 	}
 	pc.state = new
 	return nil

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -7,9 +7,9 @@ package signature
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,7 +95,7 @@ const (
 // changeContextState changes pc.state, or fails if the state is unexpected
 func (pc *PolicyContext) changeState(expected, new policyContextState) error {
 	if pc.state != expected {
-		return errors.Errorf(`"Invalid PolicyContext state, expected "%s", found "%s"`, expected, pc.state)
+		return fmt.Errorf(`"Invalid PolicyContext state, expected "%s", found "%s"`, expected, pc.state)
 	}
 	pc.state = new
 	return nil

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -4,6 +4,7 @@ package signature
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types.UnparsedImage, sig []byte) (signatureAcceptanceResult, *Signature, error) {

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -19,10 +19,10 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types
 	case SBKeyTypeGPGKeys:
 	case SBKeyTypeSignedByGPGKeys, SBKeyTypeX509Certificates, SBKeyTypeSignedByX509CAs:
 		// FIXME? Reject this at policy parsing time already?
-		return sarRejected, nil, errors.Errorf(`"Unimplemented "keyType" value "%s"`, string(pr.KeyType))
+		return sarRejected, nil, fmt.Errorf(`"Unimplemented "keyType" value "%s"`, string(pr.KeyType))
 	default:
 		// This should never happen, newPRSignedBy ensures KeyType.IsValid()
-		return sarRejected, nil, errors.Errorf(`"Unknown "keyType" value "%s"`, string(pr.KeyType))
+		return sarRejected, nil, fmt.Errorf(`"Unknown "keyType" value "%s"`, string(pr.KeyType))
 	}
 
 	if pr.KeyPath != "" && pr.KeyData != nil {
@@ -108,7 +108,7 @@ func (pr *prSignedBy) isRunningImageAllowed(ctx context.Context, image types.Unp
 			// Huh?! This should not happen at all; treat it as any other invalid value.
 			fallthrough
 		default:
-			reason = errors.Errorf(`Internal error: Unexpected signature verification result "%s"`, string(res))
+			reason = fmt.Errorf(`Internal error: Unexpected signature verification result "%s"`, string(res))
 		}
 		rejections = append(rejections, reason)
 	}

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -19,10 +19,10 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image types
 	case SBKeyTypeGPGKeys:
 	case SBKeyTypeSignedByGPGKeys, SBKeyTypeX509Certificates, SBKeyTypeSignedByX509CAs:
 		// FIXME? Reject this at policy parsing time already?
-		return sarRejected, nil, fmt.Errorf(`"Unimplemented "keyType" value "%s"`, string(pr.KeyType))
+		return sarRejected, nil, fmt.Errorf(`Unimplemented "keyType" value "%s"`, string(pr.KeyType))
 	default:
 		// This should never happen, newPRSignedBy ensures KeyType.IsValid()
-		return sarRejected, nil, fmt.Errorf(`"Unknown "keyType" value "%s"`, string(pr.KeyType))
+		return sarRejected, nil, fmt.Errorf(`Unknown "keyType" value "%s"`, string(pr.KeyType))
 	}
 
 	if pr.KeyPath != "" && pr.KeyData != nil {

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -6,12 +6,12 @@ package signature
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/containers/image/v5/version"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -2,6 +2,7 @@ package signature
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/containers/image/v5/version"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -232,19 +232,19 @@ func TestSign(t *testing.T) {
 	verified, err := verifyAndExtractSignature(mech, signature, signatureAcceptanceRules{
 		validateKeyIdentity: func(keyIdentity string) error {
 			if keyIdentity != TestKeyFingerprint {
-				return errors.Errorf("Unexpected keyIdentity")
+				return errors.New("Unexpected keyIdentity")
 			}
 			return nil
 		},
 		validateSignedDockerReference: func(signedDockerReference string) error {
 			if signedDockerReference != sig.UntrustedDockerReference {
-				return errors.Errorf("Unexpected signedDockerReference")
+				return errors.New("Unexpected signedDockerReference")
 			}
 			return nil
 		},
 		validateSignedDockerManifestDigest: func(signedDockerManifestDigest digest.Digest) error {
 			if signedDockerManifestDigest != sig.UntrustedDockerManifestDigest {
-				return errors.Errorf("Unexpected signedDockerManifestDigest")
+				return errors.New("Unexpected signedDockerManifestDigest")
 			}
 			return nil
 		},
@@ -280,21 +280,21 @@ func TestVerifyAndExtractSignature(t *testing.T) {
 		validateKeyIdentity: func(keyIdentity string) error {
 			recorded.keyIdentity = keyIdentity
 			if keyIdentity != wanted.keyIdentity {
-				return errors.Errorf("keyIdentity mismatch")
+				return errors.New("keyIdentity mismatch")
 			}
 			return nil
 		},
 		validateSignedDockerReference: func(signedDockerReference string) error {
 			recorded.signedDockerReference = signedDockerReference
 			if signedDockerReference != wanted.signedDockerReference {
-				return errors.Errorf("signedDockerReference mismatch")
+				return errors.New("signedDockerReference mismatch")
 			}
 			return nil
 		},
 		validateSignedDockerManifestDigest: func(signedDockerManifestDigest digest.Digest) error {
 			recorded.signedDockerManifestDigest = signedDockerManifestDigest
 			if signedDockerManifestDigest != wanted.signedDockerManifestDigest {
-				return errors.Errorf("signedDockerManifestDigest mismatch")
+				return errors.New("signedDockerManifestDigest mismatch")
 			}
 			return nil
 		},

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -531,7 +531,7 @@ func (s *storageImageDestination) putBlobToPendingFile(ctx context.Context, stre
 	if blobSize < 0 {
 		blobSize = counter.Count
 	} else if blobinfo.Size != counter.Count {
-		return errorBlobInfo, errors.WithStack(ErrBlobSizeMismatch)
+		return errorBlobInfo, ErrBlobSizeMismatch
 	}
 
 	// Record information about the blob.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -286,7 +286,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 		return nil, perrors.Wrapf(err, "reading image manifest for %q", s.image.ID)
 	}
 	if manifest.MIMETypeIsMultiImage(manifestType) {
-		return nil, perrors.New("can't copy layers for a manifest list (shouldn't be attempted)")
+		return nil, errors.New("can't copy layers for a manifest list (shouldn't be attempted)")
 	}
 	man, err := manifest.FromBlob(manifestBlob, manifestType)
 	if err != nil {
@@ -665,7 +665,7 @@ func (s *storageImageDestination) tryReusingBlobAsPending(ctx context.Context, b
 	}
 
 	if blobinfo.Digest == "" {
-		return false, types.BlobInfo{}, perrors.New(`Can not check for a blob with unknown digest`)
+		return false, types.BlobInfo{}, errors.New(`Can not check for a blob with unknown digest`)
 	}
 	if err := blobinfo.Digest.Validate(); err != nil {
 		return false, types.BlobInfo{}, perrors.Wrapf(err, `Can not check for a blob with invalid digest`)
@@ -783,7 +783,7 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 // information out of it for Inspect().
 func (s *storageImageDestination) getConfigBlob(info types.BlobInfo) ([]byte, error) {
 	if info.Digest == "" {
-		return nil, perrors.New(`no digest supplied when reading blob`)
+		return nil, errors.New(`no digest supplied when reading blob`)
 	}
 	if err := info.Digest.Validate(); err != nil {
 		return nil, perrors.Wrapf(err, `invalid digest supplied when reading blob`)
@@ -797,7 +797,7 @@ func (s *storageImageDestination) getConfigBlob(info types.BlobInfo) ([]byte, er
 		return contents, nil
 	}
 	// If it's not a file, it's a bug, because we're not expecting to be asked for a layer.
-	return nil, perrors.New("blob not found")
+	return nil, errors.New("blob not found")
 }
 
 // queueOrCommit queues in the specified blob to be committed to the storage.
@@ -1032,7 +1032,7 @@ func (s *storageImageDestination) commitLayer(ctx context.Context, blob manifest
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	if len(s.manifest) == 0 {
-		return perrors.New("Internal error: storageImageDestination.Commit() called without PutManifest()")
+		return errors.New("Internal error: storageImageDestination.Commit() called without PutManifest()")
 	}
 	toplevelManifest, _, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -39,10 +39,10 @@ var (
 	// with a digest-based name that doesn't match its contents.
 	// Deprecated: PutBlob() doesn't do this any more (it just accepts the caller’s value),
 	// and there is no known user of this error.
-	ErrBlobDigestMismatch = stderrors.New("blob digest mismatch")
+	ErrBlobDigestMismatch = errors.New("blob digest mismatch")
 	// ErrBlobSizeMismatch is returned when PutBlob() is given a blob
 	// with an expected size that doesn't match the reader.
-	ErrBlobSizeMismatch = stderrors.New("blob size mismatch")
+	ErrBlobSizeMismatch = errors.New("blob size mismatch")
 	// ErrNoSuchImage is returned when we attempt to access an image which
 	// doesn't exist in the storage area.
 	ErrNoSuchImage = storage.ErrNotAnImage

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -12,7 +12,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,11 +31,11 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 		return nil, ErrInvalidReference
 	}
 	if named != nil && reference.IsNameOnly(named) {
-		return nil, errors.Wrapf(ErrInvalidReference, "reference %s has neither a tag nor a digest", named.String())
+		return nil, perrors.Wrapf(ErrInvalidReference, "reference %s has neither a tag nor a digest", named.String())
 	}
 	if id != "" {
 		if err := validateImageID(id); err != nil {
-			return nil, errors.Wrapf(ErrInvalidReference, "invalid ID value %q: %v", id, err)
+			return nil, perrors.Wrapf(ErrInvalidReference, "invalid ID value %q: %v", id, err)
 		}
 	}
 	// We take a copy of the transport, which contains a pointer to the
@@ -145,12 +145,12 @@ func (s *storageReference) resolveImage(sys *types.SystemContext) (*storage.Imag
 	}
 	if s.id == "" {
 		logrus.Debugf("reference %q does not resolve to an image ID", s.StringWithinTransport())
-		return nil, errors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
+		return nil, perrors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
 	}
 	if loadedImage == nil {
 		img, err := s.transport.store.Image(s.id)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading image %q", s.id)
+			return nil, perrors.Wrapf(err, "reading image %q", s.id)
 		}
 		loadedImage = img
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	ddigest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -728,7 +728,7 @@ func TestDuplicateID(t *testing.T) {
 		manifestType:   imanifest.GuessMIMEType([]byte(manifest)),
 		signatures:     nil,
 	}
-	if err := dest.Commit(context.Background(), &unparsedToplevel); errors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background(), &unparsedToplevel); perrors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
@@ -830,7 +830,7 @@ func TestDuplicateNameID(t *testing.T) {
 		manifestType:   imanifest.GuessMIMEType([]byte(manifest)),
 		signatures:     nil,
 	}
-	if err := dest.Commit(context.Background(), &unparsedToplevel); errors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background(), &unparsedToplevel); perrors.Cause(err) != storage.ErrDuplicateID {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	ddigest "github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -728,7 +728,7 @@ func TestDuplicateID(t *testing.T) {
 		manifestType:   imanifest.GuessMIMEType([]byte(manifest)),
 		signatures:     nil,
 	}
-	if err := dest.Commit(context.Background(), &unparsedToplevel); perrors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background(), &unparsedToplevel); !errors.Is(err, storage.ErrDuplicateID) {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}
@@ -830,7 +830,7 @@ func TestDuplicateNameID(t *testing.T) {
 		manifestType:   imanifest.GuessMIMEType([]byte(manifest)),
 		signatures:     nil,
 	}
-	if err := dest.Commit(context.Background(), &unparsedToplevel); perrors.Cause(err) != storage.ErrDuplicateID {
+	if err := dest.Commit(context.Background(), &unparsedToplevel); !errors.Is(err, storage.ErrDuplicateID) {
 		if err != nil {
 			t.Fatalf("Wrong error committing changes to destination, second pass: %v", err)
 		}

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -32,10 +33,10 @@ var (
 	Transport StoreTransport = &storageTransport{}
 	// ErrInvalidReference is returned when ParseReference() is passed an
 	// empty reference.
-	ErrInvalidReference = perrors.New("invalid reference")
+	ErrInvalidReference = errors.New("invalid reference")
 	// ErrPathNotAbsolute is returned when a graph root is not an absolute
 	// path name.
-	ErrPathNotAbsolute = perrors.New("path name is not absolute")
+	ErrPathNotAbsolute = errors.New("path name is not absolute")
 )
 
 // StoreTransport is an ImageTransport that uses a storage.Store to parse
@@ -372,7 +373,7 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 			return err
 		}
 	default: // Coverage: This should never happen
-		return perrors.New("Internal error: unexpected number of fields form strings.SplitN")
+		return errors.New("Internal error: unexpected number of fields form strings.SplitN")
 	}
 	// As for field[0], if it is non-empty at all:
 	// FIXME? We could be verifying the various character set and length restrictions

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
+	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,10 +32,10 @@ var (
 	Transport StoreTransport = &storageTransport{}
 	// ErrInvalidReference is returned when ParseReference() is passed an
 	// empty reference.
-	ErrInvalidReference = errors.New("invalid reference")
+	ErrInvalidReference = perrors.New("invalid reference")
 	// ErrPathNotAbsolute is returned when a graph root is not an absolute
 	// path name.
-	ErrPathNotAbsolute = errors.New("path name is not absolute")
+	ErrPathNotAbsolute = perrors.New("path name is not absolute")
 )
 
 // StoreTransport is an ImageTransport that uses a storage.Store to parse
@@ -117,13 +117,13 @@ func (s *storageTransport) DefaultGIDMap() []idtools.IDMap {
 // relative to the given store, and returns it in a reference object.
 func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (*storageReference, error) {
 	if ref == "" {
-		return nil, errors.Wrapf(ErrInvalidReference, "%q is an empty reference", ref)
+		return nil, perrors.Wrapf(ErrInvalidReference, "%q is an empty reference", ref)
 	}
 	if ref[0] == '[' {
 		// Ignore the store specifier.
 		closeIndex := strings.IndexRune(ref, ']')
 		if closeIndex < 1 {
-			return nil, errors.Wrapf(ErrInvalidReference, "store specifier in %q did not end", ref)
+			return nil, perrors.Wrapf(ErrInvalidReference, "store specifier in %q did not end", ref)
 		}
 		ref = ref[closeIndex+1:]
 	}
@@ -135,7 +135,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	if split != -1 {
 		possibleID := ref[split+1:]
 		if possibleID == "" {
-			return nil, errors.Wrapf(ErrInvalidReference, "empty trailing digest or ID in %q", ref)
+			return nil, perrors.Wrapf(ErrInvalidReference, "empty trailing digest or ID in %q", ref)
 		}
 		// If it looks like a digest, leave it alone for now.
 		if _, err := digest.Parse(possibleID); err != nil {
@@ -147,7 +147,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 				// so we might as well use the expanded value.
 				id = img.ID
 			} else {
-				return nil, errors.Wrapf(ErrInvalidReference, "%q does not look like an image ID or digest", possibleID)
+				return nil, perrors.Wrapf(ErrInvalidReference, "%q does not look like an image ID or digest", possibleID)
 			}
 			// We have recognized an image ID; peel it off.
 			ref = ref[:split]
@@ -173,7 +173,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		var err error
 		named, err = reference.ParseNormalizedNamed(ref)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing named reference %q", ref)
+			return nil, perrors.Wrapf(err, "parsing named reference %q", ref)
 		}
 		named = reference.TagNameOnly(named)
 	}
@@ -372,7 +372,7 @@ func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {
 			return err
 		}
 	default: // Coverage: This should never happen
-		return errors.New("Internal error: unexpected number of fields form strings.SplitN")
+		return perrors.New("Internal error: unexpected number of fields form strings.SplitN")
 	}
 	// As for field[0], if it is non-empty at all:
 	// FIXME? We could be verifying the various character set and length restrictions

--- a/transports/alltransports/alltransports.go
+++ b/transports/alltransports/alltransports.go
@@ -1,6 +1,7 @@
 package alltransports
 
 import (
+	"fmt"
 	"strings"
 
 	// register all known transports
@@ -19,7 +20,6 @@ import (
 	// The storage transport is registered by storage*.go
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 // ParseImageName converts a URL-like image name to a types.ImageReference.
@@ -27,11 +27,11 @@ func ParseImageName(imgName string) (types.ImageReference, error) {
 	// Keep this in sync with TransportFromImageName!
 	parts := strings.SplitN(imgName, ":", 2)
 	if len(parts) != 2 {
-		return nil, errors.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
+		return nil, fmt.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
 	}
 	transport := transports.Get(parts[0])
 	if transport == nil {
-		return nil, errors.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
+		return nil, fmt.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
 	}
 	return transport.ParseReference(parts[1])
 }


### PR DESCRIPTION
Motivated by https://github.com/containers/podman/issues/14784 removing `pkg/errors`.

This does not remove _all_ of it: We still use `pkg/errors.Wrap*` to provide an unchanged interface to callers that rely on `pkg/errors.Cause`.

- Stop attaching stack traces to errors, other than as implied by `pkg/errors.Wrap*`. I.e. use `errors.New` instead of `pkg/errors.New`, `fmt.Errorf` instead of `errors.Errorf`, remove a few explicit `pkg/errors.WithStack`. Those were never promised (OTOH Podman does have at least one `fmt(…%+v…, err)`, so this _might_ break something).
  - We could drop stack traces also from `errors.Wrap*` by replacing that with `errors.WithMessage*`, but that’s a mouthful, and we want to eventually eliminate those fully…
- Eliminate almost all uses of `pkg/errors.Cause`; use `errors.{As,Is}`. Note that this could, in principle, change behavior, and I didn’t examine the call stack in detail. c/storage is probably the most risky in this respect — OTOH I have a hard time thinking of a specific scenario where this would break, and we need c/image to update this before c/storage can eliminate `pkg/errors.Wrap*`. We retain one `pkg/errors.Cause` in tests, at least for now.
- Consistently import `errors` as `errors`, and `pkg/errors` as `perrors`, so that we can refer to both in the same file.
- Fix some random typos in error strings.

See individual commit messages for details.

I’d be happy to split this further as suggested, or drop/defer this now and return to that effort some time later, to coordinate with other work (notably because this would almost certainly require a rebase of any other outstanding work — and one more rebase after we eliminate `pkg/errors.Wrap*`). 