### PR TITLE
Allow docker client to negotiate the API version with the server 

### DIFF
--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-const (
-	// The default API version to be used in case none is explicitly specified
-	defaultAPIVersion = "1.22"
-)
-
 // NewDockerClient initializes a new API client based on the passed SystemContext.
 func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	host := dockerclient.DefaultDockerHost
@@ -23,7 +18,6 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 
 	opts := []dockerclient.Opt{
 		dockerclient.WithHost(host),
-		dockerclient.WithVersion(defaultAPIVersion),
 	}
 
 	// We conditionalize building the TLS configuration only to TLS sockets:

--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -18,6 +18,7 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 
 	opts := []dockerclient.Opt{
 		dockerclient.WithHost(host),
+		dockerclient.WithAPIVersionNegotiation(),
 	}
 
 	// We conditionalize building the TLS configuration only to TLS sockets:

--- a/docker/daemon/client_test.go
+++ b/docker/daemon/client_test.go
@@ -18,7 +18,6 @@ func TestDockerClientFromNilSystemContext(t *testing.T) {
 	assert.NotNil(t, client, "A Docker client reference should have been returned")
 
 	assert.Equal(t, dockerclient.DefaultDockerHost, client.DaemonHost(), "The default docker host should have been used")
-	assert.Equal(t, defaultAPIVersion, client.ClientVersion(), "The default api version should have been used")
 
 	assert.NoError(t, client.Close())
 }
@@ -39,7 +38,6 @@ func TestDockerClientFromCertContext(t *testing.T) {
 	assert.NotNil(t, client, "A Docker client reference should have been returned")
 
 	assert.Equal(t, host, client.DaemonHost())
-	assert.Equal(t, "1.22", client.ClientVersion())
 
 	assert.NoError(t, client.Close())
 }

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v24.0.7+incompatible h1:wa/nIwYFW7BVTGa7SWPVyyXU9lgORqUb1xfI36MSkFg=
-github.com/docker/cli v24.0.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v25.0.0+incompatible h1:zaimaQdnX7fYWFqzN88exE9LDEvRslexpFowZBX6GoQ=
 github.com/docker/cli v25.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=


### PR DESCRIPTION
The version is currently hardcoded which is causing the issue documented here - https://github.com/containers/image/issues/2259

Decided adding a unit test wasn't feasible as as the version would change each time we pulled in a new docker client and as long as it negotiates a version that works I suspect we don't care what that exact version is. 