### PR TITLE
progress: set Current before Refill

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -743,7 +743,9 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			uploadedBlob, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, ic.c.blobInfoCache)
 			if err == nil {
 				if srcInfo.Size != -1 {
-					bar.SetRefill(srcInfo.Size - bar.Current())
+					refill := srcInfo.Size - bar.Current()
+					bar.SetCurrent(srcInfo.Size)
+					bar.SetRefill(refill)
 				}
 				bar.mark100PercentComplete()
 				hideProgressBar = false


### PR DESCRIPTION
the mpb.Progress doesn't allow to set the Refill value bigger than Current so make sure we set Current before setting Refill otherwise we will report the wrong number of skipped bytes.