### PR TITLE
manifest: pull Variant from an OCI config

### DIFF
--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -227,6 +227,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 		Created:       &s1.Created,
 		DockerVersion: s1.DockerVersion,
 		Architecture:  s1.Architecture,
+		Variant:       s1.Variant,
 		Os:            s1.OS,
 		Layers:        layerInfosToStrings(layerInfos),
 		LayersData:    imgInspectLayersFromLayerInfos(layerInfos),

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -219,6 +219,7 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 		DockerVersion: d1.DockerVersion,
 		Labels:        v1.Config.Labels,
 		Architecture:  v1.Architecture,
+		Variant:       v1.Variant,
 		Os:            v1.OS,
 		Layers:        layerInfosToStrings(layerInfos),
 		LayersData:    imgInspectLayersFromLayerInfos(layerInfos),


### PR DESCRIPTION
When reading fields from an OCI config blob, pull the `Variant` field's value, too.  Stumbled across it while looking for something else.  Read it from a v2s1 config blob, too, even if it's almost certainly going to be empty.