### PR TITLE
copy/single: accept custom `*Options` and wrap arguments in `copySingleImageOptions`

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, false)
+		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, singleImageOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -273,8 +274,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
-
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil, false)
+		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, singleImageOpts)
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,8 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, singleImageOpts)
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
 			return nil, err
 		}
@@ -274,8 +273,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
-		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil, singleImageOpts)
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,8 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, singleImageOpts)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: false})
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,8 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, false)
+			singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, singleImageOpts)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/single.go
+++ b/copy/single.go
@@ -139,10 +139,13 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		cannotModifyManifestReason:    cannotModifyManifestReason,
 		requireCompressionFormatMatch: opts.requireCompressionFormatMatch,
 	}
-	if c.options.DestinationCtx != nil {
-		// Note that compressionFormat and compressionLevel can be nil.
+	if opts.compressionFormat != nil {
 		ic.compressionFormat = opts.compressionFormat
 		ic.compressionLevel = opts.compressionLevel
+	} else if c.options.DestinationCtx != nil {
+		// Note that compressionFormat and compressionLevel can be nil.
+		ic.compressionFormat = c.options.DestinationCtx.CompressionFormat
+		ic.compressionLevel = c.options.DestinationCtx.CompressionLevel
 	}
 	// Decide whether we can substitute blobs with semantic equivalents:
 	// - Don’t do that if we can’t modify the manifest at all

--- a/copy/single.go
+++ b/copy/single.go
@@ -40,6 +40,10 @@ type imageCopier struct {
 	requireCompressionFormatMatch bool
 }
 
+type copySingleImageOptions struct {
+	requireCompressionFormatMatch bool
+}
+
 // copySingleImageResult carries data produced by copySingleImage
 type copySingleImageResult struct {
 	manifest              []byte
@@ -50,7 +54,7 @@ type copySingleImageResult struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, requireCompressionFormatMatch bool) (copySingleImageResult, error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, opts copySingleImageOptions) (copySingleImageResult, error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -131,7 +135,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		src:             src,
 		// diffIDsAreNeeded is computed later
 		cannotModifyManifestReason:    cannotModifyManifestReason,
-		requireCompressionFormatMatch: requireCompressionFormatMatch,
+		requireCompressionFormatMatch: opts.requireCompressionFormatMatch,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
@@ -180,7 +184,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		shouldUpdateSigs := len(sigs) > 0 || len(c.signers) != 0 // TODO: Consider allowing signatures updates only and skipping the image's layers/manifest copy if possible
 		noPendingManifestUpdates := ic.noPendingManifestUpdates()
 
-		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, requireCompressionFormatMatch)
+		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, opts.requireCompressionFormatMatch)
 		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates && !ic.requireCompressionFormatMatch {
 			matchedResult, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {

--- a/copy/single.go
+++ b/copy/single.go
@@ -42,6 +42,8 @@ type imageCopier struct {
 
 type copySingleImageOptions struct {
 	requireCompressionFormatMatch bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
 }
 
 // copySingleImageResult carries data produced by copySingleImage
@@ -139,8 +141,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
-		ic.compressionFormat = c.options.DestinationCtx.CompressionFormat
-		ic.compressionLevel = c.options.DestinationCtx.CompressionLevel
+		ic.compressionFormat = opts.compressionFormat
+		ic.compressionLevel = opts.compressionLevel
 	}
 	// Decide whether we can substitute blobs with semantic equivalents:
 	// - Don’t do that if we can’t modify the manifest at all


### PR DESCRIPTION
After https://github.com/containers/image/pull/2048 there is no room for `copy/multiple` to pass custom options to `copySingleImage` while processing each instance, following PR introduces that functionality again and wraps options to simpler struct.

Needed by: https://github.com/containers/image/pull/1987