### PR TITLE
distribution: remove use of deprecated dial.DualStack

### DIFF
--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -91,7 +91,6 @@ func NewTransport() *http.Transport {
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}
 	tr := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,


### PR DESCRIPTION
backported from:

https://github.com/moby/moby/commit/ff408210da8ebcb6d3c333b6270b921442bcc1da