### PR TITLE
copy: add support for `ForceCompressionFormat`

### DIFF
--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -33,6 +33,10 @@ type instanceCopy struct {
 	sourceDigest digest.Digest
 
 	// Fields which can be used by callers when operation
+	// is `instanceCopyCopy`
+	copyForceCompressionFormat bool
+
+	// Fields which can be used by callers when operation
 	// is `instanceCopyClone`
 	cloneCompressionVariant OptionCompressionVariant
 	clonePlatform           *imgspecv1.Platform
@@ -122,9 +126,14 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 		if err != nil {
 			return res, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
 		}
+		forceCompressionFormat, err := shouldRequireCompressionFormatMatch(options)
+		if err != nil {
+			return nil, err
+		}
 		res = append(res, instanceCopy{
-			op:           instanceCopyCopy,
-			sourceDigest: instanceDigest,
+			op:                         instanceCopyCopy,
+			sourceDigest:               instanceDigest,
+			copyForceCompressionFormat: forceCompressionFormat,
 		})
 		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
 		compressionList := compressionsByPlatform[platform]
@@ -230,7 +239,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: false})
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: instance.copyForceCompressionFormat})
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -32,7 +32,7 @@ func TestPrepareCopyInstancesforInstanceCopyCopy(t *testing.T) {
 
 	for _, instance := range sourceInstances {
 		compare = append(compare, instanceCopy{op: instanceCopyCopy,
-			sourceDigest: instance})
+			sourceDigest: instance, copyForceCompressionFormat: false})
 	}
 	assert.Equal(t, instancesToCopy, compare)
 
@@ -42,6 +42,9 @@ func TestPrepareCopyInstancesforInstanceCopyCopy(t *testing.T) {
 	compare = []instanceCopy{{op: instanceCopyCopy,
 		sourceDigest: sourceInstances[1]}}
 	assert.Equal(t, instancesToCopy, compare)
+
+	_, err = prepareInstanceCopies(list, sourceInstances, &Options{Instances: []digest.Digest{sourceInstances[1]}, ImageListSelection: CopySpecificImages, ForceCompressionFormat: true})
+	require.EqualError(t, err, "cannot use ForceCompressionFormat with undefined default compression format")
 }
 
 // Test `instanceCopyClone` cases.


### PR DESCRIPTION
ForceCompressionFormat allows end users to force selected compression format (set in DestinationCtx.CompressionFormat) which ensures that while copying blobs of other compression algorithms are not reused.

Following flag is a frontend wrapper for: https://github.com/containers/image/pull/2023 

Will help in:
* https://github.com/containers/buildah/issues/4613
* https://github.com/containers/podman/issues/18660