### PR TITLE
copy/multiple: instanceCopyCopy honor `UpdateCompressionAlgorithms`

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil)
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, false)
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil)
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, false)
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -134,11 +134,12 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			}
 			// Record the result of a possible conversion here.
 			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
-				ListOperation:   internalManifest.ListOpUpdate,
-				UpdateOldDigest: instance.sourceDigest,
-				UpdateDigest:    updated.manifestDigest,
-				UpdateSize:      int64(len(updated.manifest)),
-				UpdateMediaType: updated.manifestMIMEType})
+				ListOperation:               internalManifest.ListOpUpdate,
+				UpdateOldDigest:             instance.sourceDigest,
+				UpdateDigest:                updated.manifestDigest,
+				UpdateSize:                  int64(len(updated.manifest)),
+				UpdateCompressionAlgorithms: updated.compressionAlgorithms,
+				UpdateMediaType:             updated.manifestMIMEType})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, false)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/single.go
+++ b/copy/single.go
@@ -49,7 +49,7 @@ type copySingleImageResult struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (copySingleImageResult, error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, requireCompressionFormatMatch bool) (copySingleImageResult, error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -129,7 +129,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		manifestUpdates: &types.ManifestUpdateOptions{InformationOnly: types.ManifestUpdateInformation{Destination: c.dest}},
 		src:             src,
 		// diffIDsAreNeeded is computed later
-		cannotModifyManifestReason: cannotModifyManifestReason,
+		cannotModifyManifestReason:    cannotModifyManifestReason,
+		requireCompressionFormatMatch: requireCompressionFormatMatch,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.

--- a/copy/single.go
+++ b/copy/single.go
@@ -29,22 +29,23 @@ import (
 
 // imageCopier tracks state specific to a single image (possibly an item of a manifest list)
 type imageCopier struct {
-	c                          *copier
-	manifestUpdates            *types.ManifestUpdateOptions
-	src                        *image.SourcedImage
-	diffIDsAreNeeded           bool
-	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
-	canSubstituteBlobs         bool
-	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
-	compressionLevel           *int
+	c                             *copier
+	manifestUpdates               *types.ManifestUpdateOptions
+	src                           *image.SourcedImage
+	diffIDsAreNeeded              bool
+	cannotModifyManifestReason    string // The reason the manifest cannot be modified, or an empty string if it can
+	canSubstituteBlobs            bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
 	requireCompressionFormatMatch bool
 }
 
 // copySingleImageResult carries data produced by copySingleImage
 type copySingleImageResult struct {
-	manifest         []byte
-	manifestMIMEType string
-	manifestDigest   digest.Digest
+	manifest              []byte
+	manifestMIMEType      string
+	manifestDigest        digest.Digest
+	compressionAlgorithms []compressiontypes.Algorithm
 }
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
@@ -194,7 +195,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		}
 	}
 
-	if err := ic.copyLayers(ctx); err != nil {
+	compressionAlgos, err := ic.copyLayers(ctx)
+	if err != nil {
 		return copySingleImageResult{}, err
 	}
 
@@ -274,7 +276,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 			return copySingleImageResult{}, fmt.Errorf("writing signatures: %w", err)
 		}
 	}
-
+	wipResult.compressionAlgorithms = compressionAlgos
 	res := wipResult // We are done
 	return res, nil
 }
@@ -367,26 +369,38 @@ func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context,
 		return nil, nil
 	}
 
+	compressionAlgos := set.New[string]()
+	for _, srcInfo := range ic.src.LayerInfos() {
+		compression := compressionAlgorithmFromMIMEType(srcInfo)
+		compressionAlgos.Add(compression.Name())
+	}
+
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
+	}
+
 	// Destination and source manifests, types and digests should all be equivalent
 	return &copySingleImageResult{
-		manifest:         destManifest,
-		manifestMIMEType: destManifestType,
-		manifestDigest:   srcManifestDigest,
+		manifest:              destManifest,
+		manifestMIMEType:      destManifestType,
+		manifestDigest:        srcManifestDigest,
+		compressionAlgorithms: algos,
 	}, nil
 }
 
 // copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.cannotModifyManifestReason == "".
-func (ic *imageCopier) copyLayers(ctx context.Context) error {
+func (ic *imageCopier) copyLayers(ctx context.Context) ([]compressiontypes.Algorithm, error) {
 	srcInfos := ic.src.LayerInfos()
 	numLayers := len(srcInfos)
 	updatedSrcInfos, err := ic.src.LayerInfosForCopy(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	srcInfosUpdated := false
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if ic.cannotModifyManifestReason != "" {
-			return fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
+			return nil, fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
 		}
 		srcInfos = updatedSrcInfos
 		srcInfosUpdated = true
@@ -402,7 +416,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// layer is empty.
 	man, err := manifest.FromBlob(ic.src.ManifestBlob, ic.src.ManifestMIMEType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	manifestLayerInfos := man.LayerInfos()
 
@@ -468,14 +482,18 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		// A call to copyGroup.Wait() is done at this point by the defer above.
 		return nil
 	}(); err != nil {
-		return err
+		return nil, err
 	}
 
+	compressionAlgos := set.New[string]()
 	destInfos := make([]types.BlobInfo, numLayers)
 	diffIDs := make([]digest.Digest, numLayers)
 	for i, cld := range data {
 		if cld.err != nil {
-			return cld.err
+			return nil, cld.err
+		}
+		if cld.destInfo.CompressionAlgorithm != nil {
+			compressionAlgos.Add(cld.destInfo.CompressionAlgorithm.Name())
 		}
 		destInfos[i] = cld.destInfo
 		diffIDs[i] = cld.diffID
@@ -490,7 +508,11 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	if srcInfosUpdated || layerDigestsDiffer(srcInfos, destInfos) {
 		ic.manifestUpdates.LayerInfos = destInfos
 	}
-	return nil
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
+	}
+	return algos, nil
 }
 
 // layerDigestsDiffer returns true iff the digests in a and b differ (ignoring sizes and possible other fields)
@@ -595,6 +617,19 @@ type diffIDResult struct {
 	err    error
 }
 
+func compressionAlgorithmFromMIMEType(srcInfo types.BlobInfo) *compressiontypes.Algorithm {
+	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
+	// package (but we should preferably replace/change UpdatedImage instead of productizing
+	// this workaround).
+	switch srcInfo.MediaType {
+	case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
+		return &compression.Gzip
+	case imgspecv1.MediaTypeImageLayerZstd:
+		return &compression.Zstd
+	}
+	return nil
+}
+
 // copyLayer copies a layer with srcInfo (with known Digest and Annotations and possibly known Size) in src to dest, perhaps (de/re/)compressing it,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 // srcRef can be used as an additional hint to the destination during checking whether a layer can be reused but srcRef can be nil.
@@ -606,17 +641,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// which uses the compression information to compute the updated MediaType values.
 	// (Sadly UpdatedImage() is documented to not update MediaTypes from
 	//  ManifestUpdateOptions.LayerInfos[].MediaType, so we are doing it indirectly.)
-	//
-	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
-	// package (but we should preferably replace/change UpdatedImage instead of productizing
-	// this workaround).
 	if srcInfo.CompressionAlgorithm == nil {
-		switch srcInfo.MediaType {
-		case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
-			srcInfo.CompressionAlgorithm = &compression.Gzip
-		case imgspecv1.MediaTypeImageLayerZstd:
-			srcInfo.CompressionAlgorithm = &compression.Zstd
-		}
+		srcInfo.CompressionAlgorithm = compressionAlgorithmFromMIMEType(srcInfo)
 	}
 
 	ic.c.printCopyInfo("blob", srcInfo)
@@ -843,4 +869,17 @@ func computeDiffID(stream io.Reader, decompressor compressiontypes.DecompressorF
 	}
 
 	return digest.Canonical.FromReader(stream)
+}
+
+// algorithmsByNames returns slice of Algorithms from slice of Algorithm Names
+func algorithmsByNames(names []string) ([]compressiontypes.Algorithm, error) {
+	result := []compressiontypes.Algorithm{}
+	for _, name := range names {
+		algo, err := compression.AlgorithmByName(name)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, algo)
+	}
+	return result, nil
 }

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -94,14 +94,17 @@ func annotationsToCompressionAlgorithmNames(annotations map[string]string) []str
 	return result
 }
 
-func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, annotationsMap map[string]string) {
+func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, annotationsMap *map[string]string) {
 	// TODO: This should also delete the algorithm if map already contains an algorithm and compressionAlgorithm
 	// list has a different algorithm. To do that, we would need to modify the callers to always provide a reliable
 	// and full compressionAlghorithms list.
+	if *annotationsMap == nil && len(compressionAlgorithms) > 0 {
+		*annotationsMap = map[string]string{}
+	}
 	for _, algo := range compressionAlgorithms {
 		switch algo.Name() {
 		case compression.ZstdAlgorithmName:
-			annotationsMap[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
+			(*annotationsMap)[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
 		default:
 			continue
 		}
@@ -146,13 +149,13 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit) error {
 					maps.Copy(index.Manifests[targetIndex].Annotations, editInstance.UpdateAnnotations)
 				}
 			}
-			addCompressionAnnotations(editInstance.UpdateCompressionAlgorithms, index.Manifests[targetIndex].Annotations)
+			addCompressionAnnotations(editInstance.UpdateCompressionAlgorithms, &index.Manifests[targetIndex].Annotations)
 		case ListOpAdd:
 			annotations := map[string]string{}
 			if editInstance.AddAnnotations != nil {
 				annotations = maps.Clone(editInstance.AddAnnotations)
 			}
-			addCompressionAnnotations(editInstance.AddCompressionAlgorithms, annotations)
+			addCompressionAnnotations(editInstance.AddCompressionAlgorithms, &annotations)
 			addedEntries = append(addedEntries, imgspecv1.Descriptor{
 				MediaType:   editInstance.AddMediaType,
 				Size:        editInstance.AddSize,

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -25,6 +25,8 @@ func TestAdd(t *testing.T) {
 	assert.True(t, s.Contains(2))
 	s.Add(2) // Adding an already-present element
 	assert.True(t, s.Contains(2))
+	// should not contain duplicate value of `2`
+	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 	// Unrelated elements are unaffected
 	assert.True(t, s.Contains(1))
 	assert.False(t, s.Contains(3))
@@ -61,6 +63,8 @@ func TestValues(t *testing.T) {
 	s := New[int]()
 	assert.Empty(t, s.Values())
 	s.Add(1)
+	s.Add(2)
+	// ignore duplicate
 	s.Add(2)
 	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 }


### PR DESCRIPTION
Needed By: https://github.com/containers/skopeo/pull/2047

* Users can set compression formats while performing `copy` in such cases
`instanceCopyCopy` must honor UpdateCompressionAlgorithms.

* copy/single: set requiredCompression if compressionFormat is changed
 - Modifies `copy/single` to correctly use the feature from
https://github.com/containers/image/pull/2023, that is if compression is
changed blob must be resued only if it matches required compression.

* oci_index: init Annotations if nil and required
 - If `UpdateCompressionAlgorithms` is set then `Annotations` map must be
initialized if its not set.

Integration tests for `e2e` feature added here: https://github.com/containers/skopeo/pull/2047#issue-1809369600