### PR TITLE
Propagate `PolicyRequirementError` to API user

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -59,7 +59,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	// (The multiImage check above only matches the MIME type, which we have received anyway.
 	// Actual parsing of anything should be deferred.)
 	if allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
-		return nil, "", "", fmt.Errorf("Source image rejected: %w", err)
+		return nil, "", "", err
 	}
 	src, err := image.FromUnparsedImage(ctx, options.SourceCtx, unparsedImage)
 	if err != nil {

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -253,7 +253,7 @@ func (pc *PolicyContext) GetSignaturesWithAcceptedAuthor(ctx context.Context, pu
 	return res, nil
 }
 
-// IsRunningImageAllowed returns true iff the policy allows running the image.
+// IsRunningImageAllowed returns true if the policy allows running the image.
 // If it returns false, err must be non-nil, and should be an PolicyRequirementError if evaluation
 // succeeded but the result was rejection.
 // WARNING: This validates signatures and the manifest, but does not download or validate the
@@ -283,7 +283,7 @@ func (pc *PolicyContext) IsRunningImageAllowed(ctx context.Context, publicImage 
 		allowed, err := req.isRunningImageAllowed(ctx, image)
 		if !allowed {
 			logrus.Debugf("Requirement %d: denied, done", reqNumber)
-			return false, err
+			return false, PolicyRequirementError(err.Error())
 		}
 		logrus.Debugf(" Requirement %d: allowed", reqNumber)
 	}


### PR DESCRIPTION
Wrapping the error in `copy/single.go` will make a simple check like this not work any more:

```go
var e signature.PolicyRequirementError
if errors.As(err, &e) { }
```

Means we now avoid wrapping the error with another static message.

Beside that, we now wrap the internal errors from
`req.isRunningImageAllowed` as `PolicyRequirementError` to let API consumers know that the signature verification failed.