### PR TITLE
[release-5.26] backport API changes `copy` and `list` components from upstream.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,9 +6,9 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "release-5.26"
     # CI container image tag (c/skopeo branch name)
-    SKOPEO_CI_TAG: "main"
+    SKOPEO_CI_TAG: "v1.13.0"
     # Use GO module mirror (reason unknown, travis did it this way)
     GOPROXY: https://proxy.golang.org
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/copy/blob.go
+++ b/copy/blob.go
@@ -83,12 +83,12 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		return types.BlobInfo{}, err
 	}
 
-	// === Report progress using the ic.c.progress channel, if required.
-	if ic.c.progress != nil && ic.c.progressInterval > 0 {
+	// === Report progress using the ic.c.options.Progress channel, if required.
+	if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
 		progressReader := newProgressReader(
 			stream.reader,
-			ic.c.progress,
-			ic.c.progressInterval,
+			ic.c.options.Progress,
+			ic.c.options.ProgressInterval,
 			srcInfo,
 		)
 		defer progressReader.reportDone()

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -139,7 +139,6 @@ type copier struct {
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
-	ociEncryptConfig              *encconfig.EncryptConfig
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
 	downloadForeignLayers         bool
 	signers                       []*signer.Signer // Signers to use to create new signatures for the image
@@ -213,7 +212,6 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
 		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		ociEncryptConfig:      options.OciEncryptConfig,
 		downloadForeignLayers: options.DownloadForeignLayers,
 	}
 	defer c.close()

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/signer"
 	"github.com/containers/image/v5/transports"
@@ -126,6 +127,21 @@ type Options struct {
 	// Download layer contents with "nondistributable" media types ("foreign" layers) and translate the layer media type
 	// to not indicate "nondistributable".
 	DownloadForeignLayers bool
+
+	// Contains slice of OptionCompressionVariant, where copy will ensure that for each platform
+	// in the manifest list, a variant with the requested compression will exist.
+	// Invalid when copying a non-multi-architecture image. That will probably
+	// change in the future.
+	EnsureCompressionVariantsExist []OptionCompressionVariant
+}
+
+// OptionCompressionVariant allows to supply information about
+// selected compression algorithm and compression level by the
+// end-user. Refer to EnsureCompressionVariantsExist to know
+// more about its usage.
+type OptionCompressionVariant struct {
+	Algorithm compression.Algorithm
+	Level     *int // Only used when we are creating a new image instance using the specified algorithm, not when the image already contains such an instance
 }
 
 // copier allows us to keep track of diffID values for blobs, and other

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -138,8 +138,6 @@ type copier struct {
 
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
-	progressInterval              time.Duration
-	progress                      chan types.ProgressProperties
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
 	ociDecryptConfig              *encconfig.DecryptConfig
 	ociEncryptConfig              *encconfig.EncryptConfig
@@ -210,10 +208,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		rawSource: rawSource,
 		options:   options,
 
-		reportWriter:     reportWriter,
-		progressOutput:   progressOutput,
-		progressInterval: options.ProgressInterval,
-		progress:         options.Progress,
+		reportWriter:   reportWriter,
+		progressOutput: progressOutput,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,9 +251,11 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, c.unparsedToplevel, nil); err != nil {
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil)
+		if err != nil {
 			return nil, err
 		}
+		copiedManifest = single.manifest
 	} else if c.options.ImageListSelection == CopySystemImage {
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
@@ -272,9 +274,11 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, unparsedInstance, nil); err != nil {
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil)
+		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
+		copiedManifest = single.manifest
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil)
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, false)
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil)
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, false)
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -250,7 +250,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
@@ -271,7 +271,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -140,9 +140,8 @@ type copier struct {
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
-	downloadForeignLayers         bool
-	signers                       []*signer.Signer // Signers to use to create new signatures for the image
-	signersToClose                []*signer.Signer // Signers that should be closed when this copier is destroyed.
+	signers                       []*signer.Signer    // Signers to use to create new signatures for the image
+	signersToClose                []*signer.Signer    // Signers that should be closed when this copier is destroyed.
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
@@ -211,8 +210,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
-		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		downloadForeignLayers: options.DownloadForeignLayers,
+		blobInfoCache: internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
 	}
 	defer c.close()
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -256,7 +256,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if options.ImageListSelection == CopySystemImage {
@@ -277,7 +277,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -244,7 +244,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	}
 
-	if err := c.setupSigners(options); err != nil {
+	if err := c.setupSigners(); err != nil {
 		return nil, err
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -132,8 +132,10 @@ type Options struct {
 // data shared across one or more images in a possible manifest list.
 // The owner must call close() when done.
 type copier struct {
-	dest                          private.ImageDestination
-	rawSource                     private.ImageSource
+	dest      private.ImageDestination
+	rawSource private.ImageSource
+	options   *Options // never nil
+
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	progressInterval              time.Duration
@@ -204,8 +206,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:             dest,
-		rawSource:        rawSource,
+		dest:      dest,
+		rawSource: rawSource,
+		options:   options,
+
 		reportWriter:     reportWriter,
 		progressOutput:   progressOutput,
 		progressInterval: options.ProgressInterval,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -139,7 +139,6 @@ type copier struct {
 	reportWriter                  io.Writer
 	progressOutput                io.Writer
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
-	ociDecryptConfig              *encconfig.DecryptConfig
 	ociEncryptConfig              *encconfig.EncryptConfig
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
 	downloadForeignLayers         bool
@@ -214,7 +213,6 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
 		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		ociDecryptConfig:      options.OciDecryptConfig,
 		ociEncryptConfig:      options.OciEncryptConfig,
 		downloadForeignLayers: options.DownloadForeignLayers,
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -292,7 +292,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, options, unparsedToplevel); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, unparsedToplevel); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, false)
+		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, singleImageOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -273,8 +274,8 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
-
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil, false)
+		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, singleImageOpts)
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -132,9 +132,10 @@ type Options struct {
 // data shared across one or more images in a possible manifest list.
 // The owner must call close() when done.
 type copier struct {
-	dest      private.ImageDestination
-	rawSource private.ImageSource
-	options   *Options // never nil
+	policyContext *signature.PolicyContext
+	dest          private.ImageDestination
+	rawSource     private.ImageSource
+	options       *Options // never nil
 
 	reportWriter   io.Writer
 	progressOutput io.Writer
@@ -203,9 +204,10 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:      dest,
-		rawSource: rawSource,
-		options:   options,
+		policyContext: policyContext,
+		dest:          dest,
+		rawSource:     rawSource,
+		options:       options,
 
 		reportWriter:   reportWriter,
 		progressOutput: progressOutput,

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,7 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, c.unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, c.unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
@@ -272,7 +272,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedInstance, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, unparsedInstance, nil); err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -151,11 +151,6 @@ type copier struct {
 // source image admissibility.  It returns the manifest which was written to
 // the new copy of the image.
 func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef, srcRef types.ImageReference, options *Options) (copiedManifest []byte, retErr error) {
-	// NOTE this function uses an output parameter for the error return value.
-	// Setting this and returning is the ideal way to return an error.
-	//
-	// the defers in this routine will wrap the error return with its own errors
-	// which can be valuable context in the middle of a multi-streamed copy.
 	if options == nil {
 		options = &Options{}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -266,6 +266,9 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	if !multiImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// The simple case: just copy a single image.
 		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
@@ -273,6 +276,9 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		copiedManifest = single.manifest
 	} else if c.options.ImageListSelection == CopySystemImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
 		mfest, manifestType, err := c.unparsedToplevel.Manifest(ctx)

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -286,7 +286,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, unparsedToplevel); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -242,21 +242,20 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		return nil, err
 	}
 
-	unparsedToplevel := c.unparsedToplevel
-	multiImage, err := isMultiImage(ctx, unparsedToplevel)
+	multiImage, err := isMultiImage(ctx, c.unparsedToplevel)
 	if err != nil {
 		return nil, fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(srcRef), err)
 	}
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, unparsedToplevel, nil); err != nil {
+		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, c.unparsedToplevel, nil); err != nil {
 			return nil, err
 		}
 	} else if c.options.ImageListSelection == CopySystemImage {
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
-		mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
+		mfest, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("reading manifest for %s: %w", transports.ImageName(srcRef), err)
 		}
@@ -291,7 +290,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	}
 
-	if err := c.dest.Commit(ctx, unparsedToplevel); err != nil {
+	if err := c.dest.Commit(ctx, c.unparsedToplevel); err != nil {
 		return nil, fmt.Errorf("committing the finished image: %w", err)
 	}
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -251,8 +251,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	if !multiImage {
 		// The simple case: just copy a single image.
-		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, singleImageOpts)
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
 			return nil, err
 		}
@@ -274,8 +273,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
-		singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-		single, err := c.copySingleImage(ctx, unparsedInstance, nil, singleImageOpts)
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
 		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -287,7 +287,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -34,7 +34,7 @@ type bpDecryptionStepData struct {
 // srcInfo is only used for error messages.
 // Returns data for other steps; the caller should eventually use updateCryptoOperation.
 func (ic *imageCopier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo types.BlobInfo) (*bpDecryptionStepData, error) {
-	if !isOciEncrypted(stream.info.MediaType) || ic.c.ociDecryptConfig == nil {
+	if !isOciEncrypted(stream.info.MediaType) || ic.c.options.OciDecryptConfig == nil {
 		return &bpDecryptionStepData{
 			decrypting: false,
 		}, nil
@@ -47,7 +47,7 @@ func (ic *imageCopier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo 
 	desc := imgspecv1.Descriptor{
 		Annotations: stream.info.Annotations,
 	}
-	reader, decryptedDigest, err := ocicrypt.DecryptLayer(ic.c.ociDecryptConfig, stream.reader, desc, false)
+	reader, decryptedDigest, err := ocicrypt.DecryptLayer(ic.c.options.OciDecryptConfig, stream.reader, desc, false)
 	if err != nil {
 		return nil, fmt.Errorf("decrypting layer %s: %w", srcInfo.Digest, err)
 	}

--- a/copy/encryption.go
+++ b/copy/encryption.go
@@ -81,7 +81,7 @@ type bpEncryptionStepData struct {
 // Returns data for other steps; the caller should eventually call updateCryptoOperationAndAnnotations.
 func (ic *imageCopier) blobPipelineEncryptionStep(stream *sourceStream, toEncrypt bool, srcInfo types.BlobInfo,
 	decryptionStep *bpDecryptionStepData) (*bpEncryptionStepData, error) {
-	if !toEncrypt || isOciEncrypted(srcInfo.MediaType) || ic.c.ociEncryptConfig == nil {
+	if !toEncrypt || isOciEncrypted(srcInfo.MediaType) || ic.c.options.OciEncryptConfig == nil {
 		return &bpEncryptionStepData{
 			encrypting: false,
 		}, nil
@@ -101,7 +101,7 @@ func (ic *imageCopier) blobPipelineEncryptionStep(stream *sourceStream, toEncryp
 		Size:        srcInfo.Size,
 		Annotations: annotations,
 	}
-	reader, finalizer, err := ocicrypt.EncryptLayer(ic.c.ociEncryptConfig, stream.reader, desc)
+	reader, finalizer, err := ocicrypt.EncryptLayer(ic.c.options.OciEncryptConfig, stream.reader, desc)
 	if err != nil {
 		return nil, fmt.Errorf("encrypting blob %s: %w", srcInfo.Digest, err)
 	}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -122,6 +122,10 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 		if err != nil {
 			return res, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
 		}
+		res = append(res, instanceCopy{
+			op:           instanceCopyCopy,
+			sourceDigest: instanceDigest,
+		})
 		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
 		compressionList := compressionsByPlatform[platform]
 		for _, compressionVariant := range options.EnsureCompressionVariantsExist {
@@ -137,10 +141,6 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 				compressionList.Add(compressionVariant.Algorithm.Name())
 			}
 		}
-		res = append(res, instanceCopy{
-			op:           instanceCopyCopy,
-			sourceDigest: instanceDigest,
-		})
 	}
 	return res, nil
 }

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -221,7 +221,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	if err != nil {
 		return nil, fmt.Errorf("preparing instances for copy: %w", err)
 	}
-	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
+	c.Printf("Copying %d images generated from %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
 		// populate necessary fields.

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -110,8 +110,7 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 					clonePlatform:           instanceDetails.ReadOnly.Platform,
 					cloneAnnotations:        maps.Clone(instanceDetails.ReadOnly.Annotations),
 				})
-				// add current compression to the list so logic acks any
-				// duplicates while processing other instances
+				// add current compression to the list so that we don’t create duplicate clones
 				compressionList.Add(compressionVariant.Algorithm.Name())
 			}
 		}
@@ -224,7 +223,10 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Replicating instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Replicating image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: true})
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{
+				requireCompressionFormatMatch: true,
+				compressionFormat:             &instance.cloneCompressionVariant.Algorithm,
+				compressionLevel:              instance.cloneCompressionVariant.Level})
 			if err != nil {
 				return nil, fmt.Errorf("replicating image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/image/v5/internal/image"
 	internalManifest "github.com/containers/image/v5/internal/manifest"
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/image/v5/signature"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -48,8 +47,8 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 }
 
 // copyMultipleImages copies some or all of an image list's instances, using
-// policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext) (copiedManifest []byte, retErr error) {
+// c.policyContext to validate source image admissibility.
+func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 	if err != nil {

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -134,11 +134,12 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			}
 			// Record the result of a possible conversion here.
 			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
-				ListOperation:   internalManifest.ListOpUpdate,
-				UpdateOldDigest: instance.sourceDigest,
-				UpdateDigest:    updated.manifestDigest,
-				UpdateSize:      int64(len(updated.manifest)),
-				UpdateMediaType: updated.manifestMIMEType})
+				ListOperation:               internalManifest.ListOpUpdate,
+				UpdateOldDigest:             instance.sourceDigest,
+				UpdateDigest:                updated.manifestDigest,
+				UpdateSize:                  int64(len(updated.manifest)),
+				UpdateCompressionAlgorithms: updated.compressionAlgorithms,
+				UpdateMediaType:             updated.manifestMIMEType})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}
@@ -136,9 +136,9 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
 				ListOperation:   internalManifest.ListOpUpdate,
 				UpdateOldDigest: instance.sourceDigest,
-				UpdateDigest:    updatedManifestDigest,
-				UpdateSize:      int64(len(updatedManifest)),
-				UpdateMediaType: updatedManifestType})
+				UpdateDigest:    updated.manifestDigest,
+				UpdateSize:      int64(len(updated.manifest)),
+				UpdateMediaType: updated.manifestMIMEType})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -49,7 +49,7 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 
 // copyMultipleImages copies some or all of an image list's instances, using
 // policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, options *Options, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
+func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {
@@ -94,12 +94,12 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	if destIsDigestedReference {
 		cannotModifyManifestListReason = "Destination specifies a digest"
 	}
-	if options.PreserveDigests {
+	if c.options.PreserveDigests {
 		cannotModifyManifestListReason = "Instructed to preserve digests"
 	}
 
 	// Determine if we'll need to convert the manifest list to a different format.
-	forceListMIMEType := options.ForceManifestMIMEType
+	forceListMIMEType := c.options.ForceManifestMIMEType
 	switch forceListMIMEType {
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema2MediaType:
 		forceListMIMEType = manifest.DockerV2ListMediaType
@@ -119,7 +119,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	// Copy each image, or just the ones we want to copy, in turn.
 	instanceDigests := updatedList.Instances()
 	instanceEdits := []internalManifest.ListEdit{}
-	instanceCopyList := prepareInstanceCopies(instanceDigests, options)
+	instanceCopyList := prepareInstanceCopies(instanceDigests, c.options)
 	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
@@ -204,7 +204,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 
 	// Sign the manifest list.
-	newSigs, err := c.createSignatures(ctx, manifestList, options.SignIdentity)
+	newSigs, err := c.createSignatures(ctx, manifestList, c.options.SignIdentity)
 	if err != nil {
 		return nil, err
 	}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,8 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, singleImageOpts)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: false})
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -5,15 +5,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
 	internalManifest "github.com/containers/image/v5/internal/manifest"
+	"github.com/containers/image/v5/internal/set"
 	"github.com/containers/image/v5/manifest"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -27,23 +30,97 @@ const (
 type instanceCopy struct {
 	op           instanceCopyKind
 	sourceDigest digest.Digest
+
+	// Fields which can be used by callers when operation
+	// is `instanceCopyClone`
+	cloneCompressionVariant OptionCompressionVariant
+	clonePlatform           *imgspecv1.Platform
+	cloneAnnotations        map[string]string
+}
+
+// internal type only to make imgspecv1.Platform comparable
+type platformComparable struct {
+	architecture string
+	os           string
+	osVersion    string
+	osFeatures   string
+	variant      string
+}
+
+// Converts imgspecv1.Platform to a comparable format.
+func platformV1ToPlatformComparable(platform *imgspecv1.Platform) platformComparable {
+	if platform == nil {
+		return platformComparable{}
+	}
+	osFeatures := slices.Clone(platform.OSFeatures)
+	sort.Strings(osFeatures)
+	return platformComparable{architecture: platform.Architecture,
+		os: platform.OS,
+		// This is strictly speaking ambiguous, fields of OSFeatures can contain a ','. Probably good enough for now.
+		osFeatures: strings.Join(osFeatures, ","),
+		osVersion:  platform.OSVersion,
+		variant:    platform.Variant,
+	}
+}
+
+// platformCompressionMap prepares a mapping of platformComparable -> CompressionAlgorithmNames for given digests
+func platformCompressionMap(list internalManifest.List, instanceDigests []digest.Digest) (map[platformComparable]*set.Set[string], error) {
+	res := make(map[platformComparable]*set.Set[string])
+	for _, instanceDigest := range instanceDigests {
+		instanceDetails, err := list.Instance(instanceDigest)
+		if err != nil {
+			return nil, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
+		}
+		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
+		platformSet, ok := res[platform]
+		if !ok {
+			platformSet = set.New[string]()
+			res[platform] = platformSet
+		}
+		platformSet.AddSlice(instanceDetails.ReadOnly.CompressionAlgorithmNames)
+	}
+	return res, nil
 }
 
 // prepareInstanceCopies prepares a list of instances which needs to copied to the manifest list.
-func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []instanceCopy {
+func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.Digest, options *Options) ([]instanceCopy, error) {
 	res := []instanceCopy{}
+	compressionsByPlatform, err := platformCompressionMap(list, instanceDigests)
+	if err != nil {
+		return nil, err
+	}
 	for i, instanceDigest := range instanceDigests {
 		if options.ImageListSelection == CopySpecificImages &&
 			!slices.Contains(options.Instances, instanceDigest) {
 			logrus.Debugf("Skipping instance %s (%d/%d)", instanceDigest, i+1, len(instanceDigests))
 			continue
 		}
+		instanceDetails, err := list.Instance(instanceDigest)
+		if err != nil {
+			return res, fmt.Errorf("getting details for instance %s: %w", instanceDigest, err)
+		}
+		platform := platformV1ToPlatformComparable(instanceDetails.ReadOnly.Platform)
+		compressionList := compressionsByPlatform[platform]
+		for _, compressionVariant := range options.EnsureCompressionVariantsExist {
+			if !compressionList.Contains(compressionVariant.Algorithm.Name()) {
+				res = append(res, instanceCopy{
+					op:                      instanceCopyClone,
+					sourceDigest:            instanceDigest,
+					cloneCompressionVariant: compressionVariant,
+					clonePlatform:           instanceDetails.ReadOnly.Platform,
+					cloneAnnotations:        maps.Clone(instanceDetails.ReadOnly.Annotations),
+				})
+				// add current compression to the list so logic acks any
+				// duplicates while processing other instances
+				compressionList.Add(compressionVariant.Algorithm.Name())
+			}
+		}
 		res = append(res, instanceCopy{
 			op:           instanceCopyCopy,
 			sourceDigest: instanceDigest,
 		})
 	}
-	return res
+	return res, nil
 }
 
 // copyMultipleImages copies some or all of an image list's instances, using
@@ -118,7 +195,10 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	// Copy each image, or just the ones we want to copy, in turn.
 	instanceDigests := updatedList.Instances()
 	instanceEdits := []internalManifest.ListEdit{}
-	instanceCopyList := prepareInstanceCopies(instanceDigests, c.options)
+	instanceCopyList, err := prepareInstanceCopies(updatedList, instanceDigests, c.options)
+	if err != nil {
+		return nil, fmt.Errorf("preparing instances for copy: %w", err)
+	}
 	c.Printf("Copying %d of %d images in list\n", len(instanceCopyList), len(instanceDigests))
 	for i, instance := range instanceCopyList {
 		// Update instances to be edited by their `ListOperation` and
@@ -140,6 +220,24 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 				UpdateSize:                  int64(len(updated.manifest)),
 				UpdateCompressionAlgorithms: updated.compressionAlgorithms,
 				UpdateMediaType:             updated.manifestMIMEType})
+		case instanceCopyClone:
+			logrus.Debugf("Replicating instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
+			c.Printf("Replicating image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
+			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, copySingleImageOptions{requireCompressionFormatMatch: true})
+			if err != nil {
+				return nil, fmt.Errorf("replicating image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
+			}
+			// Record the result of a possible conversion here.
+			instanceEdits = append(instanceEdits, internalManifest.ListEdit{
+				ListOperation:            internalManifest.ListOpAdd,
+				AddDigest:                updated.manifestDigest,
+				AddSize:                  int64(len(updated.manifest)),
+				AddMediaType:             updated.manifestMIMEType,
+				AddPlatform:              instance.clonePlatform,
+				AddAnnotations:           instance.cloneAnnotations,
+				AddCompressionAlgorithms: updated.compressionAlgorithms,
+			})
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedToplevel, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, false)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -49,9 +49,9 @@ func prepareInstanceCopies(instanceDigests []digest.Digest, options *Options) []
 
 // copyMultipleImages copies some or all of an image list's instances, using
 // policyContext to validate source image admissibility.
-func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel *image.UnparsedImage) (copiedManifest []byte, retErr error) {
+func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signature.PolicyContext) (copiedManifest []byte, retErr error) {
 	// Parse the list and get a copy of the original value after it's re-encoded.
-	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
+	manifestList, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest list: %w", err)
 	}
@@ -61,7 +61,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	updatedList := originalList.CloneInternal()
 
-	sigs, err := c.sourceSignatures(ctx, unparsedToplevel,
+	sigs, err := c.sourceSignatures(ctx, c.unparsedToplevel,
 		"Getting image list signatures",
 		"Checking if image list destination supports signatures")
 	if err != nil {

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -128,7 +128,8 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, false)
+			singleImageOpts := copySingleImageOptions{requireCompressionFormatMatch: false}
+			updated, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest, singleImageOpts)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -129,7 +129,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			logrus.Debugf("Copying instance %s (%d/%d)", instance.sourceDigest, i+1, len(instanceCopyList))
 			c.Printf("Copying image %s (%d/%d)\n", instance.sourceDigest, i+1, len(instanceCopyList))
 			unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceCopyList[i].sourceDigest)
-			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, policyContext, unparsedInstance, &instanceCopyList[i].sourceDigest)
+			updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copySingleImage(ctx, unparsedInstance, &instanceCopyList[i].sourceDigest)
 			if err != nil {
 				return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", i+1, len(instanceCopyList), err)
 			}

--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -61,7 +61,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	updatedList := originalList.CloneInternal()
 
-	sigs, err := c.sourceSignatures(ctx, unparsedToplevel, options,
+	sigs, err := c.sourceSignatures(ctx, unparsedToplevel,
 		"Getting image list signatures",
 		"Checking if image list destination supports signatures")
 	if err != nil {

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -106,6 +106,23 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	}
 	actualResponse = convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)
+
+	// Add same instance twice but clone must appear only once.
+	ensureCompressionVariantsExist = []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+	sourceInstances = []digest.Digest{
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+	}
+	instancesToCopy, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+	// two copies but clone should happen only once
+	numberOfCopyClone := 0
+	for _, instance := range instancesToCopy {
+		if instance.op == instanceCopyClone {
+			numberOfCopyClone++
+		}
+	}
+	assert.Equal(t, 1, numberOfCopyClone)
 }
 
 // simpler version of `instanceCopy` for testing where fields are string

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -80,12 +80,12 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	// and still copy `sourceInstance[2]`.
 	expectedResponse := []simplerInstanceCopy{}
 	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
 		// If its `arm64` and sourceDigest[2] , expect a clone to happen
 		if instance == sourceInstances[2] {
 			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
 		}
-		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
-			sourceDigest: instance})
 	}
 	actualResponse := convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)
@@ -97,12 +97,12 @@ func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
 	require.NoError(t, err)
 	expectedResponse = []simplerInstanceCopy{}
 	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
 		// If its `arm64` and sourceDigest[2] , expect a clone to happen
 		if instance == sourceInstances[2] {
 			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
 		}
-		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
-			sourceDigest: instance})
 	}
 	actualResponse = convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
 	assert.Equal(t, expectedResponse, actualResponse)

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	internalManifest "github.com/containers/image/v5/internal/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,4 +42,86 @@ func TestPrepareCopyInstancesforInstanceCopyCopy(t *testing.T) {
 	compare = []instanceCopy{{op: instanceCopyCopy,
 		sourceDigest: sourceInstances[1]}}
 	assert.Equal(t, instancesToCopy, compare)
+}
+
+// Test `instanceCopyClone` cases.
+func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
+	validManifest, err := os.ReadFile(filepath.Join("..", "internal", "manifest", "testdata", "oci1.index.zstd-selection.json"))
+	require.NoError(t, err)
+	list, err := internalManifest.ListFromBlob(validManifest, internalManifest.GuessMIMEType(validManifest))
+	require.NoError(t, err)
+
+	// Prepare option for `instanceCopyClone` case.
+	ensureCompressionVariantsExist := []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+
+	sourceInstances := []digest.Digest{
+		digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+	}
+
+	// CopySpecificImage must fail with error
+	_, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist,
+		Instances:          []digest.Digest{sourceInstances[1]},
+		ImageListSelection: CopySpecificImages})
+	require.EqualError(t, err, "EnsureCompressionVariantsExist is not implemented for CopySpecificImages")
+
+	// Test copying all images with replication
+	instancesToCopy, err := prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+
+	// Following test ensures
+	// * Still copy gzip variants if they exist in the original
+	// * Not create new Zstd variants if they exist in the original.
+
+	// We crated a list of three instances `sourceInstances` and since in oci1.index.zstd-selection.json
+	// amd64 already has a zstd instance i.e sourceInstance[1] so it should not create replication for
+	// `sourceInstance[0]` and `sourceInstance[1]` but should do it for `sourceInstance[2]` for `arm64`
+	// and still copy `sourceInstance[2]`.
+	assert.Equal(t, 4, len(instancesToCopy))
+	expectedResponse := []simplerInstanceCopy{}
+	for _, instance := range sourceInstances {
+		// If its `arm64` and sourceDigest[2] , expect a clone to happen
+		if instance == sourceInstances[2] {
+			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
+		}
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
+	}
+	actualResponse := convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
+	assert.Equal(t, expectedResponse, actualResponse)
+
+}
+
+// simpler version of `instanceCopy` for testing where fields are string
+// instead of pointer
+type simplerInstanceCopy struct {
+	op           instanceCopyKind
+	sourceDigest digest.Digest
+
+	// Fields which can be used by callers when operation
+	// is `instanceCopyClone`
+	cloneCompressionVariant string
+	clonePlatform           string
+	cloneAnnotations        map[string]string
+}
+
+func convertInstanceCopyToSimplerInstanceCopy(copies []instanceCopy) []simplerInstanceCopy {
+	res := []simplerInstanceCopy{}
+	for _, instance := range copies {
+		compression := ""
+		platform := ""
+		compression = instance.cloneCompressionVariant.Algorithm.Name()
+		if instance.clonePlatform != nil {
+			platform = instance.clonePlatform.Architecture + "-" + instance.clonePlatform.OS + "-" + instance.clonePlatform.Variant
+		}
+		res = append(res, simplerInstanceCopy{
+			op:                      instance.op,
+			sourceDigest:            instance.sourceDigest,
+			cloneCompressionVariant: compression,
+			clonePlatform:           platform,
+			cloneAnnotations:        instance.cloneAnnotations,
+		})
+	}
+	return res
 }

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -50,13 +50,13 @@ func (c *copier) setupSigners() error {
 	return nil
 }
 
-// sourceSignatures returns signatures from unparsedSource based on options,
+// sourceSignatures returns signatures from unparsedSource,
 // and verifies that they can be used (to avoid copying a large image when we
 // can tell in advance that it would ultimately fail)
-func (c *copier) sourceSignatures(ctx context.Context, unparsed private.UnparsedImage, options *Options,
+func (c *copier) sourceSignatures(ctx context.Context, unparsed private.UnparsedImage,
 	gettingSignaturesMessage, checkingDestMessage string) ([]internalsig.Signature, error) {
 	var sigs []internalsig.Signature
-	if options.RemoveSignatures {
+	if c.options.RemoveSignatures {
 		sigs = []internalsig.Signature{}
 	} else {
 		c.Printf("%s\n", gettingSignaturesMessage)

--- a/copy/sign.go
+++ b/copy/sign.go
@@ -13,20 +13,20 @@ import (
 	"github.com/containers/image/v5/transports"
 )
 
-// setupSigners initializes c.signers based on options.
-func (c *copier) setupSigners(options *Options) error {
-	c.signers = append(c.signers, options.Signers...)
-	// c.signersToClose is intentionally not updated with options.Signers.
+// setupSigners initializes c.signers.
+func (c *copier) setupSigners() error {
+	c.signers = append(c.signers, c.options.Signers...)
+	// c.signersToClose is intentionally not updated with c.options.Signers.
 
 	// We immediately append created signers to c.signers, and we rely on c.close() to clean them up; so we don’t need
 	// to clean up any created signers on failure.
 
-	if options.SignBy != "" {
+	if c.options.SignBy != "" {
 		opts := []simplesigning.Option{
-			simplesigning.WithKeyFingerprint(options.SignBy),
+			simplesigning.WithKeyFingerprint(c.options.SignBy),
 		}
-		if options.SignPassphrase != "" {
-			opts = append(opts, simplesigning.WithPassphrase(options.SignPassphrase))
+		if c.options.SignPassphrase != "" {
+			opts = append(opts, simplesigning.WithPassphrase(c.options.SignPassphrase))
 		}
 		signer, err := simplesigning.NewSigner(opts...)
 		if err != nil {
@@ -36,9 +36,9 @@ func (c *copier) setupSigners(options *Options) error {
 		c.signersToClose = append(c.signersToClose, signer)
 	}
 
-	if options.SignBySigstorePrivateKeyFile != "" {
+	if c.options.SignBySigstorePrivateKeyFile != "" {
 		signer, err := sigstore.NewSigner(
-			sigstore.WithPrivateKeyFile(options.SignBySigstorePrivateKeyFile, options.SignSigstorePrivateKeyPassphrase),
+			sigstore.WithPrivateKeyFile(c.options.SignBySigstorePrivateKeyFile, c.options.SignSigstorePrivateKeyPassphrase),
 		)
 		if err != nil {
 			return err

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -135,10 +135,11 @@ func TestCreateSignatures(t *testing.T) {
 
 		c := &copier{
 			dest:         imagedestination.FromPublic(cc.dest),
+			options:      options,
 			reportWriter: io.Discard,
 		}
 		defer c.close()
-		err := c.setupSigners(options)
+		err := c.setupSigners()
 		require.NoError(t, err, cc.name)
 		sigs, err := c.createSignatures(context.Background(), manifestBlob, identity)
 		switch {

--- a/copy/single.go
+++ b/copy/single.go
@@ -97,7 +97,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		return nil, "", "", err
 	}
 
-	sigs, err := c.sourceSignatures(ctx, src, options,
+	sigs, err := c.sourceSignatures(ctx, src,
 		"Getting image source signatures",
 		"Checking if image destination supports signatures")
 	if err != nil {

--- a/copy/single.go
+++ b/copy/single.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -40,9 +39,9 @@ type imageCopier struct {
 	compressionLevel           *int
 }
 
-// copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
+// copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -57,7 +56,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	// Please keep this policy check BEFORE reading any other information about the image.
 	// (The multiImage check above only matches the MIME type, which we have received anyway.
 	// Actual parsing of anything should be deferred.)
-	if allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
+	if allowed, err := c.policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
 		return nil, "", "", fmt.Errorf("Source image rejected: %w", err)
 	}
 	src, err := image.FromUnparsedImage(ctx, c.options.SourceCtx, unparsedImage)

--- a/copy/single.go
+++ b/copy/single.go
@@ -42,7 +42,7 @@ type imageCopier struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedToplevel, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
+func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -77,7 +77,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 				return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
 			}
 			if !matches {
-				manifestList, _, err := unparsedToplevel.Manifest(ctx)
+				manifestList, _, err := c.unparsedToplevel.Manifest(ctx)
 				if err != nil {
 					return nil, "", "", fmt.Errorf("reading manifest from source image: %w", err)
 				}

--- a/copy/single.go
+++ b/copy/single.go
@@ -396,7 +396,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		defer ic.c.concurrentBlobCopiesSemaphore.Release(1)
 		defer copyGroup.Done()
 		cld := copyLayerData{}
-		if !ic.c.downloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if !ic.c.options.DownloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.

--- a/copy/single.go
+++ b/copy/single.go
@@ -642,8 +642,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			// Throw an event that the layer has been skipped
-			if ic.c.progress != nil && ic.c.progressInterval > 0 {
-				ic.c.progress <- types.ProgressProperties{
+			if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
+				ic.c.options.Progress <- types.ProgressProperties{
 					Event:    types.ProgressEventSkipped,
 					Artifact: srcInfo,
 				}

--- a/copy/single.go
+++ b/copy/single.go
@@ -139,10 +139,13 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		cannotModifyManifestReason:    cannotModifyManifestReason,
 		requireCompressionFormatMatch: opts.requireCompressionFormatMatch,
 	}
-	if c.options.DestinationCtx != nil {
-		// Note that compressionFormat and compressionLevel can be nil.
+	if opts.compressionFormat != nil {
 		ic.compressionFormat = opts.compressionFormat
 		ic.compressionLevel = opts.compressionLevel
+	} else if c.options.DestinationCtx != nil {
+		// Note that compressionFormat and compressionLevel can be nil.
+		ic.compressionFormat = c.options.DestinationCtx.CompressionFormat
+		ic.compressionLevel = c.options.DestinationCtx.CompressionLevel
 	}
 	// Decide whether we can substitute blobs with semantic equivalents:
 	// - Don’t do that if we can’t modify the manifest at all

--- a/copy/single.go
+++ b/copy/single.go
@@ -40,6 +40,10 @@ type imageCopier struct {
 	requireCompressionFormatMatch bool
 }
 
+type copySingleImageOptions struct {
+	requireCompressionFormatMatch bool
+}
+
 // copySingleImageResult carries data produced by copySingleImage
 type copySingleImageResult struct {
 	manifest              []byte
@@ -50,7 +54,7 @@ type copySingleImageResult struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, requireCompressionFormatMatch bool) (copySingleImageResult, error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, opts copySingleImageOptions) (copySingleImageResult, error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -131,7 +135,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		src:             src,
 		// diffIDsAreNeeded is computed later
 		cannotModifyManifestReason:    cannotModifyManifestReason,
-		requireCompressionFormatMatch: requireCompressionFormatMatch,
+		requireCompressionFormatMatch: opts.requireCompressionFormatMatch,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
@@ -180,7 +184,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		shouldUpdateSigs := len(sigs) > 0 || len(c.signers) != 0 // TODO: Consider allowing signatures updates only and skipping the image's layers/manifest copy if possible
 		noPendingManifestUpdates := ic.noPendingManifestUpdates()
 
-		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, requireCompressionFormatMatch)
+		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, opts.requireCompressionFormatMatch)
 		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates && !ic.requireCompressionFormatMatch {
 			matchedResult, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {

--- a/copy/single.go
+++ b/copy/single.go
@@ -38,7 +38,6 @@ type imageCopier struct {
 	canSubstituteBlobs         bool
 	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
 	compressionLevel           *int
-	ociEncryptLayers           *[]int
 }
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
@@ -124,7 +123,6 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		src:             src,
 		// diffIDsAreNeeded is computed later
 		cannotModifyManifestReason: cannotModifyManifestReason,
-		ociEncryptLayers:           c.options.OciEncryptLayers,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
@@ -415,10 +413,10 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// Decide which layers to encrypt
 	layersToEncrypt := set.New[int]()
 	var encryptAll bool
-	if ic.ociEncryptLayers != nil {
-		encryptAll = len(*ic.ociEncryptLayers) == 0
+	if ic.c.options.OciEncryptLayers != nil {
+		encryptAll = len(*ic.c.options.OciEncryptLayers) == 0
 		totalLayers := len(srcInfos)
-		for _, l := range *ic.ociEncryptLayers {
+		for _, l := range *ic.c.options.OciEncryptLayers {
 			// if layer is negative, it is reverse indexed.
 			layersToEncrypt.Add((totalLayers + l) % totalLayers)
 		}

--- a/copy/single.go
+++ b/copy/single.go
@@ -179,19 +179,15 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 
 		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates)
 		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates {
-			isSrcDestManifestEqual, retManifest, retManifestType, retManifestDigest, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
+			matchedResult, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {
 				logrus.Warnf("Failed to compare destination image manifest: %v", err)
 				return copySingleImageResult{}, err
 			}
 
-			if isSrcDestManifestEqual {
+			if matchedResult != nil {
 				c.Printf("Skipping: image already present at destination\n")
-				return copySingleImageResult{
-					manifest:         retManifest,
-					manifestMIMEType: retManifestType,
-					manifestDigest:   retManifestDigest,
-				}, nil
+				return *matchedResult, nil
 			}
 		}
 	}
@@ -336,37 +332,41 @@ func (ic *imageCopier) noPendingManifestUpdates() bool {
 }
 
 // compareImageDestinationManifestEqual compares the source and destination image manifests (reading the manifest from the
-// (possibly remote) destination). Returning true and the destination's manifest, type and digest if they compare equal.
-func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context, targetInstance *digest.Digest) (bool, []byte, string, digest.Digest, error) {
+// (possibly remote) destination). If they are equal, it returns a full copySingleImageResult, nil otherwise.
+func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context, targetInstance *digest.Digest) (*copySingleImageResult, error) {
 	srcManifestDigest, err := manifest.Digest(ic.src.ManifestBlob)
 	if err != nil {
-		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
+		return nil, fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
 	destImageSource, err := ic.c.dest.Reference().NewImageSource(ctx, ic.c.options.DestinationCtx)
 	if err != nil {
 		logrus.Debugf("Unable to create destination image %s source: %v", ic.c.dest.Reference(), err)
-		return false, nil, "", "", nil
+		return nil, nil
 	}
 
 	destManifest, destManifestType, err := destImageSource.GetManifest(ctx, targetInstance)
 	if err != nil {
 		logrus.Debugf("Unable to get destination image %s/%s manifest: %v", destImageSource, targetInstance, err)
-		return false, nil, "", "", nil
+		return nil, nil
 	}
 
 	destManifestDigest, err := manifest.Digest(destManifest)
 	if err != nil {
-		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
+		return nil, fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
 	logrus.Debugf("Comparing source and destination manifest digests: %v vs. %v", srcManifestDigest, destManifestDigest)
 	if srcManifestDigest != destManifestDigest {
-		return false, nil, "", "", nil
+		return nil, nil
 	}
 
 	// Destination and source manifests, types and digests should all be equivalent
-	return true, destManifest, destManifestType, destManifestDigest, nil
+	return &copySingleImageResult{
+		manifest:         destManifest,
+		manifestMIMEType: destManifestType,
+		manifestDigest:   srcManifestDigest,
+	}, nil
 }
 
 // copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.cannotModifyManifestReason == "".

--- a/copy/single.go
+++ b/copy/single.go
@@ -49,7 +49,7 @@ type copySingleImageResult struct {
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (copySingleImageResult, error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, requireCompressionFormatMatch bool) (copySingleImageResult, error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
@@ -129,7 +129,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		manifestUpdates: &types.ManifestUpdateOptions{InformationOnly: types.ManifestUpdateInformation{Destination: c.dest}},
 		src:             src,
 		// diffIDsAreNeeded is computed later
-		cannotModifyManifestReason: cannotModifyManifestReason,
+		cannotModifyManifestReason:    cannotModifyManifestReason,
+		requireCompressionFormatMatch: requireCompressionFormatMatch,
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.

--- a/copy/single.go
+++ b/copy/single.go
@@ -145,7 +145,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		return nil, "", "", err
 	}
 
-	destRequiresOciEncryption := (isEncrypted(src) && ic.c.ociDecryptConfig != nil) || c.options.OciEncryptLayers != nil
+	destRequiresOciEncryption := (isEncrypted(src) && ic.c.options.OciDecryptConfig != nil) || c.options.OciEncryptLayers != nil
 
 	manifestConversionPlan, err := determineManifestConversion(determineManifestConversionInputs{
 		srcMIMEType:                    ic.src.ManifestMIMEType,
@@ -608,7 +608,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// When encrypting to decrypting, only use the simple code path. We might be able to optimize more
 	// (e.g. if we know the DiffID of an encrypted compressed layer, it might not be necessary to pull, decrypt and decompress again),
 	// but it’s not trivially safe to do such things, so until someone takes the effort to make a comprehensive argument, let’s not.
-	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.ociDecryptConfig != nil)
+	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.options.OciDecryptConfig != nil)
 	canAvoidProcessingCompleteLayer := !diffIDIsNeeded && !encryptingOrDecrypting
 
 	// Don’t read the layer from the source if we already have the blob, and optimizations are acceptable.

--- a/copy/single.go
+++ b/copy/single.go
@@ -29,22 +29,23 @@ import (
 
 // imageCopier tracks state specific to a single image (possibly an item of a manifest list)
 type imageCopier struct {
-	c                          *copier
-	manifestUpdates            *types.ManifestUpdateOptions
-	src                        *image.SourcedImage
-	diffIDsAreNeeded           bool
-	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
-	canSubstituteBlobs         bool
-	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
-	compressionLevel           *int
+	c                             *copier
+	manifestUpdates               *types.ManifestUpdateOptions
+	src                           *image.SourcedImage
+	diffIDsAreNeeded              bool
+	cannotModifyManifestReason    string // The reason the manifest cannot be modified, or an empty string if it can
+	canSubstituteBlobs            bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
 	requireCompressionFormatMatch bool
 }
 
 // copySingleImageResult carries data produced by copySingleImage
 type copySingleImageResult struct {
-	manifest         []byte
-	manifestMIMEType string
-	manifestDigest   digest.Digest
+	manifest              []byte
+	manifestMIMEType      string
+	manifestDigest        digest.Digest
+	compressionAlgorithms []compressiontypes.Algorithm
 }
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
@@ -194,7 +195,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		}
 	}
 
-	if err := ic.copyLayers(ctx); err != nil {
+	compressionAlgos, err := ic.copyLayers(ctx)
+	if err != nil {
 		return copySingleImageResult{}, err
 	}
 
@@ -274,7 +276,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 			return copySingleImageResult{}, fmt.Errorf("writing signatures: %w", err)
 		}
 	}
-
+	wipResult.compressionAlgorithms = compressionAlgos
 	res := wipResult // We are done
 	return res, nil
 }
@@ -366,26 +368,38 @@ func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context,
 		return nil, nil
 	}
 
+	compressionAlgos := set.New[string]()
+	for _, srcInfo := range ic.src.LayerInfos() {
+		compression := compressionAlgorithmFromMIMEType(srcInfo)
+		compressionAlgos.Add(compression.Name())
+	}
+
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
+	}
+
 	// Destination and source manifests, types and digests should all be equivalent
 	return &copySingleImageResult{
-		manifest:         destManifest,
-		manifestMIMEType: destManifestType,
-		manifestDigest:   srcManifestDigest,
+		manifest:              destManifest,
+		manifestMIMEType:      destManifestType,
+		manifestDigest:        srcManifestDigest,
+		compressionAlgorithms: algos,
 	}, nil
 }
 
 // copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.cannotModifyManifestReason == "".
-func (ic *imageCopier) copyLayers(ctx context.Context) error {
+func (ic *imageCopier) copyLayers(ctx context.Context) ([]compressiontypes.Algorithm, error) {
 	srcInfos := ic.src.LayerInfos()
 	numLayers := len(srcInfos)
 	updatedSrcInfos, err := ic.src.LayerInfosForCopy(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	srcInfosUpdated := false
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if ic.cannotModifyManifestReason != "" {
-			return fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
+			return nil, fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
 		}
 		srcInfos = updatedSrcInfos
 		srcInfosUpdated = true
@@ -401,7 +415,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// layer is empty.
 	man, err := manifest.FromBlob(ic.src.ManifestBlob, ic.src.ManifestMIMEType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	manifestLayerInfos := man.LayerInfos()
 
@@ -467,14 +481,18 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		// A call to copyGroup.Wait() is done at this point by the defer above.
 		return nil
 	}(); err != nil {
-		return err
+		return nil, err
 	}
 
+	compressionAlgos := set.New[string]()
 	destInfos := make([]types.BlobInfo, numLayers)
 	diffIDs := make([]digest.Digest, numLayers)
 	for i, cld := range data {
 		if cld.err != nil {
-			return cld.err
+			return nil, cld.err
+		}
+		if cld.destInfo.CompressionAlgorithm != nil {
+			compressionAlgos.Add(cld.destInfo.CompressionAlgorithm.Name())
 		}
 		destInfos[i] = cld.destInfo
 		diffIDs[i] = cld.diffID
@@ -489,7 +507,11 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	if srcInfosUpdated || layerDigestsDiffer(srcInfos, destInfos) {
 		ic.manifestUpdates.LayerInfos = destInfos
 	}
-	return nil
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
+	}
+	return algos, nil
 }
 
 // layerDigestsDiffer returns true iff the digests in a and b differ (ignoring sizes and possible other fields)
@@ -594,6 +616,19 @@ type diffIDResult struct {
 	err    error
 }
 
+func compressionAlgorithmFromMIMEType(srcInfo types.BlobInfo) *compressiontypes.Algorithm {
+	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
+	// package (but we should preferably replace/change UpdatedImage instead of productizing
+	// this workaround).
+	switch srcInfo.MediaType {
+	case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
+		return &compression.Gzip
+	case imgspecv1.MediaTypeImageLayerZstd:
+		return &compression.Zstd
+	}
+	return nil
+}
+
 // copyLayer copies a layer with srcInfo (with known Digest and Annotations and possibly known Size) in src to dest, perhaps (de/re/)compressing it,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 // srcRef can be used as an additional hint to the destination during checking whether a layer can be reused but srcRef can be nil.
@@ -605,17 +640,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// which uses the compression information to compute the updated MediaType values.
 	// (Sadly UpdatedImage() is documented to not update MediaTypes from
 	//  ManifestUpdateOptions.LayerInfos[].MediaType, so we are doing it indirectly.)
-	//
-	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
-	// package (but we should preferably replace/change UpdatedImage instead of productizing
-	// this workaround).
 	if srcInfo.CompressionAlgorithm == nil {
-		switch srcInfo.MediaType {
-		case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
-			srcInfo.CompressionAlgorithm = &compression.Gzip
-		case imgspecv1.MediaTypeImageLayerZstd:
-			srcInfo.CompressionAlgorithm = &compression.Zstd
-		}
+		srcInfo.CompressionAlgorithm = compressionAlgorithmFromMIMEType(srcInfo)
 	}
 
 	ic.c.printCopyInfo("blob", srcInfo)
@@ -842,4 +868,17 @@ func computeDiffID(stream io.Reader, decompressor compressiontypes.DecompressorF
 	}
 
 	return digest.Canonical.FromReader(stream)
+}
+
+// algorithmsByNames returns slice of Algorithms from slice of Algorithm Names
+func algorithmsByNames(names []string) ([]compressiontypes.Algorithm, error) {
+	result := []compressiontypes.Algorithm{}
+	for _, name := range names {
+		algo, err := compression.AlgorithmByName(name)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, algo)
+	}
+	return result, nil
 }

--- a/copy/single.go
+++ b/copy/single.go
@@ -42,6 +42,8 @@ type imageCopier struct {
 
 type copySingleImageOptions struct {
 	requireCompressionFormatMatch bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
 }
 
 // copySingleImageResult carries data produced by copySingleImage
@@ -139,8 +141,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 	}
 	if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
-		ic.compressionFormat = c.options.DestinationCtx.CompressionFormat
-		ic.compressionLevel = c.options.DestinationCtx.CompressionLevel
+		ic.compressionFormat = opts.compressionFormat
+		ic.compressionLevel = opts.compressionLevel
 	}
 	// Decide whether we can substitute blobs with semantic equivalents:
 	// - Don’t do that if we can’t modify the manifest at all

--- a/copy/single.go
+++ b/copy/single.go
@@ -175,7 +175,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 
 		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates)
 		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates {
-			isSrcDestManifestEqual, retManifest, retManifestType, retManifestDigest, err := compareImageDestinationManifestEqual(ctx, options, src, targetInstance, c.dest)
+			isSrcDestManifestEqual, retManifest, retManifestType, retManifestDigest, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {
 				logrus.Warnf("Failed to compare destination image manifest: %v", err)
 				return nil, "", "", err
@@ -323,17 +323,17 @@ func (ic *imageCopier) noPendingManifestUpdates() bool {
 	return reflect.DeepEqual(*ic.manifestUpdates, types.ManifestUpdateOptions{InformationOnly: ic.manifestUpdates.InformationOnly})
 }
 
-// compareImageDestinationManifestEqual compares the `src` and `dest` image manifests (reading the manifest from the
+// compareImageDestinationManifestEqual compares the source and destination image manifests (reading the manifest from the
 // (possibly remote) destination). Returning true and the destination's manifest, type and digest if they compare equal.
-func compareImageDestinationManifestEqual(ctx context.Context, options *Options, src *image.SourcedImage, targetInstance *digest.Digest, dest types.ImageDestination) (bool, []byte, string, digest.Digest, error) {
-	srcManifestDigest, err := manifest.Digest(src.ManifestBlob)
+func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context, targetInstance *digest.Digest) (bool, []byte, string, digest.Digest, error) {
+	srcManifestDigest, err := manifest.Digest(ic.src.ManifestBlob)
 	if err != nil {
 		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
-	destImageSource, err := dest.Reference().NewImageSource(ctx, options.DestinationCtx)
+	destImageSource, err := ic.c.dest.Reference().NewImageSource(ctx, ic.c.options.DestinationCtx)
 	if err != nil {
-		logrus.Debugf("Unable to create destination image %s source: %v", dest.Reference(), err)
+		logrus.Debugf("Unable to create destination image %s source: %v", ic.c.dest.Reference(), err)
 		return false, nil, "", "", nil
 	}
 

--- a/copy/single.go
+++ b/copy/single.go
@@ -37,6 +37,7 @@ type imageCopier struct {
 	canSubstituteBlobs         bool
 	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
 	compressionLevel           *int
+	requireCompressionFormatMatch bool
 }
 
 // copySingleImageResult carries data produced by copySingleImage
@@ -177,8 +178,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		shouldUpdateSigs := len(sigs) > 0 || len(c.signers) != 0 // TODO: Consider allowing signatures updates only and skipping the image's layers/manifest copy if possible
 		noPendingManifestUpdates := ic.noPendingManifestUpdates()
 
-		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates)
-		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates {
+		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, requireCompressionFormatMatch)
+		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates && !ic.requireCompressionFormatMatch {
 			matchedResult, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {
 				logrus.Warnf("Failed to compare destination image manifest: %v", err)
@@ -638,12 +639,20 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// a failure when we eventually try to update the manifest with the digest and MIME type of the reused blob.
 		// Fixing that will probably require passing more information to TryReusingBlob() than the current version of
 		// the ImageDestination interface lets us pass in.
+		var requiredCompression *compressiontypes.Algorithm
+		var originalCompression *compressiontypes.Algorithm
+		if ic.requireCompressionFormatMatch {
+			requiredCompression = ic.compressionFormat
+			originalCompression = srcInfo.CompressionAlgorithm
+		}
 		reused, reusedBlob, err := ic.c.dest.TryReusingBlobWithOptions(ctx, srcInfo, private.TryReusingBlobOptions{
-			Cache:         ic.c.blobInfoCache,
-			CanSubstitute: canSubstitute,
-			EmptyLayer:    emptyLayer,
-			LayerIndex:    &layerIndex,
-			SrcRef:        srcRef,
+			Cache:               ic.c.blobInfoCache,
+			CanSubstitute:       canSubstitute,
+			EmptyLayer:          emptyLayer,
+			LayerIndex:          &layerIndex,
+			SrcRef:              srcRef,
+			RequiredCompression: requiredCompression,
+			OriginalCompression: originalCompression,
 		})
 		if err != nil {
 			return types.BlobInfo{}, "", fmt.Errorf("trying to reuse blob %s at destination: %w", srcInfo.Digest, err)

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -190,6 +190,9 @@ func (d *dirImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *dirImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if info.Digest == "" {
 		return false, private.ReusedBlob{}, fmt.Errorf("Can not check for a blob with unknown digest")
 	}

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -129,6 +129,9 @@ func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, 
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *Destination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if err := d.archive.lock(); err != nil {
 		return false, private.ReusedBlob{}, err
 	}

--- a/internal/imagedestination/impl/helpers.go
+++ b/internal/imagedestination/impl/helpers.go
@@ -1,0 +1,20 @@
+package impl
+
+import (
+	"github.com/containers/image/v5/internal/private"
+	compression "github.com/containers/image/v5/pkg/compression/types"
+)
+
+// BlobMatchesRequiredCompression validates if compression is required by the caller while selecting a blob, if it is required
+// then function performs a match against the compression requested by the caller and compression of existing blob
+// (which can be nil to represent uncompressed or unknown)
+func BlobMatchesRequiredCompression(options private.TryReusingBlobOptions, candidateCompression *compression.Algorithm) bool {
+	if options.RequiredCompression == nil {
+		return true // no requirement imposed
+	}
+	return candidateCompression != nil && (options.RequiredCompression.Name() == candidateCompression.Name())
+}
+
+func OriginalBlobMatchesRequiredCompression(opts private.TryReusingBlobOptions) bool {
+	return BlobMatchesRequiredCompression(opts, opts.OriginalCompression)
+}

--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -24,6 +24,6 @@ func TestBlobMatchesRequiredCompression(t *testing.T) {
 
 	for _, c := range cases {
 		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
-		assert.Equal(t, BlobMatchesRequiredCompression(opts, c.candidateCompression), c.result)
+		assert.Equal(t, c.result, BlobMatchesRequiredCompression(opts, c.candidateCompression))
 	}
 }

--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -1,0 +1,29 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/pkg/compression"
+	compressionTypes "github.com/containers/image/v5/pkg/compression/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlobMatchesRequiredCompression(t *testing.T) {
+	var opts private.TryReusingBlobOptions
+	cases := []struct {
+		requiredCompression  *compressionTypes.Algorithm
+		candidateCompression *compressionTypes.Algorithm
+		result               bool
+	}{
+		{&compression.Zstd, &compression.Zstd, true},
+		{&compression.Gzip, &compression.Zstd, false},
+		{&compression.Zstd, nil, false},
+		{nil, &compression.Zstd, true},
+	}
+
+	for _, c := range cases {
+		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
+		assert.Equal(t, BlobMatchesRequiredCompression(opts, c.candidateCompression), c.result)
+	}
+}

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -64,6 +64,9 @@ func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inpu
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (w *wrapped) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if options.RequiredCompression != nil {
+		return false, private.ReusedBlob{}, nil
+	}
 	reused, blob, err := w.TryReusingBlob(ctx, info, options.Cache, options.CanSubstitute)
 	if !reused || err != nil {
 		return reused, private.ReusedBlob{}, err

--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -61,6 +61,13 @@ func (list *Schema2ListPublic) Instance(instanceDigest digest.Digest) (ListUpdat
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
+				Platform: &imgspecv1.Platform{
+					OS:           manifest.Platform.OS,
+					Architecture: manifest.Platform.Architecture,
+					OSVersion:    manifest.Platform.OSVersion,
+					OSFeatures:   manifest.Platform.OSFeatures,
+					Variant:      manifest.Platform.Variant,
+				},
 			}, nil
 		}
 	}

--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	platform "github.com/containers/image/v5/internal/pkg/platform"
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -57,18 +58,20 @@ func (list *Schema2ListPublic) Instances() []digest.Digest {
 func (list *Schema2ListPublic) Instance(instanceDigest digest.Digest) (ListUpdate, error) {
 	for _, manifest := range list.Manifests {
 		if manifest.Digest == instanceDigest {
-			return ListUpdate{
+			ret := ListUpdate{
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
-				Platform: &imgspecv1.Platform{
-					OS:           manifest.Platform.OS,
-					Architecture: manifest.Platform.Architecture,
-					OSVersion:    manifest.Platform.OSVersion,
-					OSFeatures:   manifest.Platform.OSFeatures,
-					Variant:      manifest.Platform.Variant,
-				},
-			}, nil
+			}
+			ret.ReadOnly.CompressionAlgorithmNames = []string{compression.GzipAlgorithmName}
+			ret.ReadOnly.Platform = &imgspecv1.Platform{
+				OS:           manifest.Platform.OS,
+				Architecture: manifest.Platform.Architecture,
+				OSVersion:    manifest.Platform.OSVersion,
+				OSFeatures:   manifest.Platform.OSFeatures,
+				Variant:      manifest.Platform.Variant,
+			}
+			return ret, nil
 		}
 	}
 	return ListUpdate{}, fmt.Errorf("unable to find instance %s passed to Schema2List.Instances", instanceDigest)

--- a/internal/manifest/docker_schema2_list_test.go
+++ b/internal/manifest/docker_schema2_list_test.go
@@ -55,6 +55,8 @@ func TestSchema2ListEditInstances(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
+	// platform must match with instance platform set in `v2list.manifest.json` for the first instance
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.Platform)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))

--- a/internal/manifest/docker_schema2_list_test.go
+++ b/internal/manifest/docker_schema2_list_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	compressionTypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +57,8 @@ func TestSchema2ListEditInstances(t *testing.T) {
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
 	// platform must match with instance platform set in `v2list.manifest.json` for the first instance
-	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.Platform)
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.ReadOnly.Platform)
+	assert.Equal(t, []string{compressionTypes.GzipAlgorithmName}, instance.ReadOnly.CompressionAlgorithmNames)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))

--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -68,7 +68,12 @@ type ListUpdate struct {
 	Digest    digest.Digest
 	Size      int64
 	MediaType string
-	Platform  *imgspecv1.Platform // read-only field: may be set by Instance(), ignored by UpdateInstance()
+	// ReadOnly fields: may be set by Instance(), ignored by UpdateInstance()
+	ReadOnly struct {
+		Platform                  *imgspecv1.Platform
+		Annotations               map[string]string
+		CompressionAlgorithmNames []string
+	}
 }
 
 type ListOp int

--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -68,6 +68,7 @@ type ListUpdate struct {
 	Digest    digest.Digest
 	Size      int64
 	MediaType string
+	Platform  *imgspecv1.Platform // read-only field: may be set by Instance(), ignored by UpdateInstance()
 }
 
 type ListOp int

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -94,14 +94,17 @@ func annotationsToCompressionAlgorithmNames(annotations map[string]string) []str
 	return result
 }
 
-func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, annotationsMap map[string]string) {
+func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, annotationsMap *map[string]string) {
 	// TODO: This should also delete the algorithm if map already contains an algorithm and compressionAlgorithm
 	// list has a different algorithm. To do that, we would need to modify the callers to always provide a reliable
 	// and full compressionAlghorithms list.
+	if *annotationsMap == nil && len(compressionAlgorithms) > 0 {
+		*annotationsMap = map[string]string{}
+	}
 	for _, algo := range compressionAlgorithms {
 		switch algo.Name() {
 		case compression.ZstdAlgorithmName:
-			annotationsMap[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
+			(*annotationsMap)[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
 		default:
 			continue
 		}
@@ -146,13 +149,13 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit) error {
 					maps.Copy(index.Manifests[targetIndex].Annotations, editInstance.UpdateAnnotations)
 				}
 			}
-			addCompressionAnnotations(editInstance.UpdateCompressionAlgorithms, index.Manifests[targetIndex].Annotations)
+			addCompressionAnnotations(editInstance.UpdateCompressionAlgorithms, &index.Manifests[targetIndex].Annotations)
 		case ListOpAdd:
 			annotations := map[string]string{}
 			if editInstance.AddAnnotations != nil {
 				annotations = maps.Clone(editInstance.AddAnnotations)
 			}
-			addCompressionAnnotations(editInstance.AddCompressionAlgorithms, annotations)
+			addCompressionAnnotations(editInstance.AddCompressionAlgorithms, &annotations)
 			addedEntries = append(addedEntries, imgspecv1.Descriptor{
 				MediaType:   editInstance.AddMediaType,
 				Size:        editInstance.AddSize,

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -57,6 +57,7 @@ func (index *OCI1IndexPublic) Instance(instanceDigest digest.Digest) (ListUpdate
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
+				Platform:  manifest.Platform,
 			}, nil
 		}
 	}

--- a/internal/manifest/oci_index_test.go
+++ b/internal/manifest/oci_index_test.go
@@ -77,6 +77,8 @@ func TestOCI1EditInstances(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
+	// platform must match with what was set in `ociv1.image.index.json` for the first instance
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.Platform)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))

--- a/internal/manifest/oci_index_test.go
+++ b/internal/manifest/oci_index_test.go
@@ -213,10 +213,6 @@ func TestOCI1IndexChooseInstanceByCompression(t *testing.T) {
 				{"arm64", "", "sha256:6dc14a60d2ba724646cfbf5fccbb9a618a5978a64a352e060b17caf5e005da9d", true},
 				// must return first zstd even if the first entry for same platform is gzip
 				{"arm64", "", "sha256:1c98002b30a71b08ab175915ce7c8fb8da9e9b502ae082d6f0c572bac9dee324", false},
-				// must return first zstd instance agnostic of platform
-				{"", "", "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", false},
-				// must return first gzip instance agnostic of platform
-				{"", "", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
 				// must return first zstd instance with no platform
 				{"matchesImageWithNoPlatform", "", "sha256:f2f5f52a2cf2c51d4cac6df0545f751c0adc3f3427eb47c59fcb32894503e18f", false},
 				// must return first gzip instance with no platform

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -112,10 +112,11 @@ type TryReusingBlobOptions struct {
 	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
 	// if they use internal/imagedestination/impl.Compat;
 	// in that case, they will all be consistently zero-valued.
-
-	EmptyLayer bool            // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
-	LayerIndex *int            // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
-	SrcRef     reference.Named // A reference to the source image that contains the input blob.
+	RequiredCompression *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
+	OriginalCompression *compression.Algorithm // Must be set if RequiredCompression is set; can be set to nil to indicate “uncompressed” or “unknown”.
+	EmptyLayer          bool                   // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
+	LayerIndex          *int                   // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
+	SrcRef              reference.Named        // A reference to the source image that contains the input blob.
 }
 
 // ReusedBlob is information about a blob reused in a destination.

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -28,6 +28,12 @@ func (s *Set[E]) Add(v E) {
 	s.m[v] = struct{}{} // Possibly writing the same struct{}{} presence marker again.
 }
 
+func (s *Set[E]) AddSlice(slice []E) {
+	for _, v := range slice {
+		s.Add(v)
+	}
+}
+
 func (s *Set[E]) Delete(v E) {
 	delete(s.m, v)
 }

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -32,6 +32,13 @@ func TestAdd(t *testing.T) {
 	assert.False(t, s.Contains(3))
 }
 
+func TestAddSlice(t *testing.T) {
+	s := NewWithValues(1)
+	s.Add(2)
+	s.AddSlice([]int{3, 4})
+	assert.ElementsMatch(t, []int{1, 2, 3, 4}, s.Values())
+}
+
 func TestDelete(t *testing.T) {
 	s := NewWithValues(1, 2)
 	assert.True(t, s.Contains(2))

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -25,6 +25,8 @@ func TestAdd(t *testing.T) {
 	assert.True(t, s.Contains(2))
 	s.Add(2) // Adding an already-present element
 	assert.True(t, s.Contains(2))
+	// should not contain duplicate value of `2`
+	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 	// Unrelated elements are unaffected
 	assert.True(t, s.Contains(1))
 	assert.False(t, s.Contains(3))
@@ -61,6 +63,8 @@ func TestValues(t *testing.T) {
 	s := New[int]()
 	assert.Empty(t, s.Values())
 	s.Add(1)
+	s.Add(2)
+	// ignore duplicate
 	s.Add(2)
 	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -172,6 +172,9 @@ func (d *ociImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ociImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if info.Digest == "" {
 		return false, private.ReusedBlob{}, errors.New("Can not check for a blob with unknown digest")
 	}

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -335,6 +335,9 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
 		if err != nil {

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -237,6 +237,9 @@ func (d *blobCacheDestination) PutBlobPartial(ctx context.Context, chunkAccessor
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *blobCacheDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	present, reusedInfo, err := d.destination.TryReusingBlobWithOptions(ctx, info, options)
 	if err != nil || present {
 		return present, reusedInfo, err

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -307,6 +307,9 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	reused, info, err := s.tryReusingBlobAsPending(blobinfo.Digest, blobinfo.Size, &options)
 	if err != nil || !reused || options.LayerIndex == nil {
 		return reused, info, err


### PR DESCRIPTION
PR's which are backported

* https://github.com/containers/image/pull/2023
* https://github.com/containers/image/pull/2029
* https://github.com/containers/image/pull/2039
* https://github.com/containers/image/pull/2040
* https://github.com/containers/image/pull/2047
* https://github.com/containers/image/pull/2050
* https://github.com/containers/image/pull/2059
* https://github.com/containers/image/pull/2048