### PR TITLE
Use a stable Skopeo branch for testing the stable c/image branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ env:
     # Name of the ultimate destination branch for this CI run
     DEST_BRANCH: "release-5.29"
     # c/skopeo branch name which must work with this c/image branch
-    SKOPEO_CI_BRANCH: "main"
+    SKOPEO_CI_BRANCH: "release-1.14"
     # Use GO module mirror (reason unknown, travis did it this way)
     GOPROXY: https://proxy.golang.org
     # Overrides default location (/tmp/cirrus) for repo clone


### PR DESCRIPTION
... to avoid breakage on incompatible dependency updates, like https://cirrus-ci.com/build/5613830407979008 .