### PR TITLE
Remove unused environment variables in Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,12 +29,6 @@ env:
     # test changes made there, in a PR in this repository.
     SKOPEO_PR:
 
-    ####
-    #### Cache-image names to test with (double-quotes around names are critical)
-    ####
-    FEDORA_NAME: "fedora-38"
-    DEBIAN_NAME: "debian-13"
-
     # Google-cloud VM Images
     IMAGE_SUFFIX: "c20231004t194547z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Some other containers/* repos use these values in test names; we don't, so remove them so that we don't have to worry about keeping them up to date.

Previously https://github.com/containers/image/pull/2150 ; @cevich PTAL to make sure I’m not missing any non-obvious references to these variables.