### PR TITLE
Update, and support, Fulcio v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/opencontainers/selinux v1.11.0
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f
 	github.com/proglottis/gpgme v0.1.3
-	github.com/sigstore/fulcio v1.1.0
+	github.com/sigstore/fulcio v1.2.0
 	github.com/sigstore/rekor v1.1.0
 	github.com/sigstore/sigstore v1.6.0
 	github.com/sirupsen/logrus v1.9.0
@@ -59,6 +59,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -75,7 +76,7 @@ require (
 	github.com/go-playground/validator/v10 v10.12.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-containerregistry v0.13.0 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/trillian v1.5.1 // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/leodido/go-urn v1.2.2 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20230213213521-fdfea0d469b6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,7 @@ github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 h1:IeaD1VDVB
 github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 h1:a4DFiKFJiDRGFD1qIcqGLX/WlUMD9dyLSLDt+9QZgt8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -456,8 +457,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -582,8 +584,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -608,8 +611,11 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
@@ -753,7 +759,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.39.0 h1:oOyhkDq05hPZKItWVBkJ6g6AtGxi+fy7F4JvUV8uhsI=
+github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -775,6 +781,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef/go.mod h1:8AEUvGVi2uQ5b24BIhcr0GCcpd/RNAFWaN2CJFrWIIQ=
@@ -788,8 +796,8 @@ github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sigstore/fulcio v1.1.0 h1:mzzJ05Ccu8Y2inyioklNvc8MpzlGHxu8YqNeTm0dHfU=
-github.com/sigstore/fulcio v1.1.0/go.mod h1:zv1ZQTXZbUwQdRwajlQksc34pRas+2aZYpIZoQBNev8=
+github.com/sigstore/fulcio v1.2.0 h1:I4H764cDbryKXkPtasUvo8bcix/7xLvkxWYWNp+JtWI=
+github.com/sigstore/fulcio v1.2.0/go.mod h1:FS7qpBvOEqs0uEh1+hJxzxtJistWN29ybLtAzFNUi0c=
 github.com/sigstore/rekor v1.1.0 h1:9fjPvW0WERE7VPtSSVSTbDLLOsrNx3RtiIeZ4/1tmDI=
 github.com/sigstore/rekor v1.1.0/go.mod h1:jEOGDGPMURBt9WR50N0rO7X8GZzLE3UQT+ln6BKJ/m0=
 github.com/sigstore/sigstore v1.6.0 h1:0fYHVoUlPU3WM8o3U1jT9SI2lqQE68XbG+qWncXaZC8=
@@ -1106,6 +1114,7 @@ golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1139,6 +1148,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -37,26 +37,26 @@ func (f *fulcioTrustRoot) validate() error {
 // it fails if the extension is not present in the certificate, or on any inconsistency.
 func fulcioIssuerInCertificate(untrustedCertificate *x509.Certificate) (string, error) {
 	// == Validate the recorded OIDC issuer
-	gotOIDCIssuer := false
-	var oidcIssuer string
+	gotOIDCIssuer1 := false
+	var oidcIssuer1 string
 	// certificate.ParseExtensions doesn’t reject duplicate extensions.
 	// Go 1.19 rejects duplicate extensions universally; but until we can require Go 1.19,
 	// reject duplicates manually. With Go 1.19, we could call certificate.ParseExtensions again.
 	for _, untrustedExt := range untrustedCertificate.Extensions {
 		if untrustedExt.Id.Equal(certificate.OIDIssuer) {
-			if gotOIDCIssuer {
+			if gotOIDCIssuer1 {
 				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
 				// already in ParseCertificate.
 				return "", internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer extension")
 			}
-			oidcIssuer = string(untrustedExt.Value)
-			gotOIDCIssuer = true
+			oidcIssuer1 = string(untrustedExt.Value)
+			gotOIDCIssuer1 = true
 		}
 	}
-	if !gotOIDCIssuer {
+	if !gotOIDCIssuer1 {
 		return "", internal.NewInvalidSignatureError("Fulcio certificate is missing the issuer extension")
 	}
-	return oidcIssuer, nil
+	return oidcIssuer1, nil
 }
 
 func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte) (crypto.PublicKey, error) {

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -43,7 +43,7 @@ func fulcioIssuerInCertificate(untrustedCertificate *x509.Certificate) (string, 
 	// Go 1.19 rejects duplicate extensions universally; but until we can require Go 1.19,
 	// reject duplicates manually. With Go 1.19, we could call certificate.ParseExtensions again.
 	for _, untrustedExt := range untrustedCertificate.Extensions {
-		if untrustedExt.Id.Equal(certificate.OIDIssuer) {
+		if untrustedExt.Id.Equal(certificate.OIDIssuer) { //nolint:staticcheck // This is deprecated, but we must continue to accept it.
 			if gotOIDCIssuer1 {
 				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
 				// already in ParseCertificate.

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -38,25 +38,51 @@ func (f *fulcioTrustRoot) validate() error {
 func fulcioIssuerInCertificate(untrustedCertificate *x509.Certificate) (string, error) {
 	// == Validate the recorded OIDC issuer
 	gotOIDCIssuer1 := false
-	var oidcIssuer1 string
-	// certificate.ParseExtensions doesn’t reject duplicate extensions.
+	gotOIDCIssuer2 := false
+	var oidcIssuer1, oidcIssuer2 string
+	// certificate.ParseExtensions doesn’t reject duplicate extensions, and doesn’t detect inconsistencies
+	// between certificate.OIDIssuer and certificate.OIDIssuerV2.
 	// Go 1.19 rejects duplicate extensions universally; but until we can require Go 1.19,
-	// reject duplicates manually. With Go 1.19, we could call certificate.ParseExtensions again.
+	// reject duplicates manually.
 	for _, untrustedExt := range untrustedCertificate.Extensions {
 		if untrustedExt.Id.Equal(certificate.OIDIssuer) { //nolint:staticcheck // This is deprecated, but we must continue to accept it.
 			if gotOIDCIssuer1 {
 				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
 				// already in ParseCertificate.
-				return "", internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer extension")
+				return "", internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer v1 extension")
 			}
 			oidcIssuer1 = string(untrustedExt.Value)
 			gotOIDCIssuer1 = true
+		} else if untrustedExt.Id.Equal(certificate.OIDIssuerV2) {
+			if gotOIDCIssuer2 {
+				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
+				// already in ParseCertificate.
+				return "", internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer v2 extension")
+			}
+			rest, err := asn1.Unmarshal(untrustedExt.Value, &oidcIssuer2)
+			if err != nil {
+				return "", internal.NewInvalidSignatureError(fmt.Sprintf("invalid ASN.1 in OIDC issuer v2 extension: %v", err))
+			}
+			if len(rest) != 0 {
+				return "", internal.NewInvalidSignatureError("invalid ASN.1 in OIDC issuer v2 extension, trailing data")
+			}
+			gotOIDCIssuer2 = true
 		}
 	}
-	if !gotOIDCIssuer1 {
+	switch {
+	case gotOIDCIssuer1 && gotOIDCIssuer2:
+		if oidcIssuer1 != oidcIssuer2 {
+			return "", internal.NewInvalidSignatureError(fmt.Sprintf("inconsistent OIDC issuer extension values: v1 %#v, v2 %#v",
+				oidcIssuer1, oidcIssuer2))
+		}
+		return oidcIssuer1, nil
+	case gotOIDCIssuer1:
+		return oidcIssuer1, nil
+	case gotOIDCIssuer2:
+		return oidcIssuer2, nil
+	default:
 		return "", internal.NewInvalidSignatureError("Fulcio certificate is missing the issuer extension")
 	}
-	return oidcIssuer1, nil
 }
 
 func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte) (crypto.PublicKey, error) {

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -33,6 +33,32 @@ func (f *fulcioTrustRoot) validate() error {
 	return nil
 }
 
+// fulcioIssuerInCertificate returns the OIDC issuer recorded by Fulcio in unutrustedCertificate;
+// it fails if the extension is not present in the certificate, or on any inconsistency.
+func fulcioIssuerInCertificate(untrustedCertificate *x509.Certificate) (string, error) {
+	// == Validate the recorded OIDC issuer
+	gotOIDCIssuer := false
+	var oidcIssuer string
+	// certificate.ParseExtensions doesn’t reject duplicate extensions.
+	// Go 1.19 rejects duplicate extensions universally; but until we can require Go 1.19,
+	// reject duplicates manually. With Go 1.19, we could call certificate.ParseExtensions again.
+	for _, untrustedExt := range untrustedCertificate.Extensions {
+		if untrustedExt.Id.Equal(certificate.OIDIssuer) {
+			if gotOIDCIssuer {
+				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
+				// already in ParseCertificate.
+				return "", internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer extension")
+			}
+			oidcIssuer = string(untrustedExt.Value)
+			gotOIDCIssuer = true
+		}
+	}
+	if !gotOIDCIssuer {
+		return "", internal.NewInvalidSignatureError("Fulcio certificate is missing the issuer extension")
+	}
+	return oidcIssuer, nil
+}
+
 func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte) (crypto.PublicKey, error) {
 	// == Verify the certificate is correctly signed
 	var untrustedIntermediatePool *x509.CertPool // = nil
@@ -113,24 +139,9 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	// make the SCT (and all of Rekor apart from the trusted timestamp) unnecessary.
 
 	// == Validate the recorded OIDC issuer
-	gotOIDCIssuer := false
-	var oidcIssuer string
-	// certificate.ParseExtensions doesn’t reject duplicate extensions.
-	// Go 1.19 rejects duplicate extensions universally; but until we can require Go 1.19,
-	// reject duplicates manually. With Go 1.19, we could call certificate.ParseExtensions again.
-	for _, untrustedExt := range untrustedCertificate.Extensions {
-		if untrustedExt.Id.Equal(certificate.OIDIssuer) {
-			if gotOIDCIssuer {
-				// Coverage: This is unreachable in Go ≥1.19, which rejects certificates with duplicate extensions
-				// already in ParseCertificate.
-				return nil, internal.NewInvalidSignatureError("Fulcio certificate has a duplicate OIDC issuer extension")
-			}
-			oidcIssuer = string(untrustedExt.Value)
-			gotOIDCIssuer = true
-		}
-	}
-	if !gotOIDCIssuer {
-		return nil, internal.NewInvalidSignatureError("Fulcio certificate is missing the issuer extension")
+	oidcIssuer, err := fulcioIssuerInCertificate(untrustedCertificate)
+	if err != nil {
+		return nil, err
 	}
 	if oidcIssuer != f.oidcIssuer {
 		return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Unexpected Fulcio OIDC issuer %q", oidcIssuer))

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -69,8 +69,25 @@ func oidIssuerV1Ext(value string) pkix.Extension {
 	}
 }
 
+// asn1MarshalTest is asn1.MarshalWithParams that must not fail
+func asn1MarshalTest(t *testing.T, value any, params string) []byte {
+	bytes, err := asn1.MarshalWithParams(value, params)
+	require.NoError(t, err)
+	return bytes
+}
+
+// oidIssuerV2Ext creates an certificate.OIDIssuerV2 extension
+func oidIssuerV2Ext(t *testing.T, value string) pkix.Extension {
+	return pkix.Extension{
+		Id:    certificate.OIDIssuerV2,
+		Value: asn1MarshalTest(t, value, "utf8"),
+	}
+}
+
 func TestFulcioIssuerInCertificate(t *testing.T) {
 	referenceTime := time.Now()
+	fulcioExtensions, err := certificate.Extensions{Issuer: "https://github.com/login/oauth"}.Render()
+	require.NoError(t, err)
 	for _, c := range []struct {
 		name          string
 		extensions    []pkix.Extension
@@ -83,7 +100,7 @@ func TestFulcioIssuerInCertificate(t *testing.T) {
 			errorFragment: "Fulcio certificate is missing the issuer extension",
 		},
 		{
-			name: "Duplicate issuer extension",
+			name: "Duplicate issuer v1 extension",
 			extensions: []pkix.Extension{
 				oidIssuerV1Ext("https://github.com/login/oauth"),
 				oidIssuerV1Ext("this does not match"),
@@ -92,8 +109,63 @@ func TestFulcioIssuerInCertificate(t *testing.T) {
 			errorFragment: "duplicate",
 		},
 		{
-			name:       "One valid issuer",
+			name: "Duplicate issuer v2 extension",
+			extensions: []pkix.Extension{
+				oidIssuerV2Ext(t, "https://github.com/login/oauth"),
+				oidIssuerV2Ext(t, "this does not match"),
+			},
+			// Match both our message and the Go 1.19 message: "certificate contains duplicate extensions"
+			errorFragment: "duplicate",
+		},
+		{
+			name: "Completely invalid issuer v2 extension - error parsing",
+			extensions: []pkix.Extension{
+				{
+					Id:    certificate.OIDIssuerV2,
+					Value: asn1MarshalTest(t, 1, ""), // not a string type
+				},
+			},
+			errorFragment: "invalid ASN.1 in OIDC issuer v2 extension: asn1: structure error",
+		},
+		{
+			name: "Completely invalid issuer v2 extension - trailing data",
+			extensions: []pkix.Extension{
+				{
+					Id:    certificate.OIDIssuerV2,
+					Value: append(asn1MarshalTest(t, "https://", "utf8"), asn1MarshalTest(t, "example.com", "utf8")...),
+				},
+			},
+			errorFragment: "invalid ASN.1 in OIDC issuer v2 extension, trailing data",
+		},
+		{
+			name:       "One valid issuer v1",
 			extensions: []pkix.Extension{oidIssuerV1Ext("https://github.com/login/oauth")},
+			expected:   "https://github.com/login/oauth",
+		},
+		{
+			name:       "One valid issuer v2",
+			extensions: []pkix.Extension{oidIssuerV2Ext(t, "https://github.com/login/oauth")},
+			expected:   "https://github.com/login/oauth",
+		},
+		{
+			name: "Inconsistent issuer v1 and v2",
+			extensions: []pkix.Extension{
+				oidIssuerV1Ext("https://github.com/login/oauth"),
+				oidIssuerV2Ext(t, "this does not match"),
+			},
+			errorFragment: "inconsistent OIDC issuer extension values",
+		},
+		{
+			name: "Both issuer v1 and v2",
+			extensions: []pkix.Extension{
+				oidIssuerV1Ext("https://github.com/login/oauth"),
+				oidIssuerV2Ext(t, "https://github.com/login/oauth"),
+			},
+			expected: "https://github.com/login/oauth",
+		},
+		{
+			name:       "Fulcio interoperability",
+			extensions: fulcioExtensions,
 			expected:   "https://github.com/login/oauth",
 		},
 	} {

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -64,7 +64,7 @@ func TestFulcioTrustRootValidate(t *testing.T) {
 // oidIssuerV1Ext creates an certificate.OIDIssuer extension
 func oidIssuerV1Ext(value string) pkix.Extension {
 	return pkix.Extension{
-		Id:    certificate.OIDIssuer,
+		Id:    certificate.OIDIssuer, //nolint:staticcheck // This is deprecated, but we must continue to accept it.
 		Value: []byte(value),
 	}
 }


### PR DESCRIPTION
v1.2.0 deprecates an existing certificate extension, and introduces a new one. So, support that.

Tested _only_ using unit tests, not against a real certificate; at least the public Fulcio server does not yet generate the new extension.