### PR TITLE
Make it clear that cleartext signatures are not accepted in simple signing

### DIFF
--- a/docs/containers-signature.5.md
+++ b/docs/containers-signature.5.md
@@ -68,7 +68,9 @@ the consumer MUST verify at least the following aspects of the signature
 (like the `github.com/containers/image/signature` package does):
 
 - The blob MUST be a “Signed Message” as defined RFC 4880 section 11.3.
-  (e.g. it MUST NOT be an unsigned “Literal Message”, or any other non-signature format).
+  (e.g. it MUST NOT be an unsigned “Literal Message”,
+  a “Cleartext Signature” as defined in RFC 4880 section 7,
+  or any other non-signature format).
 - The signature MUST have been made by an expected key trusted for the purpose (and the specific container image).
 - The signature MUST be correctly formed and pass the cryptographic validation.
 - The signature MUST correctly authenticate the included JSON payload


### PR DESCRIPTION
The current implementation transparently accepts them in `gpgmeSigningMechanism` , but `openpgpSigningMechanism` rejects them; so make it clear that they should be rejected.

See #1852 .