### PR TITLE
Cirrus: Update CI VM images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,18 +33,13 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
     FEDORA_NAME: "fedora-36"
-    PRIOR_FEDORA_NAME: "fedora-35"
-    UBUNTU_NAME: "ubuntu-2204"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c6340043416535040"
+    IMAGE_SUFFIX: "c5495735033528320"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
 
     # Container FQIN's (include bleeding-edge development-level container deps.)
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
     UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
     # Built along with the standard PR-based workflow in c/automation_images
     SKOPEO_CIDEV_CONTAINER_FQIN: "quay.io/libpod/skopeo_cidev:${IMAGE_SUFFIX}"
@@ -156,10 +151,7 @@ meta_task:
         image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
-        IMGNAMES: >-
-            ${FEDORA_CACHE_IMAGE_NAME}
-            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-            ${UBUNTU_CACHE_IMAGE_NAME}
+        IMGNAMES: "${FEDORA_CACHE_IMAGE_NAME}"
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
         GCPJSON: ENCRYPTED[04306103eee1933f87deb8a5af6514a7e3164aa589d6079abc0451eb2360879430ed020d6e025ca64ef667138ce9d786]

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ tools: .install.gitvalidation .install.golangci-lint .install.golint
 
 .install.golangci-lint:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.44.2; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.47.2; \
 	fi
 
 .install.golint:


### PR DESCRIPTION
**Depends on**: https://github.com/containers/skopeo/pull/1711

Note: Removed disused `PRIOR_FEDORA*` and `UBUNTU_*` references since
they're not actually used in this CI.  Further, F35 VM images were not
built as part of `c6013173500215296` due to a missing golang 1.18
requirement for podman.

Signed-off-by: Chris Evich <cevich@redhat.com>