### PR TITLE
Use "io.ReadAll" instead of "os.ReadAll"

### DIFF
--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -378,7 +378,7 @@ func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 		}
 		defer sigReader.Close()
 
-		sig, err := os.ReadAll(sigReader)
+		sig, err := io.ReadAll(sigReader)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes FTBFS with go 1.18.3

Fixes: "Update users of deprecated io/ioutil" 7152f888
Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>