### PR TITLE
Rename SKOPEO_CI_TAG to SKOPEO_CI_BRANCH

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,8 @@ env:
     ####
     # Name of the ultimate destination branch for this CI run
     DEST_BRANCH: "main"
-    # CI container image tag (c/skopeo branch name)
-    SKOPEO_CI_TAG: "main"
+    # c/skopeo branch name which must work with this c/image branch
+    SKOPEO_CI_BRANCH: "main"
     # Use GO module mirror (reason unknown, travis did it this way)
     GOPROXY: https://proxy.golang.org
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -20,14 +20,14 @@ fi
 export "PATH=$PATH:$GOPATH/bin"
 
 _run_setup() {
-    req_env_vars SKOPEO_PATH SKOPEO_CI_TAG GOSRC BUILDTAGS
+    req_env_vars SKOPEO_PATH SKOPEO_CI_BRANCH GOSRC BUILDTAGS
 
     project_module=$(go list .)
 
     make tools
 
     rm -rf "${SKOPEO_PATH}"
-    git clone -b ${SKOPEO_CI_TAG} \
+    git clone -b ${SKOPEO_CI_BRANCH} \
         https://github.com/containers/skopeo.git ${SKOPEO_PATH}
 
     cd "${SKOPEO_PATH}"
@@ -37,7 +37,7 @@ _run_setup() {
         git checkout FETCH_HEAD
     fi
 
-    msg "Replacing upstream skopeo $SKOPEO_CI_TAG branch $project_module module"
+    msg "Replacing upstream skopeo $SKOPEO_CI_BRANCH branch $project_module module"
     go mod edit -replace ${project_module}=$GOSRC
 
     "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" setup


### PR DESCRIPTION
Originally (in https://github.com/containers/image/pull/1272 ) `SKOPEO_CI_TAG` was also a tag of an on-registry image. That's no longer the case.

On c/image stable branches, we typically want to test against a corresponding skopeo stable branch, not against a specific frozen version on that stable branch, so the variable name has become a bit confusing.

So, rename it to `SKOPEO_CI_BRANCH`.