### PR TITLE
Remove some inaccurate comments

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -102,8 +102,6 @@ type Options struct {
 
 	// If OciEncryptConfig is non-nil, it indicates that an image should be encrypted.
 	// The encryption options is derived from the construction of EncryptConfig object.
-	// Note: During initial encryption process of a layer, the resultant digest is not known
-	// during creation, so newDigestingReader has to be set with validateDigest = false
 	OciEncryptConfig *encconfig.EncryptConfig
 	// OciEncryptLayers represents the list of layers to encrypt.
 	// If nil, don't encrypt any layers.

--- a/copy/single.go
+++ b/copy/single.go
@@ -357,7 +357,6 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		return err
 	}
 	srcInfosUpdated := false
-	// If we only need to check authorization, no updates required.
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if ic.cannotModifyManifestReason != "" {
 			return fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)


### PR DESCRIPTION
Both the referenced features were dropped in the final version of https://github.com/containers/image/pull/673 which added these comments.