### PR TITLE
Some warning cleanups

### DIFF
--- a/copy/compression.go
+++ b/copy/compression.go
@@ -238,7 +238,7 @@ func (d *bpCompressionStepData) updateCompressionEdits(operation *types.LayerCom
 }
 
 // recordValidatedBlobData updates b.blobInfoCache with data about the created uploadedInfo adnd the original srcInfo.
-// This must ONLY be called if all data has been validated by OUR code, and is not comming from third parties.
+// This must ONLY be called if all data has been validated by OUR code, and is not coming from third parties.
 func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInfo types.BlobInfo, srcInfo types.BlobInfo,
 	encryptionStep *bpEncryptionStepData, decryptionStep *bpDecryptionStepData) error {
 	// Don’t record any associations that involve encrypted data. This is a bit crude,

--- a/directory/explicitfilepath/path_test.go
+++ b/directory/explicitfilepath/path_test.go
@@ -133,7 +133,7 @@ func runPathResolvingTestCase(t *testing.T, f func(string) (string, error), c pa
 	input := c.setup(t, topDir) + suffix // Do not call filepath.Join() on input, it calls filepath.Clean() internally!
 	description := fmt.Sprintf("%s vs. %s%s", input, c.expected, suffix)
 
-	fullOutput, err := ResolvePathToFullyExplicit(topDir + "/" + input)
+	fullOutput, err := f(topDir + "/" + input)
 	if c.expected == "" {
 		assert.Error(t, err, description)
 	} else {

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -64,7 +64,7 @@ func NewWriter(sys *types.SystemContext, path string) (*Writer, error) {
 	}, nil
 }
 
-// imageCommitted notifies the Writer that at least one image was successfully commited to the stream.
+// imageCommitted notifies the Writer that at least one image was successfully committed to the stream.
 func (w *Writer) imageCommitted() {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -407,7 +407,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
-	refTail := ""
+	var refTail string
 	if instanceDigest != nil {
 		// If the instanceDigest is provided, then use it as the refTail, because the reference,
 		// whether it includes a tag or a digest, refers to the list as a whole, and not this

--- a/internal/imagesource/stubs/stubs.go
+++ b/internal/imagesource/stubs/stubs.go
@@ -15,7 +15,7 @@
 //
 // Second, there are stubs with a constructor, like NoGetBlobAtInitialize. The Initialize marker
 // means that a constructor must be called:
-
+//
 //	type yourSource struct {
 //		stubs.NoGetBlobAtInitialize
 //		…

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -107,7 +107,7 @@ func (s *ociImageSource) GetManifest(ctx context.Context, instanceDigest *digest
 	var err error
 
 	if instanceDigest == nil {
-		dig = digest.Digest(s.descriptor.Digest)
+		dig = s.descriptor.Digest
 		mimeType = s.descriptor.MediaType
 	} else {
 		dig = *instanceDigest

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -179,11 +179,10 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 		return imgspecv1.Descriptor{}, err
 	}
 
-	var d *imgspecv1.Descriptor
 	if ref.image == "" {
 		// return manifest if only one image is in the oci directory
 		if len(index.Manifests) == 1 {
-			d = &index.Manifests[0]
+			return index.Manifests[0], nil
 		} else {
 			// ask user to choose image when more than one image in the oci directory
 			return imgspecv1.Descriptor{}, ErrMoreThanOneImage
@@ -199,15 +198,11 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 				continue
 			}
 			if refName == ref.image {
-				d = &md
-				break
+				return md, nil
 			}
 		}
 	}
-	if d == nil {
-		return imgspecv1.Descriptor{}, ImageNotFoundError{ref}
-	}
-	return *d, nil
+	return imgspecv1.Descriptor{}, ImageNotFoundError{ref}
 }
 
 // LoadManifestDescriptor loads the manifest descriptor to be used to retrieve the image name

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -181,23 +181,18 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 
 	if ref.image == "" {
 		// return manifest if only one image is in the oci directory
-		if len(index.Manifests) == 1 {
-			return index.Manifests[0], nil
-		} else {
+		if len(index.Manifests) != 1 {
 			// ask user to choose image when more than one image in the oci directory
 			return imgspecv1.Descriptor{}, ErrMoreThanOneImage
 		}
+		return index.Manifests[0], nil
 	} else {
 		// if image specified, look through all manifests for a match
 		for _, md := range index.Manifests {
 			if md.MediaType != imgspecv1.MediaTypeImageManifest && md.MediaType != imgspecv1.MediaTypeImageIndex {
 				continue
 			}
-			refName, ok := md.Annotations[imgspecv1.AnnotationRefName]
-			if !ok {
-				continue
-			}
-			if refName == ref.image {
+			if refName, ok := md.Annotations[imgspecv1.AnnotationRefName]; ok && refName == ref.image {
 				return md, nil
 			}
 		}

--- a/pkg/blobcache/src.go
+++ b/pkg/blobcache/src.go
@@ -138,7 +138,7 @@ func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest 
 			var replaceDigest []byte
 			var err error
 			blobFile := s.reference.blobPath(info.Digest, false)
-			alternate := ""
+			var alternate string
 			switch s.reference.compress {
 			case types.Compress:
 				alternate = blobFile + compressedNote

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -59,8 +59,6 @@ func parseUnnormalizedShortName(input string) (bool, reference.Named, error) {
 // the tag or digest and stores it in the return values so that both can be
 // re-added to a possible resolved alias' or USRs at a later point.
 func splitUserInput(named reference.Named) (isTagged bool, isDigested bool, normalized reference.Named, tag string, digest digest.Digest) {
-	normalized = named
-
 	tagged, isT := named.(reference.NamedTagged)
 	if isT {
 		isTagged = true

--- a/pkg/shortnames/shortnames.go
+++ b/pkg/shortnames/shortnames.go
@@ -168,7 +168,7 @@ func (r *Resolved) Description() string {
 // Note that nil is returned if len(pullErrors) == 0.  Otherwise, the amount of
 // pull errors must equal the amount of pull candidates.
 func (r *Resolved) FormatPullErrors(pullErrors []error) error {
-	if len(pullErrors) >= 0 && len(pullErrors) != len(r.PullCandidates) {
+	if len(pullErrors) > 0 && len(pullErrors) != len(r.PullCandidates) {
 		pullErrors = append(pullErrors,
 			fmt.Errorf("internal error: expected %d instead of %d errors for %d pull candidates",
 				len(r.PullCandidates), len(pullErrors), len(r.PullCandidates)))

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -475,7 +475,7 @@ func TestWriteRead(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetManifest(%q) with an instanceDigest is supposed to succeed", ref.StringWithinTransport())
 		}
-		if string(retrieved) != string(manifest) {
+		if string(retrieved) != manifest {
 			t.Fatalf("GetManifest(%q) with an instanceDigest retrieved a different manifest", ref.StringWithinTransport())
 		}
 		sigs, err := src.GetSignatures(context.Background(), nil)
@@ -603,7 +603,7 @@ func TestDuplicateName(t *testing.T) {
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
-		Size:   int64(size),
+		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer to destination, second pass: %v", err)
@@ -702,7 +702,7 @@ func TestDuplicateID(t *testing.T) {
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
-		Size:   int64(size),
+		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer to destination, second pass: %v", err)
@@ -804,7 +804,7 @@ func TestDuplicateNameID(t *testing.T) {
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
 	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
-		Size:   int64(size),
+		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer to destination, second pass: %v", err)


### PR DESCRIPTION
_very_ selectively from `golangci-lint run --enable-all ./...`, limiting to obvious bugs or constructs that seem fairly likely to risk becoming a bug.

See individual commit messages for details.