### PR TITLE
Fix builds of the ostree transport

### DIFF
--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -69,7 +69,7 @@ type manifestSchema struct {
 }
 
 type ostreeImageDestination struct {
-	compat impl.Compat
+	impl.Compat
 	impl.PropertyMethodsInitialize
 	stubs.NoPutBlobPartialInitialize
 	stubs.AlwaysSupportsSignatures


### PR DESCRIPTION
I’m afraid I broke this during refactoring; we’ve been releasing broken `ostree` since c/image 5.22.0 (Jul 2022)

It’s tempting to conclude that if no-one has noticed in that time, we really might be able to drop the transport without _noticeably_ breaking API.

This was reported in https://github.com/containers/skopeo/issues/1917 , with the suggestion that the report might volunteer to maintain the transport. So, let’s concentrate the discussion about the future of that transport in that other issue.

---

I have verified that this allows the transport to build; I didn’t actually try using it.