### PR TITLE
signature: Export the default policy path

### DIFF
--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -50,15 +50,15 @@ func (err InvalidPolicyFormatError) Error() string {
 // NOTE: When this function returns an error, report it to the user and abort.
 // DO NOT hard-code fallback policies in your application.
 func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
-	return NewPolicyFromFile(defaultPolicyPath(sys))
+	return NewPolicyFromFile(DefaultPolicyPath(sys))
 }
 
-// defaultPolicyPath returns a path to the default policy of the system.
-func defaultPolicyPath(sys *types.SystemContext) string {
+// DefaultPolicyPath returns a path to the default policy of the system.
+func DefaultPolicyPath(sys *types.SystemContext) string {
 	return defaultPolicyPathWithHomeDir(sys, homedir.Get())
 }
 
-// defaultPolicyPathWithHomeDir is an internal implementation detail of defaultPolicyPath,
+// defaultPolicyPathWithHomeDir is an internal implementation detail of DefaultPolicyPath,
 // it exists only to allow testing it with an artificial home directory.
 func defaultPolicyPathWithHomeDir(sys *types.SystemContext, homeDir string) string {
 	if sys != nil && sys.SignaturePolicyPath != "" {


### PR DESCRIPTION
This will allow using the default policy path from here in c/podman and c/common instead of duplicating the constant in those projects.

Signed-off-by: Doug Rabson <dfr@rabson.org>