### PR TITLE
copy/manifest: skip conversion if destSupportedManifestMIMETypes=nil

### DIFF
--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -76,7 +76,7 @@ func determineManifestConversion(in determineManifestConversionInputs) (manifest
 		destSupportedManifestMIMETypes = []string{in.forceManifestMIMEType}
 	}
 
-	if len(destSupportedManifestMIMETypes) == 0 && (!in.requiresOCIEncryption || manifest.MIMETypeSupportsEncryption(srcType)) {
+	if len(destSupportedManifestMIMETypes) == 0 {
 		return manifestConversionPlan{ // Anything goes; just use the original as is, do not try any conversions.
 			preferredMIMEType:       srcType,
 			otherMIMETypeCandidates: []string{},


### PR DESCRIPTION
As described in https://github.com/containers/image/issues/1919,  the `destSupportedManifestMIMETypes`  is empty when the destination format is local directory, which results in `prioritizedTypes.list` is empty and causing the error: `no candidate MIME types`. Maybe we can skip the conversion if the `destSupportedManifestMIMETypes` is empty.

Fixed: #1919 

Signed-off-by: ChengyuZhu6 [chengyu.zhu@intel.com](mailto:chengyu.zhu@intel.com)
