### PR TITLE
signing: clarify build error when cgo is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ or use the build tags described below to avoid the dependencies (e.g. using `go 
 
 ### Supported build tags
 
-- `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
-the primary downside is that creating new signatures with the Golang-only implementation is not supported.
+Additional features:
+
 - `containers_image_ostree`: Import `ostree:` transport in `github.com/containers/image/transports/alltransports`. This builds the library requiring the `libostree` development libraries. Otherwise a stub which reports that the transport is not supported gets used. The `github.com/containers/image/ostree` package is completely disabled
 and impossible to import when this build tag is not in use.
+
+Unsupported / untested / not-recommended flags:
+
+- `containers_image_openpgp`: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
+the primary downside is that creating new signatures with the Golang-only implementation is not supported.
+- `containers_image_disable_signing`: do not compile in any signing implementation. Compiles a stub which returns an error indicating that signing is disabled.
 
 ## [Contributing](CONTRIBUTING.md)
 

--- a/signature/docker_test.go
+++ b/signature/docker_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (
@@ -7,6 +10,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	testGPGHomeDirectory = "./fixtures"
 )
 
 // Kill the running gpg-agent to drop unlocked keys. This allows for testing handling of invalid passphrases.

--- a/signature/mechanism_gpgme.go
+++ b/signature/mechanism_gpgme.go
@@ -1,5 +1,5 @@
-//go:build !containers_image_openpgp && cgo
-// +build !containers_image_openpgp,cgo
+//go:build !containers_image_openpgp && !containers_image_disable_signing && cgo
+// +build !containers_image_openpgp,!containers_image_disable_signing,cgo
 
 package signature
 

--- a/signature/mechanism_gpgme.go
+++ b/signature/mechanism_gpgme.go
@@ -1,5 +1,5 @@
-//go:build !containers_image_openpgp
-// +build !containers_image_openpgp
+//go:build !containers_image_openpgp && cgo
+// +build !containers_image_openpgp,cgo
 
 package signature
 

--- a/signature/mechanism_gpgme_test.go
+++ b/signature/mechanism_gpgme_test.go
@@ -1,5 +1,5 @@
-//go:build !containers_image_openpgp
-// +build !containers_image_openpgp
+//go:build !containers_image_openpgp && !containers_image_disable_signing && cgo
+// +build !containers_image_openpgp,!containers_image_disable_signing,cgo
 
 package signature
 

--- a/signature/mechanism_none.go
+++ b/signature/mechanism_none.go
@@ -1,0 +1,19 @@
+//go:build containers_image_disable_signing
+// +build containers_image_disable_signing
+
+package signature
+
+import "errors"
+
+// errSigningDisabled is returned if container image signing is disabled.
+var errSigningDisabled = errors.New("container image signing is disabled in this build")
+
+// newGPGSigningMechanismInDirectory returns an error indicating signing is disabled.
+func newGPGSigningMechanismInDirectory(optionalDir string) (SigningMechanism, error) {
+	return nil, errSigningDisabled
+}
+
+// newEphemeralGPGSigningMechanism returns an error indicating signing is disabled.
+func newEphemeralGPGSigningMechanism(blobs [][]byte) (SigningMechanism, []string, error) {
+	return nil, nil, errSigningDisabled
+}

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -1,5 +1,5 @@
-//go:build containers_image_openpgp
-// +build containers_image_openpgp
+//go:build containers_image_openpgp && !containers_image_disable_signing
+// +build containers_image_openpgp,!containers_image_disable_signing
 
 package signature
 

--- a/signature/mechanism_other.go
+++ b/signature/mechanism_other.go
@@ -1,0 +1,10 @@
+//go:build !containers_image_openpgp && !cgo
+// +build !containers_image_openpgp,!cgo
+
+package signature
+
+// CgoIsDisabled indicates as a compiler error that this package requires cgo.
+//
+// You may enable the containers_image_openpgp build tag but beware that this
+// implementation is not actively maintained and is considered insecure.
+var CgoIsDisabled = ContainersImageSignatureRequiresCgo

--- a/signature/mechanism_other.go
+++ b/signature/mechanism_other.go
@@ -1,10 +1,26 @@
-//go:build !containers_image_openpgp && !cgo
-// +build !containers_image_openpgp,!cgo
+//go:build !containers_image_openpgp && !containers_image_disable_signing && !cgo
+// +build !containers_image_openpgp,!containers_image_disable_signing,!cgo
 
 package signature
 
 // CgoIsDisabled indicates as a compiler error that this package requires cgo.
 //
-// You may enable the containers_image_openpgp build tag but beware that this
-// implementation is not actively maintained and is considered insecure.
+// The containers_image_openpgp build tag enables the OpenPGP implementation but
+// beware that it is not actively maintained and is considered insecure.
+//
+// The containers_image_disable_signing build tag alternatively disables signing
+// and will return an error when attempting to sign an image at runtime.
+//
+// # github.com/containers/image/v5/signature
+// ./mechanism_other.go:16:21: undefined: ContainersImageSignatureRequiresCgo
 var CgoIsDisabled = ContainersImageSignatureRequiresCgo
+
+// newGPGSigningMechanismInDirectory cannot be compiled without Cgo.
+func newGPGSigningMechanismInDirectory(optionalDir string) (SigningMechanism, error) {
+	return nil, CgoIsDisabled
+}
+
+// newEphemeralGPGSigningMechanism cannot be compiled without Cgo.
+func newEphemeralGPGSigningMechanism(blobs [][]byte) (SigningMechanism, []string, error) {
+	return nil, nil, CgoIsDisabled
+}

--- a/signature/mechanism_test.go
+++ b/signature/mechanism_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 // These tests are expected to pass unmodified for _both_ mechanism_gpgme.go and mechanism_openpgp.go.
@@ -10,10 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	testGPGHomeDirectory = "./fixtures"
 )
 
 // Many of the tests use two fixtures: V4 signature packets (*.signature), and V3 signature packets (*.signature-v3)

--- a/signature/policy_eval_baselayer_test.go
+++ b/signature/policy_eval_baselayer_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (

--- a/signature/policy_eval_sigstore_test.go
+++ b/signature/policy_eval_sigstore_test.go
@@ -1,6 +1,9 @@
-// Policy evaluation for prCosignSigned.
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
 
 package signature
+
+// Policy evaluation for prCosignSigned.
 
 import (
 	"context"

--- a/signature/policy_eval_simple_test.go
+++ b/signature/policy_eval_simple_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (

--- a/signature/simple_test.go
+++ b/signature/simple_test.go
@@ -1,3 +1,6 @@
+//go:build cgo || containers_image_openpgp
+// +build cgo containers_image_openpgp
+
 package signature
 
 import (


### PR DESCRIPTION
The build fails if CGO_ENABLED=0:

```
# github.com/containers/image/v5/signature
signature/mechanism_gpgme.go:156:41: undefined: gpgme.PinEntryLoopback
signature/mechanism_gpgme.go:161:31: undefined: gpgme.Key
signature/mechanism_gpgme.go:161:31: too many errors
```

Make it clear that cgo is required by adding a comment & undefined variable:

```
# github.com/containers/image/v5/signature
./mechanism_other.go:10:21: undefined: ContainersImageSignatureRequiresCgo
```

Anyone who encounters this error (like me) will immediately understand the issue and can
read the comment on that line to understand that the alternative build tag is
not actively maintained and considered not secure.

```go
// CgoIsDisabled indicates as a compiler error that this package requires cgo.
//
// You may enable the containers_image_openpgp build tag but beware that this
// implementation is not actively maintained and is considered insecure.
var CgoIsDisabled = ContainersImageSignatureRequiresCgo
```

Fixes #1634 