### PR TITLE
Fix conversion of Zstd images to non-OCI formats

### DIFF
--- a/internal/image/common_test.go
+++ b/internal/image/common_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,16 @@ func layerInfosWithCryptoOperation(input []types.BlobInfo, op types.LayerCrypto)
 	res := slices.Clone(input)
 	for i := range res {
 		res[i].CryptoOperation = op
+	}
+	return res
+}
+
+// layerInfosWithCompressionEdits returns a copy of input where CompressionOperation and CompressionAlgorithm is set to op and algo
+func layerInfosWithCompressionEdits(input []types.BlobInfo, op types.LayerCompression, algo *compressiontypes.Algorithm) []types.BlobInfo {
+	res := slices.Clone(input)
+	for i := range res {
+		res[i].CompressionOperation = op
+		res[i].CompressionAlgorithm = algo
 	}
 	return res
 }

--- a/internal/image/fixtures/oci1-all-media-types-config.json
+++ b/internal/image/fixtures/oci1-all-media-types-config.json
@@ -1,0 +1,161 @@
+{
+    "architecture": "amd64",
+    "config": {
+        "Hostname": "383850eeb47b",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "80/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HTTPD_PREFIX=/usr/local/apache2",
+            "HTTPD_VERSION=2.4.23",
+            "HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc"
+        ],
+        "Cmd": [
+            "httpd-foreground"
+        ],
+        "ArgsEscaped": true,
+        "Image": "sha256:4f83530449c67c1ed8fca72583c5b92fdf446010990028c362a381e55dd84afd",
+        "Volumes": null,
+        "WorkingDir": "/usr/local/apache2",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {}
+    },
+    "container": "8825acde1b009729807e4b70a65a89399dd8da8e53be9216b9aaabaff4339f69",
+    "container_config": {
+        "Hostname": "383850eeb47b",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "80/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HTTPD_PREFIX=/usr/local/apache2",
+            "HTTPD_VERSION=2.4.23",
+            "HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc"
+        ],
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) ",
+            "CMD [\"httpd-foreground\"]"
+        ],
+        "ArgsEscaped": true,
+        "Image": "sha256:4f83530449c67c1ed8fca72583c5b92fdf446010990028c362a381e55dd84afd",
+        "Volumes": null,
+        "WorkingDir": "/usr/local/apache2",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {}
+    },
+    "created": "2016-09-23T23:20:45.78976459Z",
+    "docker_version": "1.12.1",
+    "history": [
+        {
+            "created": "2016-09-23T18:08:50.537223822Z",
+            "created_by": "/bin/sh -c #(nop) ADD file:c6c23585ab140b0b320d4e99bc1b0eb544c9e96c24d90fec5e069a6d57d335ca in / "
+        },
+        {
+            "created": "2016-09-23T18:08:51.133779867Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:40.725768956Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_PREFIX=/usr/local/apache2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:41.037788416Z",
+            "created_by": "/bin/sh -c #(nop)  ENV PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:41.990121202Z",
+            "created_by": "/bin/sh -c mkdir -p \"$HTTPD_PREFIX\" \t\u0026\u0026 chown www-data:www-data \"$HTTPD_PREFIX\""
+        },
+        {
+            "created": "2016-09-23T19:16:42.339911155Z",
+            "created_by": "/bin/sh -c #(nop)  WORKDIR /usr/local/apache2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:54.948461741Z",
+            "created_by": "/bin/sh -c apt-get update \t\u0026\u0026 apt-get install -y --no-install-recommends \t\tlibapr1 \t\tlibaprutil1 \t\tlibaprutil1-ldap \t\tlibapr1-dev \t\tlibaprutil1-dev \t\tlibpcre++0 \t\tlibssl1.0.0 \t\u0026\u0026 rm -r /var/lib/apt/lists/*"
+        },
+        {
+            "created": "2016-09-23T19:16:55.321573403Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_VERSION=2.4.23",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:55.629947307Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:19:03.705796801Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:19:04.009782822Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:20:44.585743332Z",
+            "created_by": "/bin/sh -c set -x \t\u0026\u0026 buildDeps=' \t\tbzip2 \t\tca-certificates \t\tgcc \t\tlibpcre++-dev \t\tlibssl-dev \t\tmake \t\twget \t' \t\u0026\u0026 apt-get update \t\u0026\u0026 apt-get install -y --no-install-recommends $buildDeps \t\u0026\u0026 rm -r /var/lib/apt/lists/* \t\t\u0026\u0026 wget -O httpd.tar.bz2 \"$HTTPD_BZ2_URL\" \t\u0026\u0026 echo \"$HTTPD_SHA1 *httpd.tar.bz2\" | sha1sum -c - \t\u0026\u0026 wget -O httpd.tar.bz2.asc \"$HTTPD_ASC_URL\" \t\u0026\u0026 export GNUPGHOME=\"$(mktemp -d)\" \t\u0026\u0026 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \t\u0026\u0026 gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \t\u0026\u0026 rm -r \"$GNUPGHOME\" httpd.tar.bz2.asc \t\t\u0026\u0026 mkdir -p src \t\u0026\u0026 tar -xvf httpd.tar.bz2 -C src --strip-components=1 \t\u0026\u0026 rm httpd.tar.bz2 \t\u0026\u0026 cd src \t\t\u0026\u0026 ./configure \t\t--prefix=\"$HTTPD_PREFIX\" \t\t--enable-mods-shared=reallyall \t\u0026\u0026 make -j\"$(nproc)\" \t\u0026\u0026 make install \t\t\u0026\u0026 cd .. \t\u0026\u0026 rm -r src \t\t\u0026\u0026 sed -ri \t\t-e 's!^(\\s*CustomLog)\\s+\\S+!\\1 /proc/self/fd/1!g' \t\t-e 's!^(\\s*ErrorLog)\\s+\\S+!\\1 /proc/self/fd/2!g' \t\t\"$HTTPD_PREFIX/conf/httpd.conf\" \t\t\u0026\u0026 apt-get purge -y --auto-remove $buildDeps"
+        },
+        {
+            "created": "2016-09-23T23:20:45.127455562Z",
+            "created_by": "/bin/sh -c #(nop) COPY file:761e313354b918b6cd7ea99975a4f6b53ff5381ba689bab2984aec4dab597215 in /usr/local/bin/ "
+        },
+        {
+            "created": "2016-09-23T23:20:45.453934921Z",
+            "created_by": "/bin/sh -c #(nop)  EXPOSE 80/tcp",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:20:45.78976459Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"httpd-foreground\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2023-10-01T02:03:04.56789764Z",
+            "created_by": "/bin/sh echo something > last"
+        }
+    ],
+    "os": "linux",
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:142a601d97936307e75220c35dde0348971a9584c21e7cb42e1f7004005432ab",
+            "sha256:90fcc66ad3be9f1757f954b750deb37032f208428aa12599fcb02182b9065a9c",
+            "sha256:5a8624bb7e76d1e6829f9c64c43185e02bc07f97a2189eb048609a8914e72c56",
+            "sha256:d349ff6b3afc6a2800054768c82bfbf4289c9aa5da55c1290f802943dcd4d1e9",
+            "sha256:8c064bb1f60e84fa8cc6079b6d2e76e0423389fd6aeb7e497dfdae5e05b2b25b",
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        ]
+    }
+}

--- a/internal/image/fixtures/oci1-all-media-types-to-schema2-config.json
+++ b/internal/image/fixtures/oci1-all-media-types-to-schema2-config.json
@@ -1,0 +1,161 @@
+{
+    "architecture": "amd64",
+    "config": {
+        "Hostname": "383850eeb47b",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "80/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HTTPD_PREFIX=/usr/local/apache2",
+            "HTTPD_VERSION=2.4.23",
+            "HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc"
+        ],
+        "Cmd": [
+            "httpd-foreground"
+        ],
+        "ArgsEscaped": true,
+        "Image": "sha256:4f83530449c67c1ed8fca72583c5b92fdf446010990028c362a381e55dd84afd",
+        "Volumes": null,
+        "WorkingDir": "/usr/local/apache2",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {}
+    },
+    "container": "8825acde1b009729807e4b70a65a89399dd8da8e53be9216b9aaabaff4339f69",
+    "container_config": {
+        "Hostname": "383850eeb47b",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "80/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HTTPD_PREFIX=/usr/local/apache2",
+            "HTTPD_VERSION=2.4.23",
+            "HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc"
+        ],
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) ",
+            "CMD [\"httpd-foreground\"]"
+        ],
+        "ArgsEscaped": true,
+        "Image": "sha256:4f83530449c67c1ed8fca72583c5b92fdf446010990028c362a381e55dd84afd",
+        "Volumes": null,
+        "WorkingDir": "/usr/local/apache2",
+        "Entrypoint": null,
+        "OnBuild": [],
+        "Labels": {}
+    },
+    "created": "2016-09-23T23:20:45.78976459Z",
+    "docker_version": "1.12.1",
+    "history": [
+        {
+            "created": "2016-09-23T18:08:50.537223822Z",
+            "created_by": "/bin/sh -c #(nop) ADD file:c6c23585ab140b0b320d4e99bc1b0eb544c9e96c24d90fec5e069a6d57d335ca in / "
+        },
+        {
+            "created": "2016-09-23T18:08:51.133779867Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:40.725768956Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_PREFIX=/usr/local/apache2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:41.037788416Z",
+            "created_by": "/bin/sh -c #(nop)  ENV PATH=/usr/local/apache2/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:41.990121202Z",
+            "created_by": "/bin/sh -c mkdir -p \"$HTTPD_PREFIX\" \t\u0026\u0026 chown www-data:www-data \"$HTTPD_PREFIX\""
+        },
+        {
+            "created": "2016-09-23T19:16:42.339911155Z",
+            "created_by": "/bin/sh -c #(nop)  WORKDIR /usr/local/apache2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:54.948461741Z",
+            "created_by": "/bin/sh -c apt-get update \t\u0026\u0026 apt-get install -y --no-install-recommends \t\tlibapr1 \t\tlibaprutil1 \t\tlibaprutil1-ldap \t\tlibapr1-dev \t\tlibaprutil1-dev \t\tlibpcre++0 \t\tlibssl1.0.0 \t\u0026\u0026 rm -r /var/lib/apt/lists/*"
+        },
+        {
+            "created": "2016-09-23T19:16:55.321573403Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_VERSION=2.4.23",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T19:16:55.629947307Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_SHA1=5101be34ac4a509b245adb70a56690a84fcc4e7f",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:19:03.705796801Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_BZ2_URL=https://www.apache.org/dyn/closer.cgi?action=download\u0026filename=httpd/httpd-2.4.23.tar.bz2",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:19:04.009782822Z",
+            "created_by": "/bin/sh -c #(nop)  ENV HTTPD_ASC_URL=https://www.apache.org/dist/httpd/httpd-2.4.23.tar.bz2.asc",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:20:44.585743332Z",
+            "created_by": "/bin/sh -c set -x \t\u0026\u0026 buildDeps=' \t\tbzip2 \t\tca-certificates \t\tgcc \t\tlibpcre++-dev \t\tlibssl-dev \t\tmake \t\twget \t' \t\u0026\u0026 apt-get update \t\u0026\u0026 apt-get install -y --no-install-recommends $buildDeps \t\u0026\u0026 rm -r /var/lib/apt/lists/* \t\t\u0026\u0026 wget -O httpd.tar.bz2 \"$HTTPD_BZ2_URL\" \t\u0026\u0026 echo \"$HTTPD_SHA1 *httpd.tar.bz2\" | sha1sum -c - \t\u0026\u0026 wget -O httpd.tar.bz2.asc \"$HTTPD_ASC_URL\" \t\u0026\u0026 export GNUPGHOME=\"$(mktemp -d)\" \t\u0026\u0026 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \t\u0026\u0026 gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \t\u0026\u0026 rm -r \"$GNUPGHOME\" httpd.tar.bz2.asc \t\t\u0026\u0026 mkdir -p src \t\u0026\u0026 tar -xvf httpd.tar.bz2 -C src --strip-components=1 \t\u0026\u0026 rm httpd.tar.bz2 \t\u0026\u0026 cd src \t\t\u0026\u0026 ./configure \t\t--prefix=\"$HTTPD_PREFIX\" \t\t--enable-mods-shared=reallyall \t\u0026\u0026 make -j\"$(nproc)\" \t\u0026\u0026 make install \t\t\u0026\u0026 cd .. \t\u0026\u0026 rm -r src \t\t\u0026\u0026 sed -ri \t\t-e 's!^(\\s*CustomLog)\\s+\\S+!\\1 /proc/self/fd/1!g' \t\t-e 's!^(\\s*ErrorLog)\\s+\\S+!\\1 /proc/self/fd/2!g' \t\t\"$HTTPD_PREFIX/conf/httpd.conf\" \t\t\u0026\u0026 apt-get purge -y --auto-remove $buildDeps"
+        },
+        {
+            "created": "2016-09-23T23:20:45.127455562Z",
+            "created_by": "/bin/sh -c #(nop) COPY file:761e313354b918b6cd7ea99975a4f6b53ff5381ba689bab2984aec4dab597215 in /usr/local/bin/ "
+        },
+        {
+            "created": "2016-09-23T23:20:45.453934921Z",
+            "created_by": "/bin/sh -c #(nop)  EXPOSE 80/tcp",
+            "empty_layer": true
+        },
+        {
+            "created": "2016-09-23T23:20:45.78976459Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"httpd-foreground\"]",
+            "empty_layer": true
+        },
+        {
+            "created": "2023-10-01T02:03:04.56789764Z",
+            "created_by": "/bin/sh echo something > last"
+        }
+    ],
+    "os": "linux",
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:142a601d97936307e75220c35dde0348971a9584c21e7cb42e1f7004005432ab",
+            "sha256:90fcc66ad3be9f1757f954b750deb37032f208428aa12599fcb02182b9065a9c",
+            "sha256:5a8624bb7e76d1e6829f9c64c43185e02bc07f97a2189eb048609a8914e72c56",
+            "sha256:d349ff6b3afc6a2800054768c82bfbf4289c9aa5da55c1290f802943dcd4d1e9",
+            "sha256:8c064bb1f60e84fa8cc6079b6d2e76e0423389fd6aeb7e497dfdae5e05b2b25b",
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        ]
+    }
+}

--- a/internal/image/fixtures/oci1-all-media-types.json
+++ b/internal/image/fixtures/oci1-all-media-types.json
@@ -4,7 +4,7 @@
     "config": {
         "mediaType": "application/vnd.oci.image.config.v1+json",
         "size": 4651,
-        "digest": "sha256:a13a0762ab7bed51a1b49adec0a702b1cd99294fd460a025b465bcfb7b152745"
+        "digest": "sha256:94ac69e4413476d061116c9d05757e46a0afc744e8b9886f75cf7f6f14c78fb3"
     },
     "layers": [
         {
@@ -28,7 +28,7 @@
             "digest": "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9"
         },
         {
-            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
             "size": 8841833,
             "digest": "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909"
         },

--- a/internal/image/oci_test.go
+++ b/internal/image/oci_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/testing/mocks"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
+	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -611,6 +613,62 @@ func TestManifestOCI1ConvertToManifestSchema1(t *testing.T) {
 		{Digest: GzippedEmptyLayerDigest, Size: -1},
 	}, s1Manifest.LayerInfos())
 
+	// Conversion to schema1 of an image with Zstd layers fails
+	mixedSrc := newOCI1ImageSource(t, "oci1-all-media-types-config.json", "httpd-copy:latest")
+	mixedImage := manifestOCI1FromFixture(t, mixedSrc, "oci1-all-media-types.json")
+	mixedImage2 := manifestOCI1FromFixture(t, mixedSrc, "oci1-all-media-types.json")
+	_, err = mixedImage.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+		ManifestMIMEType: manifest.DockerV2Schema1SignedMediaType,
+		InformationOnly: types.ManifestUpdateInformation{
+			Destination: memoryDest,
+		},
+	})
+	assert.Error(t, err) // zstd compression is not supported for docker images
+
+	// Conversion to schema1 of an image with Zstd layers, while editing layers to be uncompressed, or gzip-compressed, is possible.
+	for _, c := range []struct {
+		op   types.LayerCompression
+		algo *compressiontypes.Algorithm
+	}{
+		{types.Decompress, nil},
+		{types.PreserveOriginal, &compression.Gzip},
+	} {
+		updatedLayers = layerInfosWithCompressionEdits(mixedImage.LayerInfos(), c.op, c.algo)
+		updatedLayersCopy = slices.Clone(updatedLayers)
+		res = successfulOCI1Conversion(t, mixedImage, mixedImage2, types.ManifestUpdateOptions{
+			LayerInfos:       updatedLayers,
+			ManifestMIMEType: manifest.DockerV2Schema1SignedMediaType,
+			InformationOnly: types.ManifestUpdateInformation{
+				Destination: memoryDest,
+			},
+		})
+		assert.Equal(t, updatedLayersCopy, updatedLayers) // updatedLayers have not been modified in place
+		convertedJSON, mt, err = res.Manifest(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, manifest.DockerV2Schema1SignedMediaType, mt)
+		s1Manifest, err = manifestSchema1FromManifest(convertedJSON)
+		require.NoError(t, err)
+		// The schema1 data does not contain a MIME type (and we don’t update the digests), so both loop iterations look the same here
+		assert.Equal(t, []types.BlobInfo{
+			{Digest: "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb", Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c", Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c", Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9", Size: -1},
+			{Digest: "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909", Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: GzippedEmptyLayerDigest, Size: -1},
+			{Digest: "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa", Size: -1},
+		}, s1Manifest.LayerInfos())
+	}
+
 	// FIXME? Test also the other failure cases, if only to see that we don't crash?
 }
 
@@ -699,16 +757,114 @@ func TestConvertToManifestSchema2(t *testing.T) {
 	require.NoError(t, err)
 	assertJSONEqualsFixture(t, convertedConfig, "oci1-to-schema2-config.json")
 
-	// FIXME? Test also the other failure cases, if only to see that we don't crash?
-}
-
-func TestConvertToManifestSchema2AllMediaTypes(t *testing.T) {
-	originalSrc := newOCI1ImageSource(t, "oci1-config.json", "httpd-copy:latest")
-	original := manifestOCI1FromFixture(t, originalSrc, "oci1-all-media-types.json")
-	_, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+	// Conversion to schema2 of an image with Zstd layers fails
+	mixedSrc := newOCI1ImageSource(t, "oci1-all-media-types-config.json", "httpd-copy:latest")
+	mixedImage := manifestOCI1FromFixture(t, mixedSrc, "oci1-all-media-types.json")
+	mixedImage2 := manifestOCI1FromFixture(t, mixedSrc, "oci1-all-media-types.json")
+	_, err = mixedImage.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
 		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
 	})
-	require.Error(t, err) // zstd compression is not supported for docker images
+	assert.Error(t, err) // zstd compression is not supported for docker images
+
+	// Conversion to schema2 of an image with Zstd layers, while editing layers to be uncompressed, is possible.
+	updatedLayers = layerInfosWithCompressionEdits(mixedImage.LayerInfos(), types.Decompress, nil)
+	updatedLayersCopy = slices.Clone(updatedLayers)
+	res = successfulOCI1Conversion(t, mixedImage, mixedImage2, types.ManifestUpdateOptions{
+		LayerInfos:       updatedLayers,
+		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
+	})
+	assert.Equal(t, updatedLayersCopy, updatedLayers) // updatedLayers have not been modified in place
+	convertedJSON, mt, err = res.Manifest(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, manifest.DockerV2Schema2MediaType, mt)
+	s2Manifest, err = manifestSchema2FromManifest(mixedSrc, convertedJSON)
+	require.NoError(t, err)
+	assert.Equal(t, []types.BlobInfo{
+		{
+			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
+			Size:      51354364,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar",
+		},
+		{
+			Digest:    "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
+			Size:      150,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar",
+		},
+		{
+			Digest:    "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
+			Size:      152,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar",
+		},
+		{
+			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
+			Size:      11739507,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar",
+		},
+		{
+			Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+			Size:      8841833,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar",
+		},
+		{
+			Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
+			Size:      291,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar",
+		},
+	}, s2Manifest.LayerInfos())
+	convertedConfig, err = res.ConfigBlob(context.Background())
+	require.NoError(t, err)
+	assertJSONEqualsFixture(t, convertedConfig, "oci1-all-media-types-to-schema2-config.json")
+
+	// Conversion to schema2 of an image with Zstd layers, while editing layers to be gzip-compressed, is possible.
+	updatedLayers = layerInfosWithCompressionEdits(mixedImage.LayerInfos(), types.PreserveOriginal, &compression.Gzip)
+	updatedLayersCopy = slices.Clone(updatedLayers)
+	res = successfulOCI1Conversion(t, mixedImage, mixedImage2, types.ManifestUpdateOptions{
+		LayerInfos:       updatedLayers,
+		ManifestMIMEType: manifest.DockerV2Schema2MediaType,
+	})
+	assert.Equal(t, updatedLayersCopy, updatedLayers) // updatedLayers have not been modified in place
+	convertedJSON, mt, err = res.Manifest(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, manifest.DockerV2Schema2MediaType, mt)
+	s2Manifest, err = manifestSchema2FromManifest(mixedSrc, convertedJSON)
+	require.NoError(t, err)
+	assert.Equal(t, []types.BlobInfo{
+		{
+			Digest:    "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
+			Size:      51354364,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		},
+		{
+			Digest:    "sha256:1bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
+			Size:      150,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		},
+		{
+			Digest:    "sha256:2bbf5d58d24c47512e234a5623474acf65ae00d4d1414272a893204f44cc680c",
+			Size:      152,
+			MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		},
+		{
+			Digest:    "sha256:8f5dc8a4b12c307ac84de90cdd9a7f3915d1be04c9388868ca118831099c67a9",
+			Size:      11739507,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+		},
+		{
+			Digest:    "sha256:bbd6b22eb11afce63cc76f6bc41042d99f10d6024c96b655dafba930b8d25909",
+			Size:      8841833,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+		},
+		{
+			Digest:    "sha256:960e52ecf8200cbd84e70eb2ad8678f4367e50d14357021872c10fa3fc5935fa",
+			Size:      291,
+			MediaType: "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+		},
+	}, s2Manifest.LayerInfos())
+	convertedConfig, err = res.ConfigBlob(context.Background())
+	require.NoError(t, err)
+	assertJSONEqualsFixture(t, convertedConfig, "oci1-all-media-types-to-schema2-config.json")
+
+	// FIXME? Test also the other failure cases, if only to see that we don't crash?
 }
 
 func TestConvertToV2S2WithInvalidMIMEType(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -445,7 +445,7 @@ type ImageCloser interface {
 	Close() error
 }
 
-// ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
+// ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedImage
 type ManifestUpdateOptions struct {
 	LayerInfos              []BlobInfo // Complete BlobInfos (size+digest+urls+annotations) which should replace the originals, in order (the root layer first, and then successive layered layers). BlobInfos' MediaType fields are ignored.
 	EmbeddedDockerReference reference.Named
@@ -457,7 +457,7 @@ type ManifestUpdateOptions struct {
 // ManifestUpdateInformation is a component of ManifestUpdateOptions, named here
 // only to make writing struct literals possible.
 type ManifestUpdateInformation struct {
-	Destination  ImageDestination // and yes, UpdatedManifest may write to Destination (see the schema2 → schema1 conversion logic in image/docker_schema2.go)
+	Destination  ImageDestination // and yes, UpdatedImage may write to Destination (see the schema2 → schema1 conversion logic in image/docker_schema2.go)
 	LayerInfos   []BlobInfo       // Complete BlobInfos (size+digest) which have been uploaded, in order (the root layer first, and then successive layered layers)
 	LayerDiffIDs []digest.Digest  // Digest values for the _uncompressed_ contents of the blobs which have been uploaded, in the same order.
 }


### PR DESCRIPTION
For any Zstd layer, do a MIME type update (presumably converting from Zstd to something else) before we do the
format conversion, so that the format conversion doesn't fail with an unsupported MIME type.

Fixes #1260 .