### PR TITLE
Stop having an opinion on TLS version

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -166,8 +166,6 @@ func newBearerTokenFromJSONBlob(blob []byte) (*bearerToken, error) {
 // We'll drop this once we upgrade to docker 1.13.x deps.
 func serverDefault() *tls.Config {
 	return &tls.Config{
-		// Avoid fallback to SSL protocols < TLS1.0
-		MinVersion:   tls.VersionTLS10,
 		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
 	}
 }

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -161,15 +161,6 @@ func newBearerTokenFromJSONBlob(blob []byte) (*bearerToken, error) {
 	return token, nil
 }
 
-// this is cloned from docker/go-connections because upstream docker has changed
-// it and make deps here fails otherwise.
-// We'll drop this once we upgrade to docker 1.13.x deps.
-func serverDefault() *tls.Config {
-	return &tls.Config{
-		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
-	}
-}
-
 // dockerCertDir returns a path to a directory to be consumed by tlsclientconfig.SetupCertificates() depending on ctx and hostPort.
 func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 	if sys != nil && sys.DockerCertPath != "" {
@@ -252,7 +243,9 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 	if registry == dockerHostname {
 		registry = dockerRegistry
 	}
-	tlsClientConfig := serverDefault()
+	tlsClientConfig := &tls.Config{
+		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
+	}
 
 	// It is undefined whether the host[:port] string for dockerHostname should be dockerHostname or dockerRegistry,
 	// because docker/docker does not read the certs.d subdirectory at all in that case.  We use the user-visible

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -957,8 +957,6 @@ func tlsConfigFor(c *restConfig) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{
-		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
-		MinVersion:         tls.VersionTLS10,
 		InsecureSkipVerify: c.Insecure,
 	}
 


### PR DESCRIPTION
Instead, let Go manage the default; this effectively moves the version from TLS 1.0 to TLS 1.2 (because c/image requires Go 1.18 to compile).

(In the worst case, affected users can disable TLS; we don’t provide any other options.) Compare https://github.com/moby/moby/commit/626c097f8c29bf432e5465a961496bf41aa74cad updating to TLS 1.2; it is similarly not configurable. 

Fixes #1962 .