### PR TITLE
Remove github.com/otiai10/copy dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/opencontainers/selinux v1.11.0
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f
-	github.com/otiai10/copy v1.14.0
 	github.com/proglottis/gpgme v0.1.3
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0
 	github.com/sigstore/fulcio v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -305,9 +305,6 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
-github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
-github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
-github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/oci/layout/oci_delete_test.go
+++ b/oci/layout/oci_delete_test.go
@@ -316,12 +316,13 @@ func copyDir(src, dst string) error {
 		srcPath := filepath.Join(src, dirEntry.Name())
 		dstPath := filepath.Join(dst, dirEntry.Name())
 
-		copy := copyFile
+		var err error
 		if dirEntry.IsDir() {
-			copy = copyDir
+			err = copyDir(srcPath, dstPath)
+		} else {
+			err = copyFile(srcPath, dstPath)
 		}
-
-		if err := copy(srcPath, dstPath); err != nil {
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR replaces usage of [`copy.Copy`](https://pkg.go.dev/github.com/otiai10/copy#Copy) with hand-written `copyDir` function. It's not worth keeping this dependency used only in tests.

Yeah, `copyDir` is not ideal, and `copy.Copy` is much more powerful and covers many of OS's corner cases, but for tests it's good. In the future, we can return this dependency if `copy.Copy` will be needed for the prod code.