### PR TITLE
Renovate: Override global no-rebase option

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,10 @@
     "github>containers/automation//renovate/defaults.json5"
   ],
 
+  // Permit automatic rebasing when base-branch changes by more than
+  // one commit.
+  "rebaseWhen": "behind-base-branch",
+
   /*************************************************
    *** Repository-specific configuration options ***
    *************************************************/


### PR DESCRIPTION
The `behind-base-branch` setting means:

    Renovate will rebase whenever the branch falls 1 or more
    commit behind its base branch

Signed-off-by: Chris Evich <cevich@redhat.com>