### PR TITLE
copy: replicate manifest list instances with `zstd` compression on `ReplicateZstd:true`

### DIFF
--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -60,9 +60,11 @@ type List interface {
 // ListUpdate includes the fields which a List's UpdateInstances() method will modify.
 // This is publicly visible as c/image/manifest.ListUpdate.
 type ListUpdate struct {
-	Digest    digest.Digest
-	Size      int64
-	MediaType string
+	Digest      digest.Digest
+	Size        int64
+	MediaType   string
+	Platform    *imgspecv1.Platform
+	Annotations map[string]string
 }
 
 // ListPublicFromBlob parses a list of manifests.

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -65,7 +65,12 @@ func (index *OCI1IndexPublic) Instance(instanceDigest digest.Digest) (ListUpdate
 // which the list catalogs.
 func (index *OCI1IndexPublic) UpdateInstances(updates []ListUpdate) error {
 	if len(updates) != len(index.Manifests) {
-		return fmt.Errorf("incorrect number of update entries passed to OCI1Index.UpdateInstances: expected %d, got %d", len(index.Manifests), len(updates))
+		//return fmt.Errorf("incorrect number of update entries passed to OCI1Index.UpdateInstances: expected %d, got %d", len(index.Manifests), len(updates))
+		if len(updates) > len(index.Manifests) {
+			newIndexes := make([]imgspecv1.Descriptor, len(updates))
+			copy(newIndexes, index.Manifests)
+			index.Manifests = newIndexes
+		}
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
@@ -80,6 +85,12 @@ func (index *OCI1IndexPublic) UpdateInstances(updates []ListUpdate) error {
 			return fmt.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had no media type (was %q)", i+1, len(updates), index.Manifests[i].MediaType)
 		}
 		index.Manifests[i].MediaType = updates[i].MediaType
+		if updates[i].Platform != nil {
+			index.Manifests[i].Platform = updates[i].Platform
+		}
+		if len(updates[i].Annotations) != 0 {
+			index.Manifests[i].Annotations = updates[i].Annotations
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Extends copy to support a new operation when copying a manifest list from `src` to `dest` i.e `ReplicateZstd`. When `ReplicateZstd` is set to `true` and copy operation is performed for a manifest list then a copy for all the image will be created and added to the manifest list with compression as `zstd` and appropriate annotation i.e `"io.github.containers.compression.zstd": "true"` will be set on each image.

The CLI tools must use `ReplicateZstd` flag in order to use this new feature.

Example with skopeo

* Here src `docker://localhost:5000/list` only contains two gzip compressed image but while copying skopeo will replicated zstd instances as well

```console
$ ./skopeo copy --all --src-tls-verify=false --dest-tls-verify=false docker://localhost:5000/list docker://localhost/list
Getting image list signatures
Copying 4 of 4 images in list
Copying image sha256:915468dd2aae5e243dbb8d38afc445e8971f7076deade33b81128fdfa42a17a4 (1/4)
Getting image source signatures
Copying blob f5763aacc581 done
Copying blob 0aa932d79126 done
Copying config ba4505248d done
Writing manifest to image destination
Storing signatures
Copying image sha256:f08c3c433a2c73ba643800326a825493a862a438857a227f01ae63e0aa6f3896 (2/4)
Getting image source signatures
Copying blob 1d86523f4719 done
Copying blob 0aa932d79126 done
Copying config 1ea47b71b3 done
Writing manifest to image destination
Storing signatures
Copying image sha256:915468dd2aae5e243dbb8d38afc445e8971f7076deade33b81128fdfa42a17a4 (3/4)
Getting image source signatures
Copying blob f5763aacc581 done
Copying blob 0aa932d79126 done
Copying config ba4505248d done
Writing manifest to image destination
Storing signatures
Copying image sha256:f08c3c433a2c73ba643800326a825493a862a438857a227f01ae63e0aa6f3896 (5/4)
Getting image source signatures
Copying blob 1d86523f4719 done
Copying blob 0aa932d79126 done
Copying config 1ea47b71b3 done
Writing manifest to image destination
Storing signatures
Writing manifest list to image destination
Storing list signatures
```

* output

```json
$ skopeo inspect --tls-verify=false --raw docker://localhost/list | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:915468dd2aae5e243dbb8d38afc445e8971f7076deade33b81128fdfa42a17a4",
      "size": 759,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:f08c3c433a2c73ba643800326a825493a862a438857a227f01ae63e0aa6f3896",
      "size": 759,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2a8521136269bf9113cdf9088288a07cce52850d15b958b43aad6da5dc0115fb",
      "size": 759,
      "annotations": {
        "io.github.containers.compression.zstd": "true"
      },
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4feb1d9bf33b2f771dbee9b5ece774f1b6b4dc49b82bce686e47afd13686dcb5",
      "size": 759,
      "annotations": {
        "io.github.containers.compression.zstd": "true"
      },
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```