### PR TITLE
Bump to v5.30.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,9 +6,9 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 29
+	VersionMinor = 30
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
As we have a release-5.29 branch now that we will be updating, bump the main branch up to v5.30-dev to stop confusion.