### PR TITLE
[skip-ci] Renovate: Label renovate PRs & use preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,39 +30,35 @@
 */
 
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
   /*************************************************
    ****** Global/general configuration options *****
    *************************************************/
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
   // Re-use predefined sets of configuration options to DRY
   "extends": [
-    // https://docs.renovatebot.com/presets-config/#configbase
-    "config:base",
-    // https://docs.renovatebot.com/presets-default/#preservesemverranges
-    ":preserveSemverRanges",
-    // https://docs.renovatebot.com/presets-default/#gitsignoff
-    ":gitSignOff",
-    // Always rebase dep. update PRs from `main` when PR is stale
-    ":rebaseStalePrs",
-    // https://docs.renovatebot.com/presets-schedule/#scheduleweekly
-    "schedule:weekly",
+    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
+    "github>containers/automation//renovate/defaults.json5"
   ],
-  // Don't swamp CI, rate-limit opening of PRs w/in schedule limits.
-  "prHourlyLimit": 1,
 
   /*************************************************
    *** Repository-specific configuration options ***
    *************************************************/
+
   // Don't leave dep. update. PRs "hanging", assign them to people.
   "assignees": ["containers/image-maintainers"],
 
   /*************************************************
    ***** Golang-specific configuration options *****
    *************************************************/
+
   "golang": {
     "commitMessageTopic": "module {{depName}}",
+
     // disabled by default, safe to enable since "tidy" enforced by CI.
     "postUpdateOptions": ["gomodTidy"],
+
     // N/B: LAST MATCHING RULE WINS
     // https://docs.renovatebot.com/configuration-options/#packagerules
     "packageRules": [
@@ -71,14 +67,20 @@
         "matchDatasources": ["golang-version"],
         "enabled": false,
       },
+
       // Golang pseudo-version packages will spam with every Commit ID change.
       // Limit update frequency.
       {
         "matchUpdateTypes": ["digest"],
         "schedule": "every month",
       },
+
+      // Workaround: rollbackPRs are not compatible with digest updates.
+      // This rule must appear AFTER the "digest" rule.
+      // Ref: https://github.com/renovatebot/renovate/discussions/18250
       {
         "matchLanguages": ["go"],
+
         // Open rollback PR if updated dep. is removed (i.e. tag pulled
         // due to major bug or security issue).
         "rollbackPrs": true,


### PR DESCRIPTION
Updating dependencies is important, make PRs standout from the crowd so humans can spot (or search for) them easily.

Also added a comment to help future maintainers.