### PR TITLE
Accept URI for Sigstore Signed Images

### DIFF
--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -57,6 +57,7 @@ func (f *prSigstoreSignedFulcio) prepareTrustRoot() (*fulcioTrustRoot, error) {
 		caCertificates: certs,
 		oidcIssuer:     f.OIDCIssuer,
 		subjectEmail:   f.SubjectEmail,
+		URI:            f.URI,
 	}
 	if err := fulcio.validate(); err != nil {
 		return nil, err

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -154,6 +154,8 @@ type prSigstoreSignedFulcio struct {
 	OIDCIssuer string `json:"oidcIssuer,omitempty"`
 	// SubjectEmail specifies the expected email address of the authenticated OIDC identity, recorded by Fulcio into the generated certificates.
 	SubjectEmail string `json:"subjectEmail,omitempty"`
+	// URI specifies the expected URI of the authenticated OIDC identity, recorded by Fulcio into the generated certificates.
+	URI string `json:"URI,omitempty"`
 }
 
 // PolicyReferenceMatch specifies a set of image identities accepted in PolicyRequirement.


### PR DESCRIPTION
Fixes https://github.com/coreos/rpm-ostree/issues/4272#issuecomment-1689160021

Allows for container images signatures with a URI instead of a email
address as the SAN. This is needed in certain cases such as using a github workflow to sign a container using the github actions OIDC token.

The URI field was added to the `fulcioTrustRoot` struct and associated functions were modifed/created. Logic to handle either having a URI or email address as the SAN was also implemented.

**Testing:**
1. Copy and store `fulcio_v1.crt.pem` to `/etc/pki/containers/fulcio.sigstore.dev.pub` and `rekor.pub` to `/etc/pki/containers/rekor.sigstore.dev.pub`, both of which can be found at: https://github.com/sigstore/root-signing/blob/main/README.md

2. Configure `/etc/containers/policy.json`
```
{
  "default": [
    {
      "type": "reject"
    }
  ],
  "transports": {
    "docker": {
      "registry.access.redhat.com": [
        {
          "type": "signedBy",
          "keyType": "GPGKeys",
          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
        }
      ],
      "registry.redhat.io": [
        {
          "type": "signedBy",
          "keyType": "GPGKeys",
          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
        }
      ],
      "ghcr.io/jmpolom": [
        {
          "type": "sigstoreSigned",
          "fulcio": {
            "caPath": "/etc/pki/containers/fulcio.sigstore.dev.pub",
            "oidcIssuer": "https://token.actions.githubusercontent.com",
            "URI": "https://github.com/jmpolom/fedora-ostree-ws-container/.github/workflows/build.yml@refs/heads/main"
          },
          "rekorPublicKeyPath": "/etc/pki/containers/rekor.sigstore.dev.pub",
          "signedIdentity": {
            "type": "matchRepository"
          }
        }
      ]
    },
    "docker-daemon": {
      "": [
        {
          "type": "insecureAcceptAnything"
        }
      ]
    }
  }
}
```

3. Create `/etc/containers/registries.d/ghcr.io.yaml`
```
docker:
     ghcr.io/jmpolom:
         use-sigstore-attachments: true
```

4. Build the skopeo binary and run the following
```
$ ./bin/skopeo copy docker://ghcr.io/jmpolom/fedora-silverblue-ws:38-main dir:/some/local/directory
```