### PR TITLE
Improve documentation of ResolveReference

### DIFF
--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -102,6 +102,8 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
 
 // Resolve the reference's name to an image ID in the store, if there's already
 // one present with the same name or ID, and return the image.
+//
+// Returns an error matching ErrNoSuchImage if an image matching ref was not found.
 func (s *storageReference) resolveImage(sys *types.SystemContext) (*storage.Image, error) {
 	var loadedImage *storage.Image
 	if s.id == "" && s.named != nil {
@@ -297,6 +299,8 @@ func (s storageReference) NewImageDestination(ctx context.Context, sys *types.Sy
 // Note that it _is_ possible for the later uses to fail, either because the image was removed
 // completely, or because the name used in the reference was untaged (even if the underlying image
 // ID still exists in local storage).
+//
+// Returns an error matching ErrNoSuchImage if an image matching ref was not found.
 func ResolveReference(ref types.ImageReference) (types.ImageReference, *storage.Image, error) {
 	sref, ok := ref.(*storageReference)
 	if !ok {

--- a/storage/storage_transport.go
+++ b/storage/storage_transport.go
@@ -53,7 +53,8 @@ type StoreTransport interface {
 	// can return different images, with no way for the caller to "freeze" the storage.Image identity
 	// without discarding the name entirely.
 	//
-	// Use storage.ResolveReference instead.
+	// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
+	// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
 	GetImage(types.ImageReference) (*storage.Image, error)
 	// GetStoreImage retrieves the image from a specified store that's named
 	// by the reference.
@@ -65,7 +66,8 @@ type StoreTransport interface {
 	//
 	// Also, a StoreTransport reference already contains a store, so providing another one is redundant.
 	//
-	// Use storage.ResolveReference instead.
+	// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
+	// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
 	GetStoreImage(storage.Store, types.ImageReference) (*storage.Image, error)
 	// ParseStoreReference parses a reference, overriding any store
 	// specification that it may contain.
@@ -312,7 +314,8 @@ func (s *storageTransport) ParseReference(reference string) (types.ImageReferenc
 //
 // Also, a StoreTransport reference already contains a store, so providing another one is redundant.
 //
-// Use storage.ResolveReference instead.
+// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
+// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
 func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageReference) (*storage.Image, error) {
 	dref := ref.DockerReference()
 	if dref != nil {
@@ -334,7 +337,8 @@ func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageRefe
 // can return different images, with no way for the caller to "freeze" the storage.Image identity
 // without discarding the name entirely.
 //
-// Use storage.ResolveReference instead.
+// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
+// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
 func (s *storageTransport) GetImage(ref types.ImageReference) (*storage.Image, error) {
 	store, err := s.GetStore()
 	if err != nil {


### PR DESCRIPTION
- Document the error returned if image is not found
- Also document it for the internal resolveImage, to record the commitment
- Update the deprecation comments to warn about the error return value change

Thanks to @flouthoc for demonstrating the need for this documentation.

Possible alternatives:
- Don’t change the error type; continue using `c/storage.ErrImageUnknown` for the new `ResolveReference`
- Define a new c/image error type; the current `c/image/storage.ErrNoSuchImage` is an alias for `c/storage.ErrNotAnImage`, which is really a different error cause.
- Possibly both? Define a new c/image error type, as an alias to c/storage.ErrImageUnknown.