### PR TITLE
Remove a direct use of golang.org/x/net/http2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/crypto v0.6.0
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
-	golang.org/x/net v0.6.0
 	golang.org/x/oauth2 v0.5.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.5.0
@@ -118,6 +117,7 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/net v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.4.0 // indirect

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -931,10 +931,10 @@ func tlsCacheGet(config *restConfig) (http.RoundTripper, error) {
 		Proxy:               newProxierWithNoProxyCIDR(http.ProxyFromEnvironment),
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     tlsConfig,
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 	}
 	// Allow clients to disable http2 if needed.
 	if s := os.Getenv("DISABLE_HTTP2"); len(s) == 0 {

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -21,7 +21,6 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
-	"golang.org/x/net/http2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -938,7 +937,7 @@ func tlsCacheGet(config *restConfig) (http.RoundTripper, error) {
 	}
 	// Allow clients to disable http2 if needed.
 	if s := os.Getenv("DISABLE_HTTP2"); len(s) == 0 {
-		_ = http2.ConfigureTransport(t)
+		t.ForceAttemptHTTP2 = true
 	}
 	return t, nil
 }


### PR DESCRIPTION
A version of `golang.org/x/net/http2` is bundled into the standard library: https://github.com/golang/go/blob/master/src/net/http/h2_bundle.go and here we certainly don't care about the specific version or details.

So just enable use of the built-in one.

Note that this is very unlikely to actually remove the dependency from binaries, because it is required by `google.golang.org/grpc/internal/transport`, and that one has quite a few uses; so most of the benefit right now is just
one less package to get dependency update PRs from.

---

Also replace deprecated `Dial` by `DialContext`.