### PR TITLE
Make sure value types also implement json.Marshaler

### DIFF
--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -46,7 +46,8 @@ func NewUntrustedSigstorePayload(dockerManifestDigest digest.Digest, dockerRefer
 	}
 }
 
-// Compile-time check that UntrustedSigstorePayload implements json.Marshaler
+// A compile-time check that UntrustedSigstorePayload and *UntrustedSigstorePayload implements json.Marshaler
+var _ json.Marshaler = UntrustedSigstorePayload{}
 var _ json.Marshaler = (*UntrustedSigstorePayload)(nil)
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/signature/simple.go
+++ b/signature/simple.go
@@ -72,7 +72,8 @@ func newUntrustedSignature(dockerManifestDigest digest.Digest, dockerReference s
 	}
 }
 
-// Compile-time check that untrustedSignature implements json.Marshaler
+// A compile-time check that untrustedSignature  and *untrustedSignature implements json.Marshaler
+var _ json.Marshaler = untrustedSignature{}
 var _ json.Marshaler = (*untrustedSignature)(nil)
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
... otherwise `json.Marshal(value)` ignores the custom implementation.

Luckily the implementations were fine, so just add the extra safeguards.

(The `_` values are, AFAICS, optimized out and do not increase binary size. Usually I'd move the assertions to test code anyway, but for security-critical code it seems better to have the assertion nearby.)