### PR TITLE
Fix a panic on scheme-less lookaside base

### DIFF
--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -30,13 +30,13 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	//
 	// Similarly, if we want to communicate over plain HTTP on a TCP socket, we also need to set
 	// TLSClientConfig to nil. This can be achieved by using the form `http://`
-	url, err := dockerclient.ParseHostURL(host)
+	serverURL, err := dockerclient.ParseHostURL(host)
 	if err != nil {
 		return nil, err
 	}
 	var httpClient *http.Client
-	if url.Scheme != "unix" {
-		if url.Scheme == "http" {
+	if serverURL.Scheme != "unix" {
+		if serverURL.Scheme == "http" {
 			httpClient = httpConfig()
 		} else {
 			hc, err := tlsConfig(sys)

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -475,11 +475,11 @@ func (c *dockerClient) makeRequest(ctx context.Context, method, path string, hea
 	}
 
 	urlString := fmt.Sprintf("%s://%s%s", c.scheme, c.registry, path)
-	url, err := url.Parse(urlString)
+	requestURL, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
 	}
-	return c.makeRequestToResolvedURL(ctx, method, url, headers, stream, -1, auth, extraScope)
+	return c.makeRequestToResolvedURL(ctx, method, requestURL, headers, stream, -1, auth, extraScope)
 }
 
 // Checks if the auth headers in the response contain an indication of a failed
@@ -542,11 +542,11 @@ func parseRetryAfter(res *http.Response, fallbackDelay time.Duration) time.Durat
 // makeRequest should generally be preferred.
 // In case of an HTTP 429 status code in the response, it may automatically retry a few times.
 // TODO(runcom): too many arguments here, use a struct
-func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method string, url *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
+func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method string, requestURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
 	delay := backoffInitialDelay
 	attempts := 0
 	for {
-		res, err := c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, extraScope)
+		res, err := c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, extraScope)
 		attempts++
 
 		// By default we use pre-defined scopes per operation. In
@@ -567,7 +567,7 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method stri
 				// Note: This retry ignores extraScope. That’s, strictly speaking, incorrect, but we don’t currently
 				// expect the insufficient_scope errors to happen for those callers. If that changes, we can add support
 				// for more than one extra scope.
-				res, err = c.makeRequestToResolvedURLOnce(ctx, method, url, headers, stream, streamLen, auth, newScope)
+				res, err = c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, newScope)
 				extraScope = newScope
 			}
 		}
@@ -583,7 +583,7 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method stri
 		if delay > backoffMaxDelay {
 			delay = backoffMaxDelay
 		}
-		logrus.Debugf("Too many requests to %s: sleeping for %f seconds before next attempt", url.Redacted(), delay.Seconds())
+		logrus.Debugf("Too many requests to %s: sleeping for %f seconds before next attempt", requestURL.Redacted(), delay.Seconds())
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -598,8 +598,8 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method stri
 // streamLen, if not -1, specifies the length of the data expected on stream.
 // makeRequest should generally be preferred.
 // Note that no exponential back off is performed when receiving an http 429 status code.
-func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method string, url *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url.String(), stream)
+func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method string, resolvedURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, resolvedURL.String(), stream)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method 
 			return nil, err
 		}
 	}
-	logrus.Debugf("%s %s", method, url.Redacted())
+	logrus.Debugf("%s %s", method, resolvedURL.Redacted())
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -811,17 +811,17 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 	c.client = &http.Client{Transport: tr}
 
 	ping := func(scheme string) error {
-		url, err := url.Parse(fmt.Sprintf(resolvedPingV2URL, scheme, c.registry))
+		pingURL, err := url.Parse(fmt.Sprintf(resolvedPingV2URL, scheme, c.registry))
 		if err != nil {
 			return err
 		}
-		resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
+		resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, pingURL, nil, nil, -1, noAuth, nil)
 		if err != nil {
-			logrus.Debugf("Ping %s err %s (%#v)", url.Redacted(), err.Error(), err)
+			logrus.Debugf("Ping %s err %s (%#v)", pingURL.Redacted(), err.Error(), err)
 			return err
 		}
 		defer resp.Body.Close()
-		logrus.Debugf("Ping %s status %d", url.Redacted(), resp.StatusCode)
+		logrus.Debugf("Ping %s status %d", pingURL.Redacted(), resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 			return registryHTTPResponseToError(resp)
 		}
@@ -841,17 +841,17 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 		}
 		// best effort to understand if we're talking to a V1 registry
 		pingV1 := func(scheme string) bool {
-			url, err := url.Parse(fmt.Sprintf(resolvedPingV1URL, scheme, c.registry))
+			pingURL, err := url.Parse(fmt.Sprintf(resolvedPingV1URL, scheme, c.registry))
 			if err != nil {
 				return false
 			}
-			resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
+			resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, pingURL, nil, nil, -1, noAuth, nil)
 			if err != nil {
-				logrus.Debugf("Ping %s err %s (%#v)", url.Redacted(), err.Error(), err)
+				logrus.Debugf("Ping %s err %s (%#v)", pingURL.Redacted(), err.Error(), err)
 				return false
 			}
 			defer resp.Body.Close()
-			logrus.Debugf("Ping %s status %d", url.Redacted(), resp.StatusCode)
+			logrus.Debugf("Ping %s status %d", pingURL.Redacted(), resp.StatusCode)
 			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 				return false
 			}
@@ -909,14 +909,14 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
 	}
 	for _, u := range urls {
-		url, err := url.Parse(u)
-		if err != nil || (url.Scheme != "http" && url.Scheme != "https") {
+		blobURL, err := url.Parse(u)
+		if err != nil || (blobURL.Scheme != "http" && blobURL.Scheme != "https") {
 			continue // unsupported url. skip this url.
 		}
 		// NOTE: we must not authenticate on additional URLs as those
 		//       can be abused to leak credentials or tokens.  Please
 		//       refer to CVE-2020-15157 for more information.
-		resp, err = c.makeRequestToResolvedURL(ctx, http.MethodGet, url, nil, nil, -1, noAuth, nil)
+		resp, err = c.makeRequestToResolvedURL(ctx, http.MethodGet, blobURL, nil, nil, -1, noAuth, nil)
 		if err == nil {
 			if resp.StatusCode != http.StatusOK {
 				err = fmt.Errorf("error fetching external blob from %q: %d (%s)", u, resp.StatusCode, http.StatusText(resp.StatusCode))

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -580,8 +580,8 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 
 	// NOTE: Keep this in sync with docs/signature-protocols.md!
 	for i, signature := range signatures {
-		url := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
-		err := d.putOneSignature(url, signature)
+		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		err := d.putOneSignature(sigURL, signature)
 		if err != nil {
 			return err
 		}
@@ -592,8 +592,8 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 	// is enough for dockerImageSource to stop looking for other signatures, so that
 	// is sufficient.
 	for i := len(signatures); ; i++ {
-		url := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
-		missing, err := d.c.deleteOneSignature(url)
+		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		missing, err := d.c.deleteOneSignature(sigURL)
 		if err != nil {
 			return err
 		}
@@ -605,13 +605,13 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 	return nil
 }
 
-// putOneSignature stores sig to url.
+// putOneSignature stores sig to sigURL.
 // NOTE: Keep this in sync with docs/signature-protocols.md!
-func (d *dockerImageDestination) putOneSignature(url *url.URL, sig signature.Signature) error {
-	switch url.Scheme {
+func (d *dockerImageDestination) putOneSignature(sigURL *url.URL, sig signature.Signature) error {
+	switch sigURL.Scheme {
 	case "file":
-		logrus.Debugf("Writing to %s", url.Path)
-		err := os.MkdirAll(filepath.Dir(url.Path), 0755)
+		logrus.Debugf("Writing to %s", sigURL.Path)
+		err := os.MkdirAll(filepath.Dir(sigURL.Path), 0755)
 		if err != nil {
 			return err
 		}
@@ -619,16 +619,16 @@ func (d *dockerImageDestination) putOneSignature(url *url.URL, sig signature.Sig
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(url.Path, blob, 0644)
+		err = os.WriteFile(sigURL.Path, blob, 0644)
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case "http", "https":
-		return fmt.Errorf("Writing directly to a %s lookaside %s is not supported. Configure a lookaside-staging: location", url.Scheme, url.Redacted())
+		return fmt.Errorf("Writing directly to a %s lookaside %s is not supported. Configure a lookaside-staging: location", sigURL.Scheme, sigURL.Redacted())
 	default:
-		return fmt.Errorf("Unsupported scheme when writing signature to %s", url.Redacted())
+		return fmt.Errorf("Unsupported scheme when writing signature to %s", sigURL.Redacted())
 	}
 }
 
@@ -767,23 +767,23 @@ func (d *dockerImageDestination) putBlobBytesAsOCI(ctx context.Context, contents
 	}, nil
 }
 
-// deleteOneSignature deletes a signature from url, if it exists.
+// deleteOneSignature deletes a signature from sigURL, if it exists.
 // If it successfully determines that the signature does not exist, returns (true, nil)
 // NOTE: Keep this in sync with docs/signature-protocols.md!
-func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error) {
-	switch url.Scheme {
+func (c *dockerClient) deleteOneSignature(sigURL *url.URL) (missing bool, err error) {
+	switch sigURL.Scheme {
 	case "file":
-		logrus.Debugf("Deleting %s", url.Path)
-		err := os.Remove(url.Path)
+		logrus.Debugf("Deleting %s", sigURL.Path)
+		err := os.Remove(sigURL.Path)
 		if err != nil && os.IsNotExist(err) {
 			return true, nil
 		}
 		return false, err
 
 	case "http", "https":
-		return false, fmt.Errorf("Writing directly to a %s lookaside %s is not supported. Configure a lookaside-staging: location", url.Scheme, url.Redacted())
+		return false, fmt.Errorf("Writing directly to a %s lookaside %s is not supported. Configure a lookaside-staging: location", sigURL.Scheme, sigURL.Redacted())
 	default:
-		return false, fmt.Errorf("Unsupported scheme when deleting signature from %s", url.Redacted())
+		return false, fmt.Errorf("Unsupported scheme when deleting signature from %s", sigURL.Redacted())
 	}
 }
 

--- a/docker/fixtures/registries.d/internal-example.com.yaml
+++ b/docker/fixtures/registries.d/internal-example.com.yaml
@@ -12,3 +12,7 @@ docker:
         lookaside: file:///home/mitr/mydevelopment2
     localhost/invalid/url/test:
         lookaside: ":emptyscheme"
+    localhost/file/path/test:
+        lookaside: "/no/scheme/just/a/path"
+    localhost/relative/path/test:
+        lookaside: "no/scheme/relative/path"

--- a/docker/registries_d.go
+++ b/docker/registries_d.go
@@ -163,17 +163,17 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 // the usage of the BaseURL is defined under docker/distribution registries—separate storage of docs/signature-protocols.md
 func (config *registryConfiguration) lookasideStorageBaseURL(dr dockerReference, write bool) (*url.URL, error) {
 	topLevel := config.signatureTopLevel(dr, write)
-	var url *url.URL
+	var baseURL *url.URL
 	if topLevel != "" {
 		u, err := url.Parse(topLevel)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid signature storage URL %s: %w", topLevel, err)
 		}
-		url = u
+		baseURL = u
 	} else {
 		// returns default directory if no lookaside specified in configuration file
-		url = builtinDefaultLookasideStorageDir(rootless.GetRootlessEUID())
-		logrus.Debugf(" No signature storage configuration found for %s, using built-in default %s", dr.PolicyConfigurationIdentity(), url.Redacted())
+		baseURL = builtinDefaultLookasideStorageDir(rootless.GetRootlessEUID())
+		logrus.Debugf(" No signature storage configuration found for %s, using built-in default %s", dr.PolicyConfigurationIdentity(), baseURL.Redacted())
 	}
 	// NOTE: Keep this in sync with docs/signature-protocols.md!
 	// FIXME? Restrict to explicitly supported schemes?
@@ -181,8 +181,8 @@ func (config *registryConfiguration) lookasideStorageBaseURL(dr dockerReference,
 	if path.Clean(repo) != repo {  // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
 		return nil, fmt.Errorf("Unexpected path elements in Docker reference %s for signature storage", dr.ref.String())
 	}
-	url.Path = url.Path + "/" + repo
-	return url, nil
+	baseURL.Path = baseURL.Path + "/" + repo
+	return baseURL, nil
 }
 
 // builtinDefaultLookasideStorageDir returns default signature storage URL as per euid

--- a/docker/registries_d.go
+++ b/docker/registries_d.go
@@ -201,8 +201,8 @@ func (config *registryConfiguration) signatureTopLevel(ref dockerReference, writ
 		identity := ref.PolicyConfigurationIdentity()
 		if ns, ok := config.Docker[identity]; ok {
 			logrus.Debugf(` Lookaside configuration: using "docker" namespace %s`, identity)
-			if url := ns.signatureTopLevel(write); url != "" {
-				return url
+			if ret := ns.signatureTopLevel(write); ret != "" {
+				return ret
 			}
 		}
 
@@ -210,8 +210,8 @@ func (config *registryConfiguration) signatureTopLevel(ref dockerReference, writ
 		for _, name := range ref.PolicyConfigurationNamespaces() {
 			if ns, ok := config.Docker[name]; ok {
 				logrus.Debugf(` Lookaside configuration: using "docker" namespace %s`, name)
-				if url := ns.signatureTopLevel(write); url != "" {
-					return url
+				if ret := ns.signatureTopLevel(write); ret != "" {
+					return ret
 				}
 			}
 		}
@@ -219,8 +219,8 @@ func (config *registryConfiguration) signatureTopLevel(ref dockerReference, writ
 	// Look for a default location
 	if config.DefaultDocker != nil {
 		logrus.Debugf(` Lookaside configuration: using "default-docker" configuration`)
-		if url := config.DefaultDocker.signatureTopLevel(write); url != "" {
-			return url
+		if ret := config.DefaultDocker.signatureTopLevel(write); ret != "" {
+			return ret
 		}
 	}
 	return ""
@@ -287,7 +287,7 @@ func (ns registryNamespace) signatureTopLevel(write bool) string {
 // base is not nil from the caller
 // NOTE: Keep this in sync with docs/signature-protocols.md!
 func lookasideStorageURL(base lookasideStorageBase, manifestDigest digest.Digest, index int) *url.URL {
-	url := *base
-	url.Path = fmt.Sprintf("%s@%s=%s/signature-%d", url.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
-	return &url
+	sigURL := *base
+	sigURL.Path = fmt.Sprintf("%s@%s=%s/signature-%d", sigURL.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
+	return &sigURL
 }

--- a/docker/registries_d_test.go
+++ b/docker/registries_d_test.go
@@ -38,6 +38,16 @@ func TestSignatureStorageBaseURL(t *testing.T) {
 			"fixtures/registries.d", "//localhost/invalid/url/test",
 			"",
 		},
+		// URLs without a scheme: This will be rejected by consumers, so we don't really care about
+		// the returned value, but it should not crash at the very least.
+		{ // Absolute path
+			"fixtures/registries.d", "//localhost/file/path/test",
+			"/no/scheme/just/a/path/file/path/test",
+		},
+		{ // Relative path
+			"fixtures/registries.d", "//localhost/relative/path/test",
+			"no/scheme/relative/path/relative/path/test",
+		},
 		{ // Success
 			"fixtures/registries.d", "//example.com/my/project",
 			"https://lookaside.example.com/my/project",
@@ -199,6 +209,8 @@ func TestLoadAndMergeConfig(t *testing.T) {
 			"localhost":                      {Lookaside: "file:///home/mitr/mydevelopment1"},
 			"localhost:8080":                 {Lookaside: "file:///home/mitr/mydevelopment2"},
 			"localhost/invalid/url/test":     {Lookaside: ":emptyscheme"},
+			"localhost/file/path/test":       {Lookaside: "/no/scheme/just/a/path"},
+			"localhost/relative/path/test":   {Lookaside: "no/scheme/relative/path"},
 			"docker.io/contoso":              {Lookaside: "https://lookaside.contoso.com/fordocker"},
 			"docker.io/centos":               {Lookaside: "https://lookaside.centos.org/"},
 			"docker.io/centos/mybetaproduct": {
@@ -304,11 +316,11 @@ func TestLookasideStorageURL(t *testing.T) {
 		{"http://localhost:5555/root", 0, "http://localhost:5555/root@" + mdMapped + "/signature-1"},
 		{"http://localhost:5555/root", 1, "http://localhost:5555/root@" + mdMapped + "/signature-2"},
 	} {
-		url, err := url.Parse(c.base)
+		baseURL, err := url.Parse(c.base)
 		require.NoError(t, err)
 		expectedURL, err := url.Parse(c.expected)
 		require.NoError(t, err)
-		res := lookasideStorageURL(url, mdInput, c.index)
+		res := lookasideStorageURL(baseURL, mdInput, c.index)
 		assert.Equal(t, expectedURL, res, c.expected)
 	}
 }

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -67,14 +67,14 @@ func newOpenshiftClient(ref openshiftReference) (*openshiftClient, error) {
 
 // doRequest performs a correctly authenticated request to a specified path, and returns response body or an error object.
 func (c *openshiftClient) doRequest(ctx context.Context, method, path string, requestBody []byte) ([]byte, error) {
-	url := *c.baseURL
-	url.Path = path
+	requestURL := *c.baseURL
+	requestURL.Path = path
 	var requestBodyReader io.Reader
 	if requestBody != nil {
 		logrus.Debugf("Will send body: %s", requestBody)
 		requestBodyReader = bytes.NewReader(requestBody)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url.String(), requestBodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL.String(), requestBodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	logrus.Debugf("%s %s", method, url.Redacted())
+	logrus.Debugf("%s %s", method, requestURL.Redacted())
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
… because we shadow the `net/url` package by a `url` local variable. To be extra sure, rename all `url` variables.

Fixes https://github.com/containers/podman/issues/16301 .

See individual commit messages for details.