### PR TITLE
helpers_test,cleanup: correct argument order

### DIFF
--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -24,6 +24,6 @@ func TestBlobMatchesRequiredCompression(t *testing.T) {
 
 	for _, c := range cases {
 		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
-		assert.Equal(t, BlobMatchesRequiredCompression(opts, c.candidateCompression), c.result)
+		assert.Equal(t, c.result, BlobMatchesRequiredCompression(opts, c.candidateCompression))
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/containers/image/pull/2023#discussion_r1261581159.

`assert.Equal` expects `assert.Equal(t, expected, actual)` instead of `assert.Equal(t, actual, expected)`.

Ref:https://pkg.go.dev/github.com/stretchr/testify/assert#Assertions.Equal