### PR TITLE
Refactor data passing in c/image/copy

### DIFF
--- a/copy/blob.go
+++ b/copy/blob.go
@@ -83,12 +83,12 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		return types.BlobInfo{}, err
 	}
 
-	// === Report progress using the ic.c.progress channel, if required.
-	if ic.c.progress != nil && ic.c.progressInterval > 0 {
+	// === Report progress using the ic.c.options.Progress channel, if required.
+	if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
 		progressReader := newProgressReader(
 			stream.reader,
-			ic.c.progress,
-			ic.c.progressInterval,
+			ic.c.options.Progress,
+			ic.c.options.ProgressInterval,
 			srcInfo,
 		)
 		defer progressReader.reportDone()

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -139,7 +139,6 @@ type copier struct {
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
-	ociEncryptConfig              *encconfig.EncryptConfig
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
 	downloadForeignLayers         bool
 	signers                       []*signer.Signer // Signers to use to create new signatures for the image
@@ -213,7 +212,6 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
 		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		ociEncryptConfig:      options.OciEncryptConfig,
 		downloadForeignLayers: options.DownloadForeignLayers,
 	}
 	defer c.close()

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -138,8 +138,6 @@ type copier struct {
 
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
-	progressInterval              time.Duration
-	progress                      chan types.ProgressProperties
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
 	ociDecryptConfig              *encconfig.DecryptConfig
 	ociEncryptConfig              *encconfig.EncryptConfig
@@ -210,10 +208,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		rawSource: rawSource,
 		options:   options,
 
-		reportWriter:     reportWriter,
-		progressOutput:   progressOutput,
-		progressInterval: options.ProgressInterval,
-		progress:         options.Progress,
+		reportWriter:   reportWriter,
+		progressOutput: progressOutput,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,9 +251,11 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, c.unparsedToplevel, nil); err != nil {
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil)
+		if err != nil {
 			return nil, err
 		}
+		copiedManifest = single.manifest
 	} else if c.options.ImageListSelection == CopySystemImage {
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
@@ -272,9 +274,11 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, unparsedInstance, nil); err != nil {
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil)
+		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
+		copiedManifest = single.manifest
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -250,7 +250,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
@@ -271,7 +271,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -140,9 +140,8 @@ type copier struct {
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
-	downloadForeignLayers         bool
-	signers                       []*signer.Signer // Signers to use to create new signatures for the image
-	signersToClose                []*signer.Signer // Signers that should be closed when this copier is destroyed.
+	signers                       []*signer.Signer    // Signers to use to create new signatures for the image
+	signersToClose                []*signer.Signer    // Signers that should be closed when this copier is destroyed.
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
@@ -211,8 +210,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
-		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		downloadForeignLayers: options.DownloadForeignLayers,
+		blobInfoCache: internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
 	}
 	defer c.close()
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -256,7 +256,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if options.ImageListSelection == CopySystemImage {
@@ -277,7 +277,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -244,7 +244,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	}
 
-	if err := c.setupSigners(options); err != nil {
+	if err := c.setupSigners(); err != nil {
 		return nil, err
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -132,8 +132,10 @@ type Options struct {
 // data shared across one or more images in a possible manifest list.
 // The owner must call close() when done.
 type copier struct {
-	dest                          private.ImageDestination
-	rawSource                     private.ImageSource
+	dest      private.ImageDestination
+	rawSource private.ImageSource
+	options   *Options // never nil
+
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	progressInterval              time.Duration
@@ -204,8 +206,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:             dest,
-		rawSource:        rawSource,
+		dest:      dest,
+		rawSource: rawSource,
+		options:   options,
+
 		reportWriter:     reportWriter,
 		progressOutput:   progressOutput,
 		progressInterval: options.ProgressInterval,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -139,7 +139,6 @@ type copier struct {
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
-	ociDecryptConfig              *encconfig.DecryptConfig
 	ociEncryptConfig              *encconfig.EncryptConfig
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
 	downloadForeignLayers         bool
@@ -214,7 +213,6 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
 		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		ociDecryptConfig:      options.OciDecryptConfig,
 		ociEncryptConfig:      options.OciEncryptConfig,
 		downloadForeignLayers: options.DownloadForeignLayers,
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -292,7 +292,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, options, unparsedToplevel); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, unparsedToplevel); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -132,9 +132,10 @@ type Options struct {
 // data shared across one or more images in a possible manifest list.
 // The owner must call close() when done.
 type copier struct {
-	dest      private.ImageDestination
-	rawSource private.ImageSource
-	options   *Options // never nil
+	policyContext *signature.PolicyContext
+	dest          private.ImageDestination
+	rawSource     private.ImageSource
+	options       *Options // never nil
 
 	reportWriter   io.Writer
 	progressOutput io.Writer
@@ -203,9 +204,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:      dest,
-		rawSource: rawSource,
-		options:   options,
+		policyContext: policyContext,
+		dest:          dest,
+		rawSource:     rawSource,
+		options:       options,
 
 		reportWriter:   reportWriter,
 		progressOutput: progressOutput,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, c.unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, c.unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
@@ -272,7 +272,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -151,11 +151,6 @@ type copier struct {
 // source image admissibility.  It returns the manifest which was written to
 // the new copy of the image.
 func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef, srcRef types.ImageReference, options *Options) (copiedManifest []byte, retErr error) {
-	// NOTE this function uses an output parameter for the error return value.
-	// Setting this and returning is the ideal way to return an error.
-	//
-	// the defers in this routine will wrap the error return with its own errors
-	// which can be valuable context in the middle of a multi-streamed copy.
 	if options == nil {
 		options = &Options{}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -286,7 +286,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, unparsedToplevel); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -242,21 +242,20 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		return nil, err
 	}
 
-	unparsedToplevel := c.unparsedToplevel
-	multiImage, err := isMultiImage(ctx, unparsedToplevel)
+	multiImage, err := isMultiImage(ctx, c.unparsedToplevel)
 	if err != nil {
 		return nil, fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(srcRef), err)
 	}
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, c.unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
-		mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
+		mfest, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("reading manifest for %s: %w", transports.ImageName(srcRef), err)
 		}
@@ -291,7 +290,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	}
 
-	if err := c.dest.Commit(ctx, unparsedToplevel); err != nil {
+	if err := c.dest.Commit(ctx, c.unparsedToplevel); err != nil {
 		return nil, fmt.Errorf("committing the finished image: %w", err)
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -287,7 +287,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -34,7 +34,7 @@ type bpDecryptionStepData struct {
 // srcInfo is only used for error messages.
 // Returns data for other steps; the caller should eventually use updateCryptoOperation.
 func (ic *imageCopier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo types.BlobInfo) (*bpDecryptionStepData, error) {
-	if !isOciEncrypted(stream.info.MediaType) || ic.c.ociDecryptConfig == nil {
+	if !isOciEncrypted(stream.info.MediaType) || ic.c.options.OciDecryptConfig == nil {
 		return &bpDecryptionStepData{
 			decrypting: false,
 		}, nil
@@ -47,7 +47,7 @@ func (ic *imageCopier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo 
 	desc := imgspecv1.Descriptor{
 		Annotations: stream.info.Annotations,
 	}
-	reader, decryptedDigest, err := ocicrypt.DecryptLayer(ic.c.ociDecryptConfig, stream.reader, desc, false)
+	reader, decryptedDigest, err := ocicrypt.DecryptLayer(ic.c.options.OciDecryptConfig, stream.reader, desc, false)
 	if err != nil {
 		return nil, fmt.Errorf("decrypting layer %s: %w", srcInfo.Digest, err)
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -81,7 +81,7 @@ type bpEncryptionStepData struct {
 // Returns data for other steps; the caller should eventually call updateCryptoOperationAndAnnotations.
 func (ic *imageCopier) blobPipelineEncryptionStep(stream *sourceStream, toEncrypt bool, srcInfo types.BlobInfo,
 	decryptionStep *bpDecryptionStepData) (*bpEncryptionStepData, error) {
-	if !toEncrypt || isOciEncrypted(srcInfo.MediaType) || ic.c.ociEncryptConfig == nil {
+	if !toEncrypt || isOciEncrypted(srcInfo.MediaType) || ic.c.options.OciEncryptConfig == nil {
 		return &bpEncryptionStepData{
 			encrypting: false,
 		}, nil
@@ -101,7 +101,7 @@ func (ic *imageCopier) blobPipelineEncryptionStep(stream *sourceStream, toEncryp
 		Size:        srcInfo.Size,
 		Annotations: annotations,
 	}
-	reader, finalizer, err := ocicrypt.EncryptLayer(ic.c.ociEncryptConfig, stream.reader, desc)
+	reader, finalizer, err := ocicrypt.EncryptLayer(ic.c.options.OciEncryptConfig, stream.reader, desc)
 	if err != nil {
 		return nil, fmt.Errorf("encrypting blob %s: %w", srcInfo.Digest, err)
 	}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/image/v5/internal/image"
 	internalManifest "github.com/containers/image/v5/internal/manifest"
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/image/v5/signature"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -48,8 +47,8 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 }
 
 // copyMultipleImages copies some or all of an image list's instances, using
-// policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext) (copiedManifest []byte, retErr error) {
+// c.policyContext to validate source image admissibility.
+func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 	if err != nil {

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}
@@ -136,9 +136,9 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
 				ListOperation:   internalManifest.ListOpUpdate,
 				UpdateOldDigest: instance.sourceDigest,
-				UpdateDigest:    updatedManifestDigest,
-				UpdateSize:      int64(len(updatedManifest)),
-				UpdateMediaType: updatedManifestType})
+				UpdateDigest:    updated.manifestDigest,
+				UpdateSize:      int64(len(updated.manifest)),
+				UpdateMediaType: updated.manifestMIMEType})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -49,7 +49,7 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 
 // copyMultipleImages copies some or all of an image list's instances, using
 // policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, options *Options, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
+func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {
@@ -94,12 +94,12 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	if destIsDigestedReference {
 		cannotModifyManifestListReason = "Destination specifies a digest"
 	}
-	if options.PreserveDigests {
+	if c.options.PreserveDigests {
 		cannotModifyManifestListReason = "Instructed to preserve digests"
 	}
 
 	// Determine if we'll need to convert the manifest list to a different format.
-	forceListMIMEType := options.ForceManifestMIMEType
+	forceListMIMEType := c.options.ForceManifestMIMEType
 	switch forceListMIMEType {
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema2MediaType:
 		forceListMIMEType = manifest.DockerV2ListMediaType
@@ -119,7 +119,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	// Copy each image, or just the ones we want to copy, in turn.
 	instanceDigests := updatedList.Instances()
 	instanceEdits := []internalManifest.ListEdit{}
-	instanceCopyList := prepareInstanceCopies(instanceDigests, options)
+	instanceCopyList := prepareInstanceCopies(instanceDigests, c.options)
 	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
@@ -204,7 +204,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 
 	// Sign the manifest list.
-	newSigs, err := c.createSignatures(ctx, manifestList, options.SignIdentity)
+	newSigs, err := c.createSignatures(ctx, manifestList, c.options.SignIdentity)
 	if err != nil {
 		return nil, err
 	}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -49,9 +49,9 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 
 // copyMultipleImages copies some or all of an image list's instances, using
 // policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
+func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
-	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
+	manifestList, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest list: %w", err)
 	}
@@ -61,7 +61,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	updatedList := originalList.CloneInternal()
 
-	sigs, err := c.sourceSignatures(ctx, unparsedToplevel,
+	sigs, err := c.sourceSignatures(ctx, c.unparsedToplevel,
 		"Getting image list signatures",
 		"Checking if image list destination supports signatures")
 	if err != nil {

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -61,7 +61,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	updatedList := originalList.CloneInternal()
 
-	sigs, err := c.sourceSignatures(ctx, unparsedToplevel, options,
+	sigs, err := c.sourceSignatures(ctx, unparsedToplevel,
 		"Getting image list signatures",
 		"Checking if image list destination supports signatures")
 	if err != nil {

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -50,13 +50,13 @@ func (c *copier) setupSigners() error {
 	return nil
 }
 
-// sourceSignatures returns signatures from unparsedSource based on options,
+// sourceSignatures returns signatures from unparsedSource,
 // and verifies that they can be used (to avoid copying a large image when we
 // can tell in advance that it would ultimately fail)
-func (c *copier) sourceSignatures(ctx context.Context, unparsed private.UnparsedImage, options *Options,
+func (c *copier) sourceSignatures(ctx context.Context, unparsed private.UnparsedImage,
 	gettingSignaturesMessage, checkingDestMessage string) ([]internalsig.Signature, error) {
 	var sigs []internalsig.Signature
-	if options.RemoveSignatures {
+	if c.options.RemoveSignatures {
 		sigs = []internalsig.Signature{}
 	} else {
 		c.Printf("%s\n", gettingSignaturesMessage)

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -13,20 +13,20 @@ import (
 	"github.com/containers/image/v5/transports"
 )
 
-// setupSigners initializes c.signers based on options.
-func (c *copier) setupSigners(options *Options) error {
-	c.signers = append(c.signers, options.Signers...)
-	// c.signersToClose is intentionally not updated with options.Signers.
+// setupSigners initializes c.signers.
+func (c *copier) setupSigners() error {
+	c.signers = append(c.signers, c.options.Signers...)
+	// c.signersToClose is intentionally not updated with c.options.Signers.
 
 	// We immediately append created signers to c.signers, and we rely on c.close() to clean them up; so we don’t need
 	// to clean up any created signers on failure.
 
-	if options.SignBy != "" {
+	if c.options.SignBy != "" {
 		opts := []simplesigning.Option{
-			simplesigning.WithKeyFingerprint(options.SignBy),
+			simplesigning.WithKeyFingerprint(c.options.SignBy),
 		}
-		if options.SignPassphrase != "" {
-			opts = append(opts, simplesigning.WithPassphrase(options.SignPassphrase))
+		if c.options.SignPassphrase != "" {
+			opts = append(opts, simplesigning.WithPassphrase(c.options.SignPassphrase))
 		}
 		signer, err := simplesigning.NewSigner(opts...)
 		if err != nil {
@@ -36,9 +36,9 @@ func (c *copier) setupSigners(options *Options) error {
 		c.signersToClose = append(c.signersToClose, signer)
 	}
 
-	if options.SignBySigstorePrivateKeyFile != "" {
+	if c.options.SignBySigstorePrivateKeyFile != "" {
 		signer, err := sigstore.NewSigner(
-			sigstore.WithPrivateKeyFile(options.SignBySigstorePrivateKeyFile, options.SignSigstorePrivateKeyPassphrase),
+			sigstore.WithPrivateKeyFile(c.options.SignBySigstorePrivateKeyFile, c.options.SignSigstorePrivateKeyPassphrase),
 		)
 		if err != nil {
 			return err

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -135,10 +135,11 @@ func TestCreateSignatures(t *testing.T) {
 
 		c := &copier{
 			dest:         imagedestination.FromPublic(cc.dest),
+			options:      options,
 			reportWriter: io.Discard,
 		}
 		defer c.close()
-		err := c.setupSigners(options)
+		err := c.setupSigners()
 		require.NoError(t, err, cc.name)
 		sigs, err := c.createSignatures(context.Background(), manifestBlob, identity)
 		switch {

--- a/copy/single.go
+++ b/copy/single.go
@@ -397,7 +397,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		defer ic.c.concurrentBlobCopiesSemaphore.Release(1)
 		defer copyGroup.Done()
 		cld := copyLayerData{}
-		if !ic.c.downloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if !ic.c.options.DownloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.

--- a/copy/single.go
+++ b/copy/single.go
@@ -97,7 +97,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		return nil, "", "", err
 	}
 
-	sigs, err := c.sourceSignatures(ctx, src, options,
+	sigs, err := c.sourceSignatures(ctx, src,
 		"Getting image source signatures",
 		"Checking if image destination supports signatures")
 	if err != nil {

--- a/copy/single.go
+++ b/copy/single.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -40,9 +39,9 @@ type imageCopier struct {
 	compressionLevel           *int
 }
 
-// copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
+// copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -57,7 +56,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	// Please keep this policy check BEFORE reading any other information about the image.
 	// (The multiImage check above only matches the MIME type, which we have received anyway.
 	// Actual parsing of anything should be deferred.)
-	if allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
+	if allowed, err := c.policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
 		return nil, "", "", fmt.Errorf("Source image rejected: %w", err)
 	}
 	src, err := image.FromUnparsedImage(ctx, c.options.SourceCtx, unparsedImage)

--- a/copy/single.go
+++ b/copy/single.go
@@ -42,7 +42,7 @@ type imageCopier struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
+func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -77,7 +77,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 				return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
 			}
 			if !matches {
-				manifestList, _, err := unparsedToplevel.Manifest(ctx)
+				manifestList, _, err := c.unparsedToplevel.Manifest(ctx)
 				if err != nil {
 					return nil, "", "", fmt.Errorf("reading manifest from source image: %w", err)
 				}

--- a/copy/single.go
+++ b/copy/single.go
@@ -38,7 +38,6 @@ type imageCopier struct {
 	canSubstituteBlobs         bool
 	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
 	compressionLevel           *int
-	ociEncryptLayers           *[]int
 }
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
@@ -124,7 +123,6 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		src:             src,
 		// diffIDsAreNeeded is computed later
 		cannotModifyManifestReason: cannotModifyManifestReason,
-		ociEncryptLayers:           c.options.OciEncryptLayers,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
@@ -416,10 +414,10 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// Decide which layers to encrypt
 	layersToEncrypt := set.New[int]()
 	var encryptAll bool
-	if ic.ociEncryptLayers != nil {
-		encryptAll = len(*ic.ociEncryptLayers) == 0
+	if ic.c.options.OciEncryptLayers != nil {
+		encryptAll = len(*ic.c.options.OciEncryptLayers) == 0
 		totalLayers := len(srcInfos)
-		for _, l := range *ic.ociEncryptLayers {
+		for _, l := range *ic.c.options.OciEncryptLayers {
 			// if layer is negative, it is reverse indexed.
 			layersToEncrypt.Add((totalLayers + l) % totalLayers)
 		}

--- a/copy/single.go
+++ b/copy/single.go
@@ -145,7 +145,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		return nil, "", "", err
 	}
 
-	destRequiresOciEncryption := (isEncrypted(src) && ic.c.ociDecryptConfig != nil) || c.options.OciEncryptLayers != nil
+	destRequiresOciEncryption := (isEncrypted(src) && ic.c.options.OciDecryptConfig != nil) || c.options.OciEncryptLayers != nil
 
 	manifestConversionPlan, err := determineManifestConversion(determineManifestConversionInputs{
 		srcMIMEType:                    ic.src.ManifestMIMEType,
@@ -609,7 +609,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// When encrypting to decrypting, only use the simple code path. We might be able to optimize more
 	// (e.g. if we know the DiffID of an encrypted compressed layer, it might not be necessary to pull, decrypt and decompress again),
 	// but it’s not trivially safe to do such things, so until someone takes the effort to make a comprehensive argument, let’s not.
-	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.ociDecryptConfig != nil)
+	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.options.OciDecryptConfig != nil)
 	canAvoidProcessingCompleteLayer := !diffIDIsNeeded && !encryptingOrDecrypting
 
 	// Don’t read the layer from the source if we already have the blob, and optimizations are acceptable.

--- a/copy/single.go
+++ b/copy/single.go
@@ -643,8 +643,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			// Throw an event that the layer has been skipped
-			if ic.c.progress != nil && ic.c.progressInterval > 0 {
-				ic.c.progress <- types.ProgressProperties{
+			if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
+				ic.c.options.Progress <- types.ProgressProperties{
 					Event:    types.ProgressEventSkipped,
 					Artifact: srcInfo,
 				}


### PR DESCRIPTION
This is motivated by the concurrent Zstd work, to make it more maintainable to pass data from and to `copySingleImage`.

- Add `copier.options`, `copier.policyContext` and `copier.unparsedToplevel` instead of passing them around in parameters
- Eliminate fields of `copier` and `imageCopier` that are now reachable through `.options`
- Return a `copySingleImageResult` from `copySingleImage`

@flouthoc I realize this is disruptive, and I want to do whatever necessary not to disrupt or slow down your work. Let me know what works for you — feel free to completely ignore this (and I’ll rebase this later as necessary), to reimplement parts yourself in some other way, or to tell me to split this up (maybe only the `copySingleImageResult` part?).

Others: Please don’t merge this without an ACK from @flouthoc .