### PR TITLE
Quote the response body in an error message

### DIFF
--- a/docker/errors.go
+++ b/docker/errors.go
@@ -88,7 +88,7 @@ func registryHTTPResponseToError(res *http.Response) error {
 			response = response[:50] + "..."
 		}
 		// %.0w makes e visible to error.Unwrap() without including any text
-		err = fmt.Errorf("StatusCode: %d, %s%.0w", e.StatusCode, response, e)
+		err = fmt.Errorf("StatusCode: %d, %q%.0w", e.StatusCode, response, e)
 	case errcode.Error:
 		// e.Error() is fmt.Sprintf("%s: %s", e.Code.Error(), e.Message, which is usually
 		// rather redundant. So reword it without using e.Code.Error() if e.Message is the default.

--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -43,7 +43,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"Header1: Value1\r\n" +
 				"\r\n" +
 				"<html><body>JSON? What JSON?</body></html>\r\n",
-			errorString:       "StatusCode: 400, <html><body>JSON? What JSON?</body></html>\r\n",
+			errorString:       `StatusCode: 400, "<html><body>JSON? What JSON?</body></html>\r\n"`,
 			errorType:         nil,
 			unwrappedErrorPtr: &unwrappedUnexpectedHTTPResponseError,
 		},
@@ -161,7 +161,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 				"X-Docker-Size: -1\r\n" +
 				"\r\n" +
 				"Not found\r\n",
-			errorString:       "StatusCode: 404, Not found\r",
+			errorString:       `StatusCode: 404, "Not found\r"`,
 			errorType:         nil,
 			unwrappedErrorPtr: &unwrappedUnexpectedHTTPResponseError,
 			fn: func(t *testing.T, err error) {


### PR DESCRIPTION
... to make sure we don't output raw control characters, for example.

A probably unexpected outcome of https://github.com/containers/podman/issues/20343 .