### PR TITLE
Also annotate image instances using zstd:chunked as using zstd

### DIFF
--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -103,7 +103,7 @@ func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, an
 	}
 	for _, algo := range compressionAlgorithms {
 		switch algo.Name() {
-		case compression.ZstdAlgorithmName:
+		case compression.ZstdAlgorithmName, compression.ZstdChunkedAlgorithmName:
 			(*annotationsMap)[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
 		default:
 			continue


### PR DESCRIPTION
... so that zstd-preferring implementations like c/image can choose them.

Fixes #2077.

#2077 also talks about writing down what `InternalUnstableUndocumentedMIMEQuestionMark` means; this does not do that yet – the currently outstanding items in #2189 center around how `BlobInfoCache` deals with `zstd`/`zstd:chunked` as (not) interchangeable. Here we can trivially just check for two values without determining the exact semantics, `BlobInfoCache` will quite likely care a bit more, so decide the semantics at that point; for now, this PR just leaves a breadcrumb.