### PR TITLE
[release-5.24] Backport retries heuristics updates

### DIFF
--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -229,12 +229,12 @@ func (br *bodyReader) errorIfNotReconnecting(originalErr error, redactedURL stri
 		logrus.Infof("Reading blob body from %s failed (%v), reconnecting after %d bytes…", redactedURL, originalErr, progress)
 		return nil
 	}
-	if br.lastRetryTime == (time.Time{}) || msSinceLastRetry >= bodyReaderMSSinceLastRetry {
-		if br.lastRetryTime == (time.Time{}) {
-			logrus.Infof("Reading blob body from %s failed (%v), reconnecting (first reconnection)…", redactedURL, originalErr)
-		} else {
-			logrus.Infof("Reading blob body from %s failed (%v), reconnecting after %.3f ms…", redactedURL, originalErr, msSinceLastRetry)
-		}
+	if br.lastRetryTime == (time.Time{}) {
+		logrus.Infof("Reading blob body from %s failed (%v), reconnecting (first reconnection)…", redactedURL, originalErr)
+		return nil
+	}
+	if msSinceLastRetry >= bodyReaderMSSinceLastRetry {
+		logrus.Infof("Reading blob body from %s failed (%v), reconnecting after %.3f ms…", redactedURL, originalErr, msSinceLastRetry)
 		return nil
 	}
 	logrus.Debugf("Not reconnecting to %s: insufficient progress %d / time since last retry %.3f ms", redactedURL, progress, msSinceLastRetry)

--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -34,10 +34,10 @@ type bodyReader struct {
 	firstConnectionTime time.Time
 
 	body            io.ReadCloser // The currently open connection we use to read data, or nil if there is nothing to read from / close.
-	lastRetryOffset int64
-	lastRetryTime   time.Time // time.Time{} if N/A
-	offset          int64     // Current offset within the blob
-	lastSuccessTime time.Time // time.Time{} if N/A
+	lastRetryOffset int64         // -1 if N/A
+	lastRetryTime   time.Time     // time.Time{} if N/A
+	offset          int64         // Current offset within the blob
+	lastSuccessTime time.Time     // time.Time{} if N/A
 }
 
 // newBodyReader creates a bodyReader for request path in c.
@@ -56,7 +56,7 @@ func newBodyReader(ctx context.Context, c *dockerClient, path string, firstBody 
 		firstConnectionTime: time.Now(),
 
 		body:            firstBody,
-		lastRetryOffset: 0,
+		lastRetryOffset: -1,
 		lastRetryTime:   time.Time{},
 		offset:          0,
 		lastSuccessTime: time.Time{},

--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -211,15 +211,15 @@ func millisecondsSinceOptional(currentTime time.Time, tm time.Time) float64 {
 // otherwise it returns an appropriate error to return to the caller (possibly augmented with data about the heuristic)
 func (br *bodyReader) errorIfNotReconnecting(originalErr error, redactedURL string) error {
 	currentTime := time.Now()
-	totalTime := millisecondsSinceOptional(currentTime, br.firstConnectionTime)
-	failureTime := millisecondsSinceOptional(currentTime, br.lastSuccessTime)
+	msSinceFirstConnection := millisecondsSinceOptional(currentTime, br.firstConnectionTime)
+	msSinceLastSuccess := millisecondsSinceOptional(currentTime, br.lastSuccessTime)
 	logrus.Debugf("Reading blob body from %s failed (%#v), decision inputs: lastRetryOffset %d, offset %d, %.3f ms since first connection, %.3f ms since last progress",
-		redactedURL, originalErr, br.lastRetryOffset, br.offset, totalTime, failureTime)
+		redactedURL, originalErr, br.lastRetryOffset, br.offset, msSinceFirstConnection, msSinceLastSuccess)
 	progress := br.offset - br.lastRetryOffset
 	if progress < bodyReaderMinimumProgress {
 		logrus.Debugf("Not reconnecting to %s because only %d bytes progress made", redactedURL, progress)
 		return fmt.Errorf("(heuristic tuning data: last retry %d, current offset %d; %.3f ms total, %.3f ms since progress): %w",
-			br.lastRetryOffset, br.offset, totalTime, failureTime, originalErr)
+			br.lastRetryOffset, br.offset, msSinceFirstConnection, msSinceLastSuccess, originalErr)
 	}
 	logrus.Infof("Reading blob body from %s failed (%v), reconnecting…", redactedURL, originalErr)
 	return nil

--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -23,16 +23,16 @@ const bodyReaderMinimumProgress = 1 * 1024 * 1024
 // bodyReader is an io.ReadCloser returned by dockerImageSource.GetBlob,
 // which can transparently resume some (very limited) kinds of aborted connections.
 type bodyReader struct {
-	ctx context.Context
-	c   *dockerClient
-
-	path                string        // path to pass to makeRequest to retry
-	logURL              *url.URL      // a string to use in error messages
-	body                io.ReadCloser // The currently open connection we use to read data, or nil if there is nothing to read from / close.
-	lastRetryOffset     int64
-	offset              int64 // Current offset within the blob
+	ctx                 context.Context
+	c                   *dockerClient
+	path                string   // path to pass to makeRequest to retry
+	logURL              *url.URL // a string to use in error messages
 	firstConnectionTime time.Time
-	lastSuccessTime     time.Time // time.Time{} if N/A
+
+	body            io.ReadCloser // The currently open connection we use to read data, or nil if there is nothing to read from / close.
+	lastRetryOffset int64
+	offset          int64     // Current offset within the blob
+	lastSuccessTime time.Time // time.Time{} if N/A
 }
 
 // newBodyReader creates a bodyReader for request path in c.
@@ -44,15 +44,15 @@ func newBodyReader(ctx context.Context, c *dockerClient, path string, firstBody 
 		return nil, err
 	}
 	res := &bodyReader{
-		ctx: ctx,
-		c:   c,
-
+		ctx:                 ctx,
+		c:                   c,
 		path:                path,
 		logURL:              logURL,
-		body:                firstBody,
-		lastRetryOffset:     0,
-		offset:              0,
 		firstConnectionTime: time.Now(),
+
+		body:            firstBody,
+		lastRetryOffset: 0,
+		offset:          0,
 	}
 	return res, nil
 }

--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -198,20 +198,21 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 	}
 }
 
-// millisecondsSinceOptional is like time.Since(tm).Milliseconds, but it returns a floating-point value.
-// If the input time is time.Time{}, it returns math.NaN()
-func millisecondsSinceOptional(tm time.Time) float64 {
+// millisecondsSinceOptional is like currentTime.Sub(tm).Milliseconds, but it returns a floating-point value.
+// If tm is time.Time{}, it returns math.NaN()
+func millisecondsSinceOptional(currentTime time.Time, tm time.Time) float64 {
 	if tm == (time.Time{}) {
 		return math.NaN()
 	}
-	return float64(time.Since(tm).Nanoseconds()) / 1_000_000.0
+	return float64(currentTime.Sub(tm).Nanoseconds()) / 1_000_000.0
 }
 
 // errorIfNotReconnecting makes a heuristic decision whether we should reconnect after err at redactedURL; if so, it returns nil,
 // otherwise it returns an appropriate error to return to the caller (possibly augmented with data about the heuristic)
 func (br *bodyReader) errorIfNotReconnecting(originalErr error, redactedURL string) error {
-	totalTime := millisecondsSinceOptional(br.firstConnectionTime)
-	failureTime := millisecondsSinceOptional(br.lastSuccessTime)
+	currentTime := time.Now()
+	totalTime := millisecondsSinceOptional(currentTime, br.firstConnectionTime)
+	failureTime := millisecondsSinceOptional(currentTime, br.lastSuccessTime)
 	logrus.Debugf("Reading blob body from %s failed (%#v), decision inputs: lastRetryOffset %d, offset %d, %.3f ms since first connection, %.3f ms since last progress",
 		redactedURL, originalErr, br.lastRetryOffset, br.offset, totalTime, failureTime)
 	progress := br.offset - br.lastRetryOffset

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 24
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This is:
- a backport of #1847 
- a backport of #1850 
- A release of 5.24.2

… so that CRI-O can vendor the latest version of the heuristics while remaining on the 5.24 stable branch.

Cc: @vrothberg @umohnani8 