### PR TITLE
[CI:DOCS] Update renovate config. comment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,7 +62,9 @@
     // N/B: LAST MATCHING RULE WINS
     // https://docs.renovatebot.com/configuration-options/#packagerules
     "packageRules": [
-      // Leave developers in control, never update golang version automatically.
+      // Workaround https://github.com/renovatebot/renovate/issues/16715
+      // our own way.  Rec. workaround in issue seems to disable more than
+      // only golang updates.
       {
         "matchDatasources": ["golang-version"],
         "enabled": false,


### PR DESCRIPTION
Discovered the golang-version update behavior is recent and up for some debate.  Reference open issue on the topic in case the config. needs to be corrected in the future due to a fix.

Signed-off-by: Chris Evich <cevich@redhat.com>