### PR TITLE
Don't maintain URLs for foreign layers when pushing them

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -406,6 +406,11 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 			}
 		} else {
 			cld.destInfo, cld.diffID, cld.err = ic.copyLayer(ctx, srcLayer, toEncrypt, pool, index, srcRef, manifestLayerInfos[index].EmptyLayer)
+
+			// It's already unset on cld.destInfo, this forces the manifest to be regenerated.
+			if len(srcLayer.URLs) != 0 {
+				srcInfosUpdated = true
+			}
 		}
 		data[index] = cld
 	}


### PR DESCRIPTION
For images with non-distributable layers, if we're pushing the layer to the destination we want to remove any URLs on the layer since they're generally preferred over the repository itself ([containerd](https://github.com/containerd/containerd/blob/main/remotes/docker/fetcher.go#L54-L55) example) - this is important for deployments to air-gapped installations that don't have access to any of the URLs.