### PR TITLE
storage, dest: clarify when TOCDigest is used

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -746,7 +746,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 				wrapped: ic.c.rawSource,
 				bar:     bar,
 			}
-			uploadedBlob, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, ic.c.blobInfoCache)
+			uploadedBlob, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, &layerIndex, ic.c.blobInfoCache)
 			if err == nil {
 				if srcInfo.Size != -1 {
 					refill := srcInfo.Size - bar.Current()

--- a/copy/single.go
+++ b/copy/single.go
@@ -690,10 +690,15 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			requiredCompression = ic.compressionFormat
 		}
 
+		var tocDigest digest.Digest
+
 		// Check if we have a chunked layer in storage that's based on that blob.  These layers are stored by their TOC digest.
-		tocDigest, err := chunkedToc.GetTOCDigest(srcInfo.Annotations)
+		d, err := chunkedToc.GetTOCDigest(srcInfo.Annotations)
 		if err != nil {
 			return types.BlobInfo{}, "", err
+		}
+		if d != nil {
+			tocDigest = *d
 		}
 
 		reused, reusedBlob, err := ic.c.dest.TryReusingBlobWithOptions(ctx, srcInfo, private.TryReusingBlobOptions{
@@ -713,7 +718,12 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		if reused {
 			logrus.Debugf("Skipping blob %s (already present):", srcInfo.Digest)
 			func() { // A scope for defer
-				bar := ic.c.createProgressBar(pool, false, types.BlobInfo{Digest: reusedBlob.Digest, Size: 0}, "blob", "skipped: already exists")
+				d := reusedBlob.Digest
+				label := "skipped: already exists"
+				if reusedBlob.TOCDigest != "" {
+					label = "skipped: already exists (found by TOC)"
+				}
+				bar := ic.c.createProgressBar(pool, false, types.BlobInfo{Digest: d, Size: 0}, "blob", label)
 				defer bar.Abort(false)
 				bar.mark100PercentComplete()
 			}()

--- a/internal/imagedestination/stubs/put_blob_partial.go
+++ b/internal/imagedestination/stubs/put_blob_partial.go
@@ -39,7 +39,7 @@ func (stub NoPutBlobPartialInitialize) SupportsPutBlobPartial() bool {
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
+func (stub NoPutBlobPartialInitialize) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
 	return private.UploadedBlob{}, fmt.Errorf("internal error: PutBlobPartial is not supported by the %q transport", stub.transportName)
 }
 

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -81,8 +81,9 @@ type ImageDestination interface {
 // UploadedBlob is information about a blob written to a destination.
 // It is the subset of types.BlobInfo fields the transport is responsible for setting; all fields must be provided.
 type UploadedBlob struct {
-	Digest digest.Digest
-	Size   int64
+	Digest    digest.Digest
+	Size      int64
+	TOCDigest digest.Digest
 }
 
 // PutBlobOptions are used in PutBlobWithOptions.
@@ -118,14 +119,15 @@ type TryReusingBlobOptions struct {
 	PossibleManifestFormats []string               // A set of possible manifest formats; at least one should support the reused layer blob.
 	RequiredCompression     *compression.Algorithm // If set, reuse blobs with a matching algorithm as per implementations in internal/imagedestination/impl.helpers.go
 	OriginalCompression     *compression.Algorithm // May be nil to indicate “uncompressed” or “unknown”.
-	TOCDigest               *digest.Digest         // If specified, the blob can be looked up in the destination also by its TOC digest.
+	TOCDigest               digest.Digest          // If specified, the blob can be looked up in the destination also by its TOC digest.
 }
 
 // ReusedBlob is information about a blob reused in a destination.
 // It is the subset of types.BlobInfo fields the transport is responsible for setting.
 type ReusedBlob struct {
-	Digest digest.Digest // Must be provided
-	Size   int64         // Must be provided
+	Digest    digest.Digest // Must be provided, can be empty if TOCDigest is present
+	TOCDigest digest.Digest // Must be provided, can be empty if Digest is present
+	Size      int64         // Must be provided
 	// The following compression fields should be set when the reuse substitutes
 	// a differently-compressed blob.
 	CompressionOperation types.LayerCompression // Compress/Decompress, matching the reused blob; PreserveOriginal if N/A

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -55,7 +55,7 @@ type ImageDestinationInternalOnly interface {
 	// It is available only if SupportsPutBlobPartial().
 	// Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 	// should fall back to PutBlobWithOptions.
-	PutBlobPartial(ctx context.Context, chunkAccessor BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (UploadedBlob, error)
+	PutBlobPartial(ctx context.Context, chunkAccessor BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (UploadedBlob, error)
 
 	// TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination
 	// (e.g. if the blob is a filesystem layer, this signifies that the changes it describes need to be applied again when composing a filesystem tree).

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -120,8 +120,8 @@ func (d *ociArchiveImageDestination) PutBlobWithOptions(ctx context.Context, str
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (d *ociArchiveImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
-	return d.unpackedDest.PutBlobPartial(ctx, chunkAccessor, srcInfo, cache)
+func (d *ociArchiveImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
+	return d.unpackedDest.PutBlobPartial(ctx, chunkAccessor, srcInfo, index, cache)
 }
 
 // TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/openshift/openshift_dest.go
+++ b/openshift/openshift_dest.go
@@ -128,8 +128,8 @@ func (d *openshiftImageDestination) PutBlobWithOptions(ctx context.Context, stre
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (d *openshiftImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
-	return d.docker.PutBlobPartial(ctx, chunkAccessor, srcInfo, cache)
+func (d *openshiftImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
+	return d.docker.PutBlobPartial(ctx, chunkAccessor, srcInfo, index, cache)
 }
 
 // TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -227,8 +227,8 @@ func (d *blobCacheDestination) SupportsPutBlobPartial() bool {
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (d *blobCacheDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
-	return d.destination.PutBlobPartial(ctx, chunkAccessor, srcInfo, cache)
+func (d *blobCacheDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
+	return d.destination.PutBlobPartial(ctx, chunkAccessor, srcInfo, index, cache)
 }
 
 // TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -269,7 +269,7 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 // It is available only if SupportsPutBlobPartial().
 // Even if SupportsPutBlobPartial() returns true, the call can fail, in which case the caller
 // should fall back to PutBlobWithOptions.
-func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
+func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAccessor private.BlobChunkAccessor, srcInfo types.BlobInfo, index *int, cache blobinfocache.BlobInfoCache2) (private.UploadedBlob, error) {
 	fetcher := zstdFetcher{
 		chunkAccessor: chunkAccessor,
 		ctx:           ctx,


### PR DESCRIPTION
This update introduces an enhancement in the blob handling mechanism, specifically by separating the TOC digest from the uncompressed/compressed digest.

Follow-up for: #1080.