### PR TITLE
Add a way to customize the gpg program used for signing

### DIFF
--- a/signature/mechanism.go
+++ b/signature/mechanism.go
@@ -60,6 +60,13 @@ func NewGPGSigningMechanism() (SigningMechanism, error) {
 	return newGPGSigningMechanismInDirectory("")
 }
 
+// NewGPGSigningMechanismWithProgram returns a new GPG/OpenPGP signing mechanism using the given programm
+// instead of the default gpg binary.
+// The caller must call .Close() on the returned SigningMechanism.
+func NewGPGSigningMechanismWithProgram(program string) (SigningMechanism, error) {
+	return newGPGSigningMechanismWithProgram(program)
+}
+
 // NewEphemeralGPGSigningMechanism returns a new GPG/OpenPGP signing mechanism which
 // recognizes _only_ public keys from the supplied blob, and returns the identities
 // of these keys.


### PR DESCRIPTION
Add a constructor to make a SigningMechanism with a custom program. This
can be used to sign images with a gpg wrapper (e.g. qubes-gpg-client-wrapper)
or an alternative implementation (e.g. sequoia-chameleon-gnupg).

Related to https://github.com/containers/podman/issues/15838