### PR TITLE
Set Directory Transport Destination as Thread-Safe

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -105,7 +105,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 			AcceptsForeignLayerURLs:        false,
 			MustMatchRuntimeOS:             false,
 			IgnoresEmbeddedDockerReference: false, // N/A, DockerReference() returns nil.
-			HasThreadSafePutBlob:           false,
+			HasThreadSafePutBlob:           true,
 		}),
 		NoPutBlobPartialInitialize: stubs.NoPutBlobPartial(ref),
 


### PR DESCRIPTION
Just like #1481 did for OCI Layout Destination, this patch marks Directory Transport Destination as thread-safe. The `PutBlobWithOptions` implementation of both transports are almost identical, differing only on the path where the blob will be stored.

```diff
- 	blobPath := d.ref.layerPath(blobDigest)
+ 	blobPath, err := d.ref.blobPath(blobDigest, d.sharedBlobDir)
+	if err != nil {
+		return types.BlobInfo{}, err
+	}
+	if err := ensureParentDirectoryExists(blobPath); err != nil {
+		return types.BlobInfo{}, err
+	}
```