### PR TITLE
Simplify the tarball: transport

### DIFF
--- a/docker/distribution_error_test.go
+++ b/docker/distribution_error_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 func TestHandleErrorResponse401ValidBody(t *testing.T) {
-	json := "{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"action requires authentication\"}]}"
+	json := []byte("{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"action requires authentication\"}]}")
 	response := &http.Response{
 		Status:     "401 Unauthorized",
 		StatusCode: 401,
-		Body:       io.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewReader(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -39,11 +39,11 @@ func TestHandleErrorResponse401ValidBody(t *testing.T) {
 }
 
 func TestHandleErrorResponse401WithInvalidBody(t *testing.T) {
-	json := "{invalid json}"
+	json := []byte("{invalid json}")
 	response := &http.Response{
 		Status:     "401 Unauthorized",
 		StatusCode: 401,
-		Body:       io.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewReader(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -54,11 +54,11 @@ func TestHandleErrorResponse401WithInvalidBody(t *testing.T) {
 }
 
 func TestHandleErrorResponseExpectedStatusCode400ValidBody(t *testing.T) {
-	json := "{\"errors\":[{\"code\":\"DIGEST_INVALID\",\"message\":\"provided digest does not match\"}]}"
+	json := []byte("{\"errors\":[{\"code\":\"DIGEST_INVALID\",\"message\":\"provided digest does not match\"}]}")
 	response := &http.Response{
 		Status:     "400 Bad Request",
 		StatusCode: 400,
-		Body:       io.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewReader(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -69,11 +69,11 @@ func TestHandleErrorResponseExpectedStatusCode400ValidBody(t *testing.T) {
 }
 
 func TestHandleErrorResponseExpectedStatusCode404EmptyErrorSlice(t *testing.T) {
-	json := `{"randomkey": "randomvalue"}`
+	json := []byte(`{"randomkey": "randomvalue"}`)
 	response := &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: 404,
-		Body:       io.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewReader(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -84,11 +84,11 @@ func TestHandleErrorResponseExpectedStatusCode404EmptyErrorSlice(t *testing.T) {
 }
 
 func TestHandleErrorResponseExpectedStatusCode404InvalidBody(t *testing.T) {
-	json := "{invalid json}"
+	json := []byte("{invalid json}")
 	response := &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: 404,
-		Body:       io.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewReader(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -102,7 +102,7 @@ func TestHandleErrorResponseUnexpectedStatusCode501(t *testing.T) {
 	response := &http.Response{
 		Status:     "501 Not Implemented",
 		StatusCode: 501,
-		Body:       io.NopCloser(bytes.NewBufferString("{\"Error Encountered\" : \"Function not implemented.\"}")),
+		Body:       io.NopCloser(bytes.NewReader([]byte("{\"Error Encountered\" : \"Function not implemented.\"}"))),
 	}
 	err := handleErrorResponse(response)
 

--- a/docker/distribution_error_test.go
+++ b/docker/distribution_error_test.go
@@ -23,18 +23,12 @@ import (
 	"testing"
 )
 
-type nopCloser struct {
-	io.Reader
-}
-
-func (nopCloser) Close() error { return nil }
-
 func TestHandleErrorResponse401ValidBody(t *testing.T) {
 	json := "{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"action requires authentication\"}]}"
 	response := &http.Response{
 		Status:     "401 Unauthorized",
 		StatusCode: 401,
-		Body:       nopCloser{bytes.NewBufferString(json)},
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -49,7 +43,7 @@ func TestHandleErrorResponse401WithInvalidBody(t *testing.T) {
 	response := &http.Response{
 		Status:     "401 Unauthorized",
 		StatusCode: 401,
-		Body:       nopCloser{bytes.NewBufferString(json)},
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -64,7 +58,7 @@ func TestHandleErrorResponseExpectedStatusCode400ValidBody(t *testing.T) {
 	response := &http.Response{
 		Status:     "400 Bad Request",
 		StatusCode: 400,
-		Body:       nopCloser{bytes.NewBufferString(json)},
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -79,7 +73,7 @@ func TestHandleErrorResponseExpectedStatusCode404EmptyErrorSlice(t *testing.T) {
 	response := &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: 404,
-		Body:       nopCloser{bytes.NewBufferString(json)},
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -94,7 +88,7 @@ func TestHandleErrorResponseExpectedStatusCode404InvalidBody(t *testing.T) {
 	response := &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: 404,
-		Body:       nopCloser{bytes.NewBufferString(json)},
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 	}
 	err := handleErrorResponse(response)
 
@@ -108,7 +102,7 @@ func TestHandleErrorResponseUnexpectedStatusCode501(t *testing.T) {
 	response := &http.Response{
 		Status:     "501 Not Implemented",
 		StatusCode: 501,
-		Body:       nopCloser{bytes.NewBufferString("{\"Error Encountered\" : \"Function not implemented.\"}")},
+		Body:       io.NopCloser(bytes.NewBufferString("{\"Error Encountered\" : \"Function not implemented.\"}")),
 	}
 	err := handleErrorResponse(response)
 

--- a/sif/src.go
+++ b/sif/src.go
@@ -180,7 +180,7 @@ func (s *sifImageSource) Close() error {
 func (s *sifImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	switch info.Digest {
 	case s.configDigest:
-		return io.NopCloser(bytes.NewBuffer(s.config)), int64(len(s.config)), nil
+		return io.NopCloser(bytes.NewReader(s.config)), int64(len(s.config)), nil
 	case s.layerDigest:
 		reader, err := os.Open(s.layerFile)
 		if err != nil {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -379,7 +379,7 @@ func TestWriteRead(t *testing.T) {
 			compression = archive.Gzip
 		}
 		digest, decompressedSize, size, blob := makeLayer(t, compression)
-		if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+		if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 			Size:   size,
 			Digest: digest,
 		}, cache, false); err != nil {
@@ -557,7 +557,7 @@ func TestDuplicateName(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Uncompressed)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -598,7 +598,7 @@ func TestDuplicateName(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -656,7 +656,7 @@ func TestDuplicateID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -697,7 +697,7 @@ func TestDuplicateID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -758,7 +758,7 @@ func TestDuplicateNameID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, first pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -799,7 +799,7 @@ func TestDuplicateNameID(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q, second pass) returned no destination", ref.StringWithinTransport())
 	}
 	digest, _, size, blob = makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size,
 		Digest: digest,
 	}, cache, false); err != nil {
@@ -909,14 +909,14 @@ func TestSize(t *testing.T) {
 		t.Fatalf("Error saving config to destination: %v", err)
 	}
 	digest1, usize1, size1, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination: %v", err)
 	}
 	digest2, usize2, size2, blob := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, cache, false); err != nil {
@@ -1004,26 +1004,26 @@ func TestDuplicateBlob(t *testing.T) {
 		t.Fatalf("NewImageDestination(%q) returned no destination", ref.StringWithinTransport())
 	}
 	digest1, _, size1, blob1 := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob1), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob1), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination (first copy): %v", err)
 	}
 	digest2, _, size2, blob2 := makeLayer(t, archive.Gzip)
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob2), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob2), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 2 to destination (first copy): %v", err)
 	}
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob1), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob1), types.BlobInfo{
 		Size:   size1,
 		Digest: digest1,
 	}, cache, false); err != nil {
 		t.Fatalf("Error saving randomly-generated layer 1 to destination (second copy): %v", err)
 	}
-	if _, err := dest.PutBlob(context.Background(), bytes.NewBuffer(blob2), types.BlobInfo{
+	if _, err := dest.PutBlob(context.Background(), bytes.NewReader(blob2), types.BlobInfo{
 		Size:   size2,
 		Digest: digest2,
 	}, cache, false); err != nil {

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -67,7 +67,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		} else {
 			file, err := os.Open(filename)
 			if err != nil {
-				return nil, fmt.Errorf("error opening %q for reading: %w", filename, err)
+				return nil, err
 			}
 			defer file.Close()
 			reader = file
@@ -213,7 +213,7 @@ func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobIn
 	}
 	reader, err := os.Open(blob.filename)
 	if err != nil {
-		return nil, -1, fmt.Errorf("error opening %q: %v", blob.filename, err)
+		return nil, -1, err
 	}
 	return reader, blob.size, nil
 }

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -40,7 +40,6 @@ type tarballImageSource struct {
 
 func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
 	// Gather up the digests, sizes, and date information for all of the files.
-	filenames := []string{}
 	diffIDs := []digest.Digest{}
 	blobIDs := []digest.Digest{}
 	blobSizes := []int64{}
@@ -97,7 +96,6 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		}
 
 		// Grab our uncompressed and possibly-compressed digests and sizes.
-		filenames = append(filenames, filename)
 		diffIDs = append(diffIDs, diffIDdigester.Digest())
 		blobIDs = append(blobIDs, blobIDdigester.Digest())
 		blobSizes = append(blobSizes, blobSize)
@@ -187,7 +185,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		NoGetBlobAtInitialize: stubs.NoGetBlobAt(r),
 
 		reference: *r,
-		filenames: filenames,
+		filenames: slices.Clone(r.filenames),
 		blobIDs:   blobIDs,
 		blobSizes: blobSizes,
 		config:    configBytes,

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -47,8 +47,6 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	blobTimes := []time.Time{}
 	blobTypes := []string{}
 	for _, filename := range r.filenames {
-		var file *os.File
-		var err error
 		var blobSize int64
 		var blobTime time.Time
 		var reader io.Reader
@@ -57,7 +55,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 			blobTime = time.Now()
 			reader = bytes.NewReader(r.stdin)
 		} else {
-			file, err = os.Open(filename)
+			file, err := os.Open(filename)
 			if err != nil {
 				return nil, fmt.Errorf("error opening %q for reading: %w", filename, err)
 			}

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -31,11 +31,8 @@ type tarballImageSource struct {
 
 	reference  tarballReference
 	filenames  []string
-	diffIDs    []digest.Digest
-	diffSizes  []int64
 	blobIDs    []digest.Digest
 	blobSizes  []int64
-	blobTypes  []string
 	config     []byte
 	configID   digest.Digest
 	configSize int64
@@ -46,7 +43,6 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	// Gather up the digests, sizes, and date information for all of the files.
 	filenames := []string{}
 	diffIDs := []digest.Digest{}
-	diffSizes := []int64{}
 	blobIDs := []digest.Digest{}
 	blobSizes := []int64{}
 	blobTimes := []time.Time{}
@@ -96,8 +92,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 			uncompressed = nil
 		}
 		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-		n, err := io.Copy(io.Discard, reader)
-		if err != nil {
+		if _, err := io.Copy(io.Discard, reader); err != nil {
 			return nil, fmt.Errorf("error reading %q: %v", filename, err)
 		}
 		if uncompressed != nil {
@@ -107,7 +102,6 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		// Grab our uncompressed and possibly-compressed digests and sizes.
 		filenames = append(filenames, filename)
 		diffIDs = append(diffIDs, diffIDdigester.Digest())
-		diffSizes = append(diffSizes, n)
 		blobIDs = append(blobIDs, blobIDdigester.Digest())
 		blobSizes = append(blobSizes, blobSize)
 		blobTimes = append(blobTimes, blobTime)
@@ -198,11 +192,8 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 
 		reference:  *r,
 		filenames:  filenames,
-		diffIDs:    diffIDs,
-		diffSizes:  diffSizes,
 		blobIDs:    blobIDs,
 		blobSizes:  blobSizes,
-		blobTypes:  blobTypes,
 		config:     configBytes,
 		configID:   configID,
 		configSize: configSize,

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -214,7 +214,7 @@ func (is *tarballImageSource) Close() error {
 func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
 	// We should only be asked about things in the manifest.  Maybe the configuration blob.
 	if blobinfo.Digest == is.configID {
-		return io.NopCloser(bytes.NewBuffer(is.config)), is.configSize, nil
+		return io.NopCloser(bytes.NewReader(is.config)), is.configSize, nil
 	}
 	// Maybe one of the layer blobs.
 	i := slices.Index(is.blobIDs, blobinfo.Digest)
@@ -223,7 +223,7 @@ func (is *tarballImageSource) GetBlob(ctx context.Context, blobinfo types.BlobIn
 	}
 	// We want to read that layer: open the file or memory block and hand it back.
 	if is.filenames[i] == "-" {
-		return io.NopCloser(bytes.NewBuffer(is.reference.stdin)), int64(len(is.reference.stdin)), nil
+		return io.NopCloser(bytes.NewReader(is.reference.stdin)), int64(len(is.reference.stdin)), nil
 	}
 	reader, err := os.Open(is.filenames[i])
 	if err != nil {


### PR DESCRIPTION
Track layer data in a single `map[digest]struct` instead of 6 separate arrays, some completely unused, and other fields.

Also simplify how that data is created, and fix pedantically-invalid uses of `bytes.NewBuffer`.

See individual commit messages for details.

(Motivated by https://github.com/containers/podman/issues/18193 but this doesn’t do anything to actually fix it.)