### PR TITLE
Moving policy.json and default.yaml from containers/skopeo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 MANPAGES_MD = $(wildcard docs/*.5.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
+ifeq ($(shell uname -s),FreeBSD)
+CONTAINERSCONFDIR ?= /usr/local/etc/containers
+else
+CONTAINERSCONFDIR ?= /etc/containers
+endif
+REGISTRIESDDIR ?= ${CONTAINERSCONFDIR}/registries.d
+
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
@@ -46,6 +53,10 @@ install-docs: docs
 	install -m 644 docs/*.5 ${MANINSTALLDIR}/man5/
 
 install: install-docs
+	install -d -m 755 ${DESTDIR}${CONTAINERSCONFDIR}
+	install -m 644 default-policy.json ${DESTDIR}${CONTAINERSCONFDIR}/policy.json
+	install -d -m 755 ${DESTDIR}${REGISTRIESDDIR}
+	install -m 644 default.yaml ${DESTDIR}${REGISTRIESDDIR}/default.yaml
 
 cross:
 	GOOS=windows $(MAKE) build BUILDTAGS="$(BUILDTAGS) $(BUILD_TAGS_WINDOWS_CROSS)"

--- a/default-policy.json
+++ b/default-policy.json
@@ -1,0 +1,14 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,27 @@
+# This is a default registries.d configuration file.  You may
+# add to this file or create additional files in registries.d/.
+#
+# lookaside: for reading/writing simple signing signatures
+# lookaside-staging: for writing simple signing signatures, preferred over lookaside
+#
+# lookaside and lookaside-staging take a value of the following:
+#   lookaside:  {schema}://location
+#
+# For reading signatures, schema may be http, https, or file.
+# For writing signatures, schema may only be file.
+
+# The default locations are built-in, for both reading and writing:
+# /var/lib/containers/sigstore for root, or
+# ~/.local/share/containers/sigstore for non-root users.
+default-docker:
+#  lookaside: https://…
+#  lookaside-staging: file:///…
+
+# The 'docker' indicator here is the start of the configuration
+# for docker registries.
+#
+# docker:
+#
+#   privateregistry.com:
+#    lookaside: https://privateregistry.com/sigstore/
+#    lookaside-staging: /mnt/nfs/privateregistry/sigstore


### PR DESCRIPTION
It makes more sense to keep these 2 files along with their man pages...in c/image

As discussed in
https://github.com/containers/common/pull/1757