### PR TITLE
Clarify the semantics of the optional.creator field in simple signature payload

### DIFF
--- a/docs/containers-signature.5.md
+++ b/docs/containers-signature.5.md
@@ -210,7 +210,8 @@ Consumers still SHOULD reject any signature where a member of an `optional` obje
 
 ### `optional.creator`
 
-If present, this MUST be a JSON string, identifying the name and version of the software which has created the signature.
+If present, this MUST be a JSON string, identifying the name and version of the software which has created the signature
+(identifying the low-level software implementation; not the top-level caller).
 
 The contents of this string is not defined in detail; however each implementation creating container signatures:
 


### PR DESCRIPTION
As an alternative to #1499.