### PR TITLE
Fix TestOCI1IndexChooseInstanceByCompression on non-amd64

### DIFF
--- a/internal/manifest/oci_index_test.go
+++ b/internal/manifest/oci_index_test.go
@@ -213,10 +213,6 @@ func TestOCI1IndexChooseInstanceByCompression(t *testing.T) {
 				{"arm64", "", "sha256:6dc14a60d2ba724646cfbf5fccbb9a618a5978a64a352e060b17caf5e005da9d", true},
 				// must return first zstd even if the first entry for same platform is gzip
 				{"arm64", "", "sha256:1c98002b30a71b08ab175915ce7c8fb8da9e9b502ae082d6f0c572bac9dee324", false},
-				// must return first zstd instance agnostic of platform
-				{"", "", "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", false},
-				// must return first gzip instance agnostic of platform
-				{"", "", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
 				// must return first zstd instance with no platform
 				{"matchesImageWithNoPlatform", "", "sha256:f2f5f52a2cf2c51d4cac6df0545f751c0adc3f3427eb47c59fcb32894503e18f", false},
 				// must return first gzip instance with no platform


### PR DESCRIPTION
Setting `SystemContext.ArchitectureChoice` to `""` does not mean "match any/the first platform"; it's the default behavior of `SystemContext`, and it means "choose for the current runtime architecture". (Originally discussed in https://github.com/containers/image/pull/1789#discussion_r1115647449 )

I.e. on `amd64` these two test cases are redundant with the first two instances above, and on other architectures (notably ARM) they cause failures.

So just drop them.