### PR TITLE
WIP:  Only obtain a bearer token once at a time

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -117,7 +117,8 @@ type dockerClient struct {
 	supportsSignatures bool
 
 	// Private state for setupRequestAuth (key: string, value: bearerToken)
-	tokenCache sync.Map
+	tokenCacheLock sync.Mutex // Protects tokenCache
+	tokenCache     map[string]bearerToken
 	// Private state for detectProperties:
 	detectPropertiesOnce  sync.Once // detectPropertiesOnce is used to execute detectProperties() at most once.
 	detectPropertiesError error     // detectPropertiesError caches the initial error.
@@ -269,6 +270,7 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		registry:         registry,
 		userAgent:        userAgent,
 		tlsClientConfig:  tlsClientConfig,
+		tokenCache:       map[string]bearerToken{},
 		reportedWarnings: set.New[string](),
 	}, nil
 }
@@ -751,10 +753,12 @@ func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challeng
 	}
 
 	var token bearerToken
-	t, inCache := c.tokenCache.Load(cacheKey)
-	if inCache {
-		token = t.(bearerToken)
-	}
+	var inCache bool
+	func() { // A scope for defer
+		c.tokenCacheLock.Lock()
+		defer c.tokenCacheLock.Unlock()
+		token, inCache = c.tokenCache[cacheKey]
+	}()
 	if !inCache || time.Now().After(token.expirationTime) {
 		var (
 			t   *bearerToken
@@ -770,7 +774,11 @@ func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challeng
 		}
 
 		token = *t
-		c.tokenCache.Store(cacheKey, token)
+		func() { // A scope for defer
+			c.tokenCacheLock.Lock()
+			defer c.tokenCacheLock.Unlock()
+			c.tokenCache[cacheKey] = token
+		}()
 	}
 	return token.token, nil
 }

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -728,50 +728,51 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 
 // obtainBearerToken gets an "Authorization: Bearer" token if one is available, or obtains a fresh one.
 func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challenge, extraScope *authScope) (string, error) {
-	registryToken := c.registryToken
-	if registryToken == "" {
-		cacheKey := ""
-		scopes := []authScope{c.scope}
-		if extraScope != nil {
-			// Using ':' as a separator here is unambiguous because getBearerToken below
-			// uses the same separator when formatting a remote request (and because
-			// repository names that we create can't contain colons, and extraScope values
-			// coming from a server come from `parseAuthScope`, which also splits on colons).
-			cacheKey = fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
-			if colonCount := strings.Count(cacheKey, ":"); colonCount != 2 {
-				return "", fmt.Errorf(
-					"Internal error: there must be exactly 2 colons in the cacheKey ('%s') but got %d",
-					cacheKey,
-					colonCount,
-				)
-			}
-			scopes = append(scopes, *extraScope)
-		}
-		var token bearerToken
-		t, inCache := c.tokenCache.Load(cacheKey)
-		if inCache {
-			token = t.(bearerToken)
-		}
-		if !inCache || time.Now().After(token.expirationTime) {
-			var (
-				t   *bearerToken
-				err error
-			)
-			if c.auth.IdentityToken != "" {
-				t, err = c.getBearerTokenOAuth2(ctx, challenge, scopes)
-			} else {
-				t, err = c.getBearerToken(ctx, challenge, scopes)
-			}
-			if err != nil {
-				return "", err
-			}
-
-			token = *t
-			c.tokenCache.Store(cacheKey, token)
-		}
-		registryToken = token.token
+	if c.registryToken != "" {
+		return c.registryToken, nil
 	}
-	return registryToken, nil
+
+	cacheKey := ""
+	scopes := []authScope{c.scope}
+	if extraScope != nil {
+		// Using ':' as a separator here is unambiguous because getBearerToken below
+		// uses the same separator when formatting a remote request (and because
+		// repository names that we create can't contain colons, and extraScope values
+		// coming from a server come from `parseAuthScope`, which also splits on colons).
+		cacheKey = fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
+		if colonCount := strings.Count(cacheKey, ":"); colonCount != 2 {
+			return "", fmt.Errorf(
+				"Internal error: there must be exactly 2 colons in the cacheKey ('%s') but got %d",
+				cacheKey,
+				colonCount,
+			)
+		}
+		scopes = append(scopes, *extraScope)
+	}
+
+	var token bearerToken
+	t, inCache := c.tokenCache.Load(cacheKey)
+	if inCache {
+		token = t.(bearerToken)
+	}
+	if !inCache || time.Now().After(token.expirationTime) {
+		var (
+			t   *bearerToken
+			err error
+		)
+		if c.auth.IdentityToken != "" {
+			t, err = c.getBearerTokenOAuth2(ctx, challenge, scopes)
+		} else {
+			t, err = c.getBearerToken(ctx, challenge, scopes)
+		}
+		if err != nil {
+			return "", err
+		}
+
+		token = *t
+		c.tokenCache.Store(cacheKey, token)
+	}
+	return token.token, nil
 }
 
 func (c *dockerClient) getBearerTokenOAuth2(ctx context.Context, challenge challenge,

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -118,7 +118,7 @@ type dockerClient struct {
 
 	// Private state for setupRequestAuth (key: string, value: bearerToken)
 	tokenCacheLock sync.Mutex // Protects tokenCache
-	tokenCache     map[string]bearerToken
+	tokenCache     map[string]*bearerToken
 	// Private state for detectProperties:
 	detectPropertiesOnce  sync.Once // detectPropertiesOnce is used to execute detectProperties() at most once.
 	detectPropertiesError error     // detectPropertiesError caches the initial error.
@@ -270,7 +270,7 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		registry:         registry,
 		userAgent:        userAgent,
 		tlsClientConfig:  tlsClientConfig,
-		tokenCache:       map[string]bearerToken{},
+		tokenCache:       map[string]*bearerToken{},
 		reportedWarnings: set.New[string](),
 	}, nil
 }
@@ -752,7 +752,7 @@ func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challeng
 		scopes = append(scopes, *extraScope)
 	}
 
-	var token bearerToken
+	var token *bearerToken
 	var inCache bool
 	func() { // A scope for defer
 		c.tokenCacheLock.Lock()
@@ -773,7 +773,7 @@ func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challeng
 			return "", err
 		}
 
-		token = *t
+		token = t
 		func() { // A scope for defer
 			c.tokenCacheLock.Lock()
 			defer c.tokenCacheLock.Unlock()

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -106,7 +106,7 @@ func testTokenHTTPResponse(t *testing.T, body string) *http.Response {
 	}
 }
 
-func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
+func TestBearerTokenReadFromHTTPResponseBody(t *testing.T) {
 	for _, c := range []struct {
 		input    string
 		expected *bearerToken // or nil if a failure is expected
@@ -128,7 +128,8 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 			expected: &bearerToken{token: "IAmAToken", expirationTime: time.Unix(1514800802+60, 0)},
 		},
 	} {
-		token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, c.input))
+		token := &bearerToken{}
+		err := token.readFromHTTPResponseBody(testTokenHTTPResponse(t, c.input))
 		if c.expected == nil {
 			assert.Error(t, err, c.input)
 		} else {
@@ -140,11 +141,12 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 	}
 }
 
-func TestNewBearerTokenFromHTTPResponseBodyIssuedAtZero(t *testing.T) {
+func TestBearerTokenReadFromHTTPResponseBodyIssuedAtZero(t *testing.T) {
 	zeroTime := time.Time{}.Format(time.RFC3339)
 	now := time.Now()
 	tokenBlob := fmt.Sprintf(`{"token":"IAmAToken","expires_in":100,"issued_at":"%s"}`, zeroTime)
-	token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, tokenBlob))
+	token := &bearerToken{}
+	err := token.readFromHTTPResponseBody(testTokenHTTPResponse(t, tokenBlob))
 	require.NoError(t, err)
 	expectedExpiration := now.Add(time.Duration(100) * time.Second)
 	require.False(t, token.expirationTime.Before(expectedExpiration),


### PR DESCRIPTION
Currently, on pushes, we can start several concurrent layer pushes; each one will check for a bearer token in `tokenCache`, find none, and ask the server for one, and then write it into the cache.

So, we can hammer the server with 6 basically-concurrent token requests. That's unnecessary, slower than just asking once, and potentially might impact rate limiting heuristics.

Instead, serialize writes to a bearerToken so that we only have one request in flight at a time.

This does not apply to pulls, where the first request is for a manifest, which obtains a token, so subsequent concurrent layer pulls will not request a token again.

WIP: Clean up the debugging log entries.