### PR TITLE
Use io.SeekStart instead of a hard-coded 0

### DIFF
--- a/storage/storage_src.go
+++ b/storage/storage_src.go
@@ -111,7 +111,7 @@ func (s *storageImageSource) GetBlob(ctx context.Context, info types.BlobInfo, c
 		return nil, 0, err
 	}
 
-	if _, err := tmpFile.Seek(0, 0); err != nil {
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
The hard-coded 0 is defined in the API, so this works fine; this is just a readability improvement.

Should not change behavior.