### PR TITLE
pkg/docker: use the same default auth path as macOS on FreeBSD

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -519,11 +519,12 @@ func getPathToAuthWithOS(sys *types.SystemContext, goOS string) (authPath, bool,
 		if sys.LegacyFormatAuthFilePath != "" {
 			return authPath{path: sys.LegacyFormatAuthFilePath, legacyFormat: true}, true, nil
 		}
-		if sys.RootForImplicitAbsolutePaths != "" {
+		// Note: RootForImplicitAbsolutePaths should not affect paths starting with $HOME
+		if sys.RootForImplicitAbsolutePaths != "" && goOS == "linux" {
 			return newAuthPathDefault(filepath.Join(sys.RootForImplicitAbsolutePaths, fmt.Sprintf(defaultPerUIDPathFormat, os.Getuid()))), false, nil
 		}
 	}
-	if goOS == "windows" || goOS == "darwin" {
+	if goOS != "linux" {
 		return newAuthPathDefault(filepath.Join(homedir.Get(), nonLinuxAuthFilePath)), false, nil
 	}
 

--- a/pkg/docker/config/testdata/docker-credential-helper-registry
+++ b/pkg/docker/config/testdata/docker-credential-helper-registry
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 case "${1}" in
     get)


### PR DESCRIPTION
This was defaulting to "/run/containers/\<uid\>/auth.json" unless the OS was "darwin" or "windows". It makes more sense to use "~/.config/containers/auth.json" instead which removes the need for a "/run" directory on the host.