### PR TITLE
Fix and simplify storage tests

### DIFF
--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -192,10 +192,6 @@ func TestParseWithGraphDriverOptions(t *testing.T) {
 	}
 }
 
-func systemContext() *types.SystemContext {
-	return &types.SystemContext{}
-}
-
 // makeLayerGoroutine writes to pwriter, and on success, updates uncompressedCount
 // before it terminates.
 func makeLayerGoroutine(pwriter io.Writer, uncompressedCount *int64, compression archive.Compression) error {
@@ -426,7 +422,7 @@ func TestWriteRead(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, manifestFmt := range manifests {
-		dest, err := ref.NewImageDestination(context.Background(), systemContext())
+		dest, err := ref.NewImageDestination(context.Background(), nil)
 		require.NoError(t, err)
 		require.Equal(t, ref.StringWithinTransport(), dest.Reference().StringWithinTransport())
 		t.Logf("supported manifest MIME types: %v", dest.SupportedManifestMIMETypes())
@@ -464,7 +460,7 @@ func TestWriteRead(t *testing.T) {
 		err = dest.Close()
 		require.NoError(t, err)
 
-		img, err := ref.NewImage(context.Background(), systemContext())
+		img, err := ref.NewImage(context.Background(), nil)
 		require.NoError(t, err)
 		imageConfigInfo := img.ConfigInfo()
 		if imageConfigInfo.Digest != "" {
@@ -480,7 +476,7 @@ func TestWriteRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, imageInfo.Created.IsZero())
 
-		src, err := ref.NewImageSource(context.Background(), systemContext())
+		src, err := ref.NewImageSource(context.Background(), nil)
 		require.NoError(t, err)
 		if src.Reference().StringWithinTransport() != ref.StringWithinTransport() {
 			// As long as it's only the addition of an ID suffix, that's okay.
@@ -527,7 +523,7 @@ func TestWriteRead(t *testing.T) {
 		require.NoError(t, err)
 		err = img.Close()
 		require.NoError(t, err)
-		err = ref.DeleteImage(context.Background(), systemContext())
+		err = ref.DeleteImage(context.Background(), nil)
 		require.NoError(t, err)
 	}
 }
@@ -645,7 +641,7 @@ func TestSize(t *testing.T) {
 
 	createImage(t, ref, cache, []testBlob{layer1, layer2}, &config)
 
-	img, err := ref.NewImage(context.Background(), systemContext())
+	img, err := ref.NewImage(context.Background(), nil)
 	require.NoError(t, err)
 	manifest, _, err := img.Manifest(context.Background())
 	require.NoError(t, err)
@@ -680,9 +676,9 @@ func TestDuplicateBlob(t *testing.T) {
 
 	createImage(t, ref, cache, []testBlob{layer1, layer2, layer1, layer2}, &config)
 
-	img, err := ref.NewImage(context.Background(), systemContext())
+	img, err := ref.NewImage(context.Background(), nil)
 	require.NoError(t, err)
-	src, err := ref.NewImageSource(context.Background(), systemContext())
+	src, err := ref.NewImageSource(context.Background(), nil)
 	require.NoError(t, err)
 	source, ok := src.(*storageImageSource)
 	require.True(t, ok)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -330,9 +330,10 @@ func TestWriteRead(t *testing.T) {
 		    ]
 		}`,
 	}
+	// Start signatures with 0xA0 to fool internal/signature.FromBlob into thinking it is valid GPG
 	signatures := [][]byte{
-		[]byte("Signature A"),
-		[]byte("Signature B"),
+		[]byte("\xA0Signature A"),
+		[]byte("\xA0Signature B"),
 	}
 	newStore(t)
 	ref, err := Transport.ParseReference("test")

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -269,10 +269,16 @@ func makeLayer(t *testing.T, compression archive.Compression) (ddigest.Digest, i
 	return sum, uncompressedCount, int64(tbuffer.Len()), tbuffer.Bytes()
 }
 
-func TestWriteRead(t *testing.T) {
+// ensureTestCanCreateImages skips the current test if it is not possible to create layers and images in a private store.
+func ensureTestCanCreateImages(t *testing.T) {
+	t.Helper()
 	if os.Geteuid() != 0 {
-		t.Skip("TestWriteRead requires root privileges")
+		t.Skip("test requires root privileges")
 	}
+}
+
+func TestWriteRead(t *testing.T) {
+	ensureTestCanCreateImages(t)
 
 	config := `{"config":{"labels":{}},"created":"2006-01-02T15:04:05Z"}`
 	sum := ddigest.SHA256.FromBytes([]byte(config))
@@ -521,9 +527,7 @@ func TestWriteRead(t *testing.T) {
 }
 
 func TestDuplicateName(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("TestDuplicateName requires root privileges")
-	}
+	ensureTestCanCreateImages(t)
 
 	newStore(t)
 	cache := memory.New()
@@ -620,9 +624,7 @@ func TestDuplicateName(t *testing.T) {
 }
 
 func TestDuplicateID(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("TestDuplicateID requires root privileges")
-	}
+	ensureTestCanCreateImages(t)
 
 	newStore(t)
 	cache := memory.New()
@@ -722,9 +724,7 @@ func TestDuplicateID(t *testing.T) {
 }
 
 func TestDuplicateNameID(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("TestDuplicateNameID requires root privileges")
-	}
+	ensureTestCanCreateImages(t)
 
 	newStore(t)
 	cache := memory.New()
@@ -863,9 +863,7 @@ func TestNamespaces(t *testing.T) {
 }
 
 func TestSize(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("TestSize requires root privileges")
-	}
+	ensureTestCanCreateImages(t)
 
 	config := `{"config":{"labels":{}},"created":"2006-01-02T15:04:05Z"}`
 	sum := ddigest.SHA256.FromBytes([]byte(config))
@@ -961,9 +959,7 @@ func TestSize(t *testing.T) {
 }
 
 func TestDuplicateBlob(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("TestDuplicateBlob requires root privileges")
-	}
+	ensureTestCanCreateImages(t)
 
 	config := `{"config":{"labels":{}},"created":"2006-01-02T15:04:05Z"}`
 	sum := ddigest.SHA256.FromBytes([]byte(config))

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -205,7 +205,14 @@ func makeLayerGoroutine(pwriter io.Writer, uncompressedCount *int64, compression
 		uncompressed = ioutils.NewWriteCounter(pwriter)
 	}
 	twriter := tar.NewWriter(uncompressed)
-	defer twriter.Close()
+	// 	defer twriter.Close()
+	// should be called here to correctly terminate the archive.
+	// We do not do that, to workaround https://github.com/containers/storage/issues/1729 :
+	// tar-split runs a goroutine that consumes/forwards tar content and might access
+	// concurrently-freed objects if it sees a valid EOF marker.
+	// Instead, realy on raw EOF to terminate the goroutine.
+	// This depends on implementation details of tar.Writer (that it does not do any
+	// internal buffering).
 
 	buf := make([]byte, layerSize)
 	n, err := rand.Read(buf)


### PR DESCRIPTION
For CRI-O (and, maybe, Podman/libimate), I want to introduce a new reference lookup method, and that needs tests against a locally-created image.

It turns out those tests required root, and we never run them as root. So a large part of storage transport tests have been unused for _4 years_ now.

This fixes that problem:
Fixes #1729 . And at least on a Mac (?), the tests don’t actually require any privileges, so run them unconditionally.

This PR also consolidates the existing code to create/test images to significantly reduce duplication, to benefit from `testify`, and to make it easier to add more test cases, now that I have been reading the code.

@vrothberg PTAL. Cc: @saschagrunert 