### PR TITLE
Fix tests of the ostree transport

### DIFF
--- a/ostree/ostree_dest_test.go
+++ b/ostree/ostree_dest_test.go
@@ -3,4 +3,8 @@
 
 package ostree
 
+import (
+	"github.com/containers/image/v5/internal/private"
+)
+
 var _ private.ImageDestination = (*ostreeImageDestination)(nil)

--- a/ostree/ostree_transport_test.go
+++ b/ostree/ostree_transport_test.go
@@ -134,7 +134,7 @@ func TestNewReference(t *testing.T) {
 		require.NoError(t, err, path)
 	}
 
-	_, err = NewReference("busybox", tmpDir+"/thisparentdoesnotexist/something")
+	_, err := NewReference("busybox", tmpDir+"/thisparentdoesnotexist/something")
 	assert.Error(t, err)
 }
 
@@ -239,7 +239,7 @@ func TestReferenceNewImage(t *testing.T) {
 func TestReferenceNewImageSource(t *testing.T) {
 	ref, err := Transport.ParseReference("busybox")
 	require.NoError(t, err)
-	src, err = ref.NewImageSource(context.Background(), nil)
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	defer src.Close()
 }


### PR DESCRIPTION
... which I broke on 2022-03-16, and noone noticed.

(The actual non-test code was, at least east as of today, buildable, so this does not prove that noone is using the code... but it's a hint in that direction.)