### PR TITLE
copy: fix nil pointer dereference when checking compression algorithm

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -380,8 +380,9 @@ func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context,
 
 	compressionAlgos := set.New[string]()
 	for _, srcInfo := range ic.src.LayerInfos() {
-		compression := compressionAlgorithmFromMIMEType(srcInfo)
-		compressionAlgos.Add(compression.Name())
+		if c := compressionAlgorithmFromMIMEType(srcInfo); c != nil {
+			compressionAlgos.Add(c.Name())
+		}
 	}
 
 	algos, err := algorithmsByNames(compressionAlgos.Values())


### PR DESCRIPTION
related to #2047 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xcbbbf7]

goroutine 1 [running]:
github.com/containers/image/v5/copy.(*imageCopier).compareImageDestinationManifestEqual(0xc0000c3860, {0x1b88850, 0xc000044158}, 0xc00001cc08)
        /home/crazymax/github.com/containers/image/v5@v5.28.0/copy/single.go:384 +0x677
github.com/containers/image/v5/copy.(*copier).copySingleImage(0xc000427b80, {0x1b88850, 0xc000044158}, 0xc00048dc80, 0xc00001cc08, {0x4?, 0x0?, 0x0?})
        /home/crazymax/github.com/containers/image/v5@v5.28.0/copy/single.go:194 +0xde5
github.com/containers/image/v5/copy.(*copier).copyMultipleImages(0xc000427b80, {0x1b88850, 0xc000044158})
        /home/crazymax/github.com/containers/image/v5@v5.28.0/copy/multiple.go:242 +0x1149
github.com/containers/image/v5/copy.Image({0x1b88850, 0xc000044158}, 0xc0005670f8, {0x1b8e7e0, 0xc0002a8c60}, {0x1b8e660?, 0xc00071e840?}, 0x0?)
        /home/crazymax/github.com/containers/image/v5@v5.28.0/copy/copy.go:337 +0x1485
```

cc @flouthoc @mtrmac