### PR TITLE
Release 5.25.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 24
+	VersionMinor = 25
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 3
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 25
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Registry accesses now benefit from HTTP keep-alives, instead of making a separate connection for each request.

If an image provides a Zstd variant, it is now read preferentially.

Image copies preserve OCI layer descriptor annotations in more (but not all) cases.

Now requires Go 1.18.

- Convert openshift from ghodss/yaml to gopkg.in/yaml.v3
- Convert docker from ghodss/yaml to yaml.v3
- Add a more specific error message on invalid docker-config-in-OCI-image images
- Cirrus: Use human-readable CI VM Images
- Update to github.com/vbauerster/mpb/v8
- Update to docker/docker v23.0.0
- Manually add dependencies of github.com/docker/docker
- go mod tidy -go=1.18
- Use bytes.Cut instead of bytes.Index
- Use strings.Cut instead of strings.SplitN
- Use golang.org/x/exp to avoid open-coded loops.
- Add internal/set, use it
- s/interface{}/any/g
- Use struct{} instead of interface{} for close-only channels
- Make policyJSONUmarshallerTests generic over the used type/interface
- Use net/netip.Addr instead of net.IP
- Update to golangci-lint 1.51.0
- Close http.Response.Body
- Remove duplicate words in comments
- Correctly propagate wrapped errors
- Don't use an unofficial println function
- Reformat import sections
- Use short-form assignments in various places
- Start a local variable name with lower case
- Fix some comments
- Add comment punctuation
- Remove an unnecessary else
- Update a doc string
- Don't use an underscore in variable name
- Fix a typo in an error message
- Pre-allocate arrays of known size
- Avoid an unused parameter warning
- Remove an unused error return value
- Remove unexpected blank lines
- Split dockerClient.resolveRequestURL from makeRequest
- Reconnecting blob reader
- manifest: introduce internal/manifest.ListInternal and freeze manifest.List
- Disable dependabot
- Run codespell on codebase
- Use DialContext instead of the deprecated Dial.
- Remove a direct use of golang.org/x/net/http2
- Merge pullSource tests as table driven format
- Reorder bodyReader fields to separate constants and state
- Turn millisecondsSince into millisecondsSinceOptional
- Only get current time once in errorIfNotReconnecting
- Rename some variables
- Also record, and output, the time of last retry, if any
- Relax retry heuristics
- Differentiate between no retry and immediate retry also in the printed offset
- Add unit tests for the retry heuristics
- Simplify bodyReader.errorIfNotReconnecting
- Fix various unused parameters
- Avoid importing the same subpackage twice
- Make it clear that cleartext signatures are not accepted in simple signing
- Make SigstoreFromBlobChunk package-private
- Make fields of untrustedSignature private
- Make fields of UntrustedSigstorePayload private
- distribution: remove use of deprecated dial.DualStack
- Fix builds of the ostree transport
- manifest,zstd: give priority to zstd compressed images
- copy: Image use ChooseInstanceByCompression
- oci_index: optimize lookup when platform is nil
- client: enable HTTP(S) keep-alive
- Move copyOneImage, imageCopier, and exclusive callees, to copy/single.go
- Reorder copy/single.go a bit
- Move copyMultipleImages to copy/multiple.go
- Reorder copy/copy.go a bit
- Move compression-specific variables to copy/compression.go
- Rename copyOneImage to copySingleImage
- Remove some inaccurate comments
- copy: move c.compression* to imageCopier
- Don't claim auth.json contains encrypted information
- refactor(docs): Disambiguate sigstoreSigned documentation
- Cirrus: Replace Ubuntu container w/ Debian VM
- Fix golangci-lint cache location error
- Fix a potential recursion when committing unknown blobs
- Don't use manifest.LayerInfo in storageImageDestination.indexToPulledLayerInfo
- Rename the blob parameter of commitLayer to info
- Pass individual parameter instead of types.BlobInfo to tryReusingBlobAsPending
- Use only the necesary fields in addedLayerInfo
- Rename addedLayerInfo.Digest to digest
- Don't track layer size in addedLayerInfo
- Return private.ReusedBlob from TryReusingBlobWithOptions
- Return private.UploadedBlob from PutBlobWithOptions
- Return UploadedBlob also from PutBlobPartial
- Rename sigstorePrivateKeyPemType to cosignPrivateKeyPemType
- Allow using cosign-generated private keys with a "SIGSTORE" type
- Introduce oidIssuerV1Ext
- Split fulcioIssuerInCertificate from fulcioTrustRoot.verifyFulcioCertificateAtTime
- Rename oidcIssuer and gotOIDCIssuer to oidcIssuer1 and gotOIDCIssuer1
- Update to github.com/sigstore/fulcio v1.2.0
- Add support for the Fulcio OIDIssuerV2 extension
- Add ability to verify a signature with a set of fingerprints
- Fix a repeated typo
- Add FIXMEs about handling of zstd:chunked blob annotations on blob changes
