### PR TITLE
Add allowed seccomp specific config media type

### DIFF
--- a/internal/image/oci.go
+++ b/internal/image/oci.go
@@ -87,7 +87,7 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 // layers in the resulting configuration isn't guaranteed to be returned to due how
 // old image manifests work (docker v2s1 especially).
 func (m *manifestOCI1) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) {
-	if m.m.Config.MediaType != imgspecv1.MediaTypeImageConfig {
+	if !internalManifest.IsSupportedConfigMediaType(m.m.Config.MediaType) {
 		return nil, internalManifest.NewNonImageArtifactError(&m.m.Manifest)
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -31,6 +31,8 @@ const (
 	DockerV2Schema2ForeignLayerMediaType = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for gzipped schema 2 foreign layers.
 	DockerV2Schema2ForeignLayerMediaTypeGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+	// CNCFSeccompProfileConfigMediaType is a custom media type used for seccomp profiles.
+	CNCFSeccompProfileConfigMediaType = "application/vnd.cncf.seccomp-profile.config.v1+json"
 )
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.
@@ -186,6 +188,16 @@ func MIMETypeSupportsCompressionAlgorithm(mimeType string, algo compressiontypes
 	case compressiontypes.ZstdAlgorithmName, compressiontypes.ZstdChunkedAlgorithmName:
 		return mimeType == imgspecv1.MediaTypeImageManifest
 	default: // Includes Bzip2AlgorithmName and XzAlgorithmName, which are defined names but are not supported anywhere
+		return false
+	}
+}
+
+// IsSupportedConfigMediaType returns true if the config media type is supported.
+func IsSupportedConfigMediaType(m string) bool {
+	switch m {
+	case imgspecv1.MediaTypeImageConfig, CNCFSeccompProfileConfigMediaType:
+		return true
+	default:
 		return false
 	}
 }

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -197,7 +197,7 @@ func (m *OCI1) Serialize() ([]byte, error) {
 
 // Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*types.ImageInspectInfo, error) {
-	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig {
+	if !manifest.IsSupportedConfigMediaType(m.Config.MediaType) {
 		// We could return at least the layers, but that’s already available in a better format via types.Image.LayerInfos.
 		// Most software calling this without human intervention is going to expect the values to be realistic and relevant,
 		// and is probably better served by failing; we can always re-visit that later if we fail now, but


### PR DESCRIPTION
Adding the new seccomp related config media type `application/vnd.cncf.seccomp-profile.config.v1+json` to the list of allowed configurations.

Alternative to https://github.com/containers/image/issues/2279
Testing in https://github.com/cri-o/cri-o/pull/7804

cc @sftim @mtrmac 