### PR TITLE
copy: implement `instanceCopyClone` for `zstd` compression

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/signer"
 	"github.com/containers/image/v5/transports"
@@ -126,6 +127,21 @@ type Options struct {
 	// Download layer contents with "nondistributable" media types ("foreign" layers) and translate the layer media type
 	// to not indicate "nondistributable".
 	DownloadForeignLayers bool
+
+	// Contains slice of OptionCompressionVariant, where copy will ensure that for each platform
+	// in the manifest list, a variant with the requested compression will exist.
+	// Invalid when copying a non-multi-architecture image. That will probably
+	// change in the future.
+	EnsureCompressionVariantsExist []OptionCompressionVariant
+}
+
+// OptionCompressionVariant allows to supply information about
+// selected compression algorithm and compression level by the
+// end-user. Refer to EnsureCompressionVariantsExist to know
+// more about its usage.
+type OptionCompressionVariant struct {
+	Algorithm compression.Algorithm
+	Level     *int // Only used when we are creating a new image instance using the specified algorithm, not when the image already contains such an instance
 }
 
 // copier allows us to keep track of diffID values for blobs, and other

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -266,6 +266,9 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	if !multiImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// The simple case: just copy a single image.
 		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
@@ -273,6 +276,9 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		copiedManifest = single.manifest
 	} else if c.options.ImageListSelection == CopySystemImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
 		mfest, manifestType, err := c.unparsedToplevel.Manifest(ctx)

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -221,7 +221,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	if err != nil {
 		return nil, fmt.Errorf("preparing instances for copy: %w", err)
 	}
-	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
+	c.Printf("Copying %d images generated from %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
 		// populate necessary fields.

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -110,8 +110,7 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 					clonePlatform:           instanceDetails.ReadOnly.Platform,
 					cloneAnnotations:        maps.Clone(instanceDetails.ReadOnly.Annotations),
 				})
-				// add current compression to the list so logic acks any
-				// duplicates while processing other instances
+				// add current compression to the list so that we don’t create duplicate clones
 				compressionList.Add(compressionVariant.Algorithm.Name())
 			}
 		}
@@ -224,7 +223,10 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Replicating instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Replicating image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: true})
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{
+				requireCompressionFormatMatch: true,
+				compressionFormat:             &instance.cloneCompressionVariant.Algorithm,
+				compressionLevel:              instance.cloneCompressionVariant.Level})
 			if err != nil {
 				return nil, fmt.Errorf("replicating image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -5,15 +5,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
 	internalManifest "github.com/containers/image/v5/internal/manifest"
+	"github.com/containers/image/v5/internal/set"
 	"github.com/containers/image/v5/manifest"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -27,23 +30,97 @@ const (
 type instanceCopy struct {
 	op           instanceCopyKind
 	sourceDigest digest.Digest
+
+	// Fields which can be used by callers when operation
+	// is `instanceCopyClone`
+	cloneCompressionVariant OptionCompressionVariant
+	clonePlatform           *imgspecv1.Platform
+	cloneAnnotations        map[string]string
+}
+
+// internal type only to make imgspecv1.Platform comparable
+type platformComparable struct {
+	architecture string
+	os           string
+	osVersion    string
+	osFeatures   string
+	variant      string
+}
+
+// Converts imgspecv1.Platform to a comparable format.
+func platformV1ToPlatformComparable(platform *imgspecv1.Platform) platformComparable {
+	if platform == nil {
+		return platformComparable{}
+	}
+	osFeatures := slices.Clone(platform.OSFeatures)
+	sort.Strings(osFeatures)
+	return platformComparable{architecture: platform.Architecture,
+		os: platform.OS,
+		// This is strictly speaking ambiguous, fields of OSFeatures can contain a ','. Probably good enough for now.
+		osFeatures: strings.Join(osFeatures, ","),
+		osVersion:  platform.OSVersion,
+		variant:    platform.Variant,
+	}
+}
+
+// platformCompressionMap prepares a mapping of platformComparable -> CompressionAlgorithmNames for given digests
+func platformCompressionMap(list internalManifest.List, instanceDigests []digest.Digest) (map[platformComparable]*set.Set[string], error) {
+	res := make(map[platformComparable]*set.Set[string])
+	for _, instanceDigest := range instanceDigests {
+		instanceDetails, err := list.Instance(instanceDigest)
+		if err != nil {
+			return nil, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
+		}
+		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
+		platformSet, ok := res[platform]
+		if !ok {
+			platformSet = set.New[string]()
+			res[platform] = platformSet
+		}
+		platformSet.AddSlice(instanceDetails.ReadOnly.CompressionAlgorithmNames)
+	}
+	return res, nil
 }
 
 // prepareInstanceCopies prepares a list of instances which needs to copied to the manifest list.
-func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []instanceCopy {
+func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.Digest, options *Options) ([]instanceCopy, error) {
 	res := []instanceCopy{}
+	compressionsByPlatform, err := platformCompressionMap(list, instanceDigests)
+	if err != nil {
+		return nil, err
+	}
 	for i, instanceDigest := range instanceDigests {
 		if options.ImageListSelection == CopySpecificImages &&
 			!slices.Contains(options.Instances, instanceDigest) {
 			logrus.Debugf("Skipping instance %s (%d/%d)", instanceDigest, i+1, len(instanceDigests))
 			continue
 		}
+		instanceDetails, err := list.Instance(instanceDigest)
+		if err != nil {
+			return res, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
+		}
+		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
+		compressionList := compressionsByPlatform[platform]
+		for _, compressionVariant := range options.EnsureCompressionVariantsExist {
+			if !compressionList.Contains(compressionVariant.Algorithm.Name()) {
+				res = append(res, instanceCopy{
+					op:                      instanceCopyClone,
+					sourceDigest:            instanceDigest,
+					cloneCompressionVariant: compressionVariant,
+					clonePlatform:           instanceDetails.ReadOnly.Platform,
+					cloneAnnotations:        maps.Clone(instanceDetails.ReadOnly.Annotations),
+				})
+				// add current compression to the list so logic acks any
+				// duplicates while processing other instances
+				compressionList.Add(compressionVariant.Algorithm.Name())
+			}
+		}
 		res = append(res, instanceCopy{
 			op:           instanceCopyCopy,
 			sourceDigest: instanceDigest,
 		})
 	}
-	return res
+	return res, nil
 }
 
 // copyMultipleImages copies some or all of an image list's instances, using
@@ -118,7 +195,10 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	// Copy each image, or just the ones we want to copy, in turn.
 	instanceDigests := updatedList.Instances()
 	instanceEdits := []internalManifest.ListEdit{}
-	instanceCopyList := prepareInstanceCopies(instanceDigests, c.options)
+	instanceCopyList, err := prepareInstanceCopies(updatedList, instanceDigests, c.options)
+	if err != nil {
+		return nil, fmt.Errorf("preparing instances for copy: %w", err)
+	}
 	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
@@ -140,6 +220,24 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 				UpdateSize:                  int64(len(updated.manifest)),
 				UpdateCompressionAlgorithms: updated.compressionAlgorithms,
 				UpdateMediaType:             updated.manifestMIMEType})
+		case instanceCopyClone:
+			logrus.Debugf("Replicating instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
+			c.Printf("Replicating image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
+			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: true})
+			if err != nil {
+				return nil, fmt.Errorf("replicating image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
+			}
+			// Record the result of a possible conversion here.
+			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
+				ListOperation:            internalManifest.ListOpAdd,
+				AddDigest:                updated.manifestDigest,
+				AddSize:                  int64(len(updated.manifest)),
+				AddMediaType:             updated.manifestMIMEType,
+				AddPlatform:              instance.clonePlatform,
+				AddAnnotations:           instance.cloneAnnotations,
+				AddCompressionAlgorithms: updated.compressionAlgorithms,
+			})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -106,6 +106,23 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	}
 	actualResponse = convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)
+
+	// Add same instance twice but clone must appear only once.
+	ensureCompressionVariantsExist = []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+	sourceInstances = []digest.Digest{
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+	}
+	instancesToCopy, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+	// two copies but clone should happen only once
+	numberOfCopyClone := 0
+	for _, instance := range instancesToCopy {
+		if instance.op == instanceCopyClone {
+			numberOfCopyClone++
+		}
+	}
+	assert.Equal(t, 1, numberOfCopyClone)
 }
 
 // simpler version of `instanceCopy` for testing where fields are string

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	internalManifest "github.com/containers/image/v5/internal/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,4 +42,86 @@ func TestPrepareCopyInstancesforInstanceCopyCopy(t *testing.T) {
 	compare = []instanceCopy{{op: instanceCopyCopy,
 		sourceDigest: sourceInstances[1]}}
 	assert.Equal(t, instancesToCopy, compare)
+}
+
+// Test `instanceCopyClone` cases.
+func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
+	validManifest, err := os.ReadFile(filepath.Join("..", "internal", "manifest", "testdata", "oci1.index.zstd-selection.json"))
+	require.NoError(t, err)
+	list, err := internalManifest.ListFromBlob(validManifest, internalManifest.GuessMIMEType(validManifest))
+	require.NoError(t, err)
+
+	// Prepare option for `instanceCopyClone` case.
+	ensureCompressionVariantsExist := []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+
+	sourceInstances := []digest.Digest{
+		digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+	}
+
+	// CopySpecificImage must fail with error
+	_, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist,
+		Instances:          []digest.Digest{sourceInstances[1]},
+		ImageListSelection: CopySpecificImages})
+	require.EqualError(t, err, "EnsureCompressionVariantsExist is not implemented for CopySpecificImages")
+
+	// Test copying all images with replication
+	instancesToCopy, err := prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+
+	// Following test ensures
+	// * Still copy gzip variants if they exist in the original
+	// * Not create new Zstd variants if they exist in the original.
+
+	// We crated a list of three instances `sourceInstances` and since in oci1.index.zstd-selection.json
+	// amd64 already has a zstd instance i.e sourceInstance[1] so it should not create replication for
+	// `sourceInstance[0]` and `sourceInstance[1]` but should do it for `sourceInstance[2]` for `arm64`
+	// and still copy `sourceInstance[2]`.
+	assert.Equal(t, 4, len(instancesToCopy))
+	expectedResponse := []simplerInstanceCopy{}
+	for _, instance := range sourceInstances {
+		// If its `arm64` and sourceDigest[2] , expect a clone to happen
+		if instance == sourceInstances[2] {
+			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
+		}
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
+	}
+	actualResponse := convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
+	assert.Equal(t, expectedResponse, actualResponse)
+
+}
+
+// simpler version of `instanceCopy` for testing where fields are string
+// instead of pointer
+type simplerInstanceCopy struct {
+	op           instanceCopyKind
+	sourceDigest digest.Digest
+
+	// Fields which can be used by callers when operation
+	// is `instanceCopyClone`
+	cloneCompressionVariant string
+	clonePlatform           string
+	cloneAnnotations        map[string]string
+}
+
+func convertInstanceCopyToSimplerInstanceCopy(copies []instanceCopy) []simplerInstanceCopy {
+	res := []simplerInstanceCopy{}
+	for _, instance := range copies {
+		compression := ""
+		platform := ""
+		compression = instance.cloneCompressionVariant.Algorithm.Name()
+		if instance.clonePlatform != nil {
+			platform = instance.clonePlatform.Architecture + "-" + instance.clonePlatform.OS + "-" + instance.clonePlatform.Variant
+		}
+		res = append(res, simplerInstanceCopy{
+			op:                      instance.op,
+			sourceDigest:            instance.sourceDigest,
+			cloneCompressionVariant: compression,
+			clonePlatform:           platform,
+			cloneAnnotations:        instance.cloneAnnotations,
+		})
+	}
+	return res
 }

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -28,6 +28,12 @@ func (s *Set[E]) Add(v E) {
 	s.m[v] = struct{}{} // Possibly writing the same struct{}{} presence marker again.
 }
 
+func (s *Set[E]) AddSlice(slice []E) {
+	for _, v := range slice {
+		s.Add(v)
+	}
+}
+
 func (s *Set[E]) Delete(v E) {
 	delete(s.m, v)
 }

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -32,6 +32,13 @@ func TestAdd(t *testing.T) {
 	assert.False(t, s.Contains(3))
 }
 
+func TestAddSlice(t *testing.T) {
+	s := NewWithValues(1)
+	s.Add(2)
+	s.AddSlice([]int{3, 4})
+	assert.ElementsMatch(t, []int{1, 2, 3, 4}, s.Values())
+}
+
 func TestDelete(t *testing.T) {
 	s := NewWithValues(1, 2)
 	assert.True(t, s.Contains(2))


### PR DESCRIPTION
* `copy.Options` now contains a new field `EnsureCompressionVariantExists map[string]int` which allows users to specify if they want to clone images with specified `compression`.

* `copyMultipleImages` now implements `instanceCopyClone` and extends function specifically for `zstd` compression.