### PR TITLE
Migrate from ghodss/yaml to gopkg.in/yaml.v3

### DIFF
--- a/docker/registries_d.go
+++ b/docker/registries_d.go
@@ -13,9 +13,9 @@ import (
 	"github.com/containers/image/v5/internal/rootless"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 // systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.
@@ -39,18 +39,18 @@ var defaultDockerDir = "/var/lib/containers/sigstore"
 // registryConfiguration is one of the files in registriesDirPath configuring lookaside locations, or the result of merging them all.
 // NOTE: Keep this in sync with docs/registries.d.md!
 type registryConfiguration struct {
-	DefaultDocker *registryNamespace `json:"default-docker"`
+	DefaultDocker *registryNamespace `yaml:"default-docker"`
 	// The key is a namespace, using fully-expanded Docker reference format or parent namespaces (per dockerReference.PolicyConfiguration*),
-	Docker map[string]registryNamespace `json:"docker"`
+	Docker map[string]registryNamespace `yaml:"docker"`
 }
 
 // registryNamespace defines lookaside locations for a single namespace.
 type registryNamespace struct {
-	Lookaside              string `json:"lookaside"`         // For reading, and if LookasideStaging is not present, for writing.
-	LookasideStaging       string `json:"lookaside-staging"` // For writing only.
-	SigStore               string `json:"sigstore"`          // For compatibility, deprecated in favor of Lookaside.
-	SigStoreStaging        string `json:"sigstore-staging"`  // For compatibility, deprecated in favor of LookasideStaging.
-	UseSigstoreAttachments *bool  `json:"use-sigstore-attachments,omitempty"`
+	Lookaside              string `yaml:"lookaside"`         // For reading, and if LookasideStaging is not present, for writing.
+	LookasideStaging       string `yaml:"lookaside-staging"` // For writing only.
+	SigStore               string `yaml:"sigstore"`          // For compatibility, deprecated in favor of Lookaside.
+	SigStoreStaging        string `yaml:"sigstore-staging"`  // For compatibility, deprecated in favor of LookasideStaging.
+	UseSigstoreAttachments *bool  `yaml:"use-sigstore-attachments,omitempty"`
 }
 
 // lookasideStorageBase is an "opaque" type representing a lookaside Docker signature storage.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/docker/docker v20.10.23+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/docker/go-connections v0.4.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.22.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1059,7 +1059,6 @@ github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASx
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=

--- a/openshift/openshift-copies_test.go
+++ b/openshift/openshift-copies_test.go
@@ -1,13 +1,22 @@
 package openshift
 
 import (
+	"encoding"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 const fixtureKubeConfigPath = "testdata/admin.kubeconfig"
+
+var (
+	_ yaml.Unmarshaler         = (*clustersMap)(nil)
+	_ yaml.Unmarshaler         = (*authInfosMap)(nil)
+	_ yaml.Unmarshaler         = (*contextsMap)(nil)
+	_ encoding.TextUnmarshaler = (*yamlBinaryAsBase64String)(nil)
+)
 
 // These are only smoke tests based on the skopeo integration test cluster. Error handling, non-trivial configuration merging,
 // and any other situations are not currently covered.


### PR DESCRIPTION
This attempts to remove a dependency on yaml.v2 which we, sort of, control. This parallels https://github.com/containers/skopeo/pull/1885 .

At the very least this will allow removing `ghodss/yaml` from Skopeo (but not from Podman, because Podman uses this package directly). That’s at least a bit of code.

Note that the whole of c/image will continue to depend on  `yaml.v2` , via a Swagger-generated Rekor client, depending on https://github.com/go-openapi/runtime/issues/245 .

Tested, so far, only using unit tests; that suggests that the migration from `ghodss/yaml` _might_ be fairly tricky. The `openshift` case is one where we would be quite unlikely to notice breakage in practice, but it has fairly good unit tests. The `registries.d` case has worse unit tests, but simpler data types and probably better integration test coverage.