### PR TITLE
Allow using cosign-generated private keys with a "SIGSTORE" type

### DIFF
--- a/signature/sigstore/copied.go
+++ b/signature/sigstore/copied.go
@@ -33,8 +33,10 @@ import (
 // limitations under the License.
 
 const (
-	// from sigstore/cosign/pkg/cosign.cosignPrivateKeyPemType.
+	// from sigstore/cosign/pkg/cosign.CosignPrivateKeyPemType.
 	cosignPrivateKeyPemType = "ENCRYPTED COSIGN PRIVATE KEY"
+	// from sigstore/cosign/pkg/cosign.SigstorePrivateKeyPemType.
+	sigstorePrivateKeyPemType = "ENCRYPTED SIGSTORE PRIVATE KEY"
 )
 
 // from sigstore/cosign/pkg/cosign.loadPrivateKey
@@ -45,7 +47,7 @@ func loadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 	if p == nil {
 		return nil, errors.New("invalid pem block")
 	}
-	if p.Type != cosignPrivateKeyPemType {
+	if p.Type != sigstorePrivateKeyPemType && p.Type != cosignPrivateKeyPemType {
 		return nil, fmt.Errorf("unsupported pem type: %s", p.Type)
 	}
 
@@ -86,7 +88,9 @@ func marshalKeyPair(privateKey crypto.PrivateKey, publicKey crypto.PublicKey, pa
 	// store in PEM format
 	privBytes := pem.EncodeToMemory(&pem.Block{
 		Bytes: encBytes,
-		Type:  cosignPrivateKeyPemType,
+		// Use the older “COSIGN” type name; as of 2023-03-30 cosign’s main branch generates “SIGSTORE” types,
+		// but a version of cosign that can accept them has not yet been released.
+		Type: cosignPrivateKeyPemType,
 	})
 
 	// Now do the public key

--- a/signature/sigstore/copied.go
+++ b/signature/sigstore/copied.go
@@ -33,8 +33,8 @@ import (
 // limitations under the License.
 
 const (
-	// from sigstore/cosign/pkg/cosign.sigstorePrivateKeyPemType.
-	sigstorePrivateKeyPemType = "ENCRYPTED COSIGN PRIVATE KEY"
+	// from sigstore/cosign/pkg/cosign.cosignPrivateKeyPemType.
+	cosignPrivateKeyPemType = "ENCRYPTED COSIGN PRIVATE KEY"
 )
 
 // from sigstore/cosign/pkg/cosign.loadPrivateKey
@@ -45,7 +45,7 @@ func loadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 	if p == nil {
 		return nil, errors.New("invalid pem block")
 	}
-	if p.Type != sigstorePrivateKeyPemType {
+	if p.Type != cosignPrivateKeyPemType {
 		return nil, fmt.Errorf("unsupported pem type: %s", p.Type)
 	}
 
@@ -86,7 +86,7 @@ func marshalKeyPair(privateKey crypto.PrivateKey, publicKey crypto.PublicKey, pa
 	// store in PEM format
 	privBytes := pem.EncodeToMemory(&pem.Block{
 		Bytes: encBytes,
-		Type:  sigstorePrivateKeyPemType,
+		Type:  cosignPrivateKeyPemType,
 	})
 
 	// Now do the public key


### PR DESCRIPTION
Don't (yet) generate them, no released version of cosign can work with them.

Compare Cosign’s change: https://github.com/sigstore/cosign/pull/2735