### PR TITLE
Remove go-conections uses in tlsclientconfig

### DIFF
--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-connections/sockets"
 	"github.com/sirupsen/logrus"
 )
 
@@ -102,9 +101,6 @@ func NewTransport() *http.Transport {
 		TLSHandshakeTimeout: 10 * time.Second,
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
 		DisableKeepAlives: true,
-	}
-	if _, err := sockets.DialerFromEnvironment(direct); err != nil {
-		logrus.Debugf("Can't execute DialerFromEnvironment: %v", err)
 	}
 	return tr
 }

--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -2,6 +2,7 @@ package tlsclientconfig
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/sockets"
-	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
 
@@ -47,7 +47,7 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 				return err
 			}
 			if tlsc.RootCAs == nil {
-				systemPool, err := tlsconfig.SystemCertPool()
+				systemPool, err := x509.SystemCertPool()
 				if err != nil {
 					return fmt.Errorf("unable to get system cert pool: %w", err)
 				}


### PR DESCRIPTION
A small cleanup that should not affect behavior; see individual commit messages for details.

Motivated by https://github.com/containers/image/issues/161 .

Note that this does not change anything about the TLS configuration, or express any opinions about the HTTP configuration. Also, the dependency is still used indirectly due to other sub packages.