### PR TITLE
Fix building with Go 1.19

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,32 +1,31 @@
 // The package image provides libraries and commands to interact with container images.
 //
-//  package main
+//	package main
 //
-//  import (
-//	"context"
-//	"fmt"
+//	import (
+//		"context"
+//		"fmt"
 //
-//	"github.com/containers/image/v5/docker"
-//  )
+//		"github.com/containers/image/v5/docker"
+//	)
 //
-//  func main() {
-//	ref, err := docker.ParseReference("//fedora")
-//	if err != nil {
-//		panic(err)
+//	func main() {
+//		ref, err := docker.ParseReference("//fedora")
+//		if err != nil {
+//			panic(err)
+//		}
+//		ctx := context.Background()
+//		img, err := ref.NewImage(ctx, nil)
+//		if err != nil {
+//			panic(err)
+//		}
+//		defer img.Close()
+//		b, _, err := img.Manifest(ctx)
+//		if err != nil {
+//			panic(err)
+//		}
+//		fmt.Printf("%s", string(b))
 //	}
-//	ctx := context.Background()
-//	img, err := ref.NewImage(ctx, nil)
-//	if err != nil {
-//		panic(err)
-//	}
-//	defer img.Close()
-//	b, _, err := img.Manifest(ctx)
-//	if err != nil {
-//		panic(err)
-//	}
-//	fmt.Printf("%s", string(b))
-//  }
-//
 //
 // ## Notes on running in rootless mode
 //
@@ -34,38 +33,38 @@
 // mode, then the following additional steps have to be performed at start-up of
 // your application:
 //
-//  package main
+//	package main
 //
-//  import (
-//  	"github.com/containers/storage/pkg/reexec"
-//	"github.com/syndtr/gocapability/capability"
-//      "github.com/containers/storage/pkg/unshare"
-//  )
+//	import (
+//		"github.com/containers/storage/pkg/reexec"
+//		"github.com/syndtr/gocapability/capability"
+//		"github.com/containers/storage/pkg/unshare"
+//	)
 //
-//  var neededCapabilities = []capability.Cap{
-//          capability.CAP_CHOWN,
-//          capability.CAP_DAC_OVERRIDE,
-//          capability.CAP_FOWNER,
-//          capability.CAP_FSETID,
-//          capability.CAP_MKNOD,
-//          capability.CAP_SETFCAP,
-//  }
+//	var neededCapabilities = []capability.Cap{
+//		capability.CAP_CHOWN,
+//		capability.CAP_DAC_OVERRIDE,
+//		capability.CAP_FOWNER,
+//		capability.CAP_FSETID,
+//		capability.CAP_MKNOD,
+//		capability.CAP_SETFCAP,
+//	}
 //
-//  func main() {
-//          	reexec.Init()
+//	func main() {
+//		reexec.Init()
 //
-//        	capabilities, err := capability.NewPid(0)
+//		capabilities, err := capability.NewPid(0)
 //		if err != nil {
 //			panic(err)
-// 		}
+//		}
 //		for _, cap := range neededCapabilities {
 //			if !capabilities.Get(capability.EFFECTIVE, cap) {
 //				// We miss a capability we need, create a user namespaces
 //				unshare.MaybeReexecUsingUserNamespace(true)
 //			}
 //		}
-//  		// rest of your code follows here
-//  }
+//		// rest of your code follows here
+//	}
 //
 // TODO(runcom)
 package image

--- a/docker/daemon/daemon_transport.go
+++ b/docker/daemon/daemon_transport.go
@@ -53,7 +53,7 @@ func (t daemonTransport) ValidatePolicyConfigurationScope(scope string) error {
 // For daemonImageSource, both id and ref are acceptable, ref must not be a NameOnly (interpreted as all tags in that repository by the daemon)
 // For daemonImageDestination, it must be a ref, which is NamedTagged.
 // (We could, in principle, also allow storing images without tagging them, and the user would have to refer to them using the docker image ID = config digest.
-//  Using the config digest requires the caller to parse the manifest themselves, which is very cumbersome; so, for now, we don’t bother.)
+// Using the config digest requires the caller to parse the manifest themselves, which is very cumbersome; so, for now, we don’t bother.)
 type daemonReference struct {
 	id  digest.Digest
 	ref reference.Named // !reference.IsNameOnly

--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -3,13 +3,13 @@
 //
 // Grammar
 //
-// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	reference                       := name [ ":" tag ] [ "@" digest ]
 //	name                            := [domain '/'] path-component ['/' path-component]*
 //	domain                          := domain-component ['.' domain-component]* [':' port-number]
 //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
-// 	alpha-numeric                   := /[a-z0-9]+/
+//	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
 //
 //	tag                             := /[\w][\w.-]{0,127}/

--- a/internal/imagedestination/impl/compat.go
+++ b/internal/imagedestination/impl/compat.go
@@ -22,13 +22,14 @@ type Compat struct {
 // for implementations of private.ImageDestination.
 //
 // Use it like this:
-// type yourDestination struct {
-//     impl.Compat
-//     …
-// }
-// dest := &yourDestination{…}
-// dest.Compat = impl.AddCompat(dest)
 //
+//	type yourDestination struct {
+//		impl.Compat
+//		…
+//	}
+//
+//	dest := &yourDestination{…}
+//	dest.Compat = impl.AddCompat(dest)
 func AddCompat(dest private.ImageDestinationInternalOnly) Compat {
 	return Compat{dest}
 }

--- a/internal/imagedestination/stubs/stubs.go
+++ b/internal/imagedestination/stubs/stubs.go
@@ -3,23 +3,25 @@
 // Compare with imagedestination/impl, which might require non-trivial implementation work.
 //
 // There are two kinds of stubs:
-// - Pure stubs, like ImplementsPutBlobPartial. Those can just be included in an imageDestination
-//   implementation:
 //
-//   type yourDestination struct {
-//       stubs.ImplementsPutBlobPartial
-//       …
-//   }
-// - Stubs with a constructor, like NoPutBlobPartialInitialize. The Initialize marker
-//   means that a constructor must be called:
-//   type yourDestination struct {
-//       stubs.NoPutBlobPartialInitialize
-//       …
-//   }
+// First, there are pure stubs, like ImplementsPutBlobPartial. Those can just be included in an imageDestination
+// implementation:
 //
-//   dest := &yourDestination{
-//       …
-//       NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
-//   }
+//	type yourDestination struct {
+//		stubs.ImplementsPutBlobPartial
+//		…
+//	}
 //
+// Second, there are stubs with a constructor, like NoPutBlobPartialInitialize. The Initialize marker
+// means that a constructor must be called:
+//
+//	type yourDestination struct {
+//		stubs.NoPutBlobPartialInitialize
+//		…
+//	}
+//
+//	dest := &yourDestination{
+//		…
+//		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
+//	}
 package stubs

--- a/internal/imagesource/impl/compat.go
+++ b/internal/imagesource/impl/compat.go
@@ -19,13 +19,14 @@ type Compat struct {
 // for implementations of private.ImageSource.
 //
 // Use it like this:
-// type yourSource struct {
-//     impl.Compat
-//     …
-// }
-// src := &yourSource{…}
-// src.Compat = impl.AddCompat(src)
 //
+//	type yourSource struct {
+//		impl.Compat
+//		…
+//	}
+//
+//	src := &yourSource{…}
+//	src.Compat = impl.AddCompat(src)
 func AddCompat(src private.ImageSourceInternalOnly) Compat {
 	return Compat{src}
 }

--- a/internal/imagesource/stubs/stubs.go
+++ b/internal/imagesource/stubs/stubs.go
@@ -3,23 +3,26 @@
 // Compare with imagesource/impl, which might require non-trivial implementation work.
 //
 // There are two kinds of stubs:
-// - Pure stubs, like ImplementsGetBlobAt. Those can just be included in an ImageSource
-//   implementation:
 //
-//   type yourSource struct {
-//       stubs.ImplementsGetBlobAt
-//       …
-//   }
-// - Stubs with a constructor, like NoGetBlobAtInitialize. The Initialize marker
-//   means that a constructor must be called:
-//   type yourSource struct {
-//       stubs.NoGetBlobAtInitialize
-//       …
-//   }
+// First, there are pure stubs, like ImplementsGetBlobAt. Those can just be included in an ImageSource
 //
-//   dest := &yourSource{
-//       …
-//       NoGetBlobAtInitialize: stubs.NoGetBlobAt(ref),
-//   }
+// implementation:
 //
+//	type yourSource struct {
+//		stubs.ImplementsGetBlobAt
+//		…
+//	}
+//
+// Second, there are stubs with a constructor, like NoGetBlobAtInitialize. The Initialize marker
+// means that a constructor must be called:
+
+//	type yourSource struct {
+//		stubs.NoGetBlobAtInitialize
+//		…
+//	}
+//
+//	dest := &yourSource{
+//		…
+//		NoGetBlobAtInitialize: stubs.NoGetBlobAt(ref),
+//	}
 package stubs

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -332,7 +332,7 @@ var (
 	errEmptyCluster = errors.New("cluster has no server defined")
 )
 
-//helper for checking certificate/key/CA
+// helper for checking certificate/key/CA
 func validateFileIsReadable(name string) error {
 	answer, err := os.Open(name)
 	defer func() {
@@ -545,8 +545,10 @@ type clientConfigLoadingRules struct {
 // Load is a modified copy of k8s.io/kubernetes/pkg/client/unversioned/clientcmd.ClientConfigLoadingRules.Load
 // Load starts by running the MigrationRules and then
 // takes the loading rules and returns a Config object based on following rules.
-//   if the ExplicitPath, return the unmerged explicit file
-//   Otherwise, return a merged config based on the Precedence slice
+//
+//   - if the ExplicitPath, return the unmerged explicit file
+//   - Otherwise, return a merged config based on the Precedence slice
+//
 // A missing ExplicitPath file produces an error. Empty filenames or other missing files are ignored.
 // Read errors or files with non-deserializable content produce errors.
 // The first file to set a particular map key wins and map key's value is never changed.

--- a/pkg/blobcache/src_test.go
+++ b/pkg/blobcache/src_test.go
@@ -3,7 +3,6 @@ package blobcache
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/containers/image/v5/internal/private"
@@ -17,7 +16,7 @@ func readNextStream(streams chan io.ReadCloser, errs chan error) ([]byte, error)
 			return nil, nil
 		}
 		defer r.Close()
-		return ioutil.ReadAll(r)
+		return io.ReadAll(r)
 	case err := <-errs:
 		return nil, err
 	}

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -20,9 +20,9 @@ import (
 // short names.
 //
 // Examples:
-//  * short names: "image:tag", "library/fedora"
-//  * not short names: "quay.io/image", "localhost/image:tag",
-//                     "server.org:5000/lib/image", "image@sha256:..."
+//   - short names: "image:tag", "library/fedora"
+//   - not short names: "quay.io/image", "localhost/image:tag",
+//     "server.org:5000/lib/image", "image@sha256:..."
 func IsShortName(input string) bool {
 	isShort, _, _ := parseUnnormalizedShortName(input)
 	return isShort
@@ -402,9 +402,9 @@ func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
 // not a short name), it is returned as is.  In case, it's a short name, the
 // returned slice of named references looks as follows:
 //
-//  1) If present, the short-name alias
-//  2) "localhost/" as used by many container engines such as Podman and Buildah
-//  3) Unqualified-search registries from the registries.conf files
+//  1. If present, the short-name alias
+//  2. "localhost/" as used by many container engines such as Podman and Buildah
+//  3. Unqualified-search registries from the registries.conf files
 //
 // Note that tags and digests are stripped from the specified name before
 // looking up an alias. Stripped off tags and digests are later on appended to

--- a/sif/transport_test.go
+++ b/sif/transport_test.go
@@ -72,7 +72,8 @@ func testNewReference(t *testing.T, fn func(string) (types.ImageReference, error
 
 // refToTempFile creates a temporary file and returns a reference to it.
 // The caller should
-//   defer os.Remove(tmpFile)
+//
+//	defer os.Remove(tmpFile)
 func refToTempFile(t *testing.T) (ref types.ImageReference, tmpDir string) {
 	f, err := os.CreateTemp("", "sif-transport-test")
 	require.NoError(t, err)

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -172,10 +172,10 @@ func (pc *PolicyContext) requirementsForImageRef(ref types.ImageReference) Polic
 // but it does not necessarily mean that the contents of the signature are
 // consistent with local policy.
 // For example:
-// - Do not use a an existence of an accepted signature to determine whether to run
-//   a container based on this image; use IsRunningImageAllowed instead.
-// - Just because a signature is accepted does not automatically mean the contents of the
-//   signature are authorized to run code as root, or to affect system or cluster configuration.
+//   - Do not use a an existence of an accepted signature to determine whether to run
+//     a container based on this image; use IsRunningImageAllowed instead.
+//   - Just because a signature is accepted does not automatically mean the contents of the
+//     signature are authorized to run code as root, or to affect system or cluster configuration.
 func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(ctx context.Context, publicImage types.UnparsedImage) (sigs []*Signature, finalErr error) {
 	if err := pc.changeState(pcReady, pcInUse); err != nil {
 		return nil, err

--- a/tarball/doc.go
+++ b/tarball/doc.go
@@ -2,6 +2,7 @@
 // tarballs and an optional template configuration.
 //
 // An example:
+//
 //	package main
 //
 //	import (

--- a/types/types.go
+++ b/types/types.go
@@ -177,24 +177,25 @@ type BICReplacementCandidate struct {
 // BlobInfoCache records data useful for reusing blobs, or substituting equivalent ones, to avoid unnecessary blob copies.
 //
 // It records two kinds of data:
-// - Sets of corresponding digest vs. uncompressed digest ("DiffID") pairs:
-//   One of the two digests is known to be uncompressed, and a single uncompressed digest may correspond to more than one compressed digest.
-//   This allows matching compressed layer blobs to existing local uncompressed layers (to avoid unnecessary download and decompression),
-//   or uncompressed layer blobs to existing remote compressed layers (to avoid unnecessary compression and upload)/
 //
-//   It is allowed to record an (uncompressed digest, the same uncompressed digest) correspondence, to express that the digest is known
-//   to be uncompressed (i.e. that a conversion from schema1 does not have to decompress the blob to compute a DiffID value).
+//   - Sets of corresponding digest vs. uncompressed digest ("DiffID") pairs:
+//     One of the two digests is known to be uncompressed, and a single uncompressed digest may correspond to more than one compressed digest.
+//     This allows matching compressed layer blobs to existing local uncompressed layers (to avoid unnecessary download and decompression),
+//     or uncompressed layer blobs to existing remote compressed layers (to avoid unnecessary compression and upload)/
 //
-//   This mapping is primarily maintained in generic copy.Image code, but transports may want to contribute more data points if they independently
-//   compress/decompress blobs for their own purposes.
+//     It is allowed to record an (uncompressed digest, the same uncompressed digest) correspondence, to express that the digest is known
+//     to be uncompressed (i.e. that a conversion from schema1 does not have to decompress the blob to compute a DiffID value).
 //
-// - Known blob locations, managed by individual transports:
-//   The transports call RecordKnownLocation when encountering a blob that could possibly be reused (typically in GetBlob/PutBlob/TryReusingBlob),
-//   recording transport-specific information that allows the transport to reuse the blob in the future;
-//   then, TryReusingBlob implementations can call CandidateLocations to look up previously recorded blob locations that could be reused.
+//     This mapping is primarily maintained in generic copy.Image code, but transports may want to contribute more data points if they independently
+//     compress/decompress blobs for their own purposes.
 //
-//   Each transport defines its own “scopes” within which blob reuse is possible (e.g. in, the docker/distribution case, blobs
-//   can be directly reused within a registry, or mounted across registries within a registry server.)
+//   - Known blob locations, managed by individual transports:
+//     The transports call RecordKnownLocation when encountering a blob that could possibly be reused (typically in GetBlob/PutBlob/TryReusingBlob),
+//     recording transport-specific information that allows the transport to reuse the blob in the future;
+//     then, TryReusingBlob implementations can call CandidateLocations to look up previously recorded blob locations that could be reused.
+//
+//     Each transport defines its own “scopes” within which blob reuse is possible (e.g. in, the docker/distribution case, blobs
+//     can be directly reused within a registry, or mounted across registries within a registry server.)
 //
 // None of the methods return an error indication: errors when neither reading from, nor writing to, the cache, should be fatal;
 // users of the cache should just fall back to copying the blobs the usual way.


### PR DESCRIPTION
This is primarily `gofmt` updates (the minimal version, not a full review to benefit from the new syntax).