### PR TITLE
Remove additional check if digester is available

### DIFF
--- a/copy/digesting_reader.go
+++ b/copy/digesting_reader.go
@@ -21,15 +21,10 @@ type digestingReader struct {
 // or set validationSucceeded/validationFailed to true if the source stream does/does not match expectedDigest.
 // (neither is set if EOF is never reached).
 func newDigestingReader(source io.Reader, expectedDigest digest.Digest) (*digestingReader, error) {
-	var digester digest.Digester
 	if err := expectedDigest.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid digest specification %q: %w", expectedDigest, err)
 	}
-	digestAlgorithm := expectedDigest.Algorithm()
-	if !digestAlgorithm.Available() {
-		return nil, fmt.Errorf("invalid digest specification %q: unsupported digest algorithm %q", expectedDigest, digestAlgorithm)
-	}
-	digester = digestAlgorithm.Digester()
+	digester := expectedDigest.Algorithm().Digester()
 
 	return &digestingReader{
 		source:           source,


### PR DESCRIPTION
`expectedDigest.Validate()` already calls the `Available()` method and checks if the digest is possible or not. Therefore we can remove the additional/impossible double check for that.

Ref: https://github.com/opencontainers/go-digest/blob/429d0316a/digest.go#L111-L116

Follow-up on https://github.com/containers/image/pull/2312