### PR TITLE
Support editing ArtifactType, preserve it in lists

### DIFF
--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -38,6 +38,7 @@ type instanceCopy struct {
 
 	// Fields which can be used by callers when operation
 	// is `instanceCopyClone`
+	cloneArtifactType       string
 	cloneCompressionVariant OptionCompressionVariant
 	clonePlatform           *imgspecv1.Platform
 	cloneAnnotations        map[string]string
@@ -142,6 +143,7 @@ func prepareInstanceCopies(list internalManifest.List, instanceDigests []digest.
 				res = append(res, instanceCopy{
 					op:                      instanceCopyClone,
 					sourceDigest:            instanceDigest,
+					cloneArtifactType:       instanceDetails.ReadOnly.ArtifactType,
 					cloneCompressionVariant: compressionVariant,
 					clonePlatform:           instanceDetails.ReadOnly.Platform,
 					cloneAnnotations:        maps.Clone(instanceDetails.ReadOnly.Annotations),
@@ -268,6 +270,7 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 				AddDigest:                updated.manifestDigest,
 				AddSize:                  int64(len(updated.manifest)),
 				AddMediaType:             updated.manifestMIMEType,
+				AddArtifactType:          instance.cloneArtifactType,
 				AddPlatform:              instance.clonePlatform,
 				AddAnnotations:           instance.cloneAnnotations,
 				AddCompressionAlgorithms: updated.compressionAlgorithms,

--- a/internal/manifest/list.go
+++ b/internal/manifest/list.go
@@ -73,6 +73,7 @@ type ListUpdate struct {
 		Platform                  *imgspecv1.Platform
 		Annotations               map[string]string
 		CompressionAlgorithmNames []string
+		ArtifactType              string
 	}
 }
 
@@ -101,6 +102,7 @@ type ListEdit struct {
 	AddDigest                digest.Digest
 	AddSize                  int64
 	AddMediaType             string
+	AddArtifactType          string
 	AddPlatform              *imgspecv1.Platform
 	AddAnnotations           map[string]string
 	AddCompressionAlgorithms []compression.Algorithm

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -61,6 +61,7 @@ func (index *OCI1IndexPublic) Instance(instanceDigest digest.Digest) (ListUpdate
 			ret.ReadOnly.Platform = manifest.Platform
 			ret.ReadOnly.Annotations = manifest.Annotations
 			ret.ReadOnly.CompressionAlgorithmNames = annotationsToCompressionAlgorithmNames(manifest.Annotations)
+			ret.ReadOnly.ArtifactType = manifest.ArtifactType
 			return ret, nil
 		}
 	}
@@ -157,11 +158,13 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit) error {
 			}
 			addCompressionAnnotations(editInstance.AddCompressionAlgorithms, &annotations)
 			addedEntries = append(addedEntries, imgspecv1.Descriptor{
-				MediaType:   editInstance.AddMediaType,
-				Size:        editInstance.AddSize,
-				Digest:      editInstance.AddDigest,
-				Platform:    editInstance.AddPlatform,
-				Annotations: annotations})
+				MediaType:    editInstance.AddMediaType,
+				ArtifactType: editInstance.AddArtifactType,
+				Size:         editInstance.AddSize,
+				Digest:       editInstance.AddDigest,
+				Platform:     editInstance.AddPlatform,
+				Annotations:  annotations,
+			})
 		default:
 			return fmt.Errorf("internal error: invalid operation: %d", editInstance.ListOperation)
 		}
@@ -299,12 +302,13 @@ func OCI1IndexPublicFromComponents(components []imgspecv1.Descriptor, annotation
 			platform = &platformCopy
 		}
 		m := imgspecv1.Descriptor{
-			MediaType:   component.MediaType,
-			Size:        component.Size,
-			Digest:      component.Digest,
-			URLs:        slices.Clone(component.URLs),
-			Annotations: maps.Clone(component.Annotations),
-			Platform:    platform,
+			MediaType:    component.MediaType,
+			ArtifactType: component.ArtifactType,
+			Size:         component.Size,
+			Digest:       component.Digest,
+			URLs:         slices.Clone(component.URLs),
+			Annotations:  maps.Clone(component.Annotations),
+			Platform:     platform,
 		}
 		index.Manifests[i] = m
 	}

--- a/internal/manifest/testdata/oci1index.json
+++ b/internal/manifest/testdata/oci1index.json
@@ -22,6 +22,16 @@
           "sse4"
         ]
       }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "artifactType": "application/x-tar",
+      "size": 8221,
+      "digest": "sha256:615e8db5ae085b39e9cd24e5bc887d03fbd30ee4f55f5fedf9b697fafea4fbdd",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
     }
   ],
   "annotations": {


### PR DESCRIPTION
Add fields to manifest.ListUpdate for adding and updating the ArtifactType field in a list entry.  When copying a list or descriptor, preserve the value from the original descriptor for an entry.