### PR TITLE
Fix handling of errors when fetching layers by URLs

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -993,11 +993,11 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 		// NOTE: we must not authenticate on additional URLs as those
 		//       can be abused to leak credentials or tokens.  Please
 		//       refer to CVE-2020-15157 for more information.
-		resp, err = c.makeRequestToResolvedURL(ctx, http.MethodGet, blobURL, nil, nil, -1, noAuth, nil)
-		if err == nil {
+		resp, remoteErrors = c.makeRequestToResolvedURL(ctx, http.MethodGet, blobURL, nil, nil, -1, noAuth, nil)
+		if remoteErrors == nil {
 			if resp.StatusCode != http.StatusOK {
-				err = fmt.Errorf("error fetching external blob from %q: %d (%s)", u, resp.StatusCode, http.StatusText(resp.StatusCode))
-				logrus.Debug(err)
+				remoteErrors = fmt.Errorf("error fetching external blob from %q: %d (%s)", u, resp.StatusCode, http.StatusText(resp.StatusCode))
+				logrus.Debug(remoteErrors)
 				resp.Body.Close()
 				continue
 			}

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -978,34 +978,40 @@ func (c *dockerClient) fetchManifest(ctx context.Context, ref dockerReference, t
 // This function can return nil reader when no url is supported by this function. In this case, the caller
 // should fallback to fetch the non-external blob (i.e. pull from the registry).
 func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
-	var remoteErrors error
 	if len(urls) == 0 {
 		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
 	}
+	var remoteErrors []error
 	for _, u := range urls {
 		blobURL, err := url.Parse(u)
 		if err != nil || (blobURL.Scheme != "http" && blobURL.Scheme != "https") {
 			continue // unsupported url. skip this url.
 		}
-		var resp *http.Response
 		// NOTE: we must not authenticate on additional URLs as those
 		//       can be abused to leak credentials or tokens.  Please
 		//       refer to CVE-2020-15157 for more information.
-		resp, remoteErrors = c.makeRequestToResolvedURL(ctx, http.MethodGet, blobURL, nil, nil, -1, noAuth, nil)
-		if remoteErrors == nil {
-			if resp.StatusCode != http.StatusOK {
-				remoteErrors = fmt.Errorf("error fetching external blob from %q: %d (%s)", u, resp.StatusCode, http.StatusText(resp.StatusCode))
-				logrus.Debug(remoteErrors)
-				resp.Body.Close()
-				continue
-			}
-			return resp.Body, getBlobSize(resp), nil
+		resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, blobURL, nil, nil, -1, noAuth, nil)
+		if err != nil {
+			remoteErrors = append(remoteErrors, err)
+			continue
 		}
+		if resp.StatusCode != http.StatusOK {
+			err := fmt.Errorf("error fetching external blob from %q: %d (%s)", u, resp.StatusCode, http.StatusText(resp.StatusCode))
+			remoteErrors = append(remoteErrors, err)
+			logrus.Debug(err)
+			resp.Body.Close()
+			continue
+		}
+		return resp.Body, getBlobSize(resp), nil
 	}
 	if remoteErrors == nil {
 		return nil, 0, nil // fallback to non-external blob
 	}
-	return nil, 0, remoteErrors
+	err := fmt.Errorf("failed fetching external blob from all urls: %w", remoteErrors[0])
+	for _, e := range remoteErrors[1:] {
+		err = fmt.Errorf("%s, %w", err, e)
+	}
+	return nil, 0, err
 }
 
 func getBlobSize(resp *http.Response) int64 {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -979,8 +979,8 @@ func (c *dockerClient) fetchManifest(ctx context.Context, ref dockerReference, t
 // should fallback to fetch the non-external blob (i.e. pull from the registry).
 func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.ReadCloser, int64, error) {
 	var (
-		resp *http.Response
-		err  error
+		resp         *http.Response
+		remoteErrors error
 	)
 	if len(urls) == 0 {
 		return nil, 0, errors.New("internal error: getExternalBlob called with no URLs")
@@ -1004,11 +1004,11 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 			break
 		}
 	}
-	if resp == nil && err == nil {
+	if resp == nil && remoteErrors == nil {
 		return nil, 0, nil // fallback to non-external blob
 	}
-	if err != nil {
-		return nil, 0, err
+	if remoteErrors != nil {
+		return nil, 0, remoteErrors
 	}
 	return resp.Body, getBlobSize(resp), nil
 }


### PR DESCRIPTION
`gopls 0.15` identifies always-true/always-false conditions in the code; I broke that in fa54b28a4d7a7e97fe899f958326b2bd3f91a11a .

- Don’t ignore errors accessing layers by URLs. Note that this might break setups which were created in the past two years; they now don’t fall back to registry accesses.
- If we fail, also report all errors, not just the last one, as the original version of the code did.