### PR TITLE
Backport Docker Daemon fix #2260, bump to 5.29.2, then 5.29.3-dev 

### DIFF
--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -9,11 +9,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-const (
-	// The default API version to be used in case none is explicitly specified
-	defaultAPIVersion = "1.22"
-)
-
 // NewDockerClient initializes a new API client based on the passed SystemContext.
 func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	host := dockerclient.DefaultDockerHost
@@ -23,7 +18,7 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 
 	opts := []dockerclient.Opt{
 		dockerclient.WithHost(host),
-		dockerclient.WithVersion(defaultAPIVersion),
+		dockerclient.WithAPIVersionNegotiation(),
 	}
 
 	// We conditionalize building the TLS configuration only to TLS sockets:

--- a/docker/daemon/client_test.go
+++ b/docker/daemon/client_test.go
@@ -18,7 +18,6 @@ func TestDockerClientFromNilSystemContext(t *testing.T) {
 	assert.NotNil(t, client, "A Docker client reference should have been returned")
 
 	assert.Equal(t, dockerclient.DefaultDockerHost, client.DaemonHost(), "The default docker host should have been used")
-	assert.Equal(t, defaultAPIVersion, client.ClientVersion(), "The default api version should have been used")
 
 	assert.NoError(t, client.Close())
 }
@@ -39,7 +38,6 @@ func TestDockerClientFromCertContext(t *testing.T) {
 	assert.NotNil(t, client, "A Docker client reference should have been returned")
 
 	assert.Equal(t, host, client.DaemonHost())
-	assert.Equal(t, "1.22", client.ClientVersion())
 
 	assert.NoError(t, client.Close())
 }

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 29
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
In preparation for Podman v4.9.1, add the Docker Daemon version fix from #2260 and then bump the version to 5.29.2 before creating a release from this branch. 