### PR TITLE
[release-5.27] Test the release-5.27 branch against the 1.13 branch of Skopeo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ env:
     # Name of the ultimate destination branch for this CI run
     DEST_BRANCH: "main"
     # CI container image tag (c/skopeo branch name)
-    SKOPEO_CI_TAG: "main"
+    SKOPEO_CI_TAG: "release-1.13"
     # Use GO module mirror (reason unknown, travis did it this way)
     GOPROXY: https://proxy.golang.org
     # Overrides default location (/tmp/cirrus) for repo clone


### PR DESCRIPTION
Skopeo has updated golang.org/x/exp to an API-incompatible version, so test this stable branch against a corresponding Skopeo stable branch.