### PR TITLE
[CI:DOCS] Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-    timezone: Europe/Berlin
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes: https://github.com/containers/image/issues/1836

Ref: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates

Disabling it via the WebUI isn't good enough, the configuration file must also be absent.

Signed-off-by: Chris Evich <cevich@redhat.com>