### PR TITLE
Fix conversion determination when encrypting

### DIFF
--- a/copy/blob.go
+++ b/copy/blob.go
@@ -43,7 +43,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 	stream.reader = bar.ProxyReader(stream.reader)
 
 	// === Decrypt the stream, if required.
-	decryptionStep, err := ic.c.blobPipelineDecryptionStep(&stream, srcInfo)
+	decryptionStep, err := ic.blobPipelineDecryptionStep(&stream, srcInfo)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -78,7 +78,7 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		// Before relaxing this, see the original pull request’s review if there are other reasons to reject this.
 		return types.BlobInfo{}, errors.New("Unable to support both decryption and encryption in the same copy")
 	}
-	encryptionStep, err := ic.c.blobPipelineEncryptionStep(&stream, toEncrypt, srcInfo, decryptionStep)
+	encryptionStep, err := ic.blobPipelineEncryptionStep(&stream, toEncrypt, srcInfo, decryptionStep)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -40,6 +40,10 @@ func (ic *imageCopier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo 
 		}, nil
 	}
 
+	if ic.cannotModifyManifestReason != "" {
+		return nil, fmt.Errorf("layer %s should be decrypted, but we can’t modify the manifest: %s", srcInfo.Digest, ic.cannotModifyManifestReason)
+	}
+
 	desc := imgspecv1.Descriptor{
 		Annotations: stream.info.Annotations,
 	}
@@ -81,6 +85,10 @@ func (ic *imageCopier) blobPipelineEncryptionStep(stream *sourceStream, toEncryp
 		return &bpEncryptionStepData{
 			encrypting: false,
 		}, nil
+	}
+
+	if ic.cannotModifyManifestReason != "" {
+		return nil, fmt.Errorf("layer %s should be encrypted, but we can’t modify the manifest: %s", srcInfo.Digest, ic.cannotModifyManifestReason)
 	}
 
 	var annotations map[string]string


### PR DESCRIPTION
- When encrypting, actually make a choice even if the destination does not care about manifest formats
- Don't try converting to formats that don't support encryption at all
- Fail with a readable error message instead of "internal error"  if we filter out all candidates.
- Explicitly fail encryption/decryption if we can't change the manifest, instead of failing later with an internal error

See individual commit messages for a bit more detail.