### PR TITLE
Random storage-related cleanups

### DIFF
--- a/oci/layout/oci_src_test.go
+++ b/oci/layout/oci_src_test.go
@@ -49,7 +49,7 @@ func TestGetBlobForRemoteLayers(t *testing.T) {
 	imageSource := createImageSource(t, &types.SystemContext{})
 	defer imageSource.Close()
 	layerInfo := types.BlobInfo{
-		Digest: digest.FromBytes([]byte("Hello world")),
+		Digest: digest.FromString("Hello world"),
 		Size:   -1,
 		URLs: []string{
 			"brokenurl",

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -828,7 +828,7 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		}
 	}
 	var lastLayer string
-	if len(layerBlobs) > 0 { // Can happen when using caches
+	if len(layerBlobs) > 0 { // Zero-layer images rarely make sense, but it is technically possible, and may happen for non-image artifacts.
 		prev, ok := s.indexToStorageID[len(layerBlobs)-1]
 		if !ok {
 			return fmt.Errorf("Internal error: storageImageDestination.Commit(): previous layer %d hasn't been committed (lastLayer == nil)", len(layerBlobs)-1)

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -588,7 +588,11 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 	// `s.indexToStorageID` can only be accessed by *one* goroutine at any
 	// given time. Hence, we don't need to lock accesses.
 	var lastLayer string
-	if prev, ok := s.indexToStorageID[index-1]; ok {
+	if index != 0 {
+		prev, ok := s.indexToStorageID[index-1]
+		if !ok {
+			return false, fmt.Errorf("Internal error: commitLayer called with previous layer %d not committed yet", index-1)
+		}
 		lastLayer = prev
 	}
 

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -632,8 +632,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 	}
 	if layer, err2 := s.imageRef.transport.store.Layer(id); layer != nil && err2 == nil {
 		// There's already a layer that should have the right contents, just reuse it.
-		lastLayer = layer.ID
-		s.indexToStorageID[index] = lastLayer
+		s.indexToStorageID[index] = layer.ID
 		return false, nil
 	}
 
@@ -695,8 +694,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 		if err != nil && !errors.Is(err, storage.ErrDuplicateID) {
 			return false, fmt.Errorf("failed to put layer from digest and labels: %w", err)
 		}
-		lastLayer = layer.ID
-		s.indexToStorageID[index] = lastLayer
+		s.indexToStorageID[index] = layer.ID
 		return false, nil
 	}
 

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -74,7 +74,8 @@ type storageImageDestination struct {
 	// `queueOrCommit()` for further details on how the single-caller
 	// guarantee is implemented.
 	indexToStorageID map[int]string
-	// All accesses to below data are protected by `lock` which is made
+	// All accesses to below data are, during the concurrent TryReusingBlob/PutBlob/* calls
+	// (but not necessarily during the final Commit) protected by `lock` which is made
 	// *explicit* in the code.
 	uncompressedOrTocDigest map[digest.Digest]digest.Digest                       // Mapping from layer blobsums to their corresponding DiffIDs or TOC IDs.
 	fileSizes               map[digest.Digest]int64                               // Mapping from layer blobsums to their sizes

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -633,7 +633,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 	}
 	id := diffIDOrTOCDigest.Hex()
 	if parentLayer != "" {
-		id = digest.Canonical.FromBytes([]byte(parentLayer + "+" + diffIDOrTOCDigest.Hex())).Hex()
+		id = digest.Canonical.FromString(parentLayer + "+" + diffIDOrTOCDigest.Hex()).Hex()
 	}
 	if layer, err2 := s.imageRef.transport.store.Layer(id); layer != nil && err2 == nil {
 		// There's already a layer that should have the right contents, just reuse it.

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -31,6 +31,12 @@ func signatureBigDataKey(digest digest.Digest) string {
 	return "signature-" + digest.Encoded()
 }
 
+// storageImageMetadata is stored, as JSON, in storage.Image.Metadata
+type storageImageMetadata struct {
+	SignatureSizes  []int                   `json:"signature-sizes,omitempty"`  // List of sizes of each signature slice
+	SignaturesSizes map[digest.Digest][]int `json:"signatures-sizes,omitempty"` // Sizes of each manifest's signature slice
+}
+
 type storageImageCloser struct {
 	types.ImageCloser
 	size int64

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -18,11 +18,6 @@ var (
 	ErrNoSuchImage = storage.ErrNotAnImage
 )
 
-type storageImageCloser struct {
-	types.ImageCloser
-	size int64
-}
-
 // manifestBigDataKey returns a key suitable for recording a manifest with the specified digest using storage.Store.ImageBigData and related functions.
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
 // for compatibility, if a manifest is not available under this key, check also storage.ImageDigestBigDataKey
@@ -34,6 +29,11 @@ func manifestBigDataKey(digest digest.Digest) string {
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
 func signatureBigDataKey(digest digest.Digest) string {
 	return "signature-" + digest.Encoded()
+}
+
+type storageImageCloser struct {
+	types.ImageCloser
+	size int64
 }
 
 // Size() returns the previously-computed size of the image, with no error.

--- a/storage/storage_src.go
+++ b/storage/storage_src.go
@@ -47,11 +47,10 @@ type storageImageSource struct {
 	imageRef              storageReference
 	image                 *storage.Image
 	systemContext         *types.SystemContext // SystemContext used in GetBlob() to create temporary files
-	cachedManifest        []byte               // A cached copy of the manifest, if already known, or nil
-	getBlobMutex          sync.Mutex           // Mutex to sync state for parallel GetBlob executions (it guards layerPosition and digestToLayerID)
+	metadata              storageImageMetadata
+	cachedManifest        []byte     // A cached copy of the manifest, if already known, or nil
+	getBlobMutex          sync.Mutex // Mutex to sync state for parallel GetBlob executions (it guards layerPosition and digestToLayerID)
 	getBlobMutexProtected getBlobMutexProtected
-	SignatureSizes        []int                   `json:"signature-sizes,omitempty"`  // List of sizes of each signature slice
-	SignaturesSizes       map[digest.Digest][]int `json:"signatures-sizes,omitempty"` // List of sizes of each signature slice
 }
 
 const expectedLayerDiffIDFlag = "expected-layer-diffid"
@@ -71,11 +70,13 @@ func newImageSource(sys *types.SystemContext, imageRef storageReference) (*stora
 		}),
 		NoGetBlobAtInitialize: stubs.NoGetBlobAt(imageRef),
 
-		imageRef:        imageRef,
-		systemContext:   sys,
-		image:           img,
-		SignatureSizes:  []int{},
-		SignaturesSizes: make(map[digest.Digest][]int),
+		imageRef:      imageRef,
+		systemContext: sys,
+		image:         img,
+		metadata: storageImageMetadata{
+			SignatureSizes:  []int{},
+			SignaturesSizes: make(map[digest.Digest][]int),
+		},
 		getBlobMutexProtected: getBlobMutexProtected{
 			digestToLayerID: make(map[digest.Digest]string),
 			layerPosition:   make(map[digest.Digest]int),
@@ -83,7 +84,7 @@ func newImageSource(sys *types.SystemContext, imageRef storageReference) (*stora
 	}
 	image.Compat = impl.AddCompat(image)
 	if img.Metadata != "" {
-		if err := json.Unmarshal([]byte(img.Metadata), image); err != nil {
+		if err := json.Unmarshal([]byte(img.Metadata), &image.metadata); err != nil {
 			return nil, fmt.Errorf("decoding metadata for source image: %w", err)
 		}
 	}
@@ -375,11 +376,11 @@ func buildLayerInfosForCopy(manifestInfos []manifest.LayerInfo, physicalInfos []
 func (s *storageImageSource) GetSignaturesWithFormat(ctx context.Context, instanceDigest *digest.Digest) ([]signature.Signature, error) {
 	var offset int
 	signatureBlobs := []byte{}
-	signatureSizes := s.SignatureSizes
+	signatureSizes := s.metadata.SignatureSizes
 	key := "signatures"
 	instance := "default instance"
 	if instanceDigest != nil {
-		signatureSizes = s.SignaturesSizes[*instanceDigest]
+		signatureSizes = s.metadata.SignaturesSizes[*instanceDigest]
 		key = signatureBigDataKey(*instanceDigest)
 		instance = instanceDigest.Encoded()
 	}
@@ -425,7 +426,7 @@ func (s *storageImageSource) getSize() (int64, error) {
 		sum += bigSize
 	}
 	// Add the signature sizes.
-	for _, sigSize := range s.SignatureSizes {
+	for _, sigSize := range s.metadata.SignatureSizes {
 		sum += int64(sigSize)
 	}
 	// Walk the layer list.


### PR DESCRIPTION
… on the principle that removing accidental complexity makes it easier to focus on the essential complexity.

(Yes, this conflicts with #2218 ; I’ll rebase that work.)

@giuseppe PTAL.