### PR TITLE
Don't incorrectly report success on failure paths

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -639,7 +639,7 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 
 	ociManifest, err := d.c.getSigstoreAttachmentManifest(ctx, d.ref, manifestDigest)
 	if err != nil {
-		return nil
+		return err
 	}
 	var ociConfig imgspecv1.Image // Most fields empty by default
 	if ociManifest == nil {
@@ -711,13 +711,13 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 		LayerIndex: nil,
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 	ociManifest.Config = configDesc
 
 	manifestBlob, err := ociManifest.Serialize()
 	if err != nil {
-		return nil
+		return err
 	}
 	logrus.Debugf("Uploading sigstore attachment manifest")
 	return d.uploadManifest(ctx, manifestBlob, sigstoreAttachmentTag(manifestDigest))

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -346,7 +346,7 @@ func (t *tarFI) Sys() interface{} {
 func (w *Writer) sendSymlinkLocked(path string, target string) error {
 	hdr, err := tar.FileInfoHeader(&tarFI{path: path, size: 0, isSymlink: true}, target)
 	if err != nil {
-		return nil
+		return err
 	}
 	logrus.Debugf("Sending as tar link %s -> %s", path, target)
 	return w.tar.WriteHeader(hdr)
@@ -363,7 +363,7 @@ func (w *Writer) sendBytesLocked(path string, b []byte) error {
 func (w *Writer) sendFileLocked(path string, expectedSize int64, stream io.Reader) error {
 	hdr, err := tar.FileInfoHeader(&tarFI{path: path, size: expectedSize}, "")
 	if err != nil {
-		return nil
+		return err
 	}
 	logrus.Debugf("Sending as tar file %s", path)
 	if err := w.tar.WriteHeader(hdr); err != nil {

--- a/oci/internal/oci_util_test.go
+++ b/oci/internal/oci_util_test.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testDataSplitReference struct {


### PR DESCRIPTION
... as identified by one of the non-default `golangci-lint` linters.
