### PR TITLE
Improve lint tool handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 MANPAGES_MD = $(wildcard docs/*.5.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
+# N/B: This value is managed by Renovate, manual changes are
+# possible, as long as they don't disturb the formatting
+# (i.e. DO NOT ADD A 'v' prefix!)
+GOLANGCI_LINT_VERSION := 1.51.0
+
 export PATH := $(PATH):${GOBIN}
 
 all: tools test validate .gitvalidation
@@ -55,7 +60,7 @@ tools: .install.gitvalidation .install.golangci-lint
 
 .install.golangci-lint:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.51.0; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v$(GOLANGCI_LINT_VERSION) ; \
 	fi
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ cross:
 	GOOS=windows $(MAKE) build BUILDTAGS="$(BUILDTAGS) $(BUILD_TAGS_WINDOWS_CROSS)"
 	GOOS=darwin $(MAKE) build BUILDTAGS="$(BUILDTAGS) $(BUILD_TAGS_DARWIN_CROSS)"
 
-tools: .install.gitvalidation .install.golangci-lint .install.golint
+tools: .install.gitvalidation .install.golangci-lint
 
 .install.gitvalidation:
 	if [ ! -x "$(GOBIN)/git-validation" ]; then \
@@ -56,12 +56,6 @@ tools: .install.gitvalidation .install.golangci-lint .install.golint
 .install.golangci-lint:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
 		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.51.0; \
-	fi
-
-.install.golint:
-	# Note, golint is only needed for Skopeo's tests.
-	if [ ! -x "$(GOBIN)/golint" ]; then \
-		GO111MODULE="off" go get -u $(BUILDFLAGS) golang.org/x/lint/golint; \
 	fi
 
 clean:


### PR DESCRIPTION
- Stop installing unused `golint`
- Automate `golangci-lint` version management, so that we get Renovate PRs like Skopeo’s https://github.com/containers/skopeo/pull/2139 . This intentionally does not upgrade the currently-used version, to trigger a Renovate update immediately.