### PR TITLE
Use openpgp signature if cgo is disabled

### DIFF
--- a/signature/mechanism_gpgme.go
+++ b/signature/mechanism_gpgme.go
@@ -1,5 +1,5 @@
-//go:build !containers_image_openpgp
-// +build !containers_image_openpgp
+//go:build !containers_image_openpgp && cgo
+// +build !containers_image_openpgp,cgo
 
 package signature
 

--- a/signature/mechanism_gpgme_test.go
+++ b/signature/mechanism_gpgme_test.go
@@ -1,5 +1,5 @@
-//go:build !containers_image_openpgp
-// +build !containers_image_openpgp
+//go:build !containers_image_openpgp && cgo
+// +build !containers_image_openpgp,cgo
 
 package signature
 

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -1,5 +1,5 @@
-//go:build containers_image_openpgp
-// +build containers_image_openpgp
+//go:build containers_image_openpgp || !cgo
+// +build containers_image_openpgp !cgo
 
 package signature
 

--- a/signature/mechanism_openpgp_test.go
+++ b/signature/mechanism_openpgp_test.go
@@ -1,5 +1,5 @@
-//go:build containers_image_openpgp
-// +build containers_image_openpgp
+//go:build containers_image_openpgp || !cgo
+// +build containers_image_openpgp !cgo
 
 package signature
 


### PR DESCRIPTION
Fixes build when CGO_ENABLED=0 and no tags are set.

The openpgp implementation is used only if the containers_image_openpgp tag is set, otherwise the cgo-dependent libgpgme implementation is used.

This patch also uses openpgp if cgo is unavailable (the cgo tag is not set).