### PR TITLE
manifest: `ListUpdate` add `imgspecv1.Platform` field

### DIFF
--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -61,6 +61,13 @@ func (list *Schema2ListPublic) Instance(instanceDigest digest.Digest) (ListUpdat
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
+				Platform: &imgspecv1.Platform{
+					OS:           manifest.Platform.OS,
+					Architecture: manifest.Platform.Architecture,
+					OSVersion:    manifest.Platform.OSVersion,
+					OSFeatures:   manifest.Platform.OSFeatures,
+					Variant:      manifest.Platform.Variant,
+				},
 			}, nil
 		}
 	}

--- a/internal/manifest/docker_schema2_list_test.go
+++ b/internal/manifest/docker_schema2_list_test.go
@@ -55,6 +55,8 @@ func TestSchema2ListEditInstances(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
+	// platform must match with instance platform set in `v2list.manifest.json` for the first instance
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.Platform)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))

--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -68,6 +68,7 @@ type ListUpdate struct {
 	Digest    digest.Digest
 	Size      int64
 	MediaType string
+	Platform  *imgspecv1.Platform // read-only field: may be set by Instance(), ignored by UpdateInstance()
 }
 
 type ListOp int

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -57,6 +57,7 @@ func (index *OCI1IndexPublic) Instance(instanceDigest digest.Digest) (ListUpdate
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
+				Platform:  manifest.Platform,
 			}, nil
 		}
 	}

--- a/internal/manifest/oci_index_test.go
+++ b/internal/manifest/oci_index_test.go
@@ -77,6 +77,8 @@ func TestOCI1EditInstances(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
+	// platform must match with what was set in `ociv1.image.index.json` for the first instance
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.Platform)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))


### PR DESCRIPTION
`c/image` uses `Instance(` API to get the required details of an instance while performing replication, `Platform` of instance is needed so it can use it again while adding an instance hence adding `Platform` to `ListUpdate` 

Needed by: https://github.com/containers/image/pull/1987
See prior comment here: https://github.com/containers/image/pull/1875#discussion_r1128464266