### PR TITLE
Clarify how `oci` and `oci-archive` parse colons

### DIFF
--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -65,11 +65,15 @@ The _algo:digest_ refers to the image ID reported by docker-inspect(1).
 ### **oci:**_path[:reference]_
 
 An image in a directory structure compliant with the "Open Container Image Layout Specification" at _path_.
+
+_Path_ terminates at the first `:` character; any further `:` characters are not separators, but a part of _reference_.
 Specify a _reference_ to allow storing multiple images within the same _path_.
 
 ### **oci-archive:**_path[:reference]_
 
 An image in a tar(1) archive with contents compliant with the "Open Container Image Layout Specification" at _path_.
+
+_Path_ terminates at the first `:` character; any further `:` characters are not separators, but a part of _reference_.
 Specify a _reference_ to allow storing multiple images within the same _path_.
 
 ### **ostree:**_docker-reference[@/absolute/repo/path]_

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -64,12 +64,13 @@ The _algo:digest_ refers to the image ID reported by docker-inspect(1).
 
 ### **oci:**_path[:reference]_
 
-An image compliant with the "Open Container Image Layout Specification" at _path_.
-Using a _reference_ is optional and allows for storing multiple images at the same _path_.
+An image in a directory structure compliant with the "Open Container Image Layout Specification" at _path_.
+Specify a _reference_ to allow storing multiple images within the same _path_.
 
 ### **oci-archive:**_path[:reference]_
 
-An image compliant with the "Open Container Image Layout Specification" stored as a tar(1) archive at _path_.
+An image in a tar(1) archive with contents compliant with the "Open Container Image Layout Specification" at _path_.
+Specify a _reference_ to allow storing multiple images within the same _path_.
 
 ### **ostree:**_docker-reference[@/absolute/repo/path]_
 


### PR DESCRIPTION
Motivated by https://github.com/containers/skopeo/issues/2019 .