### PR TITLE
Main is after latest release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 29
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
Release 5.29.1 happened on a branch; merge it into `main` to let Git, and go tools, now that `main` is “after” 5.29.1, notably so that updating to `main` does not trigger a downgrade of c/common to a version which does not require 5.29.1, or an upgrade of c/common does not trigger a downgrade from a `main` checkout to the branched 5.29.1 version of c/image.