### PR TITLE
Improve handling of zstd vs. zstd:chunked matching

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -383,7 +383,11 @@ func (ic *imageCopier) compareImageDestinationManifestEqual(ctx context.Context,
 
 	compressionAlgos := set.New[string]()
 	for _, srcInfo := range ic.src.LayerInfos() {
-		if _, c := compressionEditsFromMIMEType(srcInfo); c != nil {
+		_, c, err := compressionEditsFromBlobInfo(srcInfo)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
 			compressionAlgos.Add(c.Name())
 		}
 	}
@@ -636,21 +640,28 @@ type diffIDResult struct {
 	err    error
 }
 
-// compressionEditsFromMIMEType returns a (CompressionOperation, CompressionAlgorithm) value pair suitable
-// for types.BlobInfo, based on a MIME type of srcInfo.
-func compressionEditsFromMIMEType(srcInfo types.BlobInfo) (types.LayerCompression, *compressiontypes.Algorithm) {
+// compressionEditsFromBlobInfo returns a (CompressionOperation, CompressionAlgorithm) value pair suitable
+// for types.BlobInfo.
+func compressionEditsFromBlobInfo(srcInfo types.BlobInfo) (types.LayerCompression, *compressiontypes.Algorithm, error) {
 	// This MIME type → compression mapping belongs in manifest-specific code in our manifest
 	// package (but we should preferably replace/change UpdatedImage instead of productizing
 	// this workaround).
 	switch srcInfo.MediaType {
 	case manifest.DockerV2Schema2LayerMediaType, imgspecv1.MediaTypeImageLayerGzip:
-		return types.PreserveOriginal, &compression.Gzip
+		return types.PreserveOriginal, &compression.Gzip, nil
 	case imgspecv1.MediaTypeImageLayerZstd:
-		return types.PreserveOriginal, &compression.Zstd
+		tocDigest, err := chunkedToc.GetTOCDigest(srcInfo.Annotations)
+		if err != nil {
+			return types.PreserveOriginal, nil, err
+		}
+		if tocDigest != nil {
+			return types.PreserveOriginal, &compression.ZstdChunked, nil
+		}
+		return types.PreserveOriginal, &compression.Zstd, nil
 	case manifest.DockerV2SchemaLayerMediaTypeUncompressed, imgspecv1.MediaTypeImageLayer:
-		return types.Decompress, nil
+		return types.Decompress, nil, nil
 	default:
-		return types.PreserveOriginal, nil
+		return types.PreserveOriginal, nil, nil
 	}
 }
 
@@ -666,7 +677,12 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 	// (Sadly UpdatedImage() is documented to not update MediaTypes from
 	//  ManifestUpdateOptions.LayerInfos[].MediaType, so we are doing it indirectly.)
 	if srcInfo.CompressionOperation == types.PreserveOriginal && srcInfo.CompressionAlgorithm == nil {
-		srcInfo.CompressionOperation, srcInfo.CompressionAlgorithm = compressionEditsFromMIMEType(srcInfo)
+		op, algo, err := compressionEditsFromBlobInfo(srcInfo)
+		if err != nil {
+			return types.BlobInfo{}, "", err
+		}
+		srcInfo.CompressionOperation = op
+		srcInfo.CompressionAlgorithm = algo
 	}
 
 	ic.c.printCopyInfo("blob", srcInfo)

--- a/internal/imagedestination/impl/helpers.go
+++ b/internal/imagedestination/impl/helpers.go
@@ -17,7 +17,8 @@ func CandidateMatchesTryReusingBlobOptions(options private.TryReusingBlobOptions
 			// The caller must re-compress to build those annotations.
 			return false
 		}
-		if candidateCompression == nil || (options.RequiredCompression.Name() != candidateCompression.Name()) {
+		if candidateCompression == nil ||
+			(options.RequiredCompression.Name() != candidateCompression.Name() && options.RequiredCompression.Name() != candidateCompression.BaseVariantName()) {
 			return false
 		}
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -169,7 +169,8 @@ func NormalizedMIMEType(input string) string {
 
 // CompressionAlgorithmIsUniversallySupported returns true if MIMETypeSupportsCompressionAlgorithm(mimeType, algo) returns true for all mimeType values.
 func CompressionAlgorithmIsUniversallySupported(algo compressiontypes.Algorithm) bool {
-	switch algo.Name() { // Should this use InternalUnstableUndocumentedMIMEQuestionMark() ?
+	// Compare the discussion about BaseVariantName in MIMETypeSupportsCompressionAlgorithm().
+	switch algo.Name() {
 	case compressiontypes.GzipAlgorithmName:
 		return true
 	default:
@@ -182,7 +183,9 @@ func MIMETypeSupportsCompressionAlgorithm(mimeType string, algo compressiontypes
 	if CompressionAlgorithmIsUniversallySupported(algo) {
 		return true
 	}
-	switch algo.Name() { // Should this use InternalUnstableUndocumentedMIMEQuestionMark() ?
+	// This does not use BaseVariantName: Plausibly a manifest format might support zstd but not have annotation fields.
+	// The logic might have to be more complex (and more ad-hoc) if more manifest formats, with more capabilities, emerge.
+	switch algo.Name() {
 	case compressiontypes.ZstdAlgorithmName, compressiontypes.ZstdChunkedAlgorithmName:
 		return mimeType == imgspecv1.MediaTypeImageManifest
 	default: // Includes Bzip2AlgorithmName and XzAlgorithmName, which are defined names but are not supported anywhere

--- a/internal/manifest/oci_index.go
+++ b/internal/manifest/oci_index.go
@@ -103,8 +103,8 @@ func addCompressionAnnotations(compressionAlgorithms []compression.Algorithm, an
 		*annotationsMap = map[string]string{}
 	}
 	for _, algo := range compressionAlgorithms {
-		switch algo.Name() {
-		case compression.ZstdAlgorithmName, compression.ZstdChunkedAlgorithmName: // Should this use InternalUnstableUndocumentedMIMEQuestionMark() ?
+		switch algo.BaseVariantName() {
+		case compression.ZstdAlgorithmName:
 			(*annotationsMap)[OCI1InstanceAnnotationCompressionZSTD] = OCI1InstanceAnnotationCompressionZSTDValue
 		default:
 			continue

--- a/manifest/common.go
+++ b/manifest/common.go
@@ -55,7 +55,7 @@ func compressionVariantMIMEType(variantTable []compressionMIMETypeSet, mimeType 
 	if variants != nil {
 		name := mtsUncompressed
 		if algorithm != nil {
-			name = algorithm.InternalUnstableUndocumentedMIMEQuestionMark()
+			name = algorithm.BaseVariantName()
 		}
 		if res, ok := variants[name]; ok {
 			if res != mtsUnsupportedMIMEType {

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -31,7 +31,7 @@ var (
 	Zstd = internal.NewAlgorithm(types.ZstdAlgorithmName, types.ZstdAlgorithmName,
 		[]byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, zstdCompressor)
 	// ZstdChunked is a Zstd compression with chunk metadta which allows random access to individual files.
-	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName, /* Note: InternalUnstableUndocumentedMIMEQuestionMark is not ZstdChunkedAlgorithmName */
+	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName, /* Note: BaseVariantName is not ZstdChunkedAlgorithmName */
 		nil, ZstdDecompressor, compressor.ZstdCompressor)
 
 	compressionAlgorithms = map[string]Algorithm{

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -19,19 +19,19 @@ type Algorithm = types.Algorithm
 
 var (
 	// Gzip compression.
-	Gzip = internal.NewAlgorithm(types.GzipAlgorithmName, types.GzipAlgorithmName,
+	Gzip = internal.NewAlgorithm(types.GzipAlgorithmName, "",
 		[]byte{0x1F, 0x8B, 0x08}, GzipDecompressor, gzipCompressor)
 	// Bzip2 compression.
-	Bzip2 = internal.NewAlgorithm(types.Bzip2AlgorithmName, types.Bzip2AlgorithmName,
+	Bzip2 = internal.NewAlgorithm(types.Bzip2AlgorithmName, "",
 		[]byte{0x42, 0x5A, 0x68}, Bzip2Decompressor, bzip2Compressor)
 	// Xz compression.
-	Xz = internal.NewAlgorithm(types.XzAlgorithmName, types.XzAlgorithmName,
+	Xz = internal.NewAlgorithm(types.XzAlgorithmName, "",
 		[]byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}, XzDecompressor, xzCompressor)
 	// Zstd compression.
-	Zstd = internal.NewAlgorithm(types.ZstdAlgorithmName, types.ZstdAlgorithmName,
+	Zstd = internal.NewAlgorithm(types.ZstdAlgorithmName, "",
 		[]byte{0x28, 0xb5, 0x2f, 0xfd}, ZstdDecompressor, zstdCompressor)
-	// ZstdChunked is a Zstd compression with chunk metadta which allows random access to individual files.
-	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName, /* Note: BaseVariantName is not ZstdChunkedAlgorithmName */
+	// ZstdChunked is a Zstd compression with chunk metadata which allows random access to individual files.
+	ZstdChunked = internal.NewAlgorithm(types.ZstdChunkedAlgorithmName, types.ZstdAlgorithmName,
 		nil, ZstdDecompressor, compressor.ZstdCompressor)
 
 	compressionAlgorithms = map[string]Algorithm{

--- a/pkg/compression/internal/types.go
+++ b/pkg/compression/internal/types.go
@@ -12,23 +12,23 @@ type DecompressorFunc func(io.Reader) (io.ReadCloser, error)
 
 // Algorithm is a compression algorithm that can be used for CompressStream.
 type Algorithm struct {
-	name         string
-	mime         string
-	prefix       []byte // Initial bytes of a stream compressed using this algorithm, or empty to disable detection.
-	decompressor DecompressorFunc
-	compressor   CompressorFunc
+	name            string
+	baseVariantName string
+	prefix          []byte // Initial bytes of a stream compressed using this algorithm, or empty to disable detection.
+	decompressor    DecompressorFunc
+	compressor      CompressorFunc
 }
 
 // NewAlgorithm creates an Algorithm instance.
 // This function exists so that Algorithm instances can only be created by code that
 // is allowed to import this internal subpackage.
-func NewAlgorithm(name, mime string, prefix []byte, decompressor DecompressorFunc, compressor CompressorFunc) Algorithm {
+func NewAlgorithm(name, baseVariantName string, prefix []byte, decompressor DecompressorFunc, compressor CompressorFunc) Algorithm {
 	return Algorithm{
-		name:         name,
-		mime:         mime,
-		prefix:       prefix,
-		decompressor: decompressor,
-		compressor:   compressor,
+		name:            name,
+		baseVariantName: baseVariantName,
+		prefix:          prefix,
+		decompressor:    decompressor,
+		compressor:      compressor,
 	}
 }
 
@@ -37,10 +37,11 @@ func (c Algorithm) Name() string {
 	return c.name
 }
 
-// InternalUnstableUndocumentedMIMEQuestionMark ???
-// DO NOT USE THIS anywhere outside of c/image until it is properly documented.
-func (c Algorithm) InternalUnstableUndocumentedMIMEQuestionMark() string {
-	return c.mime
+// BaseVariantName returns the name of the “base variant” of the compression algorithm.
+// It is either equal to Name() of the same algorithm, or equal to Name() of some other Algorithm (the “base variant”).
+// This supports a single level of “is-a” relationship between compression algorithms, e.g. where "zstd:chunked" data is valid "zstd" data.
+func (c Algorithm) BaseVariantName() string {
+	return c.baseVariantName
 }
 
 // AlgorithmCompressor returns the compressor field of algo.

--- a/pkg/compression/internal/types.go
+++ b/pkg/compression/internal/types.go
@@ -20,9 +20,14 @@ type Algorithm struct {
 }
 
 // NewAlgorithm creates an Algorithm instance.
+// nontrivialBaseVariantName is typically "".
 // This function exists so that Algorithm instances can only be created by code that
 // is allowed to import this internal subpackage.
-func NewAlgorithm(name, baseVariantName string, prefix []byte, decompressor DecompressorFunc, compressor CompressorFunc) Algorithm {
+func NewAlgorithm(name, nontrivialBaseVariantName string, prefix []byte, decompressor DecompressorFunc, compressor CompressorFunc) Algorithm {
+	baseVariantName := name
+	if nontrivialBaseVariantName != "" {
+		baseVariantName = nontrivialBaseVariantName
+	}
 	return Algorithm{
 		name:            name,
 		baseVariantName: baseVariantName,


### PR DESCRIPTION
This is not expected to change observable behavior for now, just improve the internal logic. See individual commit messages for details.

@giuseppe PTAL.