### PR TITLE
Don't store signatures if there is none of them

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -256,9 +256,11 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	}
 	sigs = append(sigs, newSigs...)
 
-	c.Printf("Storing signatures\n")
-	if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
-		return nil, "", "", fmt.Errorf("writing signatures: %w", err)
+	if len(sigs) > 0 {
+		c.Printf("Storing signatures\n")
+		if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
+			return nil, "", "", fmt.Errorf("writing signatures: %w", err)
+		}
 	}
 
 	return manifestBytes, retManifestType, retManifestDigest, nil


### PR DESCRIPTION
Currently, the copy command prints the message 'Storing signatures' and calls the signature storing function, even if there are no signatures present. This can mislead users and make them believe that there are image signatures.

The proposed change modifies the copy function to print the message and invoke the image storing function only if there is at least one signature.