### PR TITLE
Fix raspberry pi zero cpu variant recognition

### DIFF
--- a/internal/pkg/platform/platform_matcher.go
+++ b/internal/pkg/platform/platform_matcher.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 )
 
@@ -82,15 +83,40 @@ func getCPUVariantWindows(arch string) string {
 func getCPUVariantArm() string {
 	variant, err := getCPUInfo("Cpu architecture")
 	if err != nil {
+		logrus.Errorf("Couldn't get cpu architecture: %v", err)
 		return ""
 	}
-	// TODO handle RPi Zero mismatch (https://github.com/moby/moby/pull/36121#issuecomment-398328286)
 
 	switch strings.ToLower(variant) {
 	case "8", "aarch64":
 		variant = "v8"
-	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
+	case "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"
+	case "7":
+		// handle RPi Zero variant mismatch due to wrong variant from kernel
+		// https://github.com/containerd/containerd/pull/4530
+		// https://www.raspberrypi.org/forums/viewtopic.php?t=12614
+		// https://github.com/moby/moby/pull/36121#issuecomment-398328286
+		model, err := getCPUInfo("model name")
+		if err != nil {
+			logrus.Errorf("Couldn't get cpu model name, it may be the corner case where variant is 6: %v", err)
+			return ""
+		}
+		// model name is NOT a value provided by the CPU; it is another outcome of Linux CPU detection,
+		// https://github.com/torvalds/linux/blob/190bf7b14b0cf3df19c059061be032bd8994a597/arch/arm/mm/proc-v6.S#L178C35-L178C35
+		// (matching happens based on value + mask at https://github.com/torvalds/linux/blob/190bf7b14b0cf3df19c059061be032bd8994a597/arch/arm/mm/proc-v6.S#L273-L274 )
+		// ARM CPU ID starts with a “main” ID register https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/System-Control-Registers-in-a-VMSA-implementation/VMSA-System-control-registers-descriptions--in-register-order/MIDR--Main-ID-Register--VMSA?lang=en ,
+		// but the ARMv6/ARMv7 differences are not a single dimension, https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-CPUID-Identification-Scheme?lang=en .
+		// The Linux "cpu architecture" is determined by a “memory model” feature.
+		//
+		// So, the "armv6-compatible" check basically checks for a "v6 or v7 CPU, but not one found listed as a known v7 one in the .proc.info.init tables of
+		// https://github.com/torvalds/linux/blob/190bf7b14b0cf3df19c059061be032bd8994a597/arch/arm/mm/proc-v7.S .
+		if strings.HasPrefix(strings.ToLower(model), "armv6-compatible") {
+			logrus.Debugf("Detected corner case, setting cpu variant to v6")
+			variant = "v6"
+		} else {
+			variant = "v7"
+		}
 	case "6", "6tej":
 		variant = "v6"
 	case "5", "5t", "5te", "5tej":


### PR DESCRIPTION
The PR fixes a corner-case problem in which images for raspberry pi 1 or raspberry pi zero single board computers are downloaded for a wrong architecture, resulting in unability to run containers.

Also, PR adds some prints to improve the debugging.

The problem may be easily reproduced when using a rpi 1 or rpi zero with podman:

current version:
```sh
> podman run --log-level=info --syslog busybox echo ok
INFO[0000] podman filtering at log level info
INFO[0000] Setting parallel job count to 4
Resolved "busybox" as an alias (/home/pi/.cache/containers/short-name-aliases.conf)
Trying to pull docker.io/library/busybox:latest...
Getting image source signatures
Copying blob 0983f321071f done
Copying config 87837ce2bf done
Writing manifest to image destination
Storing signatures
INFO[0011] Running conmon under slice user.slice and unitName libpod-conmon-148722857d0739cc36a346b4f035448abb0736ea3b10c04132735da82e96b49d.scope
INFO[0012] Got Conmon PID as 21404
INFO[0012] Received shutdown.Stop(), terminating!        PID=21384
➜  podman image ls
REPOSITORY                 TAG         IMAGE ID      CREATED       SIZE
docker.io/library/busybox  latest      87837ce2bf82  3 weeks ago   2.66 MB
```

expected output:
```sh
➜  podman run --log-level=info --syslog busybox echo ok
INFO[0000] ./podman filtering at log level info
INFO[0000] Setting parallel job count to 4
Resolved "busybox" as an alias (/home/pi/.cache/containers/short-name-aliases.conf)
Trying to pull docker.io/library/busybox:latest...
Getting image source signatures
Copying blob 60966b1a2cb7 done
Copying config 9f28bca8fa done
Writing manifest to image destination
WARNING: image platform (linux/arm/v6) does not match the expected platform (linux/arm)
INFO[0009] Received shutdown.Stop(), terminating!        PID=21440
INFO[0010] Failed to add conmon to cgroupfs sandbox cgroup: creating cgroup path conmon: open /sys/fs/cgroup/cgroup.subtree_control: permission denied
INFO[0010] Got Conmon PID as 21459
ok
➜  bin podman image ls
REPOSITORY                 TAG         IMAGE ID      CREATED       SIZE
docker.io/library/busybox  latest      9f28bca8fad0  3 weeks ago   1.91 MB
```


As we can see, image for arm v7 is downloaded (87837ce2bf82) instead of image for arm v6 (9f28bca8fad0)

I would also expect that explicit notice of the error been returned to the console when running failed (like in docker), however it is not a case here. I believe it is another issue, to be submitted directly to podman repo.
The error 139 is reported in syslog though: `conmon fba43d5acde494cff782 <ninfo>: container 2072 exited with status 139`


references:
- https://github.com/containerd/containerd/pull/4530
- https://www.raspberrypi.org/forums/viewtopic.php?t=12614
- https://github.com/moby/moby/pull/36121#issuecomment-398328286