### PR TITLE
Merge release branch into main

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 24
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
⚠️ This is sort of an experiment.

This merges the `release-5.24` branch into main. Effects of this:
- `version.go` on `main` is updated to a version after the last released one, reducing the risk of trying to release the same version again
- The git commit graph now correctly represents that everything in `release-5.24` is present on `main`
- The Go module pseudo-version mechanism should now name commits on `main` to be `v5.24.2-0.…`, not `v5.24.1–0.…`, because the `v5.24.1` tag is reachable on `main`. That should, in turn, help automated upgrade tools to stop proposing downgrades from the `main` branch to the release branch, like https://github.com/containers/skopeo/pull/1903 .

The last part is a somewhat-researched hypothesis, but it’s basically an experiment. We can’t do that experiment without actually publishing and tagging packages on GitHub — OTOH we _could_, plausibly, do that in a test repo instead of here.

I think that this is low-risk and not worth the extra effort to test separately, but I can be mistaken, so I do want a second pair of eyes on this before making the merge.

(Note that just looking at the list of the commits in GitHub UI might not be very helpful; see the PR branch in a GUI that shows the commit graph.)