### PR TITLE
WIP: docker/docker_image_src: Support partial signature lookups

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -400,26 +400,23 @@ func (s *dockerImageSource) GetSignaturesWithFormat(ctx context.Context, instanc
 	switch {
 	case s.c.supportsSignatures:
 		sigs, err := s.getSignaturesFromAPIExtension(ctx, instanceDigest)
-		if err != nil {
-			return nil, err
-		}
 		res = append(res, sigs...)
+		if err != nil {
+			return res, err
+		}
 	case s.c.signatureBase != nil:
 		sigs, err := s.getSignaturesFromLookaside(ctx, instanceDigest)
-		if err != nil {
-			return nil, err
-		}
 		res = append(res, sigs...)
+		if err != nil {
+			return sigs, err
+		}
 	default:
 		return nil, errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
 
 	sigstoreSigs, err := s.getSignaturesFromSigstoreAttachments(ctx, instanceDigest)
-	if err != nil {
-		return nil, err
-	}
 	res = append(res, sigstoreSigs...)
-	return res, nil
+	return res, err
 }
 
 // manifestDigest returns a digest of the manifest, from instanceDigest if non-nil; or from the supplied reference,

--- a/internal/image/unparsed.go
+++ b/internal/image/unparsed.go
@@ -108,7 +108,7 @@ func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 
 // UntrustedSignatures is like ImageSource.GetSignaturesWithFormat, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) UntrustedSignatures(ctx context.Context) ([]signature.Signature, error) {
-	if i.cachedSignatures == nil {
+	if i.cachedSignatures == nil { // FIXME: this is going to be sticky...
 		sigs, err := i.src.GetSignaturesWithFormat(ctx, i.instanceDigest)
 		if err != nil {
 			return nil, err

--- a/internal/imagesource/impl/compat.go
+++ b/internal/imagesource/impl/compat.go
@@ -42,14 +42,11 @@ func (c *Compat) GetSignatures(ctx context.Context, instanceDigest *digest.Diges
 	// Alternatively, we could possibly define the old GetSignatures to use the multi-format
 	// signature.Blob representation now, in general, but that could silently break them as well.
 	sigs, err := c.src.GetSignaturesWithFormat(ctx, instanceDigest)
-	if err != nil {
-		return nil, err
-	}
 	simpleSigs := [][]byte{}
 	for _, sig := range sigs {
 		if sig, ok := sig.(signature.SimpleSigning); ok {
 			simpleSigs = append(simpleSigs, sig.UntrustedSignature())
 		}
 	}
-	return simpleSigs, nil
+	return simpleSigs, err
 }

--- a/pkg/blobcache/src.go
+++ b/pkg/blobcache/src.go
@@ -115,8 +115,8 @@ func (s *blobCacheSource) GetSignaturesWithFormat(ctx context.Context, instanceD
 
 func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
 	signatures, err := s.source.GetSignaturesWithFormat(ctx, instanceDigest)
-	if err != nil {
-		return nil, fmt.Errorf("error checking if image %q has signatures: %w", transports.ImageName(s.reference), err)
+	if len(signatures) == 0 && err != nil {
+		return nil, fmt.Errorf("error finding any signatures for image %q: %w", transports.ImageName(s.reference), err)
 	}
 	canReplaceBlobs := len(signatures) == 0
 


### PR DESCRIPTION
Sometimes we find some signatures, but hit an error before deciding we've retrieved "all the signatures".  But "all the signatures" isn't a well-defined thing.  Additional signatures may become available at any time.  This commit adjusts the signature-fetching paths to allow for "I had some trouble, so I'm not completely satisfied, but these are the signatures I did find...", and maybe one of those will be acceptable to the caller.