### PR TITLE
feat: negotiate docker client version

### DIFF
--- a/docker/daemon/daemon_dest.go
+++ b/docker/daemon/daemon_dest.go
@@ -43,7 +43,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 		mustMatchRuntimeOS = false
 	}
 
-	c, err := newDockerClient(sys)
+	c, err := newDockerClient(ctx, sys)
 	if err != nil {
 		return nil, fmt.Errorf("initializing docker engine client: %w", err)
 	}

--- a/docker/daemon/daemon_src.go
+++ b/docker/daemon/daemon_src.go
@@ -24,7 +24,7 @@ type daemonImageSource struct {
 // is the config, and that the following len(RootFS) files are the layers, but that feels
 // way too brittle.)
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonReference) (private.ImageSource, error) {
-	c, err := newDockerClient(sys)
+	c, err := newDockerClient(ctx, sys)
 	if err != nil {
 		return nil, fmt.Errorf("initializing docker engine client: %w", err)
 	}


### PR DESCRIPTION
Instead of hardcoding the docker client version we should negotiate a version at runtime. Version 1.22 is very out of date and no longer is supported by modern daemon versions.