### PR TITLE
Implement private.ImageDestination in all transports, improve transport helpers

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -27,6 +27,7 @@ var ErrNotContainerImageDir = errors.New("not a containers image directory, don'
 
 type dirImageDestination struct {
 	impl.Compat
+	impl.PropertyMethodsInitialize
 	stubs.NoPutBlobPartialInitialize
 	stubs.AlwaysSupportsSignatures
 
@@ -99,6 +100,11 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 	}
 
 	d := &dirImageDestination{
+		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			MustMatchRuntimeOS:             false,
+			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
+			HasThreadSafePutBlob:           false,
+		}),
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
 
 		ref:                     ref,
@@ -130,23 +136,6 @@ func (d *dirImageDestination) DesiredLayerCompression() types.LayerCompression {
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 // uploaded to the image destination, true otherwise.
 func (d *dirImageDestination) AcceptsForeignLayerURLs() bool {
-	return false
-}
-
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
-func (d *dirImageDestination) MustMatchRuntimeOS() bool {
-	return false
-}
-
-// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
-// and would prefer to receive an unmodified manifest instead of one modified for the destination.
-// Does not make a difference if Reference().DockerReference() is nil.
-func (d *dirImageDestination) IgnoresEmbeddedDockerReference() bool {
-	return false // N/A, DockerReference() returns nil.
-}
-
-// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
-func (d *dirImageDestination) HasThreadSafePutBlob() bool {
 	return false
 }
 

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -28,6 +28,7 @@ var ErrNotContainerImageDir = errors.New("not a containers image directory, don'
 type dirImageDestination struct {
 	impl.Compat
 	stubs.NoPutBlobPartialInitialize
+	stubs.AlwaysSupportsSignatures
 
 	ref                     dirReference
 	desiredLayerCompression types.LayerCompression
@@ -119,12 +120,6 @@ func (d *dirImageDestination) Close() error {
 }
 
 func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
-	return nil
-}
-
-// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
-// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *dirImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -101,6 +101,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 
 	d := &dirImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			SupportedManifestMIMETypes:     nil,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
@@ -122,10 +123,6 @@ func (d *dirImageDestination) Reference() types.ImageReference {
 
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *dirImageDestination) Close() error {
-	return nil
-}
-
-func (d *dirImageDestination) SupportedManifestMIMETypes() []string {
 	return nil
 }
 

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -31,8 +31,7 @@ type dirImageDestination struct {
 	stubs.NoPutBlobPartialInitialize
 	stubs.AlwaysSupportsSignatures
 
-	ref                     dirReference
-	desiredLayerCompression types.LayerCompression
+	ref dirReference
 }
 
 // newImageDestination returns an ImageDestination for writing to a directory.
@@ -102,14 +101,14 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 	d := &dirImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
 			SupportedManifestMIMETypes:     nil,
+			DesiredLayerCompression:        desiredLayerCompression,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
 		}),
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
 
-		ref:                     ref,
-		desiredLayerCompression: desiredLayerCompression,
+		ref: ref,
 	}
 	d.Compat = impl.AddCompat(d)
 	return d, nil
@@ -124,10 +123,6 @@ func (d *dirImageDestination) Reference() types.ImageReference {
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *dirImageDestination) Close() error {
 	return nil
-}
-
-func (d *dirImageDestination) DesiredLayerCompression() types.LayerCompression {
-	return d.desiredLayerCompression
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -102,6 +102,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
 			SupportedManifestMIMETypes:     nil,
 			DesiredLayerCompression:        desiredLayerCompression,
+			AcceptsForeignLayerURLs:        false,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
@@ -123,12 +124,6 @@ func (d *dirImageDestination) Reference() types.ImageReference {
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *dirImageDestination) Close() error {
 	return nil
-}
-
-// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
-// uploaded to the image destination, true otherwise.
-func (d *dirImageDestination) AcceptsForeignLayerURLs() bool {
-	return false
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache/memory"
 	"github.com/containers/image/v5/types"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var _ private.ImageDestination = (*dirImageDestination)(nil)
 
 func TestDestinationReference(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 )
 
@@ -16,7 +17,7 @@ type archiveImageDestination struct {
 	writer               io.Closer       // May be nil if the archive is shared
 }
 
-func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
+func newImageDestination(sys *types.SystemContext, ref archiveReference) (private.ImageDestination, error) {
 	if ref.sourceIndex != -1 {
 		return nil, fmt.Errorf("Destination reference must not contain a manifest index @%d", ref.sourceIndex)
 	}

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -48,11 +48,6 @@ func newImageDestination(sys *types.SystemContext, ref archiveReference) (privat
 	}, nil
 }
 
-// DesiredLayerCompression indicates if layers must be compressed, decompressed or preserved
-func (d *archiveImageDestination) DesiredLayerCompression() types.LayerCompression {
-	return types.Decompress
-}
-
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
 // e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
 func (d *archiveImageDestination) Reference() types.ImageReference {

--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -35,7 +35,7 @@ func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.
 		archive = tarfile.NewWriter(fh)
 		writer = fh
 	}
-	tarDest := tarfile.NewDestination(sys, archive, ref.ref)
+	tarDest := tarfile.NewDestination(sys, archive, ref.Transport().Name(), ref.ref)
 	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
 		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
 	}

--- a/docker/archive/dest_test.go
+++ b/docker/archive/dest_test.go
@@ -1,0 +1,5 @@
+package archive
+
+import "github.com/containers/image/v5/internal/private"
+
+var _ private.ImageDestination = (*archiveImageDestination)(nil)

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -58,7 +58,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 	return &daemonImageDestination{
 		ref:                ref,
 		mustMatchRuntimeOS: mustMatchRuntimeOS,
-		Destination:        tarfile.NewDestination(sys, archive, namedTaggedRef),
+		Destination:        tarfile.NewDestination(sys, archive, ref.Transport().Name(), namedTaggedRef),
 		archive:            archive,
 		goroutineCancel:    goroutineCancel,
 		statusChannel:      statusChannel,

--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 	"github.com/docker/docker/client"
 	perrors "github.com/pkg/errors"
@@ -28,7 +29,7 @@ type daemonImageDestination struct {
 }
 
 // newImageDestination returns a types.ImageDestination for the specified image reference.
-func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daemonReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daemonReference) (private.ImageDestination, error) {
 	if ref.ref == nil {
 		return nil, fmt.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
 	}

--- a/docker/daemon/daemon_dest_test.go
+++ b/docker/daemon/daemon_dest_test.go
@@ -1,0 +1,5 @@
+package daemon
+
+import "github.com/containers/image/v5/internal/private"
+
+var _ private.ImageDestination = (*daemonImageDestination)(nil)

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -62,6 +62,7 @@ func newImageDestination(sys *types.SystemContext, ref dockerReference) (private
 	dest := &dockerImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
 			SupportedManifestMIMETypes:     mimeTypes,
+			DesiredLayerCompression:        types.Compress,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // We do want the manifest updated; older registry versions refuse manifests if the embedded reference does not match.
 			HasThreadSafePutBlob:           true,
@@ -100,10 +101,6 @@ func (d *dockerImageDestination) SupportsSignatures(ctx context.Context) error {
 	default:
 		return errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
-}
-
-func (d *dockerImageDestination) DesiredLayerCompression() types.LayerCompression {
-	return types.Compress
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually

--- a/docker/docker_image_dest_test.go
+++ b/docker/docker_image_dest_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/containers/image/v5/internal/private"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var _ private.ImageDestination = (*dockerImageDestination)(nil)
 
 func TestIsManifestInvalidError(t *testing.T) {
 	// Sadly only a smoke test; this really should record all known errors exactly as they happen.

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -46,6 +46,7 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 				manifest.DockerV2Schema2MediaType, // We rely on the types.Image.UpdatedImage schema conversion capabilities.
 			},
 			DesiredLayerCompression:        types.Decompress,
+			AcceptsForeignLayerURLs:        false,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
 			// The code _is_ actually thread-safe, but apart from computing sizes/digests of layers where
@@ -67,12 +68,6 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 // AddRepoTags adds the specified tags to the destination's repoTags.
 func (d *Destination) AddRepoTags(tags []reference.NamedTagged) {
 	d.repoTags = append(d.repoTags, tags...)
-}
-
-// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
-// uploaded to the image destination, true otherwise.
-func (d *Destination) AcceptsForeignLayerURLs() bool {
-	return false
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -45,6 +45,7 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 			SupportedManifestMIMETypes: []string{
 				manifest.DockerV2Schema2MediaType, // We rely on the types.Image.UpdatedImage schema conversion capabilities.
 			},
+			DesiredLayerCompression:        types.Decompress,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
 			// The code _is_ actually thread-safe, but apart from computing sizes/digests of layers where

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -42,6 +42,9 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 	}
 	dest := &Destination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			SupportedManifestMIMETypes: []string{
+				manifest.DockerV2Schema2MediaType, // We rely on the types.Image.UpdatedImage schema conversion capabilities.
+			},
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, we only accept schema2 images where EmbeddedDockerReferenceConflicts() is always false.
 			// The code _is_ actually thread-safe, but apart from computing sizes/digests of layers where
@@ -63,14 +66,6 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 // AddRepoTags adds the specified tags to the destination's repoTags.
 func (d *Destination) AddRepoTags(tags []reference.NamedTagged) {
 	d.repoTags = append(d.repoTags, tags...)
-}
-
-// SupportedManifestMIMETypes tells which manifest mime types the destination supports
-// If an empty slice or nil it's returned, then any mime type can be tried to upload
-func (d *Destination) SupportedManifestMIMETypes() []string {
-	return []string{
-		manifest.DockerV2Schema2MediaType, // We rely on the types.Image.UpdatedImage schema conversion capabilities.
-	}
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -27,7 +27,7 @@ type Destination struct {
 }
 
 // NewDestination returns a tarfile.Destination adding images to the specified Writer.
-func NewDestination(sys *types.SystemContext, archive *Writer, ref reference.NamedTagged) *Destination {
+func NewDestination(sys *types.SystemContext, archive *Writer, transportName string, ref reference.NamedTagged) *Destination {
 	repoTags := []reference.NamedTagged{}
 	if ref != nil {
 		repoTags = append(repoTags, ref)

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -8,7 +8,10 @@ import (
 	"io"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
 	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/streamdigest"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -17,8 +20,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Destination is a partial implementation of types.ImageDestination for writing to an io.Writer.
+// Destination is a partial implementation of private.ImageDestination for writing to an io.Writer.
 type Destination struct {
+	impl.Compat
+	stubs.NoPutBlobPartialInitialize
+
 	archive  *Writer
 	repoTags []reference.NamedTagged
 	// Other state.
@@ -32,11 +38,15 @@ func NewDestination(sys *types.SystemContext, archive *Writer, transportName str
 	if ref != nil {
 		repoTags = append(repoTags, ref)
 	}
-	return &Destination{
+	dest := &Destination{
+		NoPutBlobPartialInitialize: stubs.NoPutBlobPartialRaw(transportName),
+
 		archive:  archive,
 		repoTags: repoTags,
 		sysCtx:   sys,
 	}
+	dest.Compat = impl.AddCompat(dest)
+	return dest
 }
 
 // AddRepoTags adds the specified tags to the destination's repoTags.
@@ -84,14 +94,14 @@ func (d *Destination) HasThreadSafePutBlob() bool {
 	return false
 }
 
-// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
-// May update cache.
+// inputInfo.MediaType describes the blob format, if known.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
 	// Ouch, we need to stream the blob into a temporary file just to determine the size.
 	// When the layer is decompressed, we also have to generate the digest on uncompressed data.
 	if inputInfo.Size == -1 || inputInfo.Digest == "" {
@@ -119,7 +129,7 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 		return reusedInfo, nil
 	}
 
-	if isConfig {
+	if options.IsConfig {
 		buf, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return types.BlobInfo{}, perrors.Wrap(err, "reading Config file stream")
@@ -137,16 +147,14 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 	return types.BlobInfo{Digest: inputInfo.Digest, Size: inputInfo.Size}, nil
 }
 
-// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
-// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
 // include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-// May use and/or update cache.
-func (d *Destination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+func (d *Destination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
 	if err := d.archive.lock(); err != nil {
 		return false, types.BlobInfo{}, err
 	}

--- a/docker/internal/tarfile/src_test.go
+++ b/docker/internal/tarfile/src_test.go
@@ -28,7 +28,7 @@ func TestSourcePrepareLayerData(t *testing.T) {
 		ctx := context.Background()
 
 		writer := NewWriter(&tarfileBuffer)
-		dest := NewDestination(nil, writer, nil)
+		dest := NewDestination(nil, writer, "transport name", nil)
 		// No layers
 		configInfo, err := dest.PutBlob(ctx, strings.NewReader(c.config),
 			types.BlobInfo{Size: -1}, cache, true)

--- a/docker/tarfile/dest.go
+++ b/docker/tarfile/dest.go
@@ -26,7 +26,7 @@ func NewDestination(dest io.Writer, ref reference.NamedTagged) *Destination {
 func NewDestinationWithContext(sys *types.SystemContext, dest io.Writer, ref reference.NamedTagged) *Destination {
 	archive := internal.NewWriter(dest)
 	return &Destination{
-		internal: internal.NewDestination(sys, archive, ref),
+		internal: internal.NewDestination(sys, archive, "[An external docker/tarfile caller]", ref),
 		archive:  archive,
 	}
 }

--- a/internal/imagedestination/impl/compat.go
+++ b/internal/imagedestination/impl/compat.go
@@ -1,0 +1,62 @@
+package impl
+
+import (
+	"context"
+	"io"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/types"
+)
+
+// Compat implements the obsolete parts of types.ImageDestination
+// for implementations of private.ImageDestination.
+// See AddCompat below.
+type Compat struct {
+	dest private.ImageDestinationInternalOnly
+}
+
+// AddCompat initializes Compat to implement the obsolete parts of types.ImageDestination
+// for implementations of private.ImageDestination.
+//
+// Use it like this:
+// type yourDestination struct {
+//     impl.Compat
+//     …
+// }
+// dest := &yourDestination{…}
+// dest.Compat = impl.AddCompat(dest)
+//
+func AddCompat(dest private.ImageDestinationInternalOnly) Compat {
+	return Compat{dest}
+}
+
+// PutBlob writes contents of stream and returns data representing the result.
+// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
+// inputInfo.Size is the expected length of stream, if known.
+// inputInfo.MediaType describes the blob format, if known.
+// May update cache.
+// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
+// to any other readers for download using the supplied digest.
+// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
+func (c *Compat) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	return c.dest.PutBlobWithOptions(ctx, stream, inputInfo, private.PutBlobOptions{
+		Cache:    cache,
+		IsConfig: isConfig,
+	})
+}
+
+// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
+// info.Digest must not be empty.
+// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
+// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
+// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
+// reflected in the manifest that will be written.
+// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
+// May use and/or update cache.
+func (c *Compat) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	return c.dest.TryReusingBlobWithOptions(ctx, info, private.TryReusingBlobOptions{
+		Cache:         cache,
+		CanSubstitute: canSubstitute,
+	})
+}

--- a/internal/imagedestination/impl/compat.go
+++ b/internal/imagedestination/impl/compat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 )
@@ -40,7 +41,7 @@ func AddCompat(dest private.ImageDestinationInternalOnly) Compat {
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (c *Compat) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
 	return c.dest.PutBlobWithOptions(ctx, stream, inputInfo, private.PutBlobOptions{
-		Cache:    cache,
+		Cache:    blobinfocache.FromBlobInfoCache(cache),
 		IsConfig: isConfig,
 	})
 }
@@ -56,7 +57,7 @@ func (c *Compat) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.
 // May use and/or update cache.
 func (c *Compat) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
 	return c.dest.TryReusingBlobWithOptions(ctx, info, private.TryReusingBlobOptions{
-		Cache:         cache,
+		Cache:         blobinfocache.FromBlobInfoCache(cache),
 		CanSubstitute: canSubstitute,
 	})
 }

--- a/internal/imagedestination/impl/properties.go
+++ b/internal/imagedestination/impl/properties.go
@@ -10,6 +10,9 @@ type Properties struct {
 	SupportedManifestMIMETypes []string
 	// DesiredLayerCompression indicates the kind of compression to apply on layers
 	DesiredLayerCompression types.LayerCompression
+	// AcceptsForeignLayerURLs is false if foreign layers in manifest should be actually
+	// uploaded to the image destination, true otherwise.
+	AcceptsForeignLayerURLs bool
 	// MustMatchRuntimeOS is set to true if the destination can store only images targeted for the current runtime architecture and OS.
 	MustMatchRuntimeOS bool
 	// IgnoresEmbeddedDockerReference is set to true if the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
@@ -43,6 +46,12 @@ func (o PropertyMethodsInitialize) SupportedManifestMIMETypes() []string {
 // DesiredLayerCompression indicates the kind of compression to apply on layers
 func (o PropertyMethodsInitialize) DesiredLayerCompression() types.LayerCompression {
 	return o.vals.DesiredLayerCompression
+}
+
+// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
+// uploaded to the image destination, true otherwise.
+func (o PropertyMethodsInitialize) AcceptsForeignLayerURLs() bool {
+	return o.vals.AcceptsForeignLayerURLs
 }
 
 // MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.

--- a/internal/imagedestination/impl/properties.go
+++ b/internal/imagedestination/impl/properties.go
@@ -1,11 +1,15 @@
 package impl
 
+import "github.com/containers/image/v5/types"
+
 // Properties collects properties of an ImageDestination that are constant throughout its lifetime
 // (but might differ across instances).
 type Properties struct {
 	// SupportedManifestMIMETypes tells which manifest MIME types the destination supports.
 	// A empty slice or nil means any MIME type can be tried to upload.
 	SupportedManifestMIMETypes []string
+	// DesiredLayerCompression indicates the kind of compression to apply on layers
+	DesiredLayerCompression types.LayerCompression
 	// MustMatchRuntimeOS is set to true if the destination can store only images targeted for the current runtime architecture and OS.
 	MustMatchRuntimeOS bool
 	// IgnoresEmbeddedDockerReference is set to true if the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
@@ -34,6 +38,11 @@ func PropertyMethods(vals Properties) PropertyMethodsInitialize {
 // If an empty slice or nil it's returned, then any mime type can be tried to upload
 func (o PropertyMethodsInitialize) SupportedManifestMIMETypes() []string {
 	return o.vals.SupportedManifestMIMETypes
+}
+
+// DesiredLayerCompression indicates the kind of compression to apply on layers
+func (o PropertyMethodsInitialize) DesiredLayerCompression() types.LayerCompression {
+	return o.vals.DesiredLayerCompression
 }
 
 // MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.

--- a/internal/imagedestination/impl/properties.go
+++ b/internal/imagedestination/impl/properties.go
@@ -3,6 +3,9 @@ package impl
 // Properties collects properties of an ImageDestination that are constant throughout its lifetime
 // (but might differ across instances).
 type Properties struct {
+	// SupportedManifestMIMETypes tells which manifest MIME types the destination supports.
+	// A empty slice or nil means any MIME type can be tried to upload.
+	SupportedManifestMIMETypes []string
 	// MustMatchRuntimeOS is set to true if the destination can store only images targeted for the current runtime architecture and OS.
 	MustMatchRuntimeOS bool
 	// IgnoresEmbeddedDockerReference is set to true if the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
@@ -25,6 +28,12 @@ func PropertyMethods(vals Properties) PropertyMethodsInitialize {
 	return PropertyMethodsInitialize{
 		vals: vals,
 	}
+}
+
+// SupportedManifestMIMETypes tells which manifest mime types the destination supports
+// If an empty slice or nil it's returned, then any mime type can be tried to upload
+func (o PropertyMethodsInitialize) SupportedManifestMIMETypes() []string {
+	return o.vals.SupportedManifestMIMETypes
 }
 
 // MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.

--- a/internal/imagedestination/impl/properties.go
+++ b/internal/imagedestination/impl/properties.go
@@ -1,0 +1,45 @@
+package impl
+
+// Properties collects properties of an ImageDestination that are constant throughout its lifetime
+// (but might differ across instances).
+type Properties struct {
+	// MustMatchRuntimeOS is set to true if the destination can store only images targeted for the current runtime architecture and OS.
+	MustMatchRuntimeOS bool
+	// IgnoresEmbeddedDockerReference is set to true if the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+	// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+	// Does not make a difference if Reference().DockerReference() is nil.
+	IgnoresEmbeddedDockerReference bool
+	// HasThreadSafePutBlob indicates that PutBlob can be executed concurrently.
+	HasThreadSafePutBlob bool
+}
+
+// PropertyMethodsInitialize implements parts of private.ImageDestination corresponding to Properties.
+type PropertyMethodsInitialize struct {
+	// We need two separate structs, PropertyMethodsInitialize and Properties, because Go prohibits fields and methods with the same name.
+
+	vals Properties
+}
+
+// PropertyMethods creates an PropertyMethodsInitialize for vals.
+func PropertyMethods(vals Properties) PropertyMethodsInitialize {
+	return PropertyMethodsInitialize{
+		vals: vals,
+	}
+}
+
+// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
+func (o PropertyMethodsInitialize) MustMatchRuntimeOS() bool {
+	return o.vals.MustMatchRuntimeOS
+}
+
+// IgnoresEmbeddedDockerReference() returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
+// and would prefer to receive an unmodified manifest instead of one modified for the destination.
+// Does not make a difference if Reference().DockerReference() is nil.
+func (o PropertyMethodsInitialize) IgnoresEmbeddedDockerReference() bool {
+	return o.vals.IgnoresEmbeddedDockerReference
+}
+
+// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
+func (o PropertyMethodsInitialize) HasThreadSafePutBlob() bool {
+	return o.vals.HasThreadSafePutBlob
+}

--- a/internal/imagedestination/stubs/put_blob_partial.go
+++ b/internal/imagedestination/stubs/put_blob_partial.go
@@ -42,3 +42,11 @@ func (stub NoPutBlobPartialInitialize) SupportsPutBlobPartial() bool {
 func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (types.BlobInfo, error) {
 	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", stub.transportName)
 }
+
+// ImplementsPutBlobPartial implements SupportsPutBlobPartial() that returns true.
+type ImplementsPutBlobPartial struct{}
+
+// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
+func (stub ImplementsPutBlobPartial) SupportsPutBlobPartial() bool {
+	return true
+}

--- a/internal/imagedestination/stubs/put_blob_partial.go
+++ b/internal/imagedestination/stubs/put_blob_partial.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 )
@@ -38,6 +39,6 @@ func (stub NoPutBlobPartialInitialize) SupportsPutBlobPartial() bool {
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (types.BlobInfo, error) {
 	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", stub.transportName)
 }

--- a/internal/imagedestination/stubs/put_blob_partial.go
+++ b/internal/imagedestination/stubs/put_blob_partial.go
@@ -1,0 +1,43 @@
+package stubs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/types"
+)
+
+// NoPutBlobPartialInitialize implements parts of private.ImageDestination
+// for transports that don’t support PutBlobPartial().
+// See NoPutBlobPartial() below.
+type NoPutBlobPartialInitialize struct {
+	transportName string
+}
+
+// NoPutBlobPartial creates a NoPutBlobPartialInitialize for ref.
+func NoPutBlobPartial(ref types.ImageReference) NoPutBlobPartialInitialize {
+	return NoPutBlobPartialRaw(ref.Transport().Name())
+}
+
+// NoPutBlobPartialRaw is the same thing as NoPutBlobPartial, but it can be used
+// in situations where no ImageReference is available.
+func NoPutBlobPartialRaw(transportName string) NoPutBlobPartialInitialize {
+	return NoPutBlobPartialInitialize{
+		transportName: transportName,
+	}
+}
+
+// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
+func (stub NoPutBlobPartialInitialize) SupportsPutBlobPartial() bool {
+	return false
+}
+
+// PutBlobPartial attempts to create a blob using the data that is already present
+// at the destination. chunkAccessor is accessed in a non-sequential way to retrieve the missing chunks.
+// It is available only if SupportsPutBlobPartial().
+// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
+// should fall back to PutBlobWithOptions.
+func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", stub.transportName)
+}

--- a/internal/imagedestination/stubs/signatures.go
+++ b/internal/imagedestination/stubs/signatures.go
@@ -1,0 +1,49 @@
+package stubs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// NoSignaturesInitialize implements parts of private.ImageDestination
+// for transports that don’t support storing signatures.
+// See NoSignatures() below.
+type NoSignaturesInitialize struct {
+	message string
+}
+
+// NoSignatures creates a NoSignaturesInitialize, failing with message.
+func NoSignatures(message string) NoSignaturesInitialize {
+	return NoSignaturesInitialize{
+		message: message,
+	}
+}
+
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (stub NoSignaturesInitialize) SupportsSignatures(ctx context.Context) error {
+	return errors.New(stub.message)
+}
+
+// PutSignatures writes a set of signatures to the destination.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to write or overwrite the signatures for
+// (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+// MUST be called after PutManifest (signatures may reference manifest contents).
+func (stub NoSignaturesInitialize) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
+	if len(signatures) != 0 {
+		return errors.New(stub.message)
+	}
+	return nil
+}
+
+// SupportsSignatures implements SupportsSignatures() that returns nil.
+// Note that it might be even more useful to return a value dynamically detected based on
+type AlwaysSupportsSignatures struct{}
+
+// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
+// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
+func (stub AlwaysSupportsSignatures) SupportsSignatures(ctx context.Context) error {
+	return nil
+}

--- a/internal/imagedestination/stubs/stubs.go
+++ b/internal/imagedestination/stubs/stubs.go
@@ -1,0 +1,25 @@
+// Package stubs contains trivial stubs for parts of private.ImageDestination.
+// It can be used from internal/wrapper, so it should not drag in any extra dependencies.
+// Compare with imagedestination/impl, which might require non-trivial implementation work.
+//
+// There are two kinds of stubs:
+// - Pure stubs, like ImplementsPutBlobPartial. Those can just be included in an imageDestination
+//   implementation:
+//
+//   type yourDestination struct {
+//       stubs.ImplementsPutBlobPartial
+//       …
+//   }
+// - Stubs with a constructor, like NoPutBlobPartialInitialize. The Initialize marker
+//   means that a constructor must be called:
+//   type yourDestination struct {
+//       stubs.NoPutBlobPartialInitialize
+//       …
+//   }
+//
+//   dest := &yourDestination{
+//       …
+//       NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
+//   }
+//
+package stubs

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -2,9 +2,9 @@ package imagedestination
 
 import (
 	"context"
-	"fmt"
 	"io"
 
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 )
@@ -12,6 +12,8 @@ import (
 // wrapped provides the private.ImageDestination operations
 // for a destination that only implements types.ImageDestination
 type wrapped struct {
+	stubs.NoPutBlobPartialInitialize
+
 	types.ImageDestination
 }
 
@@ -29,12 +31,11 @@ func FromPublic(dest types.ImageDestination) private.ImageDestination {
 	if dest2, ok := dest.(private.ImageDestination); ok {
 		return dest2
 	}
-	return &wrapped{ImageDestination: dest}
-}
+	return &wrapped{
+		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(dest.Reference()),
 
-// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
-func (w *wrapped) SupportsPutBlobPartial() bool {
-	return false
+		ImageDestination: dest,
+	}
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.
@@ -46,15 +47,6 @@ func (w *wrapped) SupportsPutBlobPartial() bool {
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
 	return w.PutBlob(ctx, stream, inputInfo, options.Cache, options.IsConfig)
-}
-
-// PutBlobPartial attempts to create a blob using the data that is already present
-// at the destination. chunkAccessor is accessed in a non-sequential way to retrieve the missing chunks.
-// It is available only if SupportsPutBlobPartial().
-// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
-// should fall back to PutBlobWithOptions.
-func (w *wrapped) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
-	return types.BlobInfo{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", w.Reference().Transport().Name())
 }
 
 // TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -9,6 +9,12 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
+// wrapped provides the private.ImageDestination operations
+// for a destination that only implements types.ImageDestination
+type wrapped struct {
+	types.ImageDestination
+}
+
 // FromPublic(dest) returns an object that provides the private.ImageDestination API
 //
 // Eventually, we might want to expose this function, and methods of the returned object,
@@ -24,12 +30,6 @@ func FromPublic(dest types.ImageDestination) private.ImageDestination {
 		return dest2
 	}
 	return &wrapped{ImageDestination: dest}
-}
-
-// wrapped provides the private.ImageDestination operations
-// for a destination that only implements types.ImageDestination
-type wrapped struct {
-	types.ImageDestination
 }
 
 // SupportsPutBlobPartial returns true if PutBlobPartial is supported.

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -18,11 +18,9 @@ type ImageSource interface {
 	BlobChunkAccessor
 }
 
-// ImageDestination is an internal extension to the types.ImageDestination
-// interface.
-type ImageDestination interface {
-	types.ImageDestination
-
+// ImageDestinationInternalOnly is the part of private.ImageDestination that is not
+// a part of types.ImageDestination.
+type ImageDestinationInternalOnly interface {
 	// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
 	SupportsPutBlobPartial() bool
 
@@ -50,6 +48,13 @@ type ImageDestination interface {
 	// reflected in the manifest that will be written.
 	// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 	TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options TryReusingBlobOptions) (bool, types.BlobInfo, error)
+}
+
+// ImageDestination is an internal extension to the types.ImageDestination
+// interface.
+type ImageDestination interface {
+	types.ImageDestination
+	ImageDestinationInternalOnly
 }
 
 // PutBlobOptions are used in PutBlobWithOptions.

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/types"
 )
 
@@ -38,7 +39,7 @@ type ImageDestinationInternalOnly interface {
 	// It is available only if SupportsPutBlobPartial().
 	// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 	// should fall back to PutBlobWithOptions.
-	PutBlobPartial(ctx context.Context, chunkAccessor BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error)
+	PutBlobPartial(ctx context.Context, chunkAccessor BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (types.BlobInfo, error)
 
 	// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
@@ -59,8 +60,8 @@ type ImageDestination interface {
 
 // PutBlobOptions are used in PutBlobWithOptions.
 type PutBlobOptions struct {
-	Cache    types.BlobInfoCache // Cache to optionally update with the uploaded bloblook up blob infos.
-	IsConfig bool                // True if the blob is a config
+	Cache    blobinfocache.BlobInfoCache2 // Cache to optionally update with the uploaded bloblook up blob infos.
+	IsConfig bool                         // True if the blob is a config
 
 	// The following fields are new to internal/private.  Users of internal/private MUST fill them in,
 	// but they also must expect that they will be ignored by types.ImageDestination transports.
@@ -74,7 +75,7 @@ type PutBlobOptions struct {
 
 // TryReusingBlobOptions are used in TryReusingBlobWithOptions.
 type TryReusingBlobOptions struct {
-	Cache types.BlobInfoCache // Cache to use and/or update.
+	Cache blobinfocache.BlobInfoCache2 // Cache to use and/or update.
 	// If true, it is allowed to use an equivalent of the desired blob;
 	// in that case the returned info may not match the input.
 	CanSubstitute bool

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -64,6 +64,9 @@ type PutBlobOptions struct {
 
 	// The following fields are new to internal/private.  Users of internal/private MUST fill them in,
 	// but they also must expect that they will be ignored by types.ImageDestination transports.
+	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
+	// if they use internal/imagedestination/impl.Compat;
+	// in that case, they will all be consistently zero-valued.
 
 	EmptyLayer bool // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
 	LayerIndex *int // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
@@ -78,6 +81,9 @@ type TryReusingBlobOptions struct {
 
 	// The following fields are new to internal/private.  Users of internal/private MUST fill them in,
 	// but they also must expect that they will be ignored by types.ImageDestination transports.
+	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
+	// if they use internal/imagedestination/impl.Compat;
+	// in that case, they will all be consistently zero-valued.
 
 	EmptyLayer bool            // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
 	LayerIndex *int            // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -5,6 +5,10 @@ import (
 	"io"
 	"os"
 
+	"github.com/containers/image/v5/internal/blobinfocache"
+	"github.com/containers/image/v5/internal/imagedestination"
+	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
@@ -13,13 +17,15 @@ import (
 )
 
 type ociArchiveImageDestination struct {
+	impl.Compat
+
 	ref          ociArchiveReference
-	unpackedDest types.ImageDestination
+	unpackedDest private.ImageDestination
 	tempDirRef   tempDirOCIRef
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (types.ImageDestination, error) {
+func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (private.ImageDestination, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
 		return nil, perrors.Wrapf(err, "creating oci reference")
@@ -31,9 +37,13 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref ociA
 		}
 		return nil, err
 	}
-	return &ociArchiveImageDestination{ref: ref,
-		unpackedDest: unpackedDest,
-		tempDirRef:   tempDirRef}, nil
+	d := &ociArchiveImageDestination{
+		ref:          ref,
+		unpackedDest: imagedestination.FromPublic(unpackedDest),
+		tempDirRef:   tempDirRef,
+	}
+	d.Compat = impl.AddCompat(d)
+	return d, nil
 }
 
 // Reference returns the reference used to set up this destination.
@@ -87,29 +97,40 @@ func (d *ociArchiveImageDestination) HasThreadSafePutBlob() bool {
 	return false
 }
 
-// PutBlob writes contents of stream and returns data representing the result.
+// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
+func (d *ociArchiveImageDestination) SupportsPutBlobPartial() bool {
+	return d.unpackedDest.SupportsPutBlobPartial()
+}
+
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
-// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *ociArchiveImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
-	return d.unpackedDest.PutBlob(ctx, stream, inputInfo, cache, isConfig)
+func (d *ociArchiveImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlobWithOptions(ctx, stream, inputInfo, options)
 }
 
-// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// PutBlobPartial attempts to create a blob using the data that is already present
+// at the destination. chunkAccessor is accessed in a non-sequential way to retrieve the missing chunks.
+// It is available only if SupportsPutBlobPartial().
+// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
+// should fall back to PutBlobWithOptions.
+func (d *ociArchiveImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlobPartial(ctx, chunkAccessor, srcInfo, cache)
+}
+
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
-// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
 // include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-// May use and/or update cache.
-func (d *ociArchiveImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
-	return d.unpackedDest.TryReusingBlob(ctx, info, cache, canSubstitute)
+func (d *ociArchiveImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
+	return d.unpackedDest.TryReusingBlobWithOptions(ctx, info, options)
 }
 
 // PutManifest writes the manifest to the destination.

--- a/oci/archive/oci_dest_test.go
+++ b/oci/archive/oci_dest_test.go
@@ -1,0 +1,5 @@
+package archive
+
+import "github.com/containers/image/v5/internal/private"
+
+var _ private.ImageDestination = (*ociArchiveImageDestination)(nil)

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -24,6 +24,7 @@ import (
 type ociImageDestination struct {
 	impl.Compat
 	stubs.NoPutBlobPartialInitialize
+	stubs.NoSignaturesInitialize
 
 	ref                      ociReference
 	index                    imgspecv1.Index
@@ -51,6 +52,7 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (private.Im
 
 	d := &ociImageDestination{
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
+		NoSignaturesInitialize:     stubs.NoSignatures("Pushing signatures for OCI images is not supported"),
 
 		ref:   ref,
 		index: *index,
@@ -89,12 +91,6 @@ func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
 		imgspecv1.MediaTypeImageManifest,
 		imgspecv1.MediaTypeImageIndex,
 	}
-}
-
-// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
-// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *ociImageDestination) SupportsSignatures(ctx context.Context) error {
-	return errors.New("Pushing signatures for OCI images is not supported")
 }
 
 func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
@@ -298,16 +294,6 @@ func (d *ociImageDestination) addManifest(desc *imgspecv1.Descriptor) {
 	}
 	// It's a new entry to be added to the index.
 	d.index.Manifests = append(d.index.Manifests, *desc)
-}
-
-// PutSignatures would add the given signatures to the oci layout (currently not supported).
-// If instanceDigest is not nil, it contains a digest of the specific manifest instance to write or overwrite the signatures for
-// (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
-func (d *ociImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
-	if len(signatures) != 0 {
-		return errors.New("Pushing signatures for OCI images is not supported")
-	}
-	return nil
 }
 
 // Commit marks the process of storing the image as successful and asks for the image to be persisted.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -23,6 +23,7 @@ import (
 
 type ociImageDestination struct {
 	impl.Compat
+	impl.PropertyMethodsInitialize
 	stubs.NoPutBlobPartialInitialize
 	stubs.NoSignaturesInitialize
 
@@ -51,6 +52,11 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (private.Im
 	}
 
 	d := &ociImageDestination{
+		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			MustMatchRuntimeOS:             false,
+			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
+			HasThreadSafePutBlob:           true,
+		}),
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
 		NoSignaturesInitialize:     stubs.NoSignatures("Pushing signatures for OCI images is not supported"),
 
@@ -103,23 +109,6 @@ func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 // uploaded to the image destination, true otherwise.
 func (d *ociImageDestination) AcceptsForeignLayerURLs() bool {
-	return true
-}
-
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
-func (d *ociImageDestination) MustMatchRuntimeOS() bool {
-	return false
-}
-
-// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
-// and would prefer to receive an unmodified manifest instead of one modified for the destination.
-// Does not make a difference if Reference().DockerReference() is nil.
-func (d *ociImageDestination) IgnoresEmbeddedDockerReference() bool {
-	return false // N/A, DockerReference() returns nil.
-}
-
-// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
-func (d *ociImageDestination) HasThreadSafePutBlob() bool {
 	return true
 }
 

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -10,6 +10,9 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -19,6 +22,9 @@ import (
 )
 
 type ociImageDestination struct {
+	impl.Compat
+	stubs.NoPutBlobPartialInitialize
+
 	ref                      ociReference
 	index                    imgspecv1.Index
 	sharedBlobDir            string
@@ -26,7 +32,7 @@ type ociImageDestination struct {
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
+func newImageDestination(sys *types.SystemContext, ref ociReference) (private.ImageDestination, error) {
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error
@@ -43,7 +49,13 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (types.Imag
 		}
 	}
 
-	d := &ociImageDestination{ref: ref, index: *index}
+	d := &ociImageDestination{
+		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
+
+		ref:   ref,
+		index: *index,
+	}
+	d.Compat = impl.AddCompat(d)
 	if sys != nil {
 		d.sharedBlobDir = sys.OCISharedBlobDirPath
 		d.acceptUncompressedLayers = sys.OCIAcceptUncompressedLayers
@@ -115,15 +127,14 @@ func (d *ociImageDestination) HasThreadSafePutBlob() bool {
 	return true
 }
 
-// PutBlob writes contents of stream and returns data representing the result.
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
-// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+func (d *ociImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
 	blobFile, err := os.CreateTemp(d.ref.dir, "oci-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -181,16 +192,14 @@ func (d *ociImageDestination) PutBlob(ctx context.Context, stream io.Reader, inp
 	return types.BlobInfo{Digest: blobDigest, Size: size}, nil
 }
 
-// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
-// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
 // include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-// May use and/or update cache.
-func (d *ociImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+func (d *ociImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
 	if info.Digest == "" {
 		return false, types.BlobInfo{}, errors.New("Can not check for a blob with unknown digest")
 	}

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -62,6 +62,7 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (private.Im
 				imgspecv1.MediaTypeImageIndex,
 			},
 			DesiredLayerCompression:        desiredLayerCompression,
+			AcceptsForeignLayerURLs:        true,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           true,
@@ -98,12 +99,6 @@ func (d *ociImageDestination) Reference() types.ImageReference {
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *ociImageDestination) Close() error {
 	return nil
-}
-
-// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
-// uploaded to the image destination, true otherwise.
-func (d *ociImageDestination) AcceptsForeignLayerURLs() bool {
-	return true
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -53,6 +53,10 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (private.Im
 
 	d := &ociImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			SupportedManifestMIMETypes: []string{
+				imgspecv1.MediaTypeImageManifest,
+				imgspecv1.MediaTypeImageIndex,
+			},
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           true,
@@ -90,13 +94,6 @@ func (d *ociImageDestination) Reference() types.ImageReference {
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *ociImageDestination) Close() error {
 	return nil
-}
-
-func (d *ociImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
-		imgspecv1.MediaTypeImageManifest,
-		imgspecv1.MediaTypeImageIndex,
-	}
 }
 
 func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {

--- a/oci/layout/oci_dest_test.go
+++ b/oci/layout/oci_dest_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/pkg/blobinfocache/memory"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -16,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var _ private.ImageDestination = (*ociImageDestination)(nil)
 
 // readerFromFunc allows implementing Reader by any function, e.g. a closure.
 type readerFromFunc func([]byte) (int, error)

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/imagedestination"
 	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
 	"github.com/containers/image/v5/internal/iolimits"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
@@ -320,6 +321,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 
 type openshiftImageDestination struct {
 	impl.Compat
+	stubs.AlwaysSupportsSignatures
 
 	client *openshiftClient
 	docker private.ImageDestination // The docker/distribution API endpoint
@@ -368,12 +370,6 @@ func (d *openshiftImageDestination) Close() error {
 
 func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {
 	return d.docker.SupportedManifestMIMETypes()
-}
-
-// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
-// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *openshiftImageDestination) SupportsSignatures(ctx context.Context) error {
-	return nil
 }
 
 func (d *openshiftImageDestination) DesiredLayerCompression() types.LayerCompression {

--- a/openshift/openshift_test.go
+++ b/openshift/openshift_test.go
@@ -1,0 +1,5 @@
+package openshift
+
+import "github.com/containers/image/v5/internal/private"
+
+var _ private.ImageDestination = (*openshiftImageDestination)(nil)

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -92,6 +92,7 @@ func newImageDestination(ref ostreeReference, tmpDirPath string) (private.ImageD
 	}
 	d := &ostreeImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			SupportedManifestMIMETypes:     []string{manifest.DockerV2Schema2MediaType},
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
@@ -123,12 +124,6 @@ func (d *ostreeImageDestination) Close() error {
 		C.g_object_unref(C.gpointer(d.repo))
 	}
 	return os.RemoveAll(d.tmpDirPath)
-}
-
-func (d *ostreeImageDestination) SupportedManifestMIMETypes() []string {
-	return []string{
-		manifest.DockerV2Schema2MediaType,
-	}
 }
 
 // ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -94,6 +94,7 @@ func newImageDestination(ref ostreeReference, tmpDirPath string) (private.ImageD
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
 			SupportedManifestMIMETypes:     []string{manifest.DockerV2Schema2MediaType},
 			DesiredLayerCompression:        types.PreserveOriginal,
+			AcceptsForeignLayerURLs:        false,
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
@@ -125,12 +126,6 @@ func (d *ostreeImageDestination) Close() error {
 		C.g_object_unref(C.gpointer(d.repo))
 	}
 	return os.RemoveAll(d.tmpDirPath)
-}
-
-// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
-// uploaded to the image destination, true otherwise.
-func (d *ostreeImageDestination) AcceptsForeignLayerURLs() bool {
-	return false
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -21,6 +21,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -66,6 +69,9 @@ type manifestSchema struct {
 }
 
 type ostreeImageDestination struct {
+	compat impl.Compat
+	stubs.NoPutBlobPartialInitialize
+
 	ref           ostreeReference
 	manifest      string
 	schema        manifestSchema
@@ -77,12 +83,25 @@ type ostreeImageDestination struct {
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing ostree.
-func newImageDestination(ref ostreeReference, tmpDirPath string) (types.ImageDestination, error) {
+func newImageDestination(ref ostreeReference, tmpDirPath string) (private.ImageDestination, error) {
 	tmpDirPath = filepath.Join(tmpDirPath, ref.branchName)
 	if err := ensureDirectoryExists(tmpDirPath); err != nil {
 		return nil, err
 	}
-	return &ostreeImageDestination{ref, "", manifestSchema{}, tmpDirPath, map[string]*blobToImport{}, "", 0, nil}, nil
+	d := &ostreeImageDestination{
+		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
+
+		ref:           ref,
+		manifest:      "",
+		schema:        manifestSchema{},
+		tmpDirPath:    tmpDirPath,
+		blobs:         map[string]*blobToImport{},
+		digest:        "",
+		signaturesLen: 0,
+		repo:          nil,
+	}
+	d.Compat = impl.AddCompat(d)
+	return d, nil
 }
 
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
@@ -139,15 +158,14 @@ func (d *ostreeImageDestination) HasThreadSafePutBlob() bool {
 	return false
 }
 
-// PutBlob writes contents of stream and returns data representing the result.
+// PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
 // inputInfo.MediaType describes the blob format, if known.
-// May update cache.
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *ostreeImageDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+func (d *ostreeImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (types.BlobInfo, error) {
 	tmpDir, err := os.MkdirTemp(d.tmpDirPath, "blob")
 	if err != nil {
 		return types.BlobInfo{}, err
@@ -339,16 +357,14 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 	return d.ostreeCommit(repo, ostreeBranch, destinationPath, []string{fmt.Sprintf("docker.size=%d", blob.Size)})
 }
 
-// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
+// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 // (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
 // info.Digest must not be empty.
-// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
 // If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
 // include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-// May use and/or update cache.
-func (d *ostreeImageDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, types.BlobInfo, error) {
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
 		if err != nil {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -70,6 +70,7 @@ type manifestSchema struct {
 
 type ostreeImageDestination struct {
 	compat impl.Compat
+	impl.PropertyMethodsInitialize
 	stubs.NoPutBlobPartialInitialize
 	stubs.AlwaysSupportsSignatures
 
@@ -90,6 +91,11 @@ func newImageDestination(ref ostreeReference, tmpDirPath string) (private.ImageD
 		return nil, err
 	}
 	d := &ostreeImageDestination{
+		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			MustMatchRuntimeOS:             true,
+			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
+			HasThreadSafePutBlob:           false,
+		}),
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
 
 		ref:           ref,
@@ -133,23 +139,6 @@ func (d *ostreeImageDestination) DesiredLayerCompression() types.LayerCompressio
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 // uploaded to the image destination, true otherwise.
 func (d *ostreeImageDestination) AcceptsForeignLayerURLs() bool {
-	return false
-}
-
-// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime architecture and OS. False otherwise.
-func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
-	return true
-}
-
-// IgnoresEmbeddedDockerReference returns true iff the destination does not care about Image.EmbeddedDockerReferenceConflicts(),
-// and would prefer to receive an unmodified manifest instead of one modified for the destination.
-// Does not make a difference if Reference().DockerReference() is nil.
-func (d *ostreeImageDestination) IgnoresEmbeddedDockerReference() bool {
-	return false // N/A, DockerReference() returns nil.
-}
-
-// HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.
-func (d *ostreeImageDestination) HasThreadSafePutBlob() bool {
 	return false
 }
 

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -71,6 +71,7 @@ type manifestSchema struct {
 type ostreeImageDestination struct {
 	compat impl.Compat
 	stubs.NoPutBlobPartialInitialize
+	stubs.AlwaysSupportsSignatures
 
 	ref           ostreeReference
 	manifest      string
@@ -122,12 +123,6 @@ func (d *ostreeImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		manifest.DockerV2Schema2MediaType,
 	}
-}
-
-// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
-// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
-func (d *ostreeImageDestination) SupportsSignatures(ctx context.Context) error {
-	return nil
 }
 
 // ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -93,6 +93,7 @@ func newImageDestination(ref ostreeReference, tmpDirPath string) (private.ImageD
 	d := &ostreeImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
 			SupportedManifestMIMETypes:     []string{manifest.DockerV2Schema2MediaType},
+			DesiredLayerCompression:        types.PreserveOriginal,
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
 			HasThreadSafePutBlob:           false,
@@ -124,11 +125,6 @@ func (d *ostreeImageDestination) Close() error {
 		C.g_object_unref(C.gpointer(d.repo))
 	}
 	return os.RemoveAll(d.tmpDirPath)
-}
-
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *ostreeImageDestination) DesiredLayerCompression() types.LayerCompression {
-	return types.PreserveOriginal
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually

--- a/ostree/ostree_dest_test.go
+++ b/ostree/ostree_dest_test.go
@@ -1,0 +1,6 @@
+//go:build containers_image_ostree
+// +build containers_image_ostree
+
+package ostree
+
+var _ private.ImageDestination = (*ostreeImageDestination)(nil)

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -65,6 +65,7 @@ type storageImageSource struct {
 type storageImageDestination struct {
 	impl.Compat
 	stubs.ImplementsPutBlobPartial
+	stubs.AlwaysSupportsSignatures
 
 	imageRef        storageReference
 	directory       string                   // Temporary directory where we store blobs until Commit() time
@@ -1206,12 +1207,6 @@ func (s *storageImageDestination) PutManifest(ctx context.Context, manifestBlob 
 	copy(newBlob, manifestBlob)
 	s.manifest = newBlob
 	s.manifestDigest = digest
-	return nil
-}
-
-// SupportsSignatures returns an error if we can't expect GetSignatures() to return data that was
-// previously supplied to PutSignatures().
-func (s *storageImageDestination) SupportsSignatures(ctx context.Context) error {
 	return nil
 }
 

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -414,6 +414,10 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 				manifest.DockerV2Schema1SignedMediaType,
 				manifest.DockerV2Schema1MediaType,
 			},
+			// We ultimately have to decompress layers to populate trees on disk
+			// and need to explicitly ask for it here, so that the layers' MIME
+			// types can be set accordingly.
+			DesiredLayerCompression:        types.PreserveOriginal,
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: true, // Yes, we want the unmodified manifest
 			HasThreadSafePutBlob:           true,
@@ -453,13 +457,6 @@ func (s *storageImageDestination) Close() error {
 		}
 	}
 	return os.RemoveAll(s.directory)
-}
-
-func (s *storageImageDestination) DesiredLayerCompression() types.LayerCompression {
-	// We ultimately have to decompress layers to populate trees on disk
-	// and need to explicitly ask for it here, so that the layers' MIME
-	// types can be set accordingly.
-	return types.PreserveOriginal
 }
 
 func (s *storageImageDestination) computeNextBlobCacheFile() string {

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -408,6 +408,12 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 	}
 	dest := &storageImageDestination{
 		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			SupportedManifestMIMETypes: []string{
+				imgspecv1.MediaTypeImageManifest,
+				manifest.DockerV2Schema2MediaType,
+				manifest.DockerV2Schema1SignedMediaType,
+				manifest.DockerV2Schema1MediaType,
+			},
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: true, // Yes, we want the unmodified manifest
 			HasThreadSafePutBlob:           true,
@@ -1186,17 +1192,6 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 
 	commitSucceeded = true
 	return nil
-}
-
-var manifestMIMETypes = []string{
-	imgspecv1.MediaTypeImageManifest,
-	manifest.DockerV2Schema2MediaType,
-	manifest.DockerV2Schema1SignedMediaType,
-	manifest.DockerV2Schema1MediaType,
-}
-
-func (s *storageImageDestination) SupportedManifestMIMETypes() []string {
-	return manifestMIMETypes
 }
 
 // PutManifest writes the manifest to the destination.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/internal/imagedestination/impl"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/internal/tmpdir"
@@ -60,6 +61,8 @@ type storageImageSource struct {
 }
 
 type storageImageDestination struct {
+	impl.Compat
+
 	imageRef        storageReference
 	directory       string                   // Temporary directory where we store blobs until Commit() time
 	nextTempFileID  int32                    // A counter that we use for computing filenames to assign to blobs
@@ -398,7 +401,7 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 	if err != nil {
 		return nil, perrors.Wrapf(err, "creating a temporary directory")
 	}
-	image := &storageImageDestination{
+	dest := &storageImageDestination{
 		imageRef:               imageRef,
 		directory:              directory,
 		signatureses:           make(map[digest.Digest][]byte),
@@ -412,7 +415,8 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 		indexToPulledLayerInfo: make(map[int]*manifest.LayerInfo),
 		diffOutputs:            make(map[digest.Digest]*graphdriver.DriverWithDifferOutput),
 	}
-	return image, nil
+	dest.Compat = impl.AddCompat(dest)
+	return dest, nil
 }
 
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
@@ -468,21 +472,6 @@ func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream
 	}
 
 	return info, s.queueOrCommit(ctx, info, *options.LayerIndex, options.EmptyLayer)
-}
-
-// PutBlob writes contents of stream and returns data representing the result.
-// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
-// inputInfo.Size is the expected length of stream, if known.
-// inputInfo.MediaType describes the blob format, if known.
-// May update cache.
-// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
-// to any other readers for download using the supplied digest.
-// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (s *storageImageDestination) PutBlob(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
-	return s.PutBlobWithOptions(ctx, stream, blobinfo, private.PutBlobOptions{
-		Cache:    cache,
-		IsConfig: isConfig,
-	})
 }
 
 // putBlobToPendingFile implements ImageDestination.PutBlobWithOptions, storing stream into an on-disk file.
@@ -622,22 +611,6 @@ func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context,
 	}
 
 	return reused, info, s.queueOrCommit(ctx, info, *options.LayerIndex, options.EmptyLayer)
-}
-
-// TryReusingBlob checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
-// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).
-// info.Digest must not be empty.
-// If canSubstitute, TryReusingBlob can use an equivalent equivalent of the desired blob; in that case the returned info may not match the input.
-// If the blob has been successfully reused, returns (true, info, nil); info must contain at least a digest and size, and may
-// include CompressionOperation and CompressionAlgorithm fields to indicate that a change to the compression type should be
-// reflected in the manifest that will be written.
-// If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
-// May use and/or update cache.
-func (s *storageImageDestination) TryReusingBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
-	return s.TryReusingBlobWithOptions(ctx, blobinfo, private.TryReusingBlobOptions{
-		Cache:         cache,
-		CanSubstitute: canSubstitute,
-	})
 }
 
 // tryReusingBlobAsPending implements TryReusingBlobWithOptions, filling s.blobDiffIDs and other metadata.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/internal/imagedestination/impl"
+	"github.com/containers/image/v5/internal/imagedestination/stubs"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/putblobdigest"
 	"github.com/containers/image/v5/internal/tmpdir"
@@ -63,6 +64,7 @@ type storageImageSource struct {
 
 type storageImageDestination struct {
 	impl.Compat
+	stubs.ImplementsPutBlobPartial
 
 	imageRef        storageReference
 	directory       string                   // Temporary directory where we store blobs until Commit() time
@@ -1229,11 +1231,6 @@ func (s *storageImageDestination) MustMatchRuntimeOS() bool {
 // Does not make a difference if Reference().DockerReference() is nil.
 func (s *storageImageDestination) IgnoresEmbeddedDockerReference() bool {
 	return true // Yes, we want the unmodified manifest
-}
-
-// SupportsPutBlobPartial returns true if PutBlobPartial is supported.
-func (s *storageImageDestination) SupportsPutBlobPartial() bool {
-	return true
 }
 
 // PutSignatures records the image's signatures for committing as a single data blob.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/internal/imagedestination/impl"
 	"github.com/containers/image/v5/internal/private"
@@ -568,7 +569,7 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache types.BlobInfoCache) (types.BlobInfo, error) {
+func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (types.BlobInfo, error) {
 	fetcher := zstdFetcher{
 		chunkAccessor: chunkAccessor,
 		ctx:           ctx,

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -418,6 +418,7 @@ func newImageDestination(sys *types.SystemContext, imageRef storageReference) (*
 			// and need to explicitly ask for it here, so that the layers' MIME
 			// types can be set accordingly.
 			DesiredLayerCompression:        types.PreserveOriginal,
+			AcceptsForeignLayerURLs:        false,
 			MustMatchRuntimeOS:             true,
 			IgnoresEmbeddedDockerReference: true, // Yes, we want the unmodified manifest
 			HasThreadSafePutBlob:           true,
@@ -1202,12 +1203,6 @@ func (s *storageImageDestination) PutManifest(ctx context.Context, manifestBlob 
 	s.manifest = newBlob
 	s.manifestDigest = digest
 	return nil
-}
-
-// AcceptsForeignLayerURLs returns false iff foreign layers in the manifest should actually be
-// uploaded to the image destination, true otherwise.
-func (s *storageImageDestination) AcceptsForeignLayerURLs() bool {
-	return false
 }
 
 // PutSignatures records the image's signatures for committing as a single data blob.


### PR DESCRIPTION
This is a superset of the remaining part of #1439.

- Most importantly, have all transports implement `private.ImageDestination`, leaving the task of compatibility with public `types.ImageDestination` to an `internal/imagedestination/impl.Compat` helper. All transports will now think purely in terms of the private interface.
  - `BlobInfoCache` is not yet included: that needs to happen, but that will be a later PR (notably because it needs to deal with forwarding between private and public-only users).
- Try to significantly reduce copy&pasted boilerplate in transports. This doesn’t change the provided interface, just the code.
  - Instead of a bunch of methods that just return a single value, consolidate them into `imagedestination/impl.Properties`, and let the transport just provide the values to return.
  - For possibly-missing features like writing signatures, provide a stub that allows one-line opt-in into a feature, and a stub that provides a short opt-out (without having to individually implement every single method).

The move to private interfaces is, I think, generally desirable. We will soon need to extend the signatures interface, so consolidating the compatibility concerns into a single location will help.

The boilerplate reduction part is RFC. Go is really not well suited handling some of the design concerns, primarily because it allows silent zero-initialization of struct members (all of simple values, structs, and interface pointers), without requiring the user to provide a value or to call a constructor. The previously-used interface with mandatory method implementation is really the only way to _force_ a transport author to deal with a value; `impl.Properties` weakens that compile-time enforcement. I’m not quite sure that it is worth it.