### PR TITLE
Update x/exp/slices, and some small slice-related cleanups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/crypto v0.11.0
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
-golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -170,8 +170,19 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit) error {
 		index.Manifests = append(index.Manifests, addedEntries...)
 	}
 	if len(addedEntries) != 0 || updatedAnnotations {
-		slices.SortStableFunc(index.Manifests, func(a, b imgspecv1.Descriptor) bool {
-			return !instanceIsZstd(a) && instanceIsZstd(b)
+		slices.SortStableFunc(index.Manifests, func(a, b imgspecv1.Descriptor) int {
+			// FIXME? With Go 1.21 and cmp.Compare available, turn instanceIsZstd into an integer score that can be compared, and generalizes
+			// into more algorithms?
+			aZstd := instanceIsZstd(a)
+			bZstd := instanceIsZstd(b)
+			switch {
+			case aZstd == bZstd:
+				return 0
+			case !aZstd: // Implies bZstd
+				return -1
+			default: // aZstd && !bZstd
+				return 1
+			}
 		})
 	}
 	return nil

--- a/pkg/blobinfocache/internal/prioritize/prioritize.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize.go
@@ -82,6 +82,7 @@ func (css *candidateSortState) Swap(i, j int) {
 func destructivelyPrioritizeReplacementCandidatesWithMax(cs []CandidateWithTime, primaryDigest, uncompressedDigest digest.Digest, maxCandidates int) []blobinfocache.BICReplacementCandidate2 {
 	// We don't need to use sort.Stable() because nanosecond timestamps are (presumably?) unique, so no two elements should
 	// compare equal.
+	// FIXME: Use slices.SortFunc after we update to Go 1.20 (Go 1.21?) and Time.Compare and cmp.Compare are available.
 	sort.Sort(&candidateSortState{
 		cs:                 cs,
 		primaryDigest:      primaryDigest,

--- a/pkg/tlsclientconfig/tlsclientconfig_test.go
+++ b/pkg/tlsclientconfig/tlsclientconfig_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"os"
-	"sort"
 	"testing"
 
 	"github.com/containers/image/v5/internal/set"
@@ -80,8 +79,7 @@ func TestSetupCertificates(t *testing.T) {
 		require.NoError(t, err)
 		names = append(names, parsed.Subject.CommonName)
 	}
-	sort.Strings(names)
-	assert.Equal(t, []string{
+	assert.ElementsMatch(t, []string{
 		"containers/image test client certificate 1",
 		"containers/image test client certificate 2",
 	}, names)

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -921,10 +921,7 @@ func (s *storageImageDestination) PutSignaturesWithFormat(ctx context.Context, s
 			return err
 		}
 		sizes = append(sizes, len(sig))
-		newblob := make([]byte, len(sigblob)+len(sig))
-		copy(newblob, sigblob)
-		copy(newblob[len(sigblob):], sig)
-		sigblob = newblob
+		sigblob = append(sigblob, sig...)
 	}
 	if instanceDigest == nil {
 		s.signatures = sigblob


### PR DESCRIPTION
Primarily replaces #2065 ; also a few other changes found during slice usage audit.

See individual commit messages for details.