### PR TITLE
Implement private.ImageSource / ImageDestination in blobcache

### DIFF
--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -14,12 +14,6 @@ import (
 	perrors "github.com/pkg/errors"
 )
 
-var (
-	_ types.ImageReference   = &BlobCache{}
-	_ types.ImageSource      = &blobCacheSource{}
-	_ types.ImageDestination = &blobCacheDestination{}
-)
-
 const (
 	compressedNote   = ".compressed"
 	decompressedNote = ".decompressed"

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -12,13 +12,11 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/ioutils"
 	digest "github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -45,17 +43,6 @@ type BlobCache struct {
 	// both within this process and by multiple different processes
 	directory string
 	compress  types.LayerCompression
-}
-
-type blobCacheSource struct {
-	reference *BlobCache
-	source    types.ImageSource
-	sys       types.SystemContext
-	// this mutex synchronizes the counters below
-	mu          sync.Mutex
-	cacheHits   int64
-	cacheMisses int64
-	cacheErrors int64
 }
 
 type blobCacheDestination struct {
@@ -162,15 +149,6 @@ func (b *BlobCache) NewImage(ctx context.Context, sys *types.SystemContext) (typ
 	return image.FromReference(ctx, sys, b)
 }
 
-func (b *BlobCache) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
-	src, err := b.reference.NewImageSource(ctx, sys)
-	if err != nil {
-		return nil, perrors.Wrapf(err, "error creating new image source %q", transports.ImageName(b.reference))
-	}
-	logrus.Debugf("starting to read from image %q using blob cache in %q (compression=%v)", transports.ImageName(b.reference), b.directory, b.compress)
-	return &blobCacheSource{reference: b, source: src, sys: *sys}, nil
-}
-
 func (b *BlobCache) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
 	dest, err := b.reference.NewImageDestination(ctx, sys)
 	if err != nil {
@@ -178,147 +156,6 @@ func (b *BlobCache) NewImageDestination(ctx context.Context, sys *types.SystemCo
 	}
 	logrus.Debugf("starting to write to image %q using blob cache in %q", transports.ImageName(b.reference), b.directory)
 	return &blobCacheDestination{reference: b, destination: dest}, nil
-}
-
-func (s *blobCacheSource) Reference() types.ImageReference {
-	return s.reference
-}
-
-func (s *blobCacheSource) Close() error {
-	logrus.Debugf("finished reading from image %q using blob cache: cache had %d hits, %d misses, %d errors", transports.ImageName(s.reference), s.cacheHits, s.cacheMisses, s.cacheErrors)
-	return s.source.Close()
-}
-
-func (s *blobCacheSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
-	if instanceDigest != nil {
-		filename := filepath.Join(s.reference.directory, makeFilename(*instanceDigest, false))
-		manifestBytes, err := os.ReadFile(filename)
-		if err == nil {
-			s.cacheHits++
-			return manifestBytes, manifest.GuessMIMEType(manifestBytes), nil
-		}
-		if !os.IsNotExist(err) {
-			s.cacheErrors++
-			return nil, "", perrors.Wrap(err, "checking for manifest file")
-		}
-	}
-	s.cacheMisses++
-	return s.source.GetManifest(ctx, instanceDigest)
-}
-
-func (s *blobCacheSource) HasThreadSafeGetBlob() bool {
-	return s.source.HasThreadSafeGetBlob()
-}
-
-func (s *blobCacheSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-	present, size, err := s.reference.HasBlob(blobinfo)
-	if err != nil {
-		return nil, -1, err
-	}
-	if present {
-		for _, isConfig := range []bool{false, true} {
-			filename := filepath.Join(s.reference.directory, makeFilename(blobinfo.Digest, isConfig))
-			f, err := os.Open(filename)
-			if err == nil {
-				s.mu.Lock()
-				s.cacheHits++
-				s.mu.Unlock()
-				return f, size, nil
-			}
-			if !os.IsNotExist(err) {
-				s.mu.Lock()
-				s.cacheErrors++
-				s.mu.Unlock()
-				return nil, -1, perrors.Wrap(err, "checking for cache")
-			}
-		}
-	}
-	s.mu.Lock()
-	s.cacheMisses++
-	s.mu.Unlock()
-	rc, size, err := s.source.GetBlob(ctx, blobinfo, cache)
-	if err != nil {
-		return rc, size, perrors.Wrapf(err, "error reading blob from source image %q", transports.ImageName(s.reference))
-	}
-	return rc, size, nil
-}
-
-func (s *blobCacheSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
-	return s.source.GetSignatures(ctx, instanceDigest)
-}
-
-func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
-	signatures, err := s.source.GetSignatures(ctx, instanceDigest)
-	if err != nil {
-		return nil, perrors.Wrapf(err, "error checking if image %q has signatures", transports.ImageName(s.reference))
-	}
-	canReplaceBlobs := !(len(signatures) > 0 && len(signatures[0]) > 0)
-
-	infos, err := s.source.LayerInfosForCopy(ctx, instanceDigest)
-	if err != nil {
-		return nil, perrors.Wrapf(err, "error getting layer infos for copying image %q through cache", transports.ImageName(s.reference))
-	}
-	if infos == nil {
-		img, err := image.FromUnparsedImage(ctx, &s.sys, image.UnparsedInstance(s.source, instanceDigest))
-		if err != nil {
-			return nil, perrors.Wrapf(err, "error opening image to get layer infos for copying image %q through cache", transports.ImageName(s.reference))
-		}
-		infos = img.LayerInfos()
-	}
-
-	if canReplaceBlobs && s.reference.compress != types.PreserveOriginal {
-		replacedInfos := make([]types.BlobInfo, 0, len(infos))
-		for _, info := range infos {
-			var replaceDigest []byte
-			var err error
-			blobFile := filepath.Join(s.reference.directory, makeFilename(info.Digest, false))
-			alternate := ""
-			switch s.reference.compress {
-			case types.Compress:
-				alternate = blobFile + compressedNote
-				replaceDigest, err = os.ReadFile(alternate)
-			case types.Decompress:
-				alternate = blobFile + decompressedNote
-				replaceDigest, err = os.ReadFile(alternate)
-			}
-			if err == nil && digest.Digest(replaceDigest).Validate() == nil {
-				alternate = filepath.Join(filepath.Dir(alternate), makeFilename(digest.Digest(replaceDigest), false))
-				fileInfo, err := os.Stat(alternate)
-				if err == nil {
-					switch info.MediaType {
-					case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip:
-						switch s.reference.compress {
-						case types.Compress:
-							info.MediaType = v1.MediaTypeImageLayerGzip
-							info.CompressionAlgorithm = &compression.Gzip
-						case types.Decompress:
-							info.MediaType = v1.MediaTypeImageLayer
-							info.CompressionAlgorithm = nil
-						}
-					case manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2Schema2LayerMediaType:
-						switch s.reference.compress {
-						case types.Compress:
-							info.MediaType = manifest.DockerV2Schema2LayerMediaType
-							info.CompressionAlgorithm = &compression.Gzip
-						case types.Decompress:
-							// nope, not going to suggest anything, it's not allowed by the spec
-							replacedInfos = append(replacedInfos, info)
-							continue
-						}
-					}
-					logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", string(replaceDigest), info.MediaType, s.reference.compress, info.Digest.String())
-					info.CompressionOperation = s.reference.compress
-					info.Digest = digest.Digest(replaceDigest)
-					info.Size = fileInfo.Size()
-					logrus.Debugf("info = %#v", info)
-				}
-			}
-			replacedInfos = append(replacedInfos, info)
-		}
-		infos = replacedInfos
-	}
-
-	return infos, nil
 }
 
 func (d *blobCacheDestination) Reference() types.ImageReference {

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -1,24 +1,17 @@
 package blobcache
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
-	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/ioutils"
 	digest "github.com/opencontainers/go-digest"
 	perrors "github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -43,11 +36,6 @@ type BlobCache struct {
 	// both within this process and by multiple different processes
 	directory string
 	compress  types.LayerCompression
-}
-
-type blobCacheDestination struct {
-	reference   *BlobCache
-	destination types.ImageDestination
 }
 
 func makeFilename(blobSum digest.Digest, isConfig bool) string {
@@ -147,226 +135,4 @@ func (b *BlobCache) ClearCache() error {
 
 func (b *BlobCache) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
 	return image.FromReference(ctx, sys, b)
-}
-
-func (b *BlobCache) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
-	dest, err := b.reference.NewImageDestination(ctx, sys)
-	if err != nil {
-		return nil, perrors.Wrapf(err, "error creating new image destination %q", transports.ImageName(b.reference))
-	}
-	logrus.Debugf("starting to write to image %q using blob cache in %q", transports.ImageName(b.reference), b.directory)
-	return &blobCacheDestination{reference: b, destination: dest}, nil
-}
-
-func (d *blobCacheDestination) Reference() types.ImageReference {
-	return d.reference
-}
-
-func (d *blobCacheDestination) Close() error {
-	logrus.Debugf("finished writing to image %q using blob cache", transports.ImageName(d.reference))
-	return d.destination.Close()
-}
-
-func (d *blobCacheDestination) SupportedManifestMIMETypes() []string {
-	return d.destination.SupportedManifestMIMETypes()
-}
-
-func (d *blobCacheDestination) SupportsSignatures(ctx context.Context) error {
-	return d.destination.SupportsSignatures(ctx)
-}
-
-func (d *blobCacheDestination) DesiredLayerCompression() types.LayerCompression {
-	return d.destination.DesiredLayerCompression()
-}
-
-func (d *blobCacheDestination) AcceptsForeignLayerURLs() bool {
-	return d.destination.AcceptsForeignLayerURLs()
-}
-
-func (d *blobCacheDestination) MustMatchRuntimeOS() bool {
-	return d.destination.MustMatchRuntimeOS()
-}
-
-func (d *blobCacheDestination) IgnoresEmbeddedDockerReference() bool {
-	return d.destination.IgnoresEmbeddedDockerReference()
-}
-
-// Decompress and save the contents of the decompressReader stream into the passed-in temporary
-// file.  If we successfully save all of the data, rename the file to match the digest of the data,
-// and make notes about the relationship between the file that holds a copy of the compressed data
-// and this new file.
-func saveStream(wg *sync.WaitGroup, decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, alternateDigest *digest.Digest) {
-	defer wg.Done()
-	// Decompress from and digest the reading end of that pipe.
-	decompressed, err3 := archive.DecompressStream(decompressReader)
-	digester := digest.Canonical.Digester()
-	if err3 == nil {
-		// Read the decompressed data through the filter over the pipe, blocking until the
-		// writing end is closed.
-		_, err3 = io.Copy(io.MultiWriter(tempFile, digester.Hash()), decompressed)
-	} else {
-		// Drain the pipe to keep from stalling the PutBlob() thread.
-		if _, err := io.Copy(io.Discard, decompressReader); err != nil {
-			logrus.Debugf("error draining the pipe: %v", err)
-		}
-	}
-	decompressReader.Close()
-	decompressed.Close()
-	tempFile.Close()
-	// Determine the name that we should give to the uncompressed copy of the blob.
-	decompressedFilename := filepath.Join(filepath.Dir(tempFile.Name()), makeFilename(digester.Digest(), isConfig))
-	if err3 == nil {
-		// Rename the temporary file.
-		if err3 = os.Rename(tempFile.Name(), decompressedFilename); err3 != nil {
-			logrus.Debugf("error renaming new decompressed copy of blob %q into place at %q: %v", digester.Digest().String(), decompressedFilename, err3)
-			// Remove the temporary file.
-			if err3 = os.Remove(tempFile.Name()); err3 != nil {
-				logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
-			}
-		} else {
-			*alternateDigest = digester.Digest()
-			// Note the relationship between the two files.
-			if err3 = ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0600); err3 != nil {
-				logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err3)
-			}
-			if err3 = ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0600); err3 != nil {
-				logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err3)
-			}
-		}
-	} else {
-		// Remove the temporary file.
-		if err3 = os.Remove(tempFile.Name()); err3 != nil {
-			logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
-		}
-	}
-}
-
-func (d *blobCacheDestination) HasThreadSafePutBlob() bool {
-	return d.destination.HasThreadSafePutBlob()
-}
-
-func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
-	var tempfile *os.File
-	var err error
-	var n int
-	var alternateDigest digest.Digest
-	var closer io.Closer
-	wg := new(sync.WaitGroup)
-	needToWait := false
-	compression := archive.Uncompressed
-	if inputInfo.Digest != "" {
-		filename := filepath.Join(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
-		tempfile, err = os.CreateTemp(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
-		if err == nil {
-			stream = io.TeeReader(stream, tempfile)
-			defer func() {
-				if err == nil {
-					if err = os.Rename(tempfile.Name(), filename); err != nil {
-						if err2 := os.Remove(tempfile.Name()); err2 != nil {
-							logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
-						}
-						err = perrors.Wrapf(err, "error renaming new layer for blob %q into place at %q", inputInfo.Digest.String(), filename)
-					}
-				} else {
-					if err2 := os.Remove(tempfile.Name()); err2 != nil {
-						logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
-					}
-				}
-				tempfile.Close()
-			}()
-		} else {
-			logrus.Debugf("error while creating a temporary file under %q to hold blob %q: %v", d.reference.directory, inputInfo.Digest.String(), err)
-		}
-		if !isConfig {
-			initial := make([]byte, 8)
-			n, err = stream.Read(initial)
-			if n > 0 {
-				// Build a Reader that will still return the bytes that we just
-				// read, for PutBlob()'s sake.
-				stream = io.MultiReader(bytes.NewReader(initial[:n]), stream)
-				if n >= len(initial) {
-					compression = archive.DetectCompression(initial[:n])
-				}
-				if compression == archive.Gzip {
-					// The stream is compressed, so create a file which we'll
-					// use to store a decompressed copy.
-					decompressedTemp, err2 := os.CreateTemp(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
-					if err2 != nil {
-						logrus.Debugf("error while creating a temporary file under %q to hold decompressed blob %q: %v", d.reference.directory, inputInfo.Digest.String(), err2)
-						decompressedTemp.Close()
-					} else {
-						// Write a copy of the compressed data to a pipe,
-						// closing the writing end of the pipe after
-						// PutBlob() returns.
-						decompressReader, decompressWriter := io.Pipe()
-						closer = decompressWriter
-						stream = io.TeeReader(stream, decompressWriter)
-						// Let saveStream() close the reading end and handle the temporary file.
-						wg.Add(1)
-						needToWait = true
-						go saveStream(wg, decompressReader, decompressedTemp, filename, inputInfo.Digest, isConfig, &alternateDigest)
-					}
-				}
-			}
-		}
-	}
-	newBlobInfo, err := d.destination.PutBlob(ctx, stream, inputInfo, cache, isConfig)
-	if closer != nil {
-		closer.Close()
-	}
-	if needToWait {
-		wg.Wait()
-	}
-	if err != nil {
-		return newBlobInfo, perrors.Wrapf(err, "error storing blob to image destination for cache %q", transports.ImageName(d.reference))
-	}
-	if alternateDigest.Validate() == nil {
-		logrus.Debugf("added blob %q (also %q) to the cache at %q", inputInfo.Digest.String(), alternateDigest.String(), d.reference.directory)
-	} else {
-		logrus.Debugf("added blob %q to the cache at %q", inputInfo.Digest.String(), d.reference.directory)
-	}
-	return newBlobInfo, nil
-}
-
-func (d *blobCacheDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
-	present, reusedInfo, err := d.destination.TryReusingBlob(ctx, info, cache, canSubstitute)
-	if err != nil || present {
-		return present, reusedInfo, err
-	}
-
-	for _, isConfig := range []bool{false, true} {
-		filename := filepath.Join(d.reference.directory, makeFilename(info.Digest, isConfig))
-		f, err := os.Open(filename)
-		if err == nil {
-			defer f.Close()
-			uploadedInfo, err := d.destination.PutBlob(ctx, f, info, cache, isConfig)
-			if err != nil {
-				return false, types.BlobInfo{}, err
-			}
-			return true, uploadedInfo, nil
-		}
-	}
-
-	return false, types.BlobInfo{}, nil
-}
-
-func (d *blobCacheDestination) PutManifest(ctx context.Context, manifestBytes []byte, instanceDigest *digest.Digest) error {
-	manifestDigest, err := manifest.Digest(manifestBytes)
-	if err != nil {
-		logrus.Warnf("error digesting manifest %q: %v", string(manifestBytes), err)
-	} else {
-		filename := filepath.Join(d.reference.directory, makeFilename(manifestDigest, false))
-		if err = ioutils.AtomicWriteFile(filename, manifestBytes, 0600); err != nil {
-			logrus.Warnf("error saving manifest as %q: %v", filename, err)
-		}
-	}
-	return d.destination.PutManifest(ctx, manifestBytes, instanceDigest)
-}
-
-func (d *blobCacheDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
-	return d.destination.PutSignatures(ctx, signatures, instanceDigest)
-}
-
-func (d *blobCacheDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
-	return d.destination.Commit(ctx, unparsedToplevel)
 }

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -17,6 +17,7 @@ import (
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/directory"
 	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
@@ -30,6 +31,7 @@ import (
 var (
 	_ types.ImageReference   = &BlobCache{}
 	_ types.ImageSource      = &blobCacheSource{}
+	_ private.ImageSource    = (*blobCacheSource)(nil)
 	_ types.ImageDestination = &blobCacheDestination{}
 )
 

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	_ types.ImageReference   = &BlobCache{}
+	_ types.ImageSource      = &blobCacheSource{}
+	_ types.ImageDestination = &blobCacheDestination{}
+)
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Verbose() {

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 var (
-	_ types.ImageReference   = &BlobCache{}
-	_ types.ImageSource      = &blobCacheSource{}
-	_ private.ImageSource    = (*blobCacheSource)(nil)
-	_ types.ImageDestination = &blobCacheDestination{}
+	_ types.ImageReference     = &BlobCache{}
+	_ types.ImageSource        = &blobCacheSource{}
+	_ private.ImageSource      = (*blobCacheSource)(nil)
+	_ types.ImageDestination   = &blobCacheDestination{}
+	_ private.ImageDestination = (*blobCacheDestination)(nil)
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -1,0 +1,246 @@
+package blobcache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/ioutils"
+	digest "github.com/opencontainers/go-digest"
+	perrors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type blobCacheDestination struct {
+	reference   *BlobCache
+	destination types.ImageDestination
+}
+
+func (b *BlobCache) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	dest, err := b.reference.NewImageDestination(ctx, sys)
+	if err != nil {
+		return nil, perrors.Wrapf(err, "error creating new image destination %q", transports.ImageName(b.reference))
+	}
+	logrus.Debugf("starting to write to image %q using blob cache in %q", transports.ImageName(b.reference), b.directory)
+	return &blobCacheDestination{reference: b, destination: dest}, nil
+}
+
+func (d *blobCacheDestination) Reference() types.ImageReference {
+	return d.reference
+}
+
+func (d *blobCacheDestination) Close() error {
+	logrus.Debugf("finished writing to image %q using blob cache", transports.ImageName(d.reference))
+	return d.destination.Close()
+}
+
+func (d *blobCacheDestination) SupportedManifestMIMETypes() []string {
+	return d.destination.SupportedManifestMIMETypes()
+}
+
+func (d *blobCacheDestination) SupportsSignatures(ctx context.Context) error {
+	return d.destination.SupportsSignatures(ctx)
+}
+
+func (d *blobCacheDestination) DesiredLayerCompression() types.LayerCompression {
+	return d.destination.DesiredLayerCompression()
+}
+
+func (d *blobCacheDestination) AcceptsForeignLayerURLs() bool {
+	return d.destination.AcceptsForeignLayerURLs()
+}
+
+func (d *blobCacheDestination) MustMatchRuntimeOS() bool {
+	return d.destination.MustMatchRuntimeOS()
+}
+
+func (d *blobCacheDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.destination.IgnoresEmbeddedDockerReference()
+}
+
+// Decompress and save the contents of the decompressReader stream into the passed-in temporary
+// file.  If we successfully save all of the data, rename the file to match the digest of the data,
+// and make notes about the relationship between the file that holds a copy of the compressed data
+// and this new file.
+func saveStream(wg *sync.WaitGroup, decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, alternateDigest *digest.Digest) {
+	defer wg.Done()
+	// Decompress from and digest the reading end of that pipe.
+	decompressed, err3 := archive.DecompressStream(decompressReader)
+	digester := digest.Canonical.Digester()
+	if err3 == nil {
+		// Read the decompressed data through the filter over the pipe, blocking until the
+		// writing end is closed.
+		_, err3 = io.Copy(io.MultiWriter(tempFile, digester.Hash()), decompressed)
+	} else {
+		// Drain the pipe to keep from stalling the PutBlob() thread.
+		if _, err := io.Copy(io.Discard, decompressReader); err != nil {
+			logrus.Debugf("error draining the pipe: %v", err)
+		}
+	}
+	decompressReader.Close()
+	decompressed.Close()
+	tempFile.Close()
+	// Determine the name that we should give to the uncompressed copy of the blob.
+	decompressedFilename := filepath.Join(filepath.Dir(tempFile.Name()), makeFilename(digester.Digest(), isConfig))
+	if err3 == nil {
+		// Rename the temporary file.
+		if err3 = os.Rename(tempFile.Name(), decompressedFilename); err3 != nil {
+			logrus.Debugf("error renaming new decompressed copy of blob %q into place at %q: %v", digester.Digest().String(), decompressedFilename, err3)
+			// Remove the temporary file.
+			if err3 = os.Remove(tempFile.Name()); err3 != nil {
+				logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
+			}
+		} else {
+			*alternateDigest = digester.Digest()
+			// Note the relationship between the two files.
+			if err3 = ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0600); err3 != nil {
+				logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err3)
+			}
+			if err3 = ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0600); err3 != nil {
+				logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err3)
+			}
+		}
+	} else {
+		// Remove the temporary file.
+		if err3 = os.Remove(tempFile.Name()); err3 != nil {
+			logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
+		}
+	}
+}
+
+func (d *blobCacheDestination) HasThreadSafePutBlob() bool {
+	return d.destination.HasThreadSafePutBlob()
+}
+
+func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, cache types.BlobInfoCache, isConfig bool) (types.BlobInfo, error) {
+	var tempfile *os.File
+	var err error
+	var n int
+	var alternateDigest digest.Digest
+	var closer io.Closer
+	wg := new(sync.WaitGroup)
+	needToWait := false
+	compression := archive.Uncompressed
+	if inputInfo.Digest != "" {
+		filename := filepath.Join(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
+		tempfile, err = os.CreateTemp(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
+		if err == nil {
+			stream = io.TeeReader(stream, tempfile)
+			defer func() {
+				if err == nil {
+					if err = os.Rename(tempfile.Name(), filename); err != nil {
+						if err2 := os.Remove(tempfile.Name()); err2 != nil {
+							logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
+						}
+						err = perrors.Wrapf(err, "error renaming new layer for blob %q into place at %q", inputInfo.Digest.String(), filename)
+					}
+				} else {
+					if err2 := os.Remove(tempfile.Name()); err2 != nil {
+						logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
+					}
+				}
+				tempfile.Close()
+			}()
+		} else {
+			logrus.Debugf("error while creating a temporary file under %q to hold blob %q: %v", d.reference.directory, inputInfo.Digest.String(), err)
+		}
+		if !isConfig {
+			initial := make([]byte, 8)
+			n, err = stream.Read(initial)
+			if n > 0 {
+				// Build a Reader that will still return the bytes that we just
+				// read, for PutBlob()'s sake.
+				stream = io.MultiReader(bytes.NewReader(initial[:n]), stream)
+				if n >= len(initial) {
+					compression = archive.DetectCompression(initial[:n])
+				}
+				if compression == archive.Gzip {
+					// The stream is compressed, so create a file which we'll
+					// use to store a decompressed copy.
+					decompressedTemp, err2 := os.CreateTemp(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
+					if err2 != nil {
+						logrus.Debugf("error while creating a temporary file under %q to hold decompressed blob %q: %v", d.reference.directory, inputInfo.Digest.String(), err2)
+						decompressedTemp.Close()
+					} else {
+						// Write a copy of the compressed data to a pipe,
+						// closing the writing end of the pipe after
+						// PutBlob() returns.
+						decompressReader, decompressWriter := io.Pipe()
+						closer = decompressWriter
+						stream = io.TeeReader(stream, decompressWriter)
+						// Let saveStream() close the reading end and handle the temporary file.
+						wg.Add(1)
+						needToWait = true
+						go saveStream(wg, decompressReader, decompressedTemp, filename, inputInfo.Digest, isConfig, &alternateDigest)
+					}
+				}
+			}
+		}
+	}
+	newBlobInfo, err := d.destination.PutBlob(ctx, stream, inputInfo, cache, isConfig)
+	if closer != nil {
+		closer.Close()
+	}
+	if needToWait {
+		wg.Wait()
+	}
+	if err != nil {
+		return newBlobInfo, perrors.Wrapf(err, "error storing blob to image destination for cache %q", transports.ImageName(d.reference))
+	}
+	if alternateDigest.Validate() == nil {
+		logrus.Debugf("added blob %q (also %q) to the cache at %q", inputInfo.Digest.String(), alternateDigest.String(), d.reference.directory)
+	} else {
+		logrus.Debugf("added blob %q to the cache at %q", inputInfo.Digest.String(), d.reference.directory)
+	}
+	return newBlobInfo, nil
+}
+
+func (d *blobCacheDestination) TryReusingBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, canSubstitute bool) (bool, types.BlobInfo, error) {
+	present, reusedInfo, err := d.destination.TryReusingBlob(ctx, info, cache, canSubstitute)
+	if err != nil || present {
+		return present, reusedInfo, err
+	}
+
+	for _, isConfig := range []bool{false, true} {
+		filename := filepath.Join(d.reference.directory, makeFilename(info.Digest, isConfig))
+		f, err := os.Open(filename)
+		if err == nil {
+			defer f.Close()
+			uploadedInfo, err := d.destination.PutBlob(ctx, f, info, cache, isConfig)
+			if err != nil {
+				return false, types.BlobInfo{}, err
+			}
+			return true, uploadedInfo, nil
+		}
+	}
+
+	return false, types.BlobInfo{}, nil
+}
+
+func (d *blobCacheDestination) PutManifest(ctx context.Context, manifestBytes []byte, instanceDigest *digest.Digest) error {
+	manifestDigest, err := manifest.Digest(manifestBytes)
+	if err != nil {
+		logrus.Warnf("error digesting manifest %q: %v", string(manifestBytes), err)
+	} else {
+		filename := filepath.Join(d.reference.directory, makeFilename(manifestDigest, false))
+		if err = ioutils.AtomicWriteFile(filename, manifestBytes, 0600); err != nil {
+			logrus.Warnf("error saving manifest as %q: %v", filename, err)
+		}
+	}
+	return d.destination.PutManifest(ctx, manifestBytes, instanceDigest)
+}
+
+func (d *blobCacheDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
+	return d.destination.PutSignatures(ctx, signatures, instanceDigest)
+}
+
+func (d *blobCacheDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
+	return d.destination.Commit(ctx, unparsedToplevel)
+}

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -207,9 +207,12 @@ func (d *blobCacheDestination) TryReusingBlob(ctx context.Context, info types.Bl
 		return present, reusedInfo, err
 	}
 
-	for _, isConfig := range []bool{false, true} {
-		filename := d.reference.blobPath(info.Digest, isConfig)
-		f, err := os.Open(filename)
+	blobPath, _, isConfig, err := d.reference.findBlob(info)
+	if err != nil {
+		return false, types.BlobInfo{}, err
+	}
+	if blobPath != "" {
+		f, err := os.Open(blobPath)
 		if err == nil {
 			defer f.Close()
 			uploadedInfo, err := d.destination.PutBlob(ctx, f, info, cache, isConfig)

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -167,7 +167,6 @@ func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, in
 					decompressedTemp, err2 := os.CreateTemp(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
 					if err2 != nil {
 						logrus.Debugf("error while creating a temporary file under %q to hold decompressed blob %q: %v", d.reference.directory, inputInfo.Digest.String(), err2)
-						decompressedTemp.Close()
 					} else {
 						// Write a copy of the compressed data to a pipe,
 						// closing the writing end of the pipe after

--- a/pkg/blobcache/src.go
+++ b/pkg/blobcache/src.go
@@ -2,11 +2,14 @@ package blobcache
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
 
 	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/internal/imagesource"
+	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
@@ -19,7 +22,7 @@ import (
 
 type blobCacheSource struct {
 	reference *BlobCache
-	source    types.ImageSource
+	source    private.ImageSource
 	sys       types.SystemContext
 	// this mutex synchronizes the counters below
 	mu          sync.Mutex
@@ -34,7 +37,7 @@ func (b *BlobCache) NewImageSource(ctx context.Context, sys *types.SystemContext
 		return nil, perrors.Wrapf(err, "error creating new image source %q", transports.ImageName(b.reference))
 	}
 	logrus.Debugf("starting to read from image %q using blob cache in %q (compression=%v)", transports.ImageName(b.reference), b.directory, b.compress)
-	return &blobCacheSource{reference: b, source: src, sys: *sys}, nil
+	return &blobCacheSource{reference: b, source: imagesource.FromPublic(src), sys: *sys}, nil
 }
 
 func (s *blobCacheSource) Reference() types.ImageReference {
@@ -173,4 +176,86 @@ func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest 
 	}
 
 	return infos, nil
+}
+
+// SupportsGetBlobAt() returns true if GetBlobAt (BlobChunkAccessor) is supported.
+func (s *blobCacheSource) SupportsGetBlobAt() bool {
+	return s.source.SupportsGetBlobAt()
+}
+
+// streamChunksFromFile generates the channels returned by GetBlobAt for chunks of seekable file
+func streamChunksFromFile(streams chan io.ReadCloser, errs chan error, file io.ReadSeekCloser,
+	chunks []private.ImageSourceChunk) {
+	defer close(streams)
+	defer close(errs)
+	defer file.Close()
+
+	for _, c := range chunks {
+		// Always seek to the desired offest; that way we don’t need to care about the consumer
+		// not reading all of the chunk, or about the position going backwards.
+		if _, err := file.Seek(int64(c.Offset), io.SeekStart); err != nil {
+			errs <- err
+			break
+		}
+		s := signalCloseReader{
+			closed: make(chan interface{}),
+			stream: io.LimitReader(file, int64(c.Length)),
+		}
+		streams <- s
+
+		// Wait until the stream is closed before going to the next chunk
+		<-s.closed
+	}
+}
+
+type signalCloseReader struct {
+	closed chan interface{}
+	stream io.Reader
+}
+
+func (s signalCloseReader) Read(p []byte) (int, error) {
+	return s.stream.Read(p)
+}
+
+func (s signalCloseReader) Close() error {
+	close(s.closed)
+	return nil
+}
+
+// GetBlobAt returns a sequential channel of readers that contain data for the requested
+// blob chunks, and a channel that might get a single error value.
+// The specified chunks must be not overlapping and sorted by their offset.
+// The readers must be fully consumed, in the order they are returned, before blocking
+// to read the next chunk.
+func (s *blobCacheSource) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+	blobPath, _, _, err := s.reference.findBlob(info)
+	if err != nil {
+		return nil, nil, err
+	}
+	if blobPath != "" {
+		f, err := os.Open(blobPath)
+		if err == nil {
+			s.mu.Lock()
+			s.cacheHits++
+			s.mu.Unlock()
+			streams := make(chan io.ReadCloser)
+			errs := make(chan error)
+			go streamChunksFromFile(streams, errs, f, chunks)
+			return streams, errs, nil
+		}
+		if !os.IsNotExist(err) {
+			s.mu.Lock()
+			s.cacheErrors++
+			s.mu.Unlock()
+			return nil, nil, fmt.Errorf("checking for cache: %w", err)
+		}
+	}
+	s.mu.Lock()
+	s.cacheMisses++
+	s.mu.Unlock()
+	streams, errs, err := s.source.GetBlobAt(ctx, info, chunks)
+	if err != nil {
+		return streams, errs, fmt.Errorf("error reading blob chunks from source image %q: %w", transports.ImageName(s.reference), err)
+	}
+	return streams, errs, nil
 }

--- a/pkg/blobcache/src.go
+++ b/pkg/blobcache/src.go
@@ -1,0 +1,180 @@
+package blobcache
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	perrors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type blobCacheSource struct {
+	reference *BlobCache
+	source    types.ImageSource
+	sys       types.SystemContext
+	// this mutex synchronizes the counters below
+	mu          sync.Mutex
+	cacheHits   int64
+	cacheMisses int64
+	cacheErrors int64
+}
+
+func (b *BlobCache) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	src, err := b.reference.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, perrors.Wrapf(err, "error creating new image source %q", transports.ImageName(b.reference))
+	}
+	logrus.Debugf("starting to read from image %q using blob cache in %q (compression=%v)", transports.ImageName(b.reference), b.directory, b.compress)
+	return &blobCacheSource{reference: b, source: src, sys: *sys}, nil
+}
+
+func (s *blobCacheSource) Reference() types.ImageReference {
+	return s.reference
+}
+
+func (s *blobCacheSource) Close() error {
+	logrus.Debugf("finished reading from image %q using blob cache: cache had %d hits, %d misses, %d errors", transports.ImageName(s.reference), s.cacheHits, s.cacheMisses, s.cacheErrors)
+	return s.source.Close()
+}
+
+func (s *blobCacheSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		filename := filepath.Join(s.reference.directory, makeFilename(*instanceDigest, false))
+		manifestBytes, err := os.ReadFile(filename)
+		if err == nil {
+			s.cacheHits++
+			return manifestBytes, manifest.GuessMIMEType(manifestBytes), nil
+		}
+		if !os.IsNotExist(err) {
+			s.cacheErrors++
+			return nil, "", perrors.Wrap(err, "checking for manifest file")
+		}
+	}
+	s.cacheMisses++
+	return s.source.GetManifest(ctx, instanceDigest)
+}
+
+func (s *blobCacheSource) HasThreadSafeGetBlob() bool {
+	return s.source.HasThreadSafeGetBlob()
+}
+
+func (s *blobCacheSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	present, size, err := s.reference.HasBlob(blobinfo)
+	if err != nil {
+		return nil, -1, err
+	}
+	if present {
+		for _, isConfig := range []bool{false, true} {
+			filename := filepath.Join(s.reference.directory, makeFilename(blobinfo.Digest, isConfig))
+			f, err := os.Open(filename)
+			if err == nil {
+				s.mu.Lock()
+				s.cacheHits++
+				s.mu.Unlock()
+				return f, size, nil
+			}
+			if !os.IsNotExist(err) {
+				s.mu.Lock()
+				s.cacheErrors++
+				s.mu.Unlock()
+				return nil, -1, perrors.Wrap(err, "checking for cache")
+			}
+		}
+	}
+	s.mu.Lock()
+	s.cacheMisses++
+	s.mu.Unlock()
+	rc, size, err := s.source.GetBlob(ctx, blobinfo, cache)
+	if err != nil {
+		return rc, size, perrors.Wrapf(err, "error reading blob from source image %q", transports.ImageName(s.reference))
+	}
+	return rc, size, nil
+}
+
+func (s *blobCacheSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	return s.source.GetSignatures(ctx, instanceDigest)
+}
+
+func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
+	signatures, err := s.source.GetSignatures(ctx, instanceDigest)
+	if err != nil {
+		return nil, perrors.Wrapf(err, "error checking if image %q has signatures", transports.ImageName(s.reference))
+	}
+	canReplaceBlobs := !(len(signatures) > 0 && len(signatures[0]) > 0)
+
+	infos, err := s.source.LayerInfosForCopy(ctx, instanceDigest)
+	if err != nil {
+		return nil, perrors.Wrapf(err, "error getting layer infos for copying image %q through cache", transports.ImageName(s.reference))
+	}
+	if infos == nil {
+		img, err := image.FromUnparsedImage(ctx, &s.sys, image.UnparsedInstance(s.source, instanceDigest))
+		if err != nil {
+			return nil, perrors.Wrapf(err, "error opening image to get layer infos for copying image %q through cache", transports.ImageName(s.reference))
+		}
+		infos = img.LayerInfos()
+	}
+
+	if canReplaceBlobs && s.reference.compress != types.PreserveOriginal {
+		replacedInfos := make([]types.BlobInfo, 0, len(infos))
+		for _, info := range infos {
+			var replaceDigest []byte
+			var err error
+			blobFile := filepath.Join(s.reference.directory, makeFilename(info.Digest, false))
+			alternate := ""
+			switch s.reference.compress {
+			case types.Compress:
+				alternate = blobFile + compressedNote
+				replaceDigest, err = os.ReadFile(alternate)
+			case types.Decompress:
+				alternate = blobFile + decompressedNote
+				replaceDigest, err = os.ReadFile(alternate)
+			}
+			if err == nil && digest.Digest(replaceDigest).Validate() == nil {
+				alternate = filepath.Join(filepath.Dir(alternate), makeFilename(digest.Digest(replaceDigest), false))
+				fileInfo, err := os.Stat(alternate)
+				if err == nil {
+					switch info.MediaType {
+					case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip:
+						switch s.reference.compress {
+						case types.Compress:
+							info.MediaType = v1.MediaTypeImageLayerGzip
+							info.CompressionAlgorithm = &compression.Gzip
+						case types.Decompress:
+							info.MediaType = v1.MediaTypeImageLayer
+							info.CompressionAlgorithm = nil
+						}
+					case manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2Schema2LayerMediaType:
+						switch s.reference.compress {
+						case types.Compress:
+							info.MediaType = manifest.DockerV2Schema2LayerMediaType
+							info.CompressionAlgorithm = &compression.Gzip
+						case types.Decompress:
+							// nope, not going to suggest anything, it's not allowed by the spec
+							replacedInfos = append(replacedInfos, info)
+							continue
+						}
+					}
+					logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", string(replaceDigest), info.MediaType, s.reference.compress, info.Digest.String())
+					info.CompressionOperation = s.reference.compress
+					info.Digest = digest.Digest(replaceDigest)
+					info.Size = fileInfo.Size()
+					logrus.Debugf("info = %#v", info)
+				}
+			}
+			replacedInfos = append(replacedInfos, info)
+		}
+		infos = replacedInfos
+	}
+
+	return infos, nil
+}

--- a/pkg/blobcache/src_test.go
+++ b/pkg/blobcache/src_test.go
@@ -1,0 +1,57 @@
+package blobcache
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/stretchr/testify/assert"
+)
+
+func readNextStream(streams chan io.ReadCloser, errs chan error) ([]byte, error) {
+	select {
+	case r := <-streams:
+		if r == nil {
+			return nil, nil
+		}
+		defer r.Close()
+		return ioutil.ReadAll(r)
+	case err := <-errs:
+		return nil, err
+	}
+}
+
+// readSeekerNopCloser adds a no-op Close() method to a readSeeker
+type readSeekerNopCloser struct {
+	io.ReadSeeker
+}
+
+func (c *readSeekerNopCloser) Close() error {
+	return nil
+}
+
+func TestStreamChunksFromFile(t *testing.T) {
+	file := &readSeekerNopCloser{bytes.NewReader([]byte("123456789"))}
+	streams := make(chan io.ReadCloser)
+	errs := make(chan error)
+	chunks := []private.ImageSourceChunk{
+		{Offset: 1, Length: 2},
+		{Offset: 4, Length: 1},
+	}
+	go streamChunksFromFile(streams, errs, file, chunks)
+
+	for _, c := range []struct {
+		expectedData  []byte
+		expectedError error
+	}{
+		{[]byte("23"), nil},
+		{[]byte("5"), nil},
+		{[]byte(nil), nil},
+	} {
+		data, err := readNextStream(streams, errs)
+		assert.Equal(t, c.expectedData, data)
+		assert.Equal(t, c.expectedError, err)
+	}
+}


### PR DESCRIPTION
… so that we can extend the signature representation (and possibly add other features), which is why we moved `pkgblobcache` to c/image in the first place.

See individual commits for details.