### PR TITLE
Ensure we close HTTP connections on all paths

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -336,6 +336,7 @@ func compareImageDestinationManifestEqual(ctx context.Context, options *Options,
 		logrus.Debugf("Unable to create destination image %s source: %v", dest.Reference(), err)
 		return false, nil, "", "", nil
 	}
+	defer destImageSource.Close()
 
 	destManifest, destManifestType, err := destImageSource.GetManifest(ctx, targetInstance)
 	if err != nil {

--- a/docker/docker_image_src_test.go
+++ b/docker/docker_image_src_test.go
@@ -71,6 +71,7 @@ location = "@REGISTRY@/with-mirror"
 			DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
 		})
 		require.NoError(t, err, c.input)
+		defer src.Close()
 
 		// The observable behavior
 		assert.Equal(t, "//"+c.input, src.Reference().StringWithinTransport(), c.input)

--- a/oci/archive/oci_transport_test.go
+++ b/oci/archive/oci_transport_test.go
@@ -255,8 +255,9 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, tmpTarFile := refToTempOCIArchive(t)
 	defer os.RemoveAll(tmpTarFile)
-	_, err := ref.NewImageSource(context.Background(), nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
+	defer src.Close()
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {

--- a/oci/layout/oci_src_test.go
+++ b/oci/layout/oci_src_test.go
@@ -47,6 +47,7 @@ func TestGetBlobForRemoteLayers(t *testing.T) {
 	cache := memory.New()
 
 	imageSource := createImageSource(t, &types.SystemContext{})
+	defer imageSource.Close()
 	layerInfo := types.BlobInfo{
 		Digest: digest.FromBytes([]byte("Hello world")),
 		Size:   -1,
@@ -69,6 +70,7 @@ func TestGetBlobForRemoteLayersWithTLS(t *testing.T) {
 	imageSource := createImageSource(t, &types.SystemContext{
 		OCICertPath: "fixtures/accepted_certs",
 	})
+	defer imageSource.Close()
 	cache := memory.New()
 
 	layer, size, err := imageSource.GetBlob(context.Background(), types.BlobInfo{
@@ -85,6 +87,7 @@ func TestGetBlobForRemoteLayersOnTLSFailure(t *testing.T) {
 	imageSource := createImageSource(t, &types.SystemContext{
 		OCICertPath: "fixtures/rejected_certs",
 	})
+	defer imageSource.Close()
 	cache := memory.New()
 	layer, size, err := imageSource.GetBlob(context.Background(), types.BlobInfo{
 		URLs: []string{httpServerAddr},

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -307,8 +307,9 @@ func TestReferenceNewImage(t *testing.T) {
 
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, _ := refToTempOCI(t)
-	_, err := ref.NewImageSource(context.Background(), nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	assert.NoError(t, err)
+	defer src.Close()
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -65,6 +65,10 @@ func newOpenshiftClient(ref openshiftReference) (*openshiftClient, error) {
 	}, nil
 }
 
+func (c *openshiftClient) close() {
+	c.httpClient.CloseIdleConnections()
+}
+
 // doRequest performs a correctly authenticated request to a specified path, and returns response body or an error object.
 func (c *openshiftClient) doRequest(ctx context.Context, method, path string, requestBody []byte) ([]byte, error) {
 	requestURL := *c.baseURL

--- a/openshift/openshift_dest.go
+++ b/openshift/openshift_dest.go
@@ -71,7 +71,9 @@ func (d *openshiftImageDestination) Reference() types.ImageReference {
 
 // Close removes resources associated with an initialized ImageDestination, if any.
 func (d *openshiftImageDestination) Close() error {
-	return d.docker.Close()
+	err := d.docker.Close()
+	d.client.close()
+	return err
 }
 
 func (d *openshiftImageDestination) SupportedManifestMIMETypes() []string {

--- a/openshift/openshift_src.go
+++ b/openshift/openshift_src.go
@@ -60,14 +60,15 @@ func (s *openshiftImageSource) Reference() types.ImageReference {
 
 // Close removes resources associated with an initialized ImageSource, if any.
 func (s *openshiftImageSource) Close() error {
+	var err error
 	if s.docker != nil {
-		err := s.docker.Close()
+		err = s.docker.Close()
 		s.docker = nil
-
-		return err
 	}
 
-	return nil
+	s.client.close()
+
+	return err
 }
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -239,8 +239,9 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := Transport.ParseReference("busybox")
 	require.NoError(t, err)
-	_, err = ref.NewImageSource(context.Background(), nil)
+	src, err = ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
+	defer src.Close()
 }
 
 func TestReferenceNewImageDestination(t *testing.T) {


### PR DESCRIPTION
- Close `ImageSource` objects
- Close the HTTP client used by the `atomic` transport