### PR TITLE
Cirrus: Use human-readable CI VM Images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,10 +32,10 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-37"
+    FEDORA_NAME: "fedora-37" ### c20230120t152650z-f37f36u2204
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c6300530360713216"
+    IMAGE_SUFFIX: "c20230120t152650z-f37f36u2204"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
 
     # Container FQIN's (include bleeding-edge development-level container deps.)


### PR DESCRIPTION
***Depends on:*** https://github.com/containers/skopeo/pull/1888

Image content hasn't changed much, the biggest thing here is the `$IMAGE_SUFFIX` value.  This new schema is also fully manageable by renovate.  Allowing a tag-push to c/automation_images to create image update PRs in all repos automatically.

Ref: https://github.com/containers/automation_images/pull/247

Signed-off-by: Chris Evich <cevich@redhat.com>