### PR TITLE
[release-5.27] Preparing 5.27 backport

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "release-5.26"
     # CI container image tag (c/skopeo branch name)
     SKOPEO_CI_TAG: "release-1.13"
     # Use GO module mirror (reason unknown, travis did it this way)

--- a/copy/blob.go
+++ b/copy/blob.go
@@ -83,12 +83,12 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		return types.BlobInfo{}, err
 	}
 
-	// === Report progress using the ic.c.progress channel, if required.
-	if ic.c.progress != nil && ic.c.progressInterval > 0 {
+	// === Report progress using the ic.c.options.Progress channel, if required.
+	if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
 		progressReader := newProgressReader(
 			stream.reader,
-			ic.c.progress,
-			ic.c.progressInterval,
+			ic.c.options.Progress,
+			ic.c.options.ProgressInterval,
 			srcInfo,
 		)
 		defer progressReader.reportDone()

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/signer"
 	"github.com/containers/image/v5/transports"
@@ -126,36 +127,46 @@ type Options struct {
 	// Download layer contents with "nondistributable" media types ("foreign" layers) and translate the layer media type
 	// to not indicate "nondistributable".
 	DownloadForeignLayers bool
+
+	// Contains slice of OptionCompressionVariant, where copy will ensure that for each platform
+	// in the manifest list, a variant with the requested compression will exist.
+	// Invalid when copying a non-multi-architecture image. That will probably
+	// change in the future.
+	EnsureCompressionVariantsExist []OptionCompressionVariant
+}
+
+// OptionCompressionVariant allows to supply information about
+// selected compression algorithm and compression level by the
+// end-user. Refer to EnsureCompressionVariantsExist to know
+// more about its usage.
+type OptionCompressionVariant struct {
+	Algorithm compression.Algorithm
+	Level     *int // Only used when we are creating a new image instance using the specified algorithm, not when the image already contains such an instance
 }
 
 // copier allows us to keep track of diffID values for blobs, and other
 // data shared across one or more images in a possible manifest list.
 // The owner must call close() when done.
 type copier struct {
-	dest                          private.ImageDestination
-	rawSource                     private.ImageSource
-	reportWriter                  io.Writer
-	progressOutput                io.Writer
-	progressInterval              time.Duration
-	progress                      chan types.ProgressProperties
+	policyContext *signature.PolicyContext
+	dest          private.ImageDestination
+	rawSource     private.ImageSource
+	options       *Options // never nil
+
+	reportWriter   io.Writer
+	progressOutput io.Writer
+
+	unparsedToplevel              *image.UnparsedImage // for rawSource
 	blobInfoCache                 internalblobinfocache.BlobInfoCache2
-	ociDecryptConfig              *encconfig.DecryptConfig
-	ociEncryptConfig              *encconfig.EncryptConfig
 	concurrentBlobCopiesSemaphore *semaphore.Weighted // Limits the amount of concurrently copied blobs
-	downloadForeignLayers         bool
-	signers                       []*signer.Signer // Signers to use to create new signatures for the image
-	signersToClose                []*signer.Signer // Signers that should be closed when this copier is destroyed.
+	signers                       []*signer.Signer    // Signers to use to create new signatures for the image
+	signersToClose                []*signer.Signer    // Signers that should be closed when this copier is destroyed.
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
 // source image admissibility.  It returns the manifest which was written to
 // the new copy of the image.
 func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef, srcRef types.ImageReference, options *Options) (copiedManifest []byte, retErr error) {
-	// NOTE this function uses an output parameter for the error return value.
-	// Setting this and returning is the ideal way to return an error.
-	//
-	// the defers in this routine will wrap the error return with its own errors
-	// which can be valuable context in the middle of a multi-streamed copy.
 	if options == nil {
 		options = &Options{}
 	}
@@ -209,27 +220,27 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	c := &copier{
-		dest:             dest,
-		rawSource:        rawSource,
-		reportWriter:     reportWriter,
-		progressOutput:   progressOutput,
-		progressInterval: options.ProgressInterval,
-		progress:         options.Progress,
+		policyContext: policyContext,
+		dest:          dest,
+		rawSource:     rawSource,
+		options:       options,
+
+		reportWriter:   reportWriter,
+		progressOutput: progressOutput,
+
+		unparsedToplevel: image.UnparsedInstance(rawSource, nil),
 		// FIXME? The cache is used for sources and destinations equally, but we only have a SourceCtx and DestinationCtx.
 		// For now, use DestinationCtx (because blob reuse changes the behavior of the destination side more); eventually
 		// we might want to add a separate CommonCtx — or would that be too confusing?
-		blobInfoCache:         internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
-		ociDecryptConfig:      options.OciDecryptConfig,
-		ociEncryptConfig:      options.OciEncryptConfig,
-		downloadForeignLayers: options.DownloadForeignLayers,
+		blobInfoCache: internalblobinfocache.FromBlobInfoCache(blobinfocache.DefaultCache(options.DestinationCtx)),
 	}
 	defer c.close()
 
 	// Set the concurrentBlobCopiesSemaphore if we can copy layers in parallel.
 	if dest.HasThreadSafePutBlob() && rawSource.HasThreadSafeGetBlob() {
-		c.concurrentBlobCopiesSemaphore = options.ConcurrentBlobCopiesSemaphore
+		c.concurrentBlobCopiesSemaphore = c.options.ConcurrentBlobCopiesSemaphore
 		if c.concurrentBlobCopiesSemaphore == nil {
-			max := options.MaxParallelDownloads
+			max := c.options.MaxParallelDownloads
 			if max == 0 {
 				max = maxParallelDownloads
 			}
@@ -237,33 +248,40 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	} else {
 		c.concurrentBlobCopiesSemaphore = semaphore.NewWeighted(int64(1))
-		if options.ConcurrentBlobCopiesSemaphore != nil {
-			if err := options.ConcurrentBlobCopiesSemaphore.Acquire(ctx, 1); err != nil {
+		if c.options.ConcurrentBlobCopiesSemaphore != nil {
+			if err := c.options.ConcurrentBlobCopiesSemaphore.Acquire(ctx, 1); err != nil {
 				return nil, fmt.Errorf("acquiring semaphore for concurrent blob copies: %w", err)
 			}
-			defer options.ConcurrentBlobCopiesSemaphore.Release(1)
+			defer c.options.ConcurrentBlobCopiesSemaphore.Release(1)
 		}
 	}
 
-	if err := c.setupSigners(options); err != nil {
+	if err := c.setupSigners(); err != nil {
 		return nil, err
 	}
 
-	unparsedToplevel := image.UnparsedInstance(rawSource, nil)
-	multiImage, err := isMultiImage(ctx, unparsedToplevel)
+	multiImage, err := isMultiImage(ctx, c.unparsedToplevel)
 	if err != nil {
 		return nil, fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(srcRef), err)
 	}
 
 	if !multiImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// The simple case: just copy a single image.
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedToplevel, nil); err != nil {
+		single, err := c.copySingleImage(ctx, c.unparsedToplevel, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
+		if err != nil {
 			return nil, err
 		}
-	} else if options.ImageListSelection == CopySystemImage {
+		copiedManifest = single.manifest
+	} else if c.options.ImageListSelection == CopySystemImage {
+		if len(options.EnsureCompressionVariantsExist) > 0 {
+			return nil, fmt.Errorf("EnsureCompressionVariantsExist is not implemented when not creating a multi-architecture image")
+		}
 		// This is a manifest list, and we weren't asked to copy multiple images.  Choose a single image that
 		// matches the current system to copy, and copy it.
-		mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
+		mfest, manifestType, err := c.unparsedToplevel.Manifest(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("reading manifest for %s: %w", transports.ImageName(srcRef), err)
 		}
@@ -271,34 +289,35 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		if err != nil {
 			return nil, fmt.Errorf("parsing primary manifest as list for %s: %w", transports.ImageName(srcRef), err)
 		}
-		instanceDigest, err := manifestList.ChooseInstanceByCompression(options.SourceCtx, options.PreferGzipInstances) // try to pick one that matches options.SourceCtx
+		instanceDigest, err := manifestList.ChooseInstanceByCompression(c.options.SourceCtx, c.options.PreferGzipInstances) // try to pick one that matches c.options.SourceCtx
 		if err != nil {
 			return nil, fmt.Errorf("choosing an image from manifest list %s: %w", transports.ImageName(srcRef), err)
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
-
-		if copiedManifest, _, _, err = c.copySingleImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, nil); err != nil {
+		single, err := c.copySingleImage(ctx, unparsedInstance, nil, copySingleImageOptions{requireCompressionFormatMatch: false})
+		if err != nil {
 			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
-	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */
+		copiedManifest = single.manifest
+	} else { /* c.options.ImageListSelection == CopyAllImages or c.options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {
 			return nil, fmt.Errorf("copying multiple images: destination transport %q does not support copying multiple images as a group", destRef.Transport().Name())
 		}
 		// Copy some or all of the images.
-		switch options.ImageListSelection {
+		switch c.options.ImageListSelection {
 		case CopyAllImages:
 			logrus.Debugf("Source is a manifest list; copying all instances")
 		case CopySpecificImages:
 			logrus.Debugf("Source is a manifest list; copying some instances")
 		}
-		if copiedManifest, err = c.copyMultipleImages(ctx, policyContext, options, unparsedToplevel); err != nil {
+		if copiedManifest, err = c.copyMultipleImages(ctx); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := c.dest.Commit(ctx, unparsedToplevel); err != nil {
+	if err := c.dest.Commit(ctx, c.unparsedToplevel); err != nil {
 		return nil, fmt.Errorf("committing the finished image: %w", err)
 	}
 

--- a/copy/multiple_test.go
+++ b/copy/multiple_test.go
@@ -1,36 +1,159 @@
 package copy
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	internalManifest "github.com/containers/image/v5/internal/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPrepareCopyInstances(t *testing.T) {
+// Test `instanceCopyCopy` cases.
+func TestPrepareCopyInstancesforInstanceCopyCopy(t *testing.T) {
+	validManifest, err := os.ReadFile(filepath.Join("..", "internal", "manifest", "testdata", "oci1.index.zstd-selection.json"))
+	require.NoError(t, err)
+	list, err := internalManifest.ListFromBlob(validManifest, internalManifest.GuessMIMEType(validManifest))
+	require.NoError(t, err)
+
 	// Test CopyAllImages
 	sourceInstances := []digest.Digest{
-		digest.Digest("sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270"),
+		digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
 		digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
 	}
 
-	instancesToCopy := prepareInstanceCopies(sourceInstances, &Options{})
+	instancesToCopy, err := prepareInstanceCopies(list, sourceInstances, &Options{})
+	require.NoError(t, err)
 	compare := []instanceCopy{}
+
 	for _, instance := range sourceInstances {
 		compare = append(compare, instanceCopy{op: instanceCopyCopy,
 			sourceDigest: instance})
 	}
 	assert.Equal(t, instancesToCopy, compare)
 
-	// Test with CopySpecific Images
-	copyOnly := []digest.Digest{
+	// Test CopySpecificImages where selected instance is sourceInstances[1]
+	instancesToCopy, err = prepareInstanceCopies(list, sourceInstances, &Options{Instances: []digest.Digest{sourceInstances[1]}, ImageListSelection: CopySpecificImages})
+	require.NoError(t, err)
+	compare = []instanceCopy{{op: instanceCopyCopy,
+		sourceDigest: sourceInstances[1]}}
+	assert.Equal(t, instancesToCopy, compare)
+}
+
+// Test `instanceCopyClone` cases.
+func TestPrepareCopyInstancesforInstanceCopyClone(t *testing.T) {
+	validManifest, err := os.ReadFile(filepath.Join("..", "internal", "manifest", "testdata", "oci1.index.zstd-selection.json"))
+	require.NoError(t, err)
+	list, err := internalManifest.ListFromBlob(validManifest, internalManifest.GuessMIMEType(validManifest))
+	require.NoError(t, err)
+
+	// Prepare option for `instanceCopyClone` case.
+	ensureCompressionVariantsExist := []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+
+	sourceInstances := []digest.Digest{
+		digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
 		digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
 	}
-	instancesToCopy = prepareInstanceCopies(sourceInstances, &Options{
-		Instances:          copyOnly,
+
+	// CopySpecificImage must fail with error
+	_, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist,
+		Instances:          []digest.Digest{sourceInstances[1]},
 		ImageListSelection: CopySpecificImages})
-	assert.Equal(t, instancesToCopy, []instanceCopy{{
-		op:           instanceCopyCopy,
-		sourceDigest: copyOnly[0]}})
+	require.EqualError(t, err, "EnsureCompressionVariantsExist is not implemented for CopySpecificImages")
+
+	// Test copying all images with replication
+	instancesToCopy, err := prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+
+	// Following test ensures
+	// * Still copy gzip variants if they exist in the original
+	// * Not create new Zstd variants if they exist in the original.
+
+	// We crated a list of three instances `sourceInstances` and since in oci1.index.zstd-selection.json
+	// amd64 already has a zstd instance i.e sourceInstance[1] so it should not create replication for
+	// `sourceInstance[0]` and `sourceInstance[1]` but should do it for `sourceInstance[2]` for `arm64`
+	// and still copy `sourceInstance[2]`.
+	expectedResponse := []simplerInstanceCopy{}
+	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
+		// If its `arm64` and sourceDigest[2] , expect a clone to happen
+		if instance == sourceInstances[2] {
+			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
+		}
+	}
+	actualResponse := convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
+	assert.Equal(t, expectedResponse, actualResponse)
+
+	// Test option with multiple copy request for same compression format
+	// above expection should stay same, if out ensureCompressionVariantsExist requests zstd twice
+	ensureCompressionVariantsExist = []OptionCompressionVariant{{Algorithm: compression.Zstd}, {Algorithm: compression.Zstd}}
+	instancesToCopy, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+	expectedResponse = []simplerInstanceCopy{}
+	for _, instance := range sourceInstances {
+		expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyCopy,
+			sourceDigest: instance})
+		// If its `arm64` and sourceDigest[2] , expect a clone to happen
+		if instance == sourceInstances[2] {
+			expectedResponse = append(expectedResponse, simplerInstanceCopy{op: instanceCopyClone, sourceDigest: instance, cloneCompressionVariant: "zstd", clonePlatform: "arm64-linux-"})
+		}
+	}
+	actualResponse = convertInstanceCopyToSimplerInstanceCopy(instancesToCopy)
+	assert.Equal(t, expectedResponse, actualResponse)
+
+	// Add same instance twice but clone must appear only once.
+	ensureCompressionVariantsExist = []OptionCompressionVariant{{Algorithm: compression.Zstd}}
+	sourceInstances = []digest.Digest{
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+	}
+	instancesToCopy, err = prepareInstanceCopies(list, sourceInstances, &Options{EnsureCompressionVariantsExist: ensureCompressionVariantsExist})
+	require.NoError(t, err)
+	// two copies but clone should happen only once
+	numberOfCopyClone := 0
+	for _, instance := range instancesToCopy {
+		if instance.op == instanceCopyClone {
+			numberOfCopyClone++
+		}
+	}
+	assert.Equal(t, 1, numberOfCopyClone)
+}
+
+// simpler version of `instanceCopy` for testing where fields are string
+// instead of pointer
+type simplerInstanceCopy struct {
+	op           instanceCopyKind
+	sourceDigest digest.Digest
+
+	// Fields which can be used by callers when operation
+	// is `instanceCopyClone`
+	cloneCompressionVariant string
+	clonePlatform           string
+	cloneAnnotations        map[string]string
+}
+
+func convertInstanceCopyToSimplerInstanceCopy(copies []instanceCopy) []simplerInstanceCopy {
+	res := []simplerInstanceCopy{}
+	for _, instance := range copies {
+		compression := ""
+		platform := ""
+		compression = instance.cloneCompressionVariant.Algorithm.Name()
+		if instance.clonePlatform != nil {
+			platform = instance.clonePlatform.Architecture + "-" + instance.clonePlatform.OS + "-" + instance.clonePlatform.Variant
+		}
+		res = append(res, simplerInstanceCopy{
+			op:                      instance.op,
+			sourceDigest:            instance.sourceDigest,
+			cloneCompressionVariant: compression,
+			clonePlatform:           platform,
+			cloneAnnotations:        instance.cloneAnnotations,
+		})
+	}
+	return res
 }

--- a/copy/sign_test.go
+++ b/copy/sign_test.go
@@ -135,10 +135,11 @@ func TestCreateSignatures(t *testing.T) {
 
 		c := &copier{
 			dest:         imagedestination.FromPublic(cc.dest),
+			options:      options,
 			reportWriter: io.Discard,
 		}
 		defer c.close()
-		err := c.setupSigners(options)
+		err := c.setupSigners()
 		require.NoError(t, err, cc.name)
 		sigs, err := c.createSignatures(context.Background(), manifestBlob, identity)
 		switch {

--- a/copy/single.go
+++ b/copy/single.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
@@ -30,40 +29,54 @@ import (
 
 // imageCopier tracks state specific to a single image (possibly an item of a manifest list)
 type imageCopier struct {
-	c                          *copier
-	manifestUpdates            *types.ManifestUpdateOptions
-	src                        *image.SourcedImage
-	diffIDsAreNeeded           bool
-	cannotModifyManifestReason string // The reason the manifest cannot be modified, or an empty string if it can
-	canSubstituteBlobs         bool
-	compressionFormat          *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
-	compressionLevel           *int
-	ociEncryptLayers           *[]int
+	c                             *copier
+	manifestUpdates               *types.ManifestUpdateOptions
+	src                           *image.SourcedImage
+	diffIDsAreNeeded              bool
+	cannotModifyManifestReason    string // The reason the manifest cannot be modified, or an empty string if it can
+	canSubstituteBlobs            bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
+	requireCompressionFormatMatch bool
 }
 
-// copySingleImage copies a single (non-manifest-list) image unparsedImage, using policyContext to validate
+type copySingleImageOptions struct {
+	requireCompressionFormatMatch bool
+	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
+	compressionLevel              *int
+}
+
+// copySingleImageResult carries data produced by copySingleImage
+type copySingleImageResult struct {
+	manifest              []byte
+	manifestMIMEType      string
+	manifestDigest        digest.Digest
+	compressionAlgorithms []compressiontypes.Algorithm
+}
+
+// copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
 // source image admissibility.
-func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.PolicyContext, options *Options, unparsedToplevel, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest) (retManifest []byte, retManifestType string, retManifestDigest digest.Digest, retErr error) {
+func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.UnparsedImage, targetInstance *digest.Digest, opts copySingleImageOptions) (copySingleImageResult, error) {
 	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
 	// Make sure we fail cleanly in such cases.
 	multiImage, err := isMultiImage(ctx, unparsedImage)
 	if err != nil {
 		// FIXME FIXME: How to name a reference for the sub-image?
-		return nil, "", "", fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(unparsedImage.Reference()), err)
+		return copySingleImageResult{}, fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(unparsedImage.Reference()), err)
 	}
 	if multiImage {
-		return nil, "", "", fmt.Errorf("Unexpectedly received a manifest list instead of a manifest for a single image")
+		return copySingleImageResult{}, fmt.Errorf("Unexpectedly received a manifest list instead of a manifest for a single image")
 	}
 
 	// Please keep this policy check BEFORE reading any other information about the image.
 	// (The multiImage check above only matches the MIME type, which we have received anyway.
 	// Actual parsing of anything should be deferred.)
-	if allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
-		return nil, "", "", fmt.Errorf("Source image rejected: %w", err)
+	if allowed, err := c.policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
+		return copySingleImageResult{}, fmt.Errorf("Source image rejected: %w", err)
 	}
-	src, err := image.FromUnparsedImage(ctx, options.SourceCtx, unparsedImage)
+	src, err := image.FromUnparsedImage(ctx, c.options.SourceCtx, unparsedImage)
 	if err != nil {
-		return nil, "", "", fmt.Errorf("initializing image from source %s: %w", transports.ImageName(c.rawSource.Reference()), err)
+		return copySingleImageResult{}, fmt.Errorf("initializing image from source %s: %w", transports.ImageName(c.rawSource.Reference()), err)
 	}
 
 	// If the destination is a digested reference, make a note of that, determine what digest value we're
@@ -75,33 +88,33 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 			destIsDigestedReference = true
 			matches, err := manifest.MatchesDigest(src.ManifestBlob, digested.Digest())
 			if err != nil {
-				return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
+				return copySingleImageResult{}, fmt.Errorf("computing digest of source image's manifest: %w", err)
 			}
 			if !matches {
-				manifestList, _, err := unparsedToplevel.Manifest(ctx)
+				manifestList, _, err := c.unparsedToplevel.Manifest(ctx)
 				if err != nil {
-					return nil, "", "", fmt.Errorf("reading manifest from source image: %w", err)
+					return copySingleImageResult{}, fmt.Errorf("reading manifest from source image: %w", err)
 				}
 				matches, err = manifest.MatchesDigest(manifestList, digested.Digest())
 				if err != nil {
-					return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
+					return copySingleImageResult{}, fmt.Errorf("computing digest of source image's manifest: %w", err)
 				}
 				if !matches {
-					return nil, "", "", errors.New("Digest of source image's manifest would not match destination reference")
+					return copySingleImageResult{}, errors.New("Digest of source image's manifest would not match destination reference")
 				}
 			}
 		}
 	}
 
-	if err := checkImageDestinationForCurrentRuntime(ctx, options.DestinationCtx, src, c.dest); err != nil {
-		return nil, "", "", err
+	if err := checkImageDestinationForCurrentRuntime(ctx, c.options.DestinationCtx, src, c.dest); err != nil {
+		return copySingleImageResult{}, err
 	}
 
-	sigs, err := c.sourceSignatures(ctx, src, options,
+	sigs, err := c.sourceSignatures(ctx, src,
 		"Getting image source signatures",
 		"Checking if image destination supports signatures")
 	if err != nil {
-		return nil, "", "", err
+		return copySingleImageResult{}, err
 	}
 
 	// Determine if we're allowed to modify the manifest.
@@ -114,7 +127,7 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	if destIsDigestedReference {
 		cannotModifyManifestReason = "Destination specifies a digest"
 	}
-	if options.PreserveDigests {
+	if c.options.PreserveDigests {
 		cannotModifyManifestReason = "Instructed to preserve digests"
 	}
 
@@ -123,13 +136,16 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 		manifestUpdates: &types.ManifestUpdateOptions{InformationOnly: types.ManifestUpdateInformation{Destination: c.dest}},
 		src:             src,
 		// diffIDsAreNeeded is computed later
-		cannotModifyManifestReason: cannotModifyManifestReason,
-		ociEncryptLayers:           options.OciEncryptLayers,
+		cannotModifyManifestReason:    cannotModifyManifestReason,
+		requireCompressionFormatMatch: opts.requireCompressionFormatMatch,
 	}
-	if options.DestinationCtx != nil {
+	if opts.compressionFormat != nil {
+		ic.compressionFormat = opts.compressionFormat
+		ic.compressionLevel = opts.compressionLevel
+	} else if c.options.DestinationCtx != nil {
 		// Note that compressionFormat and compressionLevel can be nil.
-		ic.compressionFormat = options.DestinationCtx.CompressionFormat
-		ic.compressionLevel = options.DestinationCtx.CompressionLevel
+		ic.compressionFormat = c.options.DestinationCtx.CompressionFormat
+		ic.compressionLevel = c.options.DestinationCtx.CompressionLevel
 	}
 	// Decide whether we can substitute blobs with semantic equivalents:
 	// - Don’t do that if we can’t modify the manifest at all
@@ -142,20 +158,20 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	ic.canSubstituteBlobs = ic.cannotModifyManifestReason == "" && len(c.signers) == 0
 
 	if err := ic.updateEmbeddedDockerReference(); err != nil {
-		return nil, "", "", err
+		return copySingleImageResult{}, err
 	}
 
-	destRequiresOciEncryption := (isEncrypted(src) && ic.c.ociDecryptConfig != nil) || options.OciEncryptLayers != nil
+	destRequiresOciEncryption := (isEncrypted(src) && ic.c.options.OciDecryptConfig != nil) || c.options.OciEncryptLayers != nil
 
 	manifestConversionPlan, err := determineManifestConversion(determineManifestConversionInputs{
 		srcMIMEType:                    ic.src.ManifestMIMEType,
 		destSupportedManifestMIMETypes: ic.c.dest.SupportedManifestMIMETypes(),
-		forceManifestMIMEType:          options.ForceManifestMIMEType,
+		forceManifestMIMEType:          c.options.ForceManifestMIMEType,
 		requiresOCIEncryption:          destRequiresOciEncryption,
 		cannotModifyManifestReason:     ic.cannotModifyManifestReason,
 	})
 	if err != nil {
-		return nil, "", "", err
+		return copySingleImageResult{}, err
 	}
 	// We set up this part of ic.manifestUpdates quite early, not just around the
 	// code that calls copyUpdatedConfigAndManifest, so that other parts of the copy code
@@ -169,27 +185,28 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	ic.diffIDsAreNeeded = src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates)
 
 	// If enabled, fetch and compare the destination's manifest. And as an optimization skip updating the destination iff equal
-	if options.OptimizeDestinationImageAlreadyExists {
+	if c.options.OptimizeDestinationImageAlreadyExists {
 		shouldUpdateSigs := len(sigs) > 0 || len(c.signers) != 0 // TODO: Consider allowing signatures updates only and skipping the image's layers/manifest copy if possible
 		noPendingManifestUpdates := ic.noPendingManifestUpdates()
 
-		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates)
-		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates {
-			isSrcDestManifestEqual, retManifest, retManifestType, retManifestDigest, err := compareImageDestinationManifestEqual(ctx, options, src, targetInstance, c.dest)
+		logrus.Debugf("Checking if we can skip copying: has signatures=%t, OCI encryption=%t, no manifest updates=%t, compression match required for resuing blobs=%t", shouldUpdateSigs, destRequiresOciEncryption, noPendingManifestUpdates, opts.requireCompressionFormatMatch)
+		if !shouldUpdateSigs && !destRequiresOciEncryption && noPendingManifestUpdates && !ic.requireCompressionFormatMatch {
+			matchedResult, err := ic.compareImageDestinationManifestEqual(ctx, targetInstance)
 			if err != nil {
 				logrus.Warnf("Failed to compare destination image manifest: %v", err)
-				return nil, "", "", err
+				return copySingleImageResult{}, err
 			}
 
-			if isSrcDestManifestEqual {
+			if matchedResult != nil {
 				c.Printf("Skipping: image already present at destination\n")
-				return retManifest, retManifestType, retManifestDigest, nil
+				return *matchedResult, nil
 			}
 		}
 	}
 
-	if err := ic.copyLayers(ctx); err != nil {
-		return nil, "", "", err
+	compressionAlgos, err := ic.copyLayers(ctx)
+	if err != nil {
+		return copySingleImageResult{}, err
 	}
 
 	// With docker/distribution registries we do not know whether the registry accepts schema2 or schema1 only;
@@ -197,8 +214,12 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 	// without actually trying to upload something and getting a types.ManifestTypeRejectedError.
 	// So, try the preferred manifest MIME type with possibly-updated blob digests, media types, and sizes if
 	// we're altering how they're compressed.  If the process succeeds, fine…
-	manifestBytes, retManifestDigest, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
-	retManifestType = manifestConversionPlan.preferredMIMEType
+	manifestBytes, manifestDigest, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
+	wipResult := copySingleImageResult{
+		manifest:         manifestBytes,
+		manifestMIMEType: manifestConversionPlan.preferredMIMEType,
+		manifestDigest:   manifestDigest,
+	}
 	if err != nil {
 		logrus.Debugf("Writing manifest using preferred type %s failed: %v", manifestConversionPlan.preferredMIMEType, err)
 		// … if it fails, and the failure is either because the manifest is rejected by the registry, or
@@ -213,14 +234,14 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 			// We don’t have other options.
 			// In principle the code below would handle this as well, but the resulting  error message is fairly ugly.
 			// Don’t bother the user with MIME types if we have no choice.
-			return nil, "", "", err
+			return copySingleImageResult{}, err
 		}
 		// If the original MIME type is acceptable, determineManifestConversion always uses it as manifestConversionPlan.preferredMIMEType.
 		// So if we are here, we will definitely be trying to convert the manifest.
 		// With ic.cannotModifyManifestReason != "", that would just be a string of repeated failures for the same reason,
 		// so let’s bail out early and with a better error message.
 		if ic.cannotModifyManifestReason != "" {
-			return nil, "", "", fmt.Errorf("writing manifest failed and we cannot try conversions: %q: %w", cannotModifyManifestReason, err)
+			return copySingleImageResult{}, fmt.Errorf("writing manifest failed and we cannot try conversions: %q: %w", cannotModifyManifestReason, err)
 		}
 
 		// errs is a list of errors when trying various manifest types. Also serves as an "upload succeeded" flag when set to nil.
@@ -236,34 +257,37 @@ func (c *copier) copySingleImage(ctx context.Context, policyContext *signature.P
 			}
 
 			// We have successfully uploaded a manifest.
-			manifestBytes = attemptedManifest
-			retManifestDigest = attemptedManifestDigest
-			retManifestType = manifestMIMEType
+			wipResult = copySingleImageResult{
+				manifest:         attemptedManifest,
+				manifestMIMEType: manifestMIMEType,
+				manifestDigest:   attemptedManifestDigest,
+			}
 			errs = nil // Mark this as a success so that we don't abort below.
 			break
 		}
 		if errs != nil {
-			return nil, "", "", fmt.Errorf("Uploading manifest failed, attempted the following formats: %s", strings.Join(errs, ", "))
+			return copySingleImageResult{}, fmt.Errorf("Uploading manifest failed, attempted the following formats: %s", strings.Join(errs, ", "))
 		}
 	}
 	if targetInstance != nil {
-		targetInstance = &retManifestDigest
+		targetInstance = &wipResult.manifestDigest
 	}
 
-	newSigs, err := c.createSignatures(ctx, manifestBytes, options.SignIdentity)
+	newSigs, err := c.createSignatures(ctx, wipResult.manifest, c.options.SignIdentity)
 	if err != nil {
-		return nil, "", "", err
+		return copySingleImageResult{}, err
 	}
 	sigs = append(sigs, newSigs...)
 
 	if len(sigs) > 0 {
 		c.Printf("Storing signatures\n")
 		if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
-			return nil, "", "", fmt.Errorf("writing signatures: %w", err)
+			return copySingleImageResult{}, fmt.Errorf("writing signatures: %w", err)
 		}
 	}
-
-	return manifestBytes, retManifestType, retManifestDigest, nil
+	wipResult.compressionAlgorithms = compressionAlgos
+	res := wipResult // We are done
+	return res, nil
 }
 
 // checkImageDestinationForCurrentRuntime enforces dest.MustMatchRuntimeOS, if necessary.
@@ -323,52 +347,68 @@ func (ic *imageCopier) noPendingManifestUpdates() bool {
 	return reflect.DeepEqual(*ic.manifestUpdates, types.ManifestUpdateOptions{InformationOnly: ic.manifestUpdates.InformationOnly})
 }
 
-// compareImageDestinationManifestEqual compares the `src` and `dest` image manifests (reading the manifest from the
-// (possibly remote) destination). Returning true and the destination's manifest, type and digest if they compare equal.
-func compareImageDestinationManifestEqual(ctx context.Context, options *Options, src *image.SourcedImage, targetInstance *digest.Digest, dest types.ImageDestination) (bool, []byte, string, digest.Digest, error) {
-	srcManifestDigest, err := manifest.Digest(src.ManifestBlob)
+// compareImageDestinationManifestEqual compares the source and destination image manifests (reading the manifest from the
+// (possibly remote) destination). If they are equal, it returns a full copySingleImageResult, nil otherwise.
+func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context, targetInstance *digest.Digest) (*copySingleImageResult, error) {
+	srcManifestDigest, err := manifest.Digest(ic.src.ManifestBlob)
 	if err != nil {
-		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
+		return nil, fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
-	destImageSource, err := dest.Reference().NewImageSource(ctx, options.DestinationCtx)
+	destImageSource, err := ic.c.dest.Reference().NewImageSource(ctx, ic.c.options.DestinationCtx)
 	if err != nil {
-		logrus.Debugf("Unable to create destination image %s source: %v", dest.Reference(), err)
-		return false, nil, "", "", nil
+		logrus.Debugf("Unable to create destination image %s source: %v", ic.c.dest.Reference(), err)
+		return nil, nil
 	}
 
 	destManifest, destManifestType, err := destImageSource.GetManifest(ctx, targetInstance)
 	if err != nil {
 		logrus.Debugf("Unable to get destination image %s/%s manifest: %v", destImageSource, targetInstance, err)
-		return false, nil, "", "", nil
+		return nil, nil
 	}
 
 	destManifestDigest, err := manifest.Digest(destManifest)
 	if err != nil {
-		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
+		return nil, fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
 	logrus.Debugf("Comparing source and destination manifest digests: %v vs. %v", srcManifestDigest, destManifestDigest)
 	if srcManifestDigest != destManifestDigest {
-		return false, nil, "", "", nil
+		return nil, nil
+	}
+
+	compressionAlgos := set.New[string]()
+	for _, srcInfo := range ic.src.LayerInfos() {
+		compression := compressionAlgorithmFromMIMEType(srcInfo)
+		compressionAlgos.Add(compression.Name())
+	}
+
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
 	}
 
 	// Destination and source manifests, types and digests should all be equivalent
-	return true, destManifest, destManifestType, destManifestDigest, nil
+	return &copySingleImageResult{
+		manifest:              destManifest,
+		manifestMIMEType:      destManifestType,
+		manifestDigest:        srcManifestDigest,
+		compressionAlgorithms: algos,
+	}, nil
 }
 
 // copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.cannotModifyManifestReason == "".
-func (ic *imageCopier) copyLayers(ctx context.Context) error {
+func (ic *imageCopier) copyLayers(ctx context.Context) ([]compressiontypes.Algorithm, error) {
 	srcInfos := ic.src.LayerInfos()
 	numLayers := len(srcInfos)
 	updatedSrcInfos, err := ic.src.LayerInfosForCopy(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	srcInfosUpdated := false
 	if updatedSrcInfos != nil && !reflect.DeepEqual(srcInfos, updatedSrcInfos) {
 		if ic.cannotModifyManifestReason != "" {
-			return fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
+			return nil, fmt.Errorf("Copying this image would require changing layer representation, which we cannot do: %q", ic.cannotModifyManifestReason)
 		}
 		srcInfos = updatedSrcInfos
 		srcInfosUpdated = true
@@ -384,7 +424,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// layer is empty.
 	man, err := manifest.FromBlob(ic.src.ManifestBlob, ic.src.ManifestMIMEType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	manifestLayerInfos := man.LayerInfos()
 
@@ -396,7 +436,7 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		defer ic.c.concurrentBlobCopiesSemaphore.Release(1)
 		defer copyGroup.Done()
 		cld := copyLayerData{}
-		if !ic.c.downloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if !ic.c.options.DownloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.
@@ -415,10 +455,10 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	// Decide which layers to encrypt
 	layersToEncrypt := set.New[int]()
 	var encryptAll bool
-	if ic.ociEncryptLayers != nil {
-		encryptAll = len(*ic.ociEncryptLayers) == 0
+	if ic.c.options.OciEncryptLayers != nil {
+		encryptAll = len(*ic.c.options.OciEncryptLayers) == 0
 		totalLayers := len(srcInfos)
-		for _, l := range *ic.ociEncryptLayers {
+		for _, l := range *ic.c.options.OciEncryptLayers {
 			// if layer is negative, it is reverse indexed.
 			layersToEncrypt.Add((totalLayers + l) % totalLayers)
 		}
@@ -450,14 +490,18 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 		// A call to copyGroup.Wait() is done at this point by the defer above.
 		return nil
 	}(); err != nil {
-		return err
+		return nil, err
 	}
 
+	compressionAlgos := set.New[string]()
 	destInfos := make([]types.BlobInfo, numLayers)
 	diffIDs := make([]digest.Digest, numLayers)
 	for i, cld := range data {
 		if cld.err != nil {
-			return cld.err
+			return nil, cld.err
+		}
+		if cld.destInfo.CompressionAlgorithm != nil {
+			compressionAlgos.Add(cld.destInfo.CompressionAlgorithm.Name())
 		}
 		destInfos[i] = cld.destInfo
 		diffIDs[i] = cld.diffID
@@ -472,7 +516,11 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 	if srcInfosUpdated || layerDigestsDiffer(srcInfos, destInfos) {
 		ic.manifestUpdates.LayerInfos = destInfos
 	}
-	return nil
+	algos, err := algorithmsByNames(compressionAlgos.Values())
+	if err != nil {
+		return nil, err
+	}
+	return algos, nil
 }
 
 // layerDigestsDiffer returns true iff the digests in a and b differ (ignoring sizes and possible other fields)
@@ -577,6 +625,19 @@ type diffIDResult struct {
 	err    error
 }
 
+func compressionAlgorithmFromMIMEType(srcInfo types.BlobInfo) *compressiontypes.Algorithm {
+	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
+	// package (but we should preferably replace/change UpdatedImage instead of productizing
+	// this workaround).
+	switch srcInfo.MediaType {
+	case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
+		return &compression.Gzip
+	case imgspecv1.MediaTypeImageLayerZstd:
+		return &compression.Zstd
+	}
+	return nil
+}
+
 // copyLayer copies a layer with srcInfo (with known Digest and Annotations and possibly known Size) in src to dest, perhaps (de/re/)compressing it,
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 // srcRef can be used as an additional hint to the destination during checking whether a layer can be reused but srcRef can be nil.
@@ -588,17 +649,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// which uses the compression information to compute the updated MediaType values.
 	// (Sadly UpdatedImage() is documented to not update MediaTypes from
 	//  ManifestUpdateOptions.LayerInfos[].MediaType, so we are doing it indirectly.)
-	//
-	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
-	// package (but we should preferably replace/change UpdatedImage instead of productizing
-	// this workaround).
 	if srcInfo.CompressionAlgorithm == nil {
-		switch srcInfo.MediaType {
-		case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
-			srcInfo.CompressionAlgorithm = &compression.Gzip
-		case imgspecv1.MediaTypeImageLayerZstd:
-			srcInfo.CompressionAlgorithm = &compression.Zstd
-		}
+		srcInfo.CompressionAlgorithm = compressionAlgorithmFromMIMEType(srcInfo)
 	}
 
 	ic.c.printCopyInfo("blob", srcInfo)
@@ -608,7 +660,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// When encrypting to decrypting, only use the simple code path. We might be able to optimize more
 	// (e.g. if we know the DiffID of an encrypted compressed layer, it might not be necessary to pull, decrypt and decompress again),
 	// but it’s not trivially safe to do such things, so until someone takes the effort to make a comprehensive argument, let’s not.
-	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.ociDecryptConfig != nil)
+	encryptingOrDecrypting := toEncrypt || (isOciEncrypted(srcInfo.MediaType) && ic.c.options.OciDecryptConfig != nil)
 	canAvoidProcessingCompleteLayer := !diffIDIsNeeded && !encryptingOrDecrypting
 
 	// Don’t read the layer from the source if we already have the blob, and optimizations are acceptable.
@@ -623,12 +675,20 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// a failure when we eventually try to update the manifest with the digest and MIME type of the reused blob.
 		// Fixing that will probably require passing more information to TryReusingBlob() than the current version of
 		// the ImageDestination interface lets us pass in.
+		var requiredCompression *compressiontypes.Algorithm
+		var originalCompression *compressiontypes.Algorithm
+		if ic.requireCompressionFormatMatch {
+			requiredCompression = ic.compressionFormat
+			originalCompression = srcInfo.CompressionAlgorithm
+		}
 		reused, reusedBlob, err := ic.c.dest.TryReusingBlobWithOptions(ctx, srcInfo, private.TryReusingBlobOptions{
-			Cache:         ic.c.blobInfoCache,
-			CanSubstitute: canSubstitute,
-			EmptyLayer:    emptyLayer,
-			LayerIndex:    &layerIndex,
-			SrcRef:        srcRef,
+			Cache:               ic.c.blobInfoCache,
+			CanSubstitute:       canSubstitute,
+			EmptyLayer:          emptyLayer,
+			LayerIndex:          &layerIndex,
+			SrcRef:              srcRef,
+			RequiredCompression: requiredCompression,
+			OriginalCompression: originalCompression,
 		})
 		if err != nil {
 			return types.BlobInfo{}, "", fmt.Errorf("trying to reuse blob %s at destination: %w", srcInfo.Digest, err)
@@ -642,8 +702,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			// Throw an event that the layer has been skipped
-			if ic.c.progress != nil && ic.c.progressInterval > 0 {
-				ic.c.progress <- types.ProgressProperties{
+			if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
+				ic.c.options.Progress <- types.ProgressProperties{
 					Event:    types.ProgressEventSkipped,
 					Artifact: srcInfo,
 				}
@@ -817,4 +877,17 @@ func computeDiffID(stream io.Reader, decompressor compressiontypes.DecompressorF
 	}
 
 	return digest.Canonical.FromReader(stream)
+}
+
+// algorithmsByNames returns slice of Algorithms from slice of Algorithm Names
+func algorithmsByNames(names []string) ([]compressiontypes.Algorithm, error) {
+	result := []compressiontypes.Algorithm{}
+	for _, name := range names {
+		algo, err := compression.AlgorithmByName(name)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, algo)
+	}
+	return result, nil
 }

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -190,6 +190,9 @@ func (d *dirImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *dirImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if info.Digest == "" {
 		return false, private.ReusedBlob{}, fmt.Errorf("Can not check for a blob with unknown digest")
 	}

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -129,6 +129,9 @@ func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, 
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *Destination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if err := d.archive.lock(); err != nil {
 		return false, private.ReusedBlob{}, err
 	}

--- a/internal/imagedestination/impl/helpers.go
+++ b/internal/imagedestination/impl/helpers.go
@@ -1,0 +1,20 @@
+package impl
+
+import (
+	"github.com/containers/image/v5/internal/private"
+	compression "github.com/containers/image/v5/pkg/compression/types"
+)
+
+// BlobMatchesRequiredCompression validates if compression is required by the caller while selecting a blob, if it is required
+// then function performs a match against the compression requested by the caller and compression of existing blob
+// (which can be nil to represent uncompressed or unknown)
+func BlobMatchesRequiredCompression(options private.TryReusingBlobOptions, candidateCompression *compression.Algorithm) bool {
+	if options.RequiredCompression == nil {
+		return true // no requirement imposed
+	}
+	return candidateCompression != nil && (options.RequiredCompression.Name() == candidateCompression.Name())
+}
+
+func OriginalBlobMatchesRequiredCompression(opts private.TryReusingBlobOptions) bool {
+	return BlobMatchesRequiredCompression(opts, opts.OriginalCompression)
+}

--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -1,0 +1,29 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/pkg/compression"
+	compressionTypes "github.com/containers/image/v5/pkg/compression/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlobMatchesRequiredCompression(t *testing.T) {
+	var opts private.TryReusingBlobOptions
+	cases := []struct {
+		requiredCompression  *compressionTypes.Algorithm
+		candidateCompression *compressionTypes.Algorithm
+		result               bool
+	}{
+		{&compression.Zstd, &compression.Zstd, true},
+		{&compression.Gzip, &compression.Zstd, false},
+		{&compression.Zstd, nil, false},
+		{nil, &compression.Zstd, true},
+	}
+
+	for _, c := range cases {
+		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
+		assert.Equal(t, c.result, BlobMatchesRequiredCompression(opts, c.candidateCompression))
+	}
+}

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -64,6 +64,9 @@ func (w *wrapped) PutBlobWithOptions(ctx context.Context, stream io.Reader, inpu
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (w *wrapped) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if options.RequiredCompression != nil {
+		return false, private.ReusedBlob{}, nil
+	}
 	reused, blob, err := w.TryReusingBlob(ctx, info, options.Cache, options.CanSubstitute)
 	if !reused || err != nil {
 		return reused, private.ReusedBlob{}, err

--- a/internal/manifest/docker_schema2_list.go
+++ b/internal/manifest/docker_schema2_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	platform "github.com/containers/image/v5/internal/pkg/platform"
+	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -57,11 +58,20 @@ func (list *Schema2ListPublic) Instances() []digest.Digest {
 func (list *Schema2ListPublic) Instance(instanceDigest digest.Digest) (ListUpdate, error) {
 	for _, manifest := range list.Manifests {
 		if manifest.Digest == instanceDigest {
-			return ListUpdate{
+			ret := ListUpdate{
 				Digest:    manifest.Digest,
 				Size:      manifest.Size,
 				MediaType: manifest.MediaType,
-			}, nil
+			}
+			ret.ReadOnly.CompressionAlgorithmNames = []string{compression.GzipAlgorithmName}
+			ret.ReadOnly.Platform = &imgspecv1.Platform{
+				OS:           manifest.Platform.OS,
+				Architecture: manifest.Platform.Architecture,
+				OSVersion:    manifest.Platform.OSVersion,
+				OSFeatures:   manifest.Platform.OSFeatures,
+				Variant:      manifest.Platform.Variant,
+			}
+			return ret, nil
 		}
 	}
 	return ListUpdate{}, fmt.Errorf("unable to find instance %s passed to Schema2List.Instances", instanceDigest)

--- a/internal/manifest/docker_schema2_list_test.go
+++ b/internal/manifest/docker_schema2_list_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	compressionTypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,9 @@ func TestSchema2ListEditInstances(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "something", instance.MediaType)
 	assert.Equal(t, int64(32), instance.Size)
+	// platform must match with instance platform set in `v2list.manifest.json` for the first instance
+	assert.Equal(t, &imgspecv1.Platform{Architecture: "ppc64le", OS: "linux", OSVersion: "", OSFeatures: []string(nil), Variant: ""}, instance.ReadOnly.Platform)
+	assert.Equal(t, []string{compressionTypes.GzipAlgorithmName}, instance.ReadOnly.CompressionAlgorithmNames)
 
 	// Create a fresh list
 	list, err = ListFromBlob(validManifest, GuessMIMEType(validManifest))

--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -68,6 +68,12 @@ type ListUpdate struct {
 	Digest    digest.Digest
 	Size      int64
 	MediaType string
+	// ReadOnly fields: may be set by Instance(), ignored by UpdateInstance()
+	ReadOnly struct {
+		Platform                  *imgspecv1.Platform
+		Annotations               map[string]string
+		CompressionAlgorithmNames []string
+	}
 }
 
 type ListOp int

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -112,10 +112,11 @@ type TryReusingBlobOptions struct {
 	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
 	// if they use internal/imagedestination/impl.Compat;
 	// in that case, they will all be consistently zero-valued.
-
-	EmptyLayer bool            // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
-	LayerIndex *int            // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
-	SrcRef     reference.Named // A reference to the source image that contains the input blob.
+	RequiredCompression *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
+	OriginalCompression *compression.Algorithm // Must be set if RequiredCompression is set; can be set to nil to indicate “uncompressed” or “unknown”.
+	EmptyLayer          bool                   // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
+	LayerIndex          *int                   // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
+	SrcRef              reference.Named        // A reference to the source image that contains the input blob.
 }
 
 // ReusedBlob is information about a blob reused in a destination.

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -28,6 +28,12 @@ func (s *Set[E]) Add(v E) {
 	s.m[v] = struct{}{} // Possibly writing the same struct{}{} presence marker again.
 }
 
+func (s *Set[E]) AddSlice(slice []E) {
+	for _, v := range slice {
+		s.Add(v)
+	}
+}
+
 func (s *Set[E]) Delete(v E) {
 	delete(s.m, v)
 }

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -25,9 +25,18 @@ func TestAdd(t *testing.T) {
 	assert.True(t, s.Contains(2))
 	s.Add(2) // Adding an already-present element
 	assert.True(t, s.Contains(2))
+	// should not contain duplicate value of `2`
+	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 	// Unrelated elements are unaffected
 	assert.True(t, s.Contains(1))
 	assert.False(t, s.Contains(3))
+}
+
+func TestAddSlice(t *testing.T) {
+	s := NewWithValues(1)
+	s.Add(2)
+	s.AddSlice([]int{3, 4})
+	assert.ElementsMatch(t, []int{1, 2, 3, 4}, s.Values())
 }
 
 func TestDelete(t *testing.T) {
@@ -61,6 +70,8 @@ func TestValues(t *testing.T) {
 	s := New[int]()
 	assert.Empty(t, s.Values())
 	s.Add(1)
+	s.Add(2)
+	// ignore duplicate
 	s.Add(2)
 	assert.ElementsMatch(t, []int{1, 2}, s.Values())
 }

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -172,6 +172,9 @@ func (d *ociImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ociImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if info.Digest == "" {
 		return false, private.ReusedBlob{}, errors.New("Can not check for a blob with unknown digest")
 	}

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -335,6 +335,9 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	if d.repo == nil {
 		repo, err := openRepo(d.ref.repo)
 		if err != nil {

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -237,6 +237,9 @@ func (d *blobCacheDestination) PutBlobPartial(ctx context.Context, chunkAccessor
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *blobCacheDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	present, reusedInfo, err := d.destination.TryReusingBlobWithOptions(ctx, info, options)
 	if err != nil || present {
 		return present, reusedInfo, err

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -307,6 +307,9 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
+	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+		return false, private.ReusedBlob{}, nil
+	}
 	reused, info, err := s.tryReusingBlobAsPending(blobinfo.Digest, blobinfo.Size, &options)
 	if err != nil || !reused || options.LayerIndex == nil {
 		return reused, info, err

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 27
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
<s>Looking at #2074, CI is not running on the new `release-5.27` branch yet.</s>

This:
- <s>Includes #2074 , to hopefully make tests pass with this older codebase</s>
- Includes the #2071 backport
- Bumps `version.go` to 5.27.0

I.e. this should be all that is necessary to tag a tested 5.27.0 release — **except** that this PR is filed against the 5.26 branch, to trigger a test run.

If the test passes, this can be merged into the 5.27 branch, and (the right commit) tagged as c/image 5.27.0. (Alternatively, if the move to 5.27 were unreasonable, a variant of #2074 can be used on the `release-5.26` branch.