### PR TITLE
chore: add non-empty .golangci.yml; fix whitespace lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,21 @@
 ---
 run:
-  concurrency: 6
-  deadline: 5m
+  build-tags:
+    - btrfs_noversion
+    - libdm_no_deferred_remove
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - whitespace
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ validate: lint
 	@BUILDTAGS="$(BUILDTAGS)" hack/validate.sh
 
 lint:
-	$(GOBIN)/golangci-lint run --build-tags "$(BUILDTAGS)"
+	$(GOBIN)/golangci-lint run
 
 # When this is running in CI, it will only check the CI commit range
 .gitvalidation:

--- a/copy/progress_channel_test.go
+++ b/copy/progress_channel_test.go
@@ -76,5 +76,4 @@ func TestReadWithEvent(t *testing.T) {
 	read, err := reader.Read(b)
 	assert.Equal(t, read, 5)
 	assert.Nil(t, err)
-
 }

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -145,7 +145,6 @@ func TestNewBearerTokenIssuedAtZeroFromJsonBlob(t *testing.T) {
 	if token.IssuedAt.Before(now) {
 		t.Fatalf("expected [%s] not to be before [%s]", token.IssuedAt, now)
 	}
-
 }
 
 func assertBearerTokensEqual(t *testing.T, expected, subject *bearerToken) {

--- a/docker/reference/regexp_test.go
+++ b/docker/reference/regexp_test.go
@@ -489,7 +489,6 @@ func TestReferenceRegexp(t *testing.T) {
 	for i := range testcases {
 		checkRegexp(t, ReferenceRegexp, testcases[i])
 	}
-
 }
 
 func TestIdentifierRegexp(t *testing.T) {

--- a/internal/manifest/oci_index_test.go
+++ b/internal/manifest/oci_index_test.go
@@ -156,7 +156,6 @@ func TestOCI1EditInstances(t *testing.T) {
 	require.NoError(t, err)
 	// Digest `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` should be re-ordered on update.
 	assert.Equal(t, list.Instances(), []digest.Digest{digest.Digest("sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"), digest.Digest("sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270"), digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"), digest.Digest("sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), digest.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"), digest.Digest("sha256:hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh")})
-
 }
 
 func TestOCI1IndexChooseInstanceByCompression(t *testing.T) {

--- a/internal/signature/signature.go
+++ b/internal/signature/signature.go
@@ -87,7 +87,6 @@ func FromBlob(blob []byte) (Signature, error) {
 	default:
 		return nil, fmt.Errorf("unrecognized signature format, starting with binary %#x", blob[0])
 	}
-
 }
 
 // UnsupportedFormatError returns an error complaining about sig having an unsupported format.

--- a/internal/signature/signature_test.go
+++ b/internal/signature/signature_test.go
@@ -31,7 +31,6 @@ func TestBlobSimpleSigning(t *testing.T) {
 	fromBlobSimple, ok = fromBlob.(SimpleSigning)
 	require.True(t, ok)
 	assert.Equal(t, simpleSigData, fromBlobSimple.UntrustedSignature())
-
 }
 
 func TestBlobSigstore(t *testing.T) {

--- a/internal/tmpdir/tmpdir_test.go
+++ b/internal/tmpdir/tmpdir_test.go
@@ -32,7 +32,6 @@ func TestCreateBigFileTemp(t *testing.T) {
 	sys.BigFilesTemporaryDir = "/tmp/bogus"
 	_, err = CreateBigFileTemp(&sys, "foobar1")
 	assert.Error(t, err)
-
 }
 
 func TestMkDirBigFileTemp(t *testing.T) {

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -106,7 +106,6 @@ func (b *BlobCache) findBlob(info types.BlobInfo) (string, int64, bool, error) {
 	}
 
 	return "", -1, false, nil
-
 }
 
 func (b *BlobCache) HasBlob(blobinfo types.BlobInfo) (bool, int64, error) {

--- a/pkg/blobinfocache/sqlite/sqlite.go
+++ b/pkg/blobinfocache/sqlite/sqlite.go
@@ -329,7 +329,6 @@ func (sqc *cache) uncompressedDigest(tx *sql.Tx, anyDigest digest.Digest) (diges
 			return "", err
 		}
 		return d, nil
-
 	}
 	// A record as uncompressedDigest implies that anyDigest must already refer to an uncompressed digest.
 	// This way we don't have to waste storage space with trivial (uncompressed, uncompressed) mappings
@@ -561,7 +560,6 @@ func (sqc *cache) candidateLocations(transport types.ImageTransport, scope types
 		return []blobinfocache.BICReplacementCandidate2{} // FIXME? Log err (but throttle the log volume on repeated accesses)?
 	}
 	return prioritize.DestructivelyPrioritizeReplacementCandidates(res, primaryDigest, uncompressedDigest)
-
 }
 
 // CandidateLocations returns a prioritized, limited, number of blobs and their locations that could possibly be reused

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -714,7 +714,6 @@ func modifyDockerConfigJSON(sys *types.SystemContext, editor func(fileContents *
 	if rawCH, ok := rawContents["credHelpers"]; ok {
 		if err := json.Unmarshal(rawCH, &syntheticContents.CredHelpers); err != nil {
 			return "", fmt.Errorf(`unmarshaling "credHelpers" in JSON at %q: %w`, path, err)
-
 		}
 	}
 

--- a/pkg/strslice/strslice_test.go
+++ b/pkg/strslice/strslice_test.go
@@ -43,7 +43,6 @@ func TestStrSliceUnmarshalJSON(t *testing.T) {
 		if !reflect.DeepEqual(actualParts, expectedParts) {
 			t.Fatalf("%#v: expected %v, got %v", json, expectedParts, actualParts)
 		}
-
 	}
 }
 

--- a/pkg/sysregistriesv2/shortnames_test.go
+++ b/pkg/sysregistriesv2/shortnames_test.go
@@ -72,7 +72,6 @@ func TestParseShortNameValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, named)
 	assert.Equal(t, "docker.io/library/fedora", named.String())
-
 }
 
 func TestValidateShortName(t *testing.T) {

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -803,7 +803,6 @@ func TestInvalidMirrorConfig(t *testing.T) {
 		_, err := GetRegistries(tc.sys)
 		assert.ErrorContains(t, err, tc.expectErr)
 	}
-
 }
 
 func TestTryUpdatingCache(t *testing.T) {

--- a/signature/internal/rekor_set.go
+++ b/signature/internal/rekor_set.go
@@ -177,7 +177,6 @@ func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unver
 	}
 	if hashedRekordV001.Signature.PublicKey == nil {
 		return time.Time{}, NewInvalidSignatureError(`Missing "signature.publicKey" field in hashedrekord`)
-
 	}
 	rekorKeyOrCertPEM, rest := pem.Decode(hashedRekordV001.Signature.PublicKey.Content)
 	if rekorKeyOrCertPEM == nil {
@@ -228,7 +227,6 @@ func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unver
 	rekorPayloadHash, err := hex.DecodeString(*hashedRekordV001.Data.Hash.Value)
 	if err != nil {
 		return time.Time{}, NewInvalidSignatureError(fmt.Sprintf(`Invalid "data.hash.value" field in hashedrekord: %v`, err))
-
 	}
 	unverifiedPayloadHash := sha256.Sum256(unverifiedPayloadBytes)
 	if !bytes.Equal(rekorPayloadHash, unverifiedPayloadHash[:]) {

--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -106,7 +106,6 @@ func (pr *prSigstoreSigned) prepareTrustRoot() (*sigstoreSignedTrustRoot, error)
 		pkECDSA, ok := pk.(*ecdsa.PublicKey)
 		if !ok {
 			return nil, fmt.Errorf("Rekor public key is not using ECDSA")
-
 		}
 		res.rekorPublicKey = pkECDSA
 	}
@@ -154,7 +153,6 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 				// Coverage: The key was loaded from a PEM format, so it’s unclear how this could fail.
 				// (PEM is not essential, MarshalPublicKeyToPEM can only fail if marshaling to ASN1.DER fails.)
 				return sarRejected, fmt.Errorf("re-marshaling public key to PEM: %w", err)
-
 			}
 			// We don’t care about the Rekor timestamp, just about log presence.
 			if _, err := internal.VerifyRekorSET(trustRoot.rekorPublicKey, []byte(untrustedSET), recreatedPublicKeyPEM, untrustedBase64Signature, untrustedPayload); err != nil {

--- a/signature/policy_eval_test.go
+++ b/signature/policy_eval_test.go
@@ -127,7 +127,6 @@ func TestPolicyContextRequirementsForImageRefNotRegisteredTransport(t *testing.T
 	reqs := pc.requirementsForImageRef(pcImageReferenceMock{transportName: "docker", ref: ref})
 	assert.True(t, &(reqs[0]) == &(pr[0]))
 	assert.True(t, len(reqs) == len(pr))
-
 }
 
 func TestPolicyContextRequirementsForImageRef(t *testing.T) {

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -261,7 +261,6 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 		err = chunked.ErrBadRequest{}
 	}
 	return rc, errs, err
-
 }
 
 // PutBlobPartial attempts to create a blob using the data that is already present


### PR DESCRIPTION
This PR enables default linters for golangci-lint with `whitespace` linter, and fixes up `whitespace` lint issues.

In future, `enable` list may grow with new linters.