### PR TITLE
Use x/exp/slices, and other small cleanups

### DIFF
--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -45,12 +45,9 @@ func (list *Schema2ListPublic) MIMEType() string {
 }
 
 func (list *Schema2ListPublic) descriptorIndex(instanceDigest digest.Digest) int {
-	for i, m := range list.Manifests {
-		if m.Digest == instanceDigest {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(list.Manifests, func(m Schema2ManifestDescriptor) bool {
+		return m.Digest == instanceDigest
+	})
 }
 
 // Instances returns a slice of digests of the manifests that this list knows of.

--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -97,7 +97,7 @@ func (index *Schema2ListPublic) editInstances(editInstances []ListEdit) error {
 				return m.Digest == editInstance.UpdateOldDigest
 			})
 			if targetIndex == -1 {
-				return fmt.Errorf("Schema2List.EditInstances: Attempting to update %s which is an invalid digest", editInstance.UpdateOldDigest)
+				return fmt.Errorf("Schema2List.EditInstances: digest %s not found", editInstance.UpdateOldDigest)
 			}
 			index.Manifests[targetIndex].Digest = editInstance.UpdateDigest
 			if editInstance.UpdateSize < 0 {

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -181,15 +181,15 @@ func (index *OCI1IndexPublic) chooseInstance(ctx *types.SystemContext, preferGzi
 	for manifestIndex, d := range index.Manifests {
 		candidate := instanceCandidate{platformIndex: math.MaxInt, manifestPosition: manifestIndex, isZstd: instanceIsZstd(d), digest: d.Digest}
 		if d.Platform != nil {
+			imagePlatform := imgspecv1.Platform{
+				Architecture: d.Platform.Architecture,
+				OS:           d.Platform.OS,
+				OSVersion:    d.Platform.OSVersion,
+				OSFeatures:   slices.Clone(d.Platform.OSFeatures),
+				Variant:      d.Platform.Variant,
+			}
 			foundPlatform := false
 			for platformIndex, wantedPlatform := range wantedPlatforms {
-				imagePlatform := imgspecv1.Platform{
-					Architecture: d.Platform.Architecture,
-					OS:           d.Platform.OS,
-					OSVersion:    d.Platform.OSVersion,
-					OSFeatures:   slices.Clone(d.Platform.OSFeatures),
-					Variant:      d.Platform.Variant,
-				}
 				if platform.MatchesPlatform(imagePlatform, wantedPlatform) {
 					foundPlatform = true
 					candidate.platformIndex = platformIndex

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -91,7 +91,7 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit) error {
 				return m.Digest == editInstance.UpdateOldDigest
 			})
 			if targetIndex == -1 {
-				return fmt.Errorf("OCI1Index.EditInstances: Attempting to update %s which is an invalid digest", editInstance.UpdateOldDigest)
+				return fmt.Errorf("OCI1Index.EditInstances: digest %s not found", editInstance.UpdateOldDigest)
 			}
 			index.Manifests[targetIndex].Digest = editInstance.UpdateDigest
 			if editInstance.UpdateSize < 0 {


### PR DESCRIPTION
Use x/exp/slices, just like other code in c/image; that will allow us to trivially switch to the standard-library `slices` package coming in Go 1.21.

Also includes other small cleanups in related code.

See individual commit messages for details.