### PR TITLE
Don't use any default path fallbacks if the user specified a path

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -217,23 +217,25 @@ func getAuthFilePaths(sys *types.SystemContext, homeDir string) []authPath {
 		// Logging the error as a warning instead and moving on to pulling the image
 		logrus.Warnf("%v: Trying to pull image in the event that it is a public image.", err)
 	}
-	xdgCfgHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgCfgHome == "" {
-		xdgCfgHome = filepath.Join(homeDir, ".config")
-	}
-	paths = append(paths, authPath{path: filepath.Join(xdgCfgHome, xdgConfigHomePath), legacyFormat: false})
-	if dockerConfig := os.Getenv("DOCKER_CONFIG"); dockerConfig != "" {
+	if sys == nil || (sys.AuthFilePath == "" && sys.LegacyFormatAuthFilePath == "") {
+		xdgCfgHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgCfgHome == "" {
+			xdgCfgHome = filepath.Join(homeDir, ".config")
+		}
+		paths = append(paths, authPath{path: filepath.Join(xdgCfgHome, xdgConfigHomePath), legacyFormat: false})
+		if dockerConfig := os.Getenv("DOCKER_CONFIG"); dockerConfig != "" {
+			paths = append(paths,
+				authPath{path: filepath.Join(dockerConfig, "config.json"), legacyFormat: false},
+			)
+		} else {
+			paths = append(paths,
+				authPath{path: filepath.Join(homeDir, dockerHomePath), legacyFormat: false},
+			)
+		}
 		paths = append(paths,
-			authPath{path: filepath.Join(dockerConfig, "config.json"), legacyFormat: false},
-		)
-	} else {
-		paths = append(paths,
-			authPath{path: filepath.Join(homeDir, dockerHomePath), legacyFormat: false},
+			authPath{path: filepath.Join(homeDir, dockerLegacyHomePath), legacyFormat: true},
 		)
 	}
-	paths = append(paths,
-		authPath{path: filepath.Join(homeDir, dockerLegacyHomePath), legacyFormat: true},
-	)
 	return paths
 }
 


### PR DESCRIPTION
This means that users setting up AuthFilePath can rely on that config file, without influences from the external environment.

OTOH it might break existing users.

Fixes #596 — but I’m not really sure we want to make this change after all these years.