### PR TITLE
Add support for pushing image with unknown digest

### DIFF
--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -123,6 +123,9 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 	if !ok {
 		return "", errors.New("ref must be a dockerReference")
 	}
+	if dr.isUnknownDigest {
+		return "", fmt.Errorf("docker: reference %q is for unknown digest case; cannot get digest", dr.StringWithinTransport())
+	}
 
 	tagOrDigest, err := dr.tagOrDigest()
 	if err != nil {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -452,7 +452,15 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
 	var refTail string
-	if instanceDigest != nil {
+	// If d.ref.isUnknownDigest=true, then we push without a tag, so get the
+	// digest that will be used
+	if d.ref.isUnknownDigest {
+		digest, err := manifest.Digest(m)
+		if err != nil {
+			return err
+		}
+		refTail = digest.String()
+	} else if instanceDigest != nil {
 		// If the instanceDigest is provided, then use it as the refTail, because the reference,
 		// whether it includes a tag or a digest, refers to the list as a whole, and not this
 		// particular instance.

--- a/docs/containers-transports.5.md
+++ b/docs/containers-transports.5.md
@@ -40,10 +40,13 @@ By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.js
 If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using docker-login(1).
 The containers-registries.conf(5) further allows for configuring various settings of a registry.
 
-Note that a _docker-reference_ has the following format: `name[:tag|@digest]`.
+Note that a _docker-reference_ has the following format: _name_[**:**_tag_ | **@**_digest_].
 While the docker transport does not support both a tag and a digest at the same time some formats like containers-storage do.
 Digests can also be used in an image destination as long as the manifest matches the provided digest.
+
+The docker transport supports pushing images without a tag or digest to a registry when the image name is suffixed with **@@unknown-digest@@**. The _name_**@@unknown-digest@@** reference format cannot be used with a reference that has a tag or digest.
 The digest of images can be explored with skopeo-inspect(1).
+
 If `name` does not contain a slash, it is treated as `docker.io/library/name`.
 Otherwise, the component before the first slash is checked if it is recognized as a `hostname[:port]` (i.e., it contains either a . or a :, or the component is exactly localhost).
 If the first component of name is not recognized as a `hostname[:port]`, `name` is treated as `docker.io/name`.


### PR DESCRIPTION
Add support to push image with unknown digest and no tag to a registry. This will be used by farm build to construct a list of multi arch builds after pushing images built on each node.