### PR TITLE
storage: do not force the UncompressedDigest

### DIFF
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -606,9 +606,6 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 			return err
 		}
 
-		// FIXME: what to do with the uncompressed digest?
-		diffOutput.UncompressedDigest = info.digest
-
 		if err := s.imageRef.transport.store.ApplyDiffFromStagingDirectory(layer.ID, diffOutput.Target, diffOutput, nil); err != nil {
 			_ = s.imageRef.transport.store.Delete(layer.ID)
 			return err


### PR DESCRIPTION
do not force the UncompressedDigest to be the same as the CompressedDigest, but let the storage driver configure it.