### PR TITLE
Make blob reuse choices manifest-format-sensitive, and allow conversions when writing to format-agnostic transports

### DIFF
--- a/copy/compression.go
+++ b/copy/compression.go
@@ -286,7 +286,7 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 	if d.uploadedCompressorName != "" && d.uploadedCompressorName != internalblobinfocache.UnknownCompression {
 		if d.uploadedCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
 			// HACK: Don’t record zstd:chunked algorithms.
-			// There is already a similar hack in internal/imagedestination/impl/helpers.BlobMatchesRequiredCompression,
+			// There is already a similar hack in internal/imagedestination/impl/helpers.CandidateMatchesTryReusingBlobOptions,
 			// and that one prevents reusing zstd:chunked blobs, so recording the algorithm here would be mostly harmless.
 			//
 			// We skip that here anyway to work around the inability of blobPipelineDetectCompressionStep to differentiate

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -85,13 +85,6 @@ func determineManifestConversion(in determineManifestConversionInputs) (manifest
 
 	restrictiveCompressionRequired := in.requestedCompressionFormat != nil && !internalManifest.CompressionAlgorithmIsUniversallySupported(*in.requestedCompressionFormat)
 	if len(destSupportedManifestMIMETypes) == 0 {
-		if (!in.requiresOCIEncryption || manifest.MIMETypeSupportsEncryption(srcType)) &&
-			(!restrictiveCompressionRequired || internalManifest.MIMETypeSupportsCompressionAlgorithm(srcType, *in.requestedCompressionFormat)) {
-			return manifestConversionPlan{ // Anything goes; just use the original as is, do not try any conversions.
-				preferredMIMEType:       srcType,
-				otherMIMETypeCandidates: []string{},
-			}, nil
-		}
 		destSupportedManifestMIMETypes = allManifestMIMETypes
 	}
 	supportedByDest := set.New[string]()

--- a/copy/manifest.go
+++ b/copy/manifest.go
@@ -82,11 +82,11 @@ func determineManifestConversion(in determineManifestConversionInputs) (manifest
 	if in.forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{in.forceManifestMIMEType}
 	}
-
-	restrictiveCompressionRequired := in.requestedCompressionFormat != nil && !internalManifest.CompressionAlgorithmIsUniversallySupported(*in.requestedCompressionFormat)
 	if len(destSupportedManifestMIMETypes) == 0 {
 		destSupportedManifestMIMETypes = allManifestMIMETypes
 	}
+
+	restrictiveCompressionRequired := in.requestedCompressionFormat != nil && !internalManifest.CompressionAlgorithmIsUniversallySupported(*in.requestedCompressionFormat)
 	supportedByDest := set.New[string]()
 	for _, t := range destSupportedManifestMIMETypes {
 		if in.requiresOCIEncryption && !manifest.MIMETypeSupportsEncryption(t) {

--- a/copy/manifest_test.go
+++ b/copy/manifest_test.go
@@ -56,13 +56,13 @@ func TestDetermineManifestConversion(t *testing.T) {
 		destTypes   []string
 		expected    manifestConversionPlan
 	}{
-		// Destination accepts anything — no conversion necessary
+		// Destination accepts anything — consider all options, prefer the source format
 		{
 			"s1→anything", manifest.DockerV2Schema1SignedMediaType, nil,
 			manifestConversionPlan{
 				preferredMIMEType:                manifest.DockerV2Schema1SignedMediaType,
 				preferredMIMETypeNeedsConversion: false,
-				otherMIMETypeCandidates:          []string{},
+				otherMIMETypeCandidates:          []string{manifest.DockerV2Schema2MediaType, v1.MediaTypeImageManifest, manifest.DockerV2Schema1MediaType},
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestDetermineManifestConversion(t *testing.T) {
 			manifestConversionPlan{
 				preferredMIMEType:                manifest.DockerV2Schema2MediaType,
 				preferredMIMETypeNeedsConversion: false,
-				otherMIMETypeCandidates:          []string{},
+				otherMIMETypeCandidates:          []string{manifest.DockerV2Schema1SignedMediaType, v1.MediaTypeImageManifest, manifest.DockerV2Schema1MediaType},
 			},
 		},
 		// Destination accepts the unmodified original

--- a/copy/single.go
+++ b/copy/single.go
@@ -691,10 +691,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		// Fixing that will probably require passing more information to TryReusingBlob() than the current version of
 		// the ImageDestination interface lets us pass in.
 		var requiredCompression *compressiontypes.Algorithm
-		var originalCompression *compressiontypes.Algorithm
 		if ic.requireCompressionFormatMatch {
 			requiredCompression = ic.compressionFormat
-			originalCompression = srcInfo.CompressionAlgorithm
 		}
 
 		// Check if we have a chunked layer in storage that's based on that blob.  These layers are stored by their TOC digest.
@@ -710,7 +708,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			LayerIndex:          &layerIndex,
 			SrcRef:              srcRef,
 			RequiredCompression: requiredCompression,
-			OriginalCompression: originalCompression,
+			OriginalCompression: srcInfo.CompressionAlgorithm,
 			TOCDigest:           tocDigest,
 		})
 		if err != nil {

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -190,7 +190,7 @@ func (d *dirImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *dirImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	if info.Digest == "" {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -339,7 +339,8 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 			return true, reusedInfo, nil
 		}
 	} else {
-		logrus.Debugf("Ignoring exact blob match case due to compression mismatch ( %s vs %s )", options.RequiredCompression.Name(), optionalCompressionName(options.OriginalCompression))
+		logrus.Debugf("Ignoring exact blob match, compression %s does not match required %s or MIME types %#v",
+			optionalCompressionName(options.OriginalCompression), optionalCompressionName(options.RequiredCompression), options.PossibleManifestFormats)
 	}
 
 	// Then try reusing blobs from other locations.
@@ -361,9 +362,11 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		}
 		if !impl.CandidateMatchesTryReusingBlobOptions(options, compressionAlgorithm) {
 			if !candidate.UnknownLocation {
-				logrus.Debugf("Ignoring candidate blob %s as reuse candidate due to compression mismatch ( %s vs %s ) in %s", candidate.Digest.String(), options.RequiredCompression.Name(), optionalCompressionName(compressionAlgorithm), candidateRepo.Name())
+				logrus.Debugf("Ignoring candidate blob %s in %s, compression %s does not match required %s or MIME types %#v", candidate.Digest.String(), candidateRepo.Name(),
+					optionalCompressionName(compressionAlgorithm), optionalCompressionName(options.RequiredCompression), options.PossibleManifestFormats)
 			} else {
-				logrus.Debugf("Ignoring candidate blob %s as reuse candidate due to compression mismatch ( %s vs %s ) with no location match, checking current repo", candidate.Digest.String(), options.RequiredCompression.Name(), optionalCompressionName(compressionAlgorithm))
+				logrus.Debugf("Ignoring candidate blob %s with no known location, compression %s does not match required %s or MIME types %#v", candidate.Digest.String(),
+					optionalCompressionName(compressionAlgorithm), optionalCompressionName(options.RequiredCompression), options.PossibleManifestFormats)
 			}
 			continue
 		}

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -321,7 +321,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		return false, private.ReusedBlob{}, errors.New("Can not check for a blob with unknown digest")
 	}
 
-	if impl.OriginalBlobMatchesRequiredCompression(options) {
+	if impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		// First, check whether the blob happens to already exist at the destination.
 		haveBlob, reusedInfo, err := d.tryReusingExactBlob(ctx, info, options.Cache)
 		if err != nil {
@@ -355,7 +355,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 				continue
 			}
 		}
-		if !impl.BlobMatchesRequiredCompression(options, compressionAlgorithm) {
+		if !impl.CandidateMatchesTryReusingBlobOptions(options, compressionAlgorithm) {
 			requiredCompression := "nil"
 			if compressionAlgorithm != nil {
 				requiredCompression = compressionAlgorithm.Name()

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -129,7 +129,7 @@ func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, 
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *Destination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	if err := d.archive.lock(); err != nil {

--- a/internal/imagedestination/impl/helpers.go
+++ b/internal/imagedestination/impl/helpers.go
@@ -9,15 +9,18 @@ import (
 // then function performs a match against the compression requested by the caller and compression of existing blob
 // (which can be nil to represent uncompressed or unknown)
 func BlobMatchesRequiredCompression(options private.TryReusingBlobOptions, candidateCompression *compression.Algorithm) bool {
-	if options.RequiredCompression == nil {
-		return true // no requirement imposed
+	if options.RequiredCompression != nil {
+		if options.RequiredCompression.Name() == compression.ZstdChunkedAlgorithmName {
+			// HACK: Never match when the caller asks for zstd:chunked, because we don’t record the annotations required to use the chunked blobs.
+			// The caller must re-compress to build those annotations.
+			return false
+		}
+		if candidateCompression == nil || (options.RequiredCompression.Name() != candidateCompression.Name()) {
+			return false
+		}
 	}
-	if options.RequiredCompression.Name() == compression.ZstdChunkedAlgorithmName {
-		// HACK: Never match when the caller asks for zstd:chunked, because we don’t record the annotations required to use the chunked blobs.
-		// The caller must re-compress to build those annotations.
-		return false
-	}
-	return candidateCompression != nil && (options.RequiredCompression.Name() == candidateCompression.Name())
+
+	return true
 }
 
 func OriginalBlobMatchesRequiredCompression(opts private.TryReusingBlobOptions) bool {

--- a/internal/imagedestination/impl/helpers.go
+++ b/internal/imagedestination/impl/helpers.go
@@ -5,10 +5,10 @@ import (
 	compression "github.com/containers/image/v5/pkg/compression/types"
 )
 
-// BlobMatchesRequiredCompression validates if compression is required by the caller while selecting a blob, if it is required
+// CandidateMatchesTryReusingBlobOptions validates if compression is required by the caller while selecting a blob, if it is required
 // then function performs a match against the compression requested by the caller and compression of existing blob
 // (which can be nil to represent uncompressed or unknown)
-func BlobMatchesRequiredCompression(options private.TryReusingBlobOptions, candidateCompression *compression.Algorithm) bool {
+func CandidateMatchesTryReusingBlobOptions(options private.TryReusingBlobOptions, candidateCompression *compression.Algorithm) bool {
 	if options.RequiredCompression != nil {
 		if options.RequiredCompression.Name() == compression.ZstdChunkedAlgorithmName {
 			// HACK: Never match when the caller asks for zstd:chunked, because we don’t record the annotations required to use the chunked blobs.
@@ -23,6 +23,6 @@ func BlobMatchesRequiredCompression(options private.TryReusingBlobOptions, candi
 	return true
 }
 
-func OriginalBlobMatchesRequiredCompression(opts private.TryReusingBlobOptions) bool {
-	return BlobMatchesRequiredCompression(opts, opts.OriginalCompression)
+func OriginalCandidateMatchesTryReusingBlobOptions(opts private.TryReusingBlobOptions) bool {
+	return CandidateMatchesTryReusingBlobOptions(opts, opts.OriginalCompression)
 }

--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBlobMatchesRequiredCompression(t *testing.T) {
+func TestCandidateMatchesTryReusingBlobOptions(t *testing.T) {
 	var opts private.TryReusingBlobOptions
 	cases := []struct {
 		requiredCompression  *compressionTypes.Algorithm
@@ -24,6 +24,6 @@ func TestBlobMatchesRequiredCompression(t *testing.T) {
 
 	for _, c := range cases {
 		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
-		assert.Equal(t, c.result, BlobMatchesRequiredCompression(opts, c.candidateCompression))
+		assert.Equal(t, c.result, CandidateMatchesTryReusingBlobOptions(opts, c.candidateCompression))
 	}
 }

--- a/internal/imagedestination/impl/helpers_test.go
+++ b/internal/imagedestination/impl/helpers_test.go
@@ -4,26 +4,44 @@ import (
 	"testing"
 
 	"github.com/containers/image/v5/internal/private"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	compressionTypes "github.com/containers/image/v5/pkg/compression/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCandidateMatchesTryReusingBlobOptions(t *testing.T) {
-	var opts private.TryReusingBlobOptions
 	cases := []struct {
-		requiredCompression  *compressionTypes.Algorithm
-		candidateCompression *compressionTypes.Algorithm
-		result               bool
+		requiredCompression     *compressionTypes.Algorithm
+		possibleManifestFormats []string
+		candidateCompression    *compressionTypes.Algorithm
+		result                  bool
 	}{
-		{&compression.Zstd, &compression.Zstd, true},
-		{&compression.Gzip, &compression.Zstd, false},
-		{&compression.Zstd, nil, false},
-		{nil, &compression.Zstd, true},
+		// RequiredCompression restrictions
+		{&compression.Zstd, nil, &compression.Zstd, true},
+		{&compression.Gzip, nil, &compression.Zstd, false},
+		{&compression.Zstd, nil, nil, false},
+		{nil, nil, &compression.Zstd, true},
+		// PossibleManifestFormats restrictions
+		{nil, []string{imgspecv1.MediaTypeImageManifest}, &compression.Zstd, true},
+		{nil, []string{manifest.DockerV2Schema2MediaType}, &compression.Zstd, false},
+		{nil, []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest}, &compression.Zstd, true},
+		{nil, nil, &compression.Zstd, true},
+		{nil, []string{imgspecv1.MediaTypeImageManifest}, &compression.Gzip, true},
+		{nil, []string{manifest.DockerV2Schema2MediaType}, &compression.Gzip, true},
+		{nil, []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest}, &compression.Gzip, true},
+		{nil, nil, &compression.Gzip, true},
+		// Some possible combinations (always 1 constraint not matching)
+		{&compression.Zstd, []string{manifest.DockerV2Schema2MediaType}, &compression.Zstd, false},
+		{&compression.Gzip, []string{manifest.DockerV2Schema2MediaType, manifest.DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest}, &compression.Zstd, false},
 	}
 
 	for _, c := range cases {
-		opts = private.TryReusingBlobOptions{RequiredCompression: c.requiredCompression}
+		opts := private.TryReusingBlobOptions{
+			RequiredCompression:     c.requiredCompression,
+			PossibleManifestFormats: c.possibleManifestFormats,
+		}
 		assert.Equal(t, c.result, CandidateMatchesTryReusingBlobOptions(opts, c.candidateCompression))
 	}
 }

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -112,11 +112,11 @@ type TryReusingBlobOptions struct {
 	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
 	// if they use internal/imagedestination/impl.Compat;
 	// in that case, they will all be consistently zero-valued.
-	RequiredCompression *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
-	OriginalCompression *compression.Algorithm // Must be set if RequiredCompression is set; can be set to nil to indicate “uncompressed” or “unknown”.
 	EmptyLayer          bool                   // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
 	LayerIndex          *int                   // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
 	SrcRef              reference.Named        // A reference to the source image that contains the input blob.
+	RequiredCompression *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
+	OriginalCompression *compression.Algorithm // Must be set if RequiredCompression is set; can be set to nil to indicate “uncompressed” or “unknown”.
 	TOCDigest           *digest.Digest         // If specified, the blob can be looked up in the destination also by its TOC digest.
 }
 

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -112,12 +112,13 @@ type TryReusingBlobOptions struct {
 	// Transports, OTOH, MUST support these fields being zero-valued for types.ImageDestination callers
 	// if they use internal/imagedestination/impl.Compat;
 	// in that case, they will all be consistently zero-valued.
-	EmptyLayer          bool                   // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
-	LayerIndex          *int                   // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
-	SrcRef              reference.Named        // A reference to the source image that contains the input blob.
-	RequiredCompression *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
-	OriginalCompression *compression.Algorithm // Must be set if RequiredCompression is set; can be set to nil to indicate “uncompressed” or “unknown”.
-	TOCDigest           *digest.Digest         // If specified, the blob can be looked up in the destination also by its TOC digest.
+	EmptyLayer              bool                   // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
+	LayerIndex              *int                   // If the blob is a layer, a zero-based index of the layer within the image; nil otherwise.
+	SrcRef                  reference.Named        // A reference to the source image that contains the input blob.
+	PossibleManifestFormats []string               // A set of possible manifest formats; at least one should support the reused layer blob.
+	RequiredCompression     *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
+	OriginalCompression     *compression.Algorithm // May be nil to indicate “uncompressed” or “unknown”.
+	TOCDigest               *digest.Digest         // If specified, the blob can be looked up in the destination also by its TOC digest.
 }
 
 // ReusedBlob is information about a blob reused in a destination.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -173,7 +173,7 @@ func (d *ociImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ociImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	if info.Digest == "" {

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -335,7 +335,7 @@ func (d *ostreeImageDestination) importConfig(repo *otbuiltin.Repo, blob *blobTo
 // reflected in the manifest that will be written.
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	if d.repo == nil {

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -237,7 +237,7 @@ func (d *blobCacheDestination) PutBlobPartial(ctx context.Context, chunkAccessor
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (d *blobCacheDestination) TryReusingBlobWithOptions(ctx context.Context, info types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	present, reusedInfo, err := d.destination.TryReusingBlobWithOptions(ctx, info, options)

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -307,7 +307,7 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 // If the blob has been successfully reused, returns (true, info, nil).
 // If the transport can not reuse the requested blob, TryReusingBlob returns (false, {}, nil); it returns a non-nil error only on an unexpected failure.
 func (s *storageImageDestination) TryReusingBlobWithOptions(ctx context.Context, blobinfo types.BlobInfo, options private.TryReusingBlobOptions) (bool, private.ReusedBlob, error) {
-	if !impl.OriginalBlobMatchesRequiredCompression(options) {
+	if !impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		return false, private.ReusedBlob{}, nil
 	}
 	reused, info, err := s.tryReusingBlobAsPending(blobinfo.Digest, blobinfo.Size, &options)


### PR DESCRIPTION
Fixes #2205