### PR TITLE
Bump to v5.26.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 25
+	VersionMinor = 26
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 26
+	VersionMinor = 27
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Bump to v5.26.0

I bumped to 5.27.0-dev, too, as I'm planning to create a release branch for v5.26.0, and that's where 5.26.1 will get generated.  We'll use v5.26.* for RHEL 8.8/9.3 either in Podman v4.6 or v4.7, the version number is to be decided.
[NO NEW TESTS NEEDED]