### PR TITLE
Add image.UnparsedInstanceWithReference and storage.ResolveReference

### DIFF
--- a/image/unparsed.go
+++ b/image/unparsed.go
@@ -2,6 +2,8 @@ package image
 
 import (
 	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/internal/unparsedimage"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 )
@@ -16,4 +18,24 @@ type UnparsedImage = image.UnparsedImage
 // The UnparsedImage must not be used after the underlying ImageSource is Close()d.
 func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *UnparsedImage {
 	return image.UnparsedInstance(src, instanceDigest)
+}
+
+// unparsedWithRef wraps a private.UnparsedImage, claiming another replacementRef
+type unparsedWithRef struct {
+	private.UnparsedImage
+	ref types.ImageReference
+}
+
+func (uwr *unparsedWithRef) Reference() types.ImageReference {
+	return uwr.ref
+}
+
+// UnparsedInstanceWithReference returns a types.UnparsedImage for wrappedInstance which claims to be a replacementRef.
+// This is useful for combining image data with other reference values, e.g. to check signatures on a locally-pulled image
+// based on a remote-registry policy.
+func UnparsedInstanceWithReference(wrappedInstance types.UnparsedImage, replacementRef types.ImageReference) types.UnparsedImage {
+	return &unparsedWithRef{
+		UnparsedImage: unparsedimage.FromPublic(wrappedInstance),
+		ref:           replacementRef,
+	}
 }

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -48,9 +48,24 @@ type StoreTransport interface {
 	GetStoreIfSet() storage.Store
 	// GetImage retrieves the image from the transport's store that's named
 	// by the reference.
+	// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
+	// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
+	// can return different images, with no way for the caller to "freeze" the storage.Image identity
+	// without discarding the name entirely.
+	//
+	// Use storage.ResolveReference instead.
 	GetImage(types.ImageReference) (*storage.Image, error)
 	// GetStoreImage retrieves the image from a specified store that's named
 	// by the reference.
+	//
+	// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
+	// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
+	// can return different images, with no way for the caller to "freeze" the storage.Image identity
+	// without discarding the name entirely.
+	//
+	// Also, a StoreTransport reference already contains a store, so providing another one is redundant.
+	//
+	// Use storage.ResolveReference instead.
 	GetStoreImage(storage.Store, types.ImageReference) (*storage.Image, error)
 	// ParseStoreReference parses a reference, overriding any store
 	// specification that it may contain.
@@ -290,6 +305,14 @@ func (s *storageTransport) ParseReference(reference string) (types.ImageReferenc
 	return s.ParseStoreReference(store, reference)
 }
 
+// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
+// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
+// can return different images, with no way for the caller to "freeze" the storage.Image identity
+// without discarding the name entirely.
+//
+// Also, a StoreTransport reference already contains a store, so providing another one is redundant.
+//
+// Use storage.ResolveReference instead.
 func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageReference) (*storage.Image, error) {
 	dref := ref.DockerReference()
 	if dref != nil {
@@ -306,6 +329,12 @@ func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageRefe
 	return nil, storage.ErrImageUnknown
 }
 
+// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
+// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
+// can return different images, with no way for the caller to "freeze" the storage.Image identity
+// without discarding the name entirely.
+//
+// Use storage.ResolveReference instead.
 func (s *storageTransport) GetImage(ref types.ImageReference) (*storage.Image, error) {
 	store, err := s.GetStore()
 	if err != nil {


### PR DESCRIPTION
We need to implement this locally, instead of having external callers do it, because external wrapping would make the sigstore-relevant `UntrustedSignatures` unavailable.

See conversation in https://github.com/cri-o/cri-o/pull/7046 .