### PR TITLE
WIP: Add a `/etc/containers/auth.json`

### DIFF
--- a/docs/containers-auth.json.5.md
+++ b/docs/containers-auth.json.5.md
@@ -6,15 +6,20 @@ containers-auth.json - syntax for the registry authentication file
 # DESCRIPTION
 
 A credentials file in JSON format used to authenticate against container image registries.
-The primary (read/write) file is stored at `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux;
+The primary (read/write) per-user file is stored at `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux;
 on Windows and macOS, at `$HOME/.config/containers/auth.json`.
 
-When searching for the credential for a registry, the following files will be read in sequence until the valid credential is found:
+There is also a system-global `/etc/containers/auth.json` path.  When the current process is executing inside systemd as root, this path will be preferred.
+
+When running as a user and searching for the credential for a registry, the following files will be read in sequence until the valid credential is found:
 first reading the primary (read/write) file, or the explicit override using an option of the calling application.
 If credentials are not present, search in `${XDG_CONFIG_HOME}/containers/auth.json` (usually `~/.config/containers/auth.json`), `$HOME/.docker/config.json`, `$HOME/.dockercfg`.
 
+If the current process is not running in systemd, but is running as root, the system global path will be read last.
+
 Except the primary (read/write) file, other files are read-only, unless the user use an option of the calling application explicitly points at it as an override.
 
+Note that the `/etc/containers/auth.json` file must not be readable by group or world (i.e. mode `044`), or a fatal error will occur.
 
 ## FORMAT
 


### PR DESCRIPTION
A long-running tension in the docker/podman land is around running as a system service versus being executed by a user. (Specifically a "login user", i.e. a Unix user that can be logged
 into via `ssh` etc.)

 For login users, it makes total sense to configure the container
 runtime in `$HOME`.

 But for system services (e.g. code executed by systemd) it
 is generally a bad idea to access or read the `/root` home
 directory.  On image based systems, `/root` may be dynamically
 mutable state in contrast to `/etc` which may be managed
 by OS upgrades, or even be read-only.

 For these reasons, let's introduce `/etc/contaners/auth.json`.
 If it is present, and the current process is executing in
 systemd, it will be preferred.  (There's some further logic
 around this that is explained in the manpage; please see that
 for details)

cc https://github.com/coreos/rpm-ostree/issues/4180

Signed-off-by: Colin Walters <walters@verbum.org>