### PR TITLE
copy/multiple: priority of `instanceCopyCopy` must be higher than `instanceCopyClone`

### DIFF
--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -122,6 +122,10 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 		if err != nil {
 			return res, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
 		}
+		res = append(res, instanceCopy{
+			op:           instanceCopyCopy,
+			sourceDigest: instanceDigest,
+		})
 		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
 		compressionList := compressionsByPlatform[platform]
 		for _, compressionVariant := range options.EnsureCompressionVariantsExist {
@@ -137,10 +141,6 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 				compressionList.Add(compressionVariant.Algorithm.Name())
 			}
 		}
-		res = append(res, instanceCopy{
-			op:           instanceCopyCopy,
-			sourceDigest: instanceDigest,
-		})
 	}
 	return res, nil
 }

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -80,12 +80,12 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	// and still copy `sourceInstance[2]`.
 	expectedResponse := []simplerInstanceCopy{}
 	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
 		// If its `arm64` and sourceDigest[2] , expect a clone to happen
 		if instance == sourceInstances[2] {
 			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
 		}
-		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
-			sourceDigest: instance})
 	}
 	actualResponse := convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)
@@ -97,12 +97,12 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	require.NoError(t, err)
 	expectedResponse = []simplerInstanceCopy{}
 	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
 		// If its `arm64` and sourceDigest[2] , expect a clone to happen
 		if instance == sourceInstances[2] {
 			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
 		}
-		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
-			sourceDigest: instance})
 	}
 	actualResponse = convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)


### PR DESCRIPTION
When copying multiple images i.e `instanceCopyClone` and no image exists in registry in such case if clones are prepared and copied first then original copies will reuse blobs from the clone which is unexpected since argument `requireCompressionFormatMatch` is by default false for `instanceCopyCopy` case.

Problem described in following PR is easily reproduceable when working with tools such as buildah, because without this PR buildah will push `clones` first instead of originals and later on `originals` will reuse blobs from `clones`.

Reproducer with empty registry
```console
./buildah manifest create localhost:5000/list:latest
./buildah build -t test .
./buildah manifest add localhost:5000/list:latest test
# Push with replication for `zstd`
./buildah manifest push --tls-verify=false --all --add-compression zstd localhost:5000/list:latest
```