### PR TITLE
Add a more specific error message on invalid docker-config-in-OCI-image images

### DIFF
--- a/internal/manifest/errors.go
+++ b/internal/manifest/errors.go
@@ -2,6 +2,10 @@ package manifest
 
 import "fmt"
 
+// FIXME: This is a duplicate of c/image/manifestDockerV2Schema2ConfigMediaType.
+// Deduplicate that, depending on outcome of https://github.com/containers/image/pull/1791 .
+const dockerV2Schema2ConfigMediaType = "application/vnd.docker.container.image.v1+json"
+
 // NonImageArtifactError (detected via errors.As) is used when asking for an image-specific operation
 // on an object which is not a “container image” in the standard sense (e.g. an OCI artifact)
 //
@@ -28,5 +32,9 @@ func NewNonImageArtifactError(mimeType string) error {
 }
 
 func (e NonImageArtifactError) Error() string {
+	// Special-case these invalid mixed images, which show up from time to time:
+	if e.mimeType == dockerV2Schema2ConfigMediaType {
+		return fmt.Sprintf("invalid mixed OCI image with Docker v2s2 config (%q)", e.mimeType)
+	}
 	return fmt.Sprintf("unsupported image-specific operation on artifact with type %q", e.mimeType)
 }


### PR DESCRIPTION
The OCI artifact reference in the generic error message is a bit confusing, and these invalid images do tend to show up every few years.

<s>Draft: Test that at least once against `docker://docker.io/library/ubuntu@sha256:0b0aab2bb85da9e3168407368464cb15f828eda8860eefb4c74a57dea2f139c7` .</s>