### PR TITLE
Fix podman search for docker.io/library images

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -363,6 +363,11 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 	hostname := registry
 	if registry == dockerHostname {
 		hostname = dockerV1Hostname
+		// A search term of library/foo does not find the library/foo image on the docker.io servers,
+		// which is surprising - and that Docker is modifying the search term client-side this same way,
+		// and it seems convenient to do the same thing.
+		// Read more here: https://github.com/containers/image/pull/2133#issue-1928524334
+		image = strings.TrimPrefix(image, "library/")
 	}
 
 	client, err := newDockerClient(sys, hostname, registry)


### PR DESCRIPTION
This PR attempts to fix this issue https://github.com/containers/podman/issues/20230.

Looking at `moby`, it looks like they are doing a hacky trick when we add `library` to the image.
As seen [here](https://github.com/moby/moby/blob/master/registry/search.go#L99-L102):
```go
	if index.Official {
		// If pull "library/foo", it's stored locally under "foo"
		remoteName = strings.TrimPrefix(remoteName, "library/")
	}
```
If the registry is official then we need to trim "library/" from the image name.
Now what registries are set as official? Looking further at [the `newIndexInfo` function](https://github.com/moby/moby/blob/master/registry/config.go#L394-L404):
If the registry name is set in the configuration we will return it.
```go
	// Return any configured index info, first.
	if index, ok := config.IndexConfigs[indexName]; ok {
		return index, nil
	}
```
Otherwise we return a new IndexInfo which is not official:
```go
	// Construct a non-configured index info.
	return &registry.IndexInfo{
		Name:     indexName,
		Mirrors:  make([]string, 0),
		Secure:   config.isSecureIndex(indexName),
		Official: false,
	}, nil
```

Okay, now what is left to understand is: what registries are set to official at the configuration.
Getting [here](https://github.com/moby/moby/blob/master/registry/config.go#L84-L96) where we create a new ServiceConfig which is used in `newIndexInfo`.
This function creates a ServiceConfig and what I was interested in was how the IndexConfigs is set.
It looks like these two functions mutate the IndexConfigs: [`loadInsecureRegistries`](https://github.com/moby/moby/blob/master/registry/config.go#L184) and [`loadMirrors`](https://github.com/moby/moby/blob/master/registry/config.go#L153)

In both of them the only official IndexServer is `IndexName` which is equal to `docker.io`.
```go
	IndexName = "docker.io"
...

	// Configure public registry since mirrors may have changed.
	config.IndexConfigs = map[string]*registry.IndexInfo{
		IndexName: {
			Name:     IndexName,
			Mirrors:  unique,
			Secure:   true,
			Official: true,
		},
	}
...
			// Assume `host:port` if not CIDR.
			indexConfigs[r] = &registry.IndexInfo{
				Name:     r,
				Mirrors:  make([]string, 0),
				Secure:   false,
				Official: false,
			}
...
	// Configure public registry.
	indexConfigs[IndexName] = &registry.IndexInfo{
		Name:     IndexName,
		Mirrors:  config.Mirrors,
		Secure:   true,
		Official: true,
	}
	config.InsecureRegistryCIDRs = insecureRegistryCIDRs
	config.IndexConfigs = indexConfigs
```

So all in all - only docker.io is the official registry. Thus, to adjust docker behavior in podman, I trimmed the library/ when registry is docker hostname.


/cc @rhatdan 