### PR TITLE
Delete partial docker-archive files, to allow retries

### DIFF
--- a/docker/archive/dest.go
+++ b/docker/archive/dest.go
@@ -68,6 +68,7 @@ func (d *archiveImageDestination) Close() error {
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
 func (d *archiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
+	d.writer.imageCommitted()
 	if d.closeWriter {
 		// We could do this only in .Close(), but failures in .Close() are much more likely to be
 		// ignored by callers that use defer. So, in single-image destinations, try to complete

--- a/docker/archive/transport.go
+++ b/docker/archive/transport.go
@@ -53,7 +53,7 @@ type archiveReference struct {
 	// file, not necessarily path precisely).
 	archiveReader *tarfile.Reader
 	// If not nil, must have been created for path
-	archiveWriter *tarfile.Writer
+	writer *Writer
 }
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.
@@ -108,7 +108,7 @@ func NewIndexReference(path string, sourceIndex int) (types.ImageReference, erro
 // newReference returns a docker archive reference for a path, an optional reference or sourceIndex,
 // and optionally a tarfile.Reader and/or a tarfile.Writer matching path.
 func newReference(path string, ref reference.NamedTagged, sourceIndex int,
-	archiveReader *tarfile.Reader, archiveWriter *tarfile.Writer) (types.ImageReference, error) {
+	archiveReader *tarfile.Reader, writer *Writer) (types.ImageReference, error) {
 	if strings.Contains(path, ":") {
 		return nil, fmt.Errorf("Invalid docker-archive: reference: colon in path %q is not supported", path)
 	}
@@ -126,7 +126,7 @@ func newReference(path string, ref reference.NamedTagged, sourceIndex int,
 		ref:           ref,
 		sourceIndex:   sourceIndex,
 		archiveReader: archiveReader,
-		archiveWriter: archiveWriter,
+		writer:        writer,
 	}, nil
 }
 

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -48,7 +48,7 @@ func (w *Writer) Close() error {
 // NewReference returns an ImageReference that allows adding an image to Writer,
 // with an optional reference.
 func (w *Writer) NewReference(destinationRef reference.NamedTagged) (types.ImageReference, error) {
-	return newReference(w.path, destinationRef, -1, nil, w.archive)
+	return newReference(w.path, destinationRef, -1, nil, w)
 }
 
 // openArchiveForWriting opens path for writing a tar archive,


### PR DESCRIPTION
Per https://github.com/containers/skopeo/issues/1708 ,  `skopeo copy --retry-times 3 docker://… docker-archive:…` cannot retry because the first failing copy creates a partial archive, and the subsequent retry refuses to modify it (we only support creating archives from scratch).

So, if we are creating a regular file, and we have not _successfully_ written at least one image, delete the destination file.

_Note:_ If the destination already exists as a zero-sized file, this deletes it. That’s a weird corner case — right now we always open the destination with `O_CREATE`, and just use that file whether it is a pipe or a regular file. Conceptually, we could do the check for non-regular files and non-empty destinations separately, and then use a temporary file + `Rename()` on success if the destination is a regular file. That’s a possible future enhancement — it would be clearer but I’m not sure if there is any situation where that actually _matters_ — at the very least it’s not worse than the current version.

See individual commit messages for details.