### PR TITLE
Introduce oci/{archive,layout}.ImageNotFoundError

### DIFF
--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -21,6 +21,17 @@ import (
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// ImageNotFoundError is used when the OCI structure, in principle, exists and seems valid enough,
+// but nothing matches the “image” part of the provided reference.
+type ImageNotFoundError struct {
+	ref ociReference
+	// We may make members public, or add methods, in the future.
+}
+
+func (e ImageNotFoundError) Error() string {
+	return fmt.Sprintf("no descriptor found for reference %q", e.ref.image)
+}
+
 type ociImageSource struct {
 	impl.Compat
 	impl.PropertyMethodsInitialize

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -205,7 +205,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 		}
 	}
 	if d == nil {
-		return imgspecv1.Descriptor{}, fmt.Errorf("no descriptor found for reference %q", ref.image)
+		return imgspecv1.Descriptor{}, ImageNotFoundError{ref}
 	}
 	return *d, nil
 }


### PR DESCRIPTION
… for https://github.com/containers/skopeo/pull/1757 .

Warning: Absolutely untested.