### PR TITLE
Update to Go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/image/v5
 
-go 1.18
+go 1.19
 
 require (
 	dario.cat/mergo v1.0.0

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -57,7 +57,7 @@ type storageImageDestination struct {
 
 	imageRef        storageReference
 	directory       string                   // Temporary directory where we store blobs until Commit() time
-	nextTempFileID  int32                    // A counter that we use for computing filenames to assign to blobs
+	nextTempFileID  atomic.Int32             // A counter that we use for computing filenames to assign to blobs
 	manifest        []byte                   // Manifest contents, temporary
 	manifestDigest  digest.Digest            // Valid if len(manifest) != 0
 	signatures      []byte                   // Signature contents, temporary
@@ -154,7 +154,7 @@ func (s *storageImageDestination) Close() error {
 }
 
 func (s *storageImageDestination) computeNextBlobCacheFile() string {
-	return filepath.Join(s.directory, fmt.Sprintf("%d", atomic.AddInt32(&s.nextTempFileID, 1)))
+	return filepath.Join(s.directory, fmt.Sprintf("%d", s.nextTempFileID.Add(1)))
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.


### PR DESCRIPTION
We already require it, because docker/credential-helpers uses Go 1.19 os/exec.Cmd.Environ(). So make that official, and benefit from a new feature.