### PR TITLE
Missed null check in docker_image_dest.go

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -137,7 +137,7 @@ func (d *dockerImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 	// If requested, precompute the blob digest to prevent uploading layers that already exist on the registry.
 	// This functionality is particularly useful when BlobInfoCache has not been populated with compressed digests,
 	// the source blob is uncompressed, and the destination blob is being compressed "on the fly".
-	if inputInfo.Digest == "" && d.c.sys.DockerRegistryPushPrecomputeDigests {
+	if inputInfo.Digest == "" && d.c.sys != nil && d.c.sys.DockerRegistryPushPrecomputeDigests {
 		logrus.Debugf("Precomputing digest layer for %s", reference.Path(d.ref.ref))
 		streamCopy, cleanup, err := streamdigest.ComputeBlobInfo(d.c.sys, stream, &inputInfo)
 		if err != nil {


### PR DESCRIPTION
As the documentation says, "It is always OK to pass nil instead of a SystemContext."

I failed to get a suitable minimal reproduction project, but I got a panic on this line while using the library to copy images around once it decided to recompress a few layers, and I have confirmed that applying the change locally (or passing a suitable DestinationCtx to copy.Image) fixes the panic. Still, let me know if an actual reproduction would be necessary to get this merged.