### PR TITLE
Speed up pkg/blobcache tests

### DIFF
--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -69,9 +69,9 @@ func makeLayer(filename string, repeat int, compression archive.Compression) ([]
 func TestBlobCache(t *testing.T) {
 	cacheDir := t.TempDir()
 
-	systemContext := types.SystemContext{}
+	systemContext := types.SystemContext{BlobInfoCacheDir: "/dev/null/this/does/not/exist"}
 
-	for _, repeat := range []int{1, 10, 100, 1000, 10000} {
+	for _, repeat := range []int{1, 10000} {
 		for _, desiredCompression := range []types.LayerCompression{types.PreserveOriginal, types.Compress, types.Decompress} {
 			for _, layerCompression := range []archive.Compression{archive.Uncompressed, archive.Gzip} {
 				// Create a layer with the specified layerCompression.


### PR DESCRIPTION
- Use an invalid SystemContext.BlobInfoCacheDir to trigger use of blobinfocache/memory instead of blobinfocache/boltdb, thus avoiding some Fsync calls. This alone more than halves the total test time.
- Also don't repeat the test with 5 different file sizes; file contents are not _that_ much of a focus of the tests that we need to test so many variants.

On macOS, this reduces test time by 81% (measured by -count=3), from (in this particular instance) 8.8s to 1.6s per iteration.
