### PR TITLE
[WIP] compression: add specific prefix for zstd:chunked

### DIFF
--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -17,22 +17,36 @@ import (
 // Algorithm is a compression algorithm that can be used for CompressStream.
 type Algorithm = types.Algorithm
 
+func hasPrefix(buffer []byte, prefix []byte) bool {
+	return bytes.HasPrefix(buffer, prefix)
+}
+
 var (
 	// Gzip compression.
 	Gzip = internal.NewAlgorithm(types.GzipAlgorithmName, types.GzipAlgorithmName,
-		[]byte{0x1F, 0x8B, 0x08}, GzipDecompressor, gzipCompressor)
+		GzipDecompressor, gzipCompressor, func(x []byte) bool {
+			return hasPrefix(x, []byte{0x1F, 0x8B, 0x08})
+		})
 	// Bzip2 compression.
 	Bzip2 = internal.NewAlgorithm(types.Bzip2AlgorithmName, types.Bzip2AlgorithmName,
-		[]byte{0x42, 0x5A, 0x68}, Bzip2Decompressor, bzip2Compressor)
+		Bzip2Decompressor, bzip2Compressor, func(x []byte) bool {
+			return hasPrefix(x, []byte{0x42, 0x5A, 0x68})
+		})
 	// Xz compression.
 	Xz = internal.NewAlgorithm(types.XzAlgorithmName, types.XzAlgorithmName,
-		[]byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}, XzDecompressor, xzCompressor)
+		XzDecompressor, xzCompressor, func(x []byte) bool {
+			return hasPrefix(x, []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00})
+		})
 	// Zstd compression.
 	Zstd = internal.NewAlgorithm(types.ZstdAlgorithmName, types.ZstdAlgorithmName,
-		[]byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, zstdCompressor)
+		ZstdDecompressor, zstdCompressor, func(x []byte) bool {
+			return hasPrefix(x, []byte{0x28, 0xb5, 0x2f, 0xfd})
+		})
 	// ZstdChunked is a Zstd compression with chunk metadta which allows random access to individual files.
 	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName, /* Note: InternalUnstableUndocumentedMIMEQuestionMark is not ZstdChunkedAlgorithmName */
-		nil, ZstdDecompressor, compressor.ZstdCompressor)
+		ZstdDecompressor, compressor.ZstdCompressor, func(x []byte) bool {
+			return hasPrefix(x, []byte{0x28, 0xb5, 0x2f, 0xfd})
+		})
 
 	compressionAlgorithms = map[string]Algorithm{
 		Gzip.Name():        Gzip,
@@ -121,8 +135,8 @@ func DetectCompressionFormat(input io.Reader) (Algorithm, DecompressorFunc, io.R
 	var retAlgo Algorithm
 	var decompressor DecompressorFunc
 	for _, algo := range compressionAlgorithms {
-		prefix := internal.AlgorithmPrefix(algo)
-		if len(prefix) > 0 && bytes.HasPrefix(buffer[:n], prefix) {
+		canDecompress := internal.AlgorithmCanDecompress(algo)
+		if canDecompress != nil && canDecompress(buffer[:n]) {
 			logrus.Debugf("Detected compression format %s", algo.Name())
 			retAlgo = algo
 			decompressor = internal.AlgorithmDecompressor(algo)


### PR DESCRIPTION
it allows to differentiate between zstd and zstd:chunked

Needs: https://github.com/containers/storage/pull/1756
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
