### PR TITLE
Make some symbols in internal packages package-private

### DIFF
--- a/internal/signature/signature.go
+++ b/internal/signature/signature.go
@@ -24,7 +24,7 @@ type Signature interface {
 	blobChunk() ([]byte, error)
 }
 
-// BlobChunk returns a representation of sig as a []byte, suitable for long-term storage.
+// Blob returns a representation of sig as a []byte, suitable for long-term storage.
 func Blob(sig Signature) ([]byte, error) {
 	chunk, err := sig.blobChunk()
 	if err != nil {
@@ -79,7 +79,7 @@ func FromBlob(blob []byte) (Signature, error) {
 		case bytes.Equal(formatBytes, []byte(SimpleSigningFormat)):
 			return SimpleSigningFromBlob(blobChunk), nil
 		case bytes.Equal(formatBytes, []byte(SigstoreFormat)):
-			return SigstoreFromBlobChunk(blobChunk)
+			return sigstoreFromBlobChunk(blobChunk)
 		default:
 			return nil, fmt.Errorf("unrecognized signature format %q", string(formatBytes))
 		}

--- a/internal/signature/sigstore.go
+++ b/internal/signature/sigstore.go
@@ -50,8 +50,8 @@ func SigstoreFromComponents(untrustedMimeType string, untrustedPayload []byte, u
 	}
 }
 
-// SigstoreFromBlobChunk converts a Sigstore signature, as returned by Sigstore.blobChunk, into a Sigstore object.
-func SigstoreFromBlobChunk(blobChunk []byte) (Sigstore, error) {
+// sigstoreFromBlobChunk converts a Sigstore signature, as returned by Sigstore.blobChunk, into a Sigstore object.
+func sigstoreFromBlobChunk(blobChunk []byte) (Sigstore, error) {
 	var v sigstoreJSONRepresentation
 	if err := json.Unmarshal(blobChunk, &v); err != nil {
 		return Sigstore{}, err

--- a/internal/signature/sigstore_test.go
+++ b/internal/signature/sigstore_test.go
@@ -24,14 +24,14 @@ func TestSigstoreFromComponents(t *testing.T) {
 func TestSigstoreFromBlobChunk(t *testing.T) {
 	// Success
 	json := []byte(`{"mimeType":"mime-type","payload":"cGF5bG9hZA==", "annotations":{"a":"b","c":"d"}}`)
-	res, err := SigstoreFromBlobChunk(json)
+	res, err := sigstoreFromBlobChunk(json)
 	require.NoError(t, err)
 	assert.Equal(t, "mime-type", res.UntrustedMIMEType())
 	assert.Equal(t, []byte("payload"), res.UntrustedPayload())
 	assert.Equal(t, map[string]string{"a": "b", "c": "d"}, res.UntrustedAnnotations())
 
 	// Invalid JSON
-	_, err = SigstoreFromBlobChunk([]byte("&"))
+	_, err = sigstoreFromBlobChunk([]byte("&"))
 	assert.Error(t, err)
 }
 

--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -21,14 +21,14 @@ const (
 
 // UntrustedSigstorePayload is a parsed content of a sigstore signature payload (not the full signature)
 type UntrustedSigstorePayload struct {
-	UntrustedDockerManifestDigest digest.Digest
-	UntrustedDockerReference      string // FIXME: more precise type?
-	UntrustedCreatorID            *string
+	untrustedDockerManifestDigest digest.Digest
+	untrustedDockerReference      string // FIXME: more precise type?
+	untrustedCreatorID            *string
 	// This is intentionally an int64; the native JSON float64 type would allow to represent _some_ sub-second precision,
 	// but not nearly enough (with current timestamp values, a single unit in the last place is on the order of hundreds of nanoseconds).
 	// So, this is explicitly an int64, and we reject fractional values. If we did need more precise timestamps eventually,
 	// we would add another field, UntrustedTimestampNS int64.
-	UntrustedTimestamp *int64
+	untrustedTimestamp *int64
 }
 
 // NewUntrustedSigstorePayload returns an UntrustedSigstorePayload object with
@@ -39,10 +39,10 @@ func NewUntrustedSigstorePayload(dockerManifestDigest digest.Digest, dockerRefer
 	creatorID := "containers/image " + version.Version
 	timestamp := time.Now().Unix()
 	return UntrustedSigstorePayload{
-		UntrustedDockerManifestDigest: dockerManifestDigest,
-		UntrustedDockerReference:      dockerReference,
-		UntrustedCreatorID:            &creatorID,
-		UntrustedTimestamp:            &timestamp,
+		untrustedDockerManifestDigest: dockerManifestDigest,
+		untrustedDockerReference:      dockerReference,
+		untrustedCreatorID:            &creatorID,
+		untrustedTimestamp:            &timestamp,
 	}
 }
 
@@ -52,20 +52,20 @@ var _ json.Marshaler = (*UntrustedSigstorePayload)(nil)
 
 // MarshalJSON implements the json.Marshaler interface.
 func (s UntrustedSigstorePayload) MarshalJSON() ([]byte, error) {
-	if s.UntrustedDockerManifestDigest == "" || s.UntrustedDockerReference == "" {
+	if s.untrustedDockerManifestDigest == "" || s.untrustedDockerReference == "" {
 		return nil, errors.New("Unexpected empty signature content")
 	}
 	critical := map[string]any{
 		"type":     sigstoreSignatureType,
-		"image":    map[string]string{"docker-manifest-digest": s.UntrustedDockerManifestDigest.String()},
-		"identity": map[string]string{"docker-reference": s.UntrustedDockerReference},
+		"image":    map[string]string{"docker-manifest-digest": s.untrustedDockerManifestDigest.String()},
+		"identity": map[string]string{"docker-reference": s.untrustedDockerReference},
 	}
 	optional := map[string]any{}
-	if s.UntrustedCreatorID != nil {
-		optional["creator"] = *s.UntrustedCreatorID
+	if s.untrustedCreatorID != nil {
+		optional["creator"] = *s.untrustedCreatorID
 	}
-	if s.UntrustedTimestamp != nil {
-		optional["timestamp"] = *s.UntrustedTimestamp
+	if s.untrustedTimestamp != nil {
+		optional["timestamp"] = *s.untrustedTimestamp
 	}
 	signature := map[string]any{
 		"critical": critical,
@@ -121,14 +121,14 @@ func (s *UntrustedSigstorePayload) strictUnmarshalJSON(data []byte) error {
 		}
 	}
 	if gotCreatorID {
-		s.UntrustedCreatorID = &creatorID
+		s.untrustedCreatorID = &creatorID
 	}
 	if gotTimestamp {
 		intTimestamp := int64(timestamp)
 		if float64(intTimestamp) != timestamp {
 			return NewInvalidSignatureError("Field optional.timestamp is not is not an integer")
 		}
-		s.UntrustedTimestamp = &intTimestamp
+		s.untrustedTimestamp = &intTimestamp
 	}
 
 	var t string
@@ -150,10 +150,10 @@ func (s *UntrustedSigstorePayload) strictUnmarshalJSON(data []byte) error {
 	}); err != nil {
 		return err
 	}
-	s.UntrustedDockerManifestDigest = digest.Digest(digestString)
+	s.untrustedDockerManifestDigest = digest.Digest(digestString)
 
 	return ParanoidUnmarshalJSONObjectExactFields(identity, map[string]any{
-		"docker-reference": &s.UntrustedDockerReference,
+		"docker-reference": &s.untrustedDockerReference,
 	})
 }
 
@@ -191,10 +191,10 @@ func VerifySigstorePayload(publicKey crypto.PublicKey, unverifiedPayload []byte,
 	if err := json.Unmarshal(unverifiedPayload, &unmatchedPayload); err != nil {
 		return nil, NewInvalidSignatureError(err.Error())
 	}
-	if err := rules.ValidateSignedDockerManifestDigest(unmatchedPayload.UntrustedDockerManifestDigest); err != nil {
+	if err := rules.ValidateSignedDockerManifestDigest(unmatchedPayload.untrustedDockerManifestDigest); err != nil {
 		return nil, err
 	}
-	if err := rules.ValidateSignedDockerReference(unmatchedPayload.UntrustedDockerReference); err != nil {
+	if err := rules.ValidateSignedDockerReference(unmatchedPayload.untrustedDockerReference); err != nil {
 		return nil, err
 	}
 	// SigstorePayloadAcceptanceRules have accepted this value.

--- a/signature/internal/sigstore_payload_test.go
+++ b/signature/internal/sigstore_payload_test.go
@@ -31,14 +31,14 @@ func x(m mSA, fields ...string) mSA {
 func TestNewUntrustedSigstorePayload(t *testing.T) {
 	timeBefore := time.Now()
 	sig := NewUntrustedSigstorePayload(TestImageManifestDigest, TestImageSignatureReference)
-	assert.Equal(t, TestImageManifestDigest, sig.UntrustedDockerManifestDigest)
-	assert.Equal(t, TestImageSignatureReference, sig.UntrustedDockerReference)
-	require.NotNil(t, sig.UntrustedCreatorID)
-	assert.Equal(t, "containers/image "+version.Version, *sig.UntrustedCreatorID)
-	require.NotNil(t, sig.UntrustedTimestamp)
+	assert.Equal(t, TestImageManifestDigest, sig.untrustedDockerManifestDigest)
+	assert.Equal(t, TestImageSignatureReference, sig.untrustedDockerReference)
+	require.NotNil(t, sig.untrustedCreatorID)
+	assert.Equal(t, "containers/image "+version.Version, *sig.untrustedCreatorID)
+	require.NotNil(t, sig.untrustedTimestamp)
 	timeAfter := time.Now()
-	assert.True(t, timeBefore.Unix() <= *sig.UntrustedTimestamp)
-	assert.True(t, *sig.UntrustedTimestamp <= timeAfter.Unix())
+	assert.True(t, timeBefore.Unix() <= *sig.untrustedTimestamp)
+	assert.True(t, *sig.untrustedTimestamp <= timeAfter.Unix())
 }
 
 func TestUntrustedSigstorePayloadMarshalJSON(t *testing.T) {
@@ -60,17 +60,17 @@ func TestUntrustedSigstorePayloadMarshalJSON(t *testing.T) {
 	}{
 		{
 			UntrustedSigstorePayload{
-				UntrustedDockerManifestDigest: "digest!@#",
-				UntrustedDockerReference:      "reference#@!",
-				UntrustedCreatorID:            &creatorID,
-				UntrustedTimestamp:            &timestamp,
+				untrustedDockerManifestDigest: "digest!@#",
+				untrustedDockerReference:      "reference#@!",
+				untrustedCreatorID:            &creatorID,
+				untrustedTimestamp:            &timestamp,
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"digest!@#\"},\"type\":\"cosign container image signature\"},\"optional\":{\"creator\":\"CREATOR\",\"timestamp\":1484683104}}",
 		},
 		{
 			UntrustedSigstorePayload{
-				UntrustedDockerManifestDigest: "digest!@#",
-				UntrustedDockerReference:      "reference#@!",
+				untrustedDockerManifestDigest: "digest!@#",
+				untrustedDockerReference:      "reference#@!",
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"digest!@#\"},\"type\":\"cosign container image signature\"},\"optional\":{}}",
 		},
@@ -125,10 +125,10 @@ func TestUntrustedSigstorePayloadUnmarshalJSON(t *testing.T) {
 	// A /usr/bin/cosign-generated payload is handled correctly
 	s = successfullyUnmarshalUntrustedSigstorePayload(t, []byte(`{"critical":{"identity":{"docker-reference":"192.168.64.2:5000/cosign-signed-multi"},"image":{"docker-manifest-digest":"sha256:43955d6857268cc948ae9b370b221091057de83c4962da0826f9a2bdc9bd6b44"},"type":"cosign container image signature"},"optional":null}`))
 	assert.Equal(t, UntrustedSigstorePayload{
-		UntrustedDockerManifestDigest: "sha256:43955d6857268cc948ae9b370b221091057de83c4962da0826f9a2bdc9bd6b44",
-		UntrustedDockerReference:      "192.168.64.2:5000/cosign-signed-multi",
-		UntrustedCreatorID:            nil,
-		UntrustedTimestamp:            nil,
+		untrustedDockerManifestDigest: "sha256:43955d6857268cc948ae9b370b221091057de83c4962da0826f9a2bdc9bd6b44",
+		untrustedDockerReference:      "192.168.64.2:5000/cosign-signed-multi",
+		untrustedCreatorID:            nil,
+		untrustedTimestamp:            nil,
 	}, s)
 
 	// Various ways to corrupt the JSON
@@ -187,10 +187,10 @@ func TestUntrustedSigstorePayloadUnmarshalJSON(t *testing.T) {
 
 	// Optional fields can be missing
 	validSig = UntrustedSigstorePayload{
-		UntrustedDockerManifestDigest: "digest!@#",
-		UntrustedDockerReference:      "reference#@!",
-		UntrustedCreatorID:            nil,
-		UntrustedTimestamp:            nil,
+		untrustedDockerManifestDigest: "digest!@#",
+		untrustedDockerReference:      "reference#@!",
+		untrustedCreatorID:            nil,
+		untrustedTimestamp:            nil,
 	}
 	validJSON, err = validSig.MarshalJSON()
 	require.NoError(t, err)
@@ -247,10 +247,10 @@ func TestVerifySigstorePayload(t *testing.T) {
 	res, err := VerifySigstorePayload(publicKey, sigstoreSig.UntrustedPayload(), cryptoBase64Sig, recordingRules)
 	require.NoError(t, err)
 	assert.Equal(t, res, &UntrustedSigstorePayload{
-		UntrustedDockerManifestDigest: TestSigstoreManifestDigest,
-		UntrustedDockerReference:      TestSigstoreSignatureReference,
-		UntrustedCreatorID:            nil,
-		UntrustedTimestamp:            nil,
+		untrustedDockerManifestDigest: TestSigstoreManifestDigest,
+		untrustedDockerReference:      TestSigstoreSignatureReference,
+		untrustedCreatorID:            nil,
+		untrustedTimestamp:            nil,
 	})
 	assert.Equal(t, signatureData, recorded)
 

--- a/signature/simple_test.go
+++ b/signature/simple_test.go
@@ -18,14 +18,14 @@ import (
 func TestNewUntrustedSignature(t *testing.T) {
 	timeBefore := time.Now()
 	sig := newUntrustedSignature(TestImageManifestDigest, TestImageSignatureReference)
-	assert.Equal(t, TestImageManifestDigest, sig.UntrustedDockerManifestDigest)
-	assert.Equal(t, TestImageSignatureReference, sig.UntrustedDockerReference)
-	require.NotNil(t, sig.UntrustedCreatorID)
-	assert.Equal(t, "atomic "+version.Version, *sig.UntrustedCreatorID)
-	require.NotNil(t, sig.UntrustedTimestamp)
+	assert.Equal(t, TestImageManifestDigest, sig.untrustedDockerManifestDigest)
+	assert.Equal(t, TestImageSignatureReference, sig.untrustedDockerReference)
+	require.NotNil(t, sig.untrustedCreatorID)
+	assert.Equal(t, "atomic "+version.Version, *sig.untrustedCreatorID)
+	require.NotNil(t, sig.untrustedTimestamp)
 	timeAfter := time.Now()
-	assert.True(t, timeBefore.Unix() <= *sig.UntrustedTimestamp)
-	assert.True(t, *sig.UntrustedTimestamp <= timeAfter.Unix())
+	assert.True(t, timeBefore.Unix() <= *sig.untrustedTimestamp)
+	assert.True(t, *sig.untrustedTimestamp <= timeAfter.Unix())
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -47,17 +47,17 @@ func TestMarshalJSON(t *testing.T) {
 	}{
 		{
 			untrustedSignature{
-				UntrustedDockerManifestDigest: "digest!@#",
-				UntrustedDockerReference:      "reference#@!",
-				UntrustedCreatorID:            &creatorID,
-				UntrustedTimestamp:            &timestamp,
+				untrustedDockerManifestDigest: "digest!@#",
+				untrustedDockerReference:      "reference#@!",
+				untrustedCreatorID:            &creatorID,
+				untrustedTimestamp:            &timestamp,
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"digest!@#\"},\"type\":\"atomic container signature\"},\"optional\":{\"creator\":\"CREATOR\",\"timestamp\":1484683104}}",
 		},
 		{
 			untrustedSignature{
-				UntrustedDockerManifestDigest: "digest!@#",
-				UntrustedDockerReference:      "reference#@!",
+				untrustedDockerManifestDigest: "digest!@#",
+				untrustedDockerReference:      "reference#@!",
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"digest!@#\"},\"type\":\"atomic container signature\"},\"optional\":{}}",
 		},
@@ -196,10 +196,10 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	// Optional fields can be missing
 	validSig = untrustedSignature{
-		UntrustedDockerManifestDigest: "digest!@#",
-		UntrustedDockerReference:      "reference#@!",
-		UntrustedCreatorID:            nil,
-		UntrustedTimestamp:            nil,
+		untrustedDockerManifestDigest: "digest!@#",
+		untrustedDockerReference:      "reference#@!",
+		untrustedCreatorID:            nil,
+		untrustedTimestamp:            nil,
 	}
 	validJSON, err = validSig.MarshalJSON()
 	require.NoError(t, err)
@@ -230,13 +230,13 @@ func TestSign(t *testing.T) {
 			return nil
 		},
 		validateSignedDockerReference: func(signedDockerReference string) error {
-			if signedDockerReference != sig.UntrustedDockerReference {
+			if signedDockerReference != sig.untrustedDockerReference {
 				return errors.New("Unexpected signedDockerReference")
 			}
 			return nil
 		},
 		validateSignedDockerManifestDigest: func(signedDockerManifestDigest digest.Digest) error {
-			if signedDockerManifestDigest != sig.UntrustedDockerManifestDigest {
+			if signedDockerManifestDigest != sig.untrustedDockerManifestDigest {
 				return errors.New("Unexpected signedDockerManifestDigest")
 			}
 			return nil
@@ -244,8 +244,8 @@ func TestSign(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, sig.UntrustedDockerManifestDigest, verified.DockerManifestDigest)
-	assert.Equal(t, sig.UntrustedDockerReference, verified.DockerReference)
+	assert.Equal(t, sig.untrustedDockerManifestDigest, verified.DockerManifestDigest)
+	assert.Equal(t, sig.untrustedDockerReference, verified.DockerReference)
 
 	// Error creating blob to sign
 	_, err = untrustedSignature{}.sign(mech, TestKeyFingerprint, "")


### PR DESCRIPTION
… just to express more precisely how they are used, and to possibly help compilers/linters with scope analysis.

Should not change behavior. All of these types are internal, so we can trivially make them public again if necessary.