### PR TITLE
fix sigstore (cosign) verify failed

### DIFF
--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/signature"
 	"github.com/containers/image/v5/manifest"
@@ -53,7 +54,12 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 	signature, err := internal.VerifySigstorePayload(publicKey, sig.UntrustedPayload(), untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
 		ValidateSignedDockerReference: func(ref string) error {
 			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
-				return PolicyRequirementError(fmt.Sprintf("Signature for identity %s is not accepted", ref))
+				// If reference from sigstore attachment manifest failed, try to use image reference
+				var imgref string = image.Reference().DockerReference().Name()
+				logrus.Debugf("Signature for identity %s is not accepted, try to use image reference %s", ref, imgref)
+				if !pr.SignedIdentity.matchesDockerReference(image, imgref) {
+					return PolicyRequirementError(fmt.Sprintf("Signature for identity %s is not accepted neither", imgref))
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
While sigstore (cosign) enabled, sign a container image in registry R1, and then copy it to registry R2, if you pull it from registry R2 with sigstore (cosign) verify enabled, the verification will fail

While cosign signing, it saves reference info to sigstore attachment manifest as the meta data (payload) of signed container image.

While skopeo or podman applying cosign verify, it needs the reference info to fetch signed data.

If a container image is signed in registry R1, it records reference R1 to sigstore attachment manifest; if the container image is copied to R2, reference R1 in sigstore attachment manifest is obsolete.

Due to the sigstore attachment manifest could not be edited and it is along with container image in registry, in this situation, if reference from sigstore attachment manifest does not work, try to use image reference to fetch signed data again

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>