### PR TITLE
Don't completely silently ignore non-OCI manifests in OCI layouts

### DIFF
--- a/oci/layout/fixtures/name_lookups/index.json
+++ b/oci/layout/fixtures/name_lookups/index.json
@@ -1,0 +1,38 @@
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "size": 1,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "a"
+            }
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "size": 2,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "b"
+            }
+        },
+        {
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "size": 3,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "invalid-mime"
+            }
+        },
+        {
+            "mediaType": "x-completely-unknown",
+            "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "size": 4,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "invalid-mime"
+            }
+        }
+    ]
+}

--- a/oci/layout/fixtures/two_images_manifest/index.json
+++ b/oci/layout/fixtures/two_images_manifest/index.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 2,
-  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
-      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "size": 7143,
       "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
       "platform": {
@@ -12,7 +12,7 @@
       }
     },
     {
-      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "size": 7682,
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {


### PR DESCRIPTION
Instead, report that we did find a match and that it is not supported.

Partially fixes https://github.com/containers/skopeo/issues/1975 .

Also, significantly improve unit tests of that code.