### PR TITLE
Update to Go 1.20

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -671,10 +671,14 @@ func parseRegistryWarningHeader(header string) string {
 
 	// warning-value = warn-code SP warn-agent SP warn-text	[ SP warn-date ]
 	// distribution-spec requires warn-code=299, warn-agent="-", warn-date missing
-	if !strings.HasPrefix(header, expectedPrefix) || !strings.HasSuffix(header, expectedSuffix) {
+	header, ok := strings.CutPrefix(header, expectedPrefix)
+	if !ok {
 		return ""
 	}
-	header = header[len(expectedPrefix) : len(header)-len(expectedSuffix)]
+	header, ok = strings.CutSuffix(header, expectedSuffix)
+	if !ok {
+		return ""
+	}
 
 	// ”Recipients that process the value of a quoted-string MUST handle a quoted-pair
 	// as if it were replaced by the octet following the backslash.”, so let’s do that…

--- a/docker/docker_transport.go
+++ b/docker/docker_transport.go
@@ -54,16 +54,12 @@ type dockerReference struct {
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an Docker ImageReference.
 func ParseReference(refString string) (types.ImageReference, error) {
-	if !strings.HasPrefix(refString, "//") {
+	refString, ok := strings.CutPrefix(refString, "//")
+	if !ok {
 		return nil, fmt.Errorf("docker: image reference %s does not start with //", refString)
 	}
-	// Check if ref has UnknownDigestSuffix suffixed to it
-	unknownDigest := false
-	if strings.HasSuffix(refString, UnknownDigestSuffix) {
-		unknownDigest = true
-		refString = strings.TrimSuffix(refString, UnknownDigestSuffix)
-	}
-	ref, err := reference.ParseNormalizedNamed(strings.TrimPrefix(refString, "//"))
+	refString, unknownDigest := strings.CutSuffix(refString, UnknownDigestSuffix)
+	ref, err := reference.ParseNormalizedNamed(refString)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_transport_test.go
+++ b/docker/docker_transport_test.go
@@ -125,14 +125,14 @@ func TestNewReference(t *testing.T) {
 func TestNewReferenceUnknownDigest(t *testing.T) {
 	// References with tags and digests should be rejected
 	for _, c := range validReferenceTestCases {
-		if !strings.Contains(c.input, unknownDigestSuffixTest) {
+		in, ok := strings.CutSuffix(c.input, unknownDigestSuffixTest)
+		if !ok {
 			parsed, err := reference.ParseNormalizedNamed(c.input)
 			require.NoError(t, err)
 			_, err = NewReferenceUnknownDigest(parsed)
 			assert.Error(t, err)
 			continue
 		}
-		in := strings.TrimSuffix(c.input, unknownDigestSuffixTest)
 		parsed, err := reference.ParseNormalizedNamed(in)
 		require.NoError(t, err)
 		ref, err := NewReferenceUnknownDigest(parsed)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/image/v5
 
-go 1.19
+go 1.20
 
 require (
 	dario.cat/mergo v1.0.0

--- a/internal/signature/sigstore.go
+++ b/internal/signature/sigstore.go
@@ -1,10 +1,10 @@
 package signature
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -45,7 +45,7 @@ type sigstoreJSONRepresentation struct {
 func SigstoreFromComponents(untrustedMimeType string, untrustedPayload []byte, untrustedAnnotations map[string]string) Sigstore {
 	return Sigstore{
 		untrustedMIMEType:    untrustedMimeType,
-		untrustedPayload:     slices.Clone(untrustedPayload),
+		untrustedPayload:     bytes.Clone(untrustedPayload),
 		untrustedAnnotations: maps.Clone(untrustedAnnotations),
 	}
 }
@@ -79,7 +79,7 @@ func (s Sigstore) UntrustedMIMEType() string {
 	return s.untrustedMIMEType
 }
 func (s Sigstore) UntrustedPayload() []byte {
-	return slices.Clone(s.untrustedPayload)
+	return bytes.Clone(s.untrustedPayload)
 }
 
 func (s Sigstore) UntrustedAnnotations() map[string]string {

--- a/internal/signature/simple.go
+++ b/internal/signature/simple.go
@@ -1,6 +1,6 @@
 package signature
 
-import "golang.org/x/exp/slices"
+import "bytes"
 
 // SimpleSigning is a “simple signing” signature.
 type SimpleSigning struct {
@@ -10,7 +10,7 @@ type SimpleSigning struct {
 // SimpleSigningFromBlob converts a “simple signing” signature into a SimpleSigning object.
 func SimpleSigningFromBlob(blobChunk []byte) SimpleSigning {
 	return SimpleSigning{
-		untrustedSignature: slices.Clone(blobChunk),
+		untrustedSignature: bytes.Clone(blobChunk),
 	}
 }
 
@@ -21,9 +21,9 @@ func (s SimpleSigning) FormatID() FormatID {
 // blobChunk returns a representation of signature as a []byte, suitable for long-term storage.
 // Almost everyone should use signature.Blob() instead.
 func (s SimpleSigning) blobChunk() ([]byte, error) {
-	return slices.Clone(s.untrustedSignature), nil
+	return bytes.Clone(s.untrustedSignature), nil
 }
 
 func (s SimpleSigning) UntrustedSignature() []byte {
-	return slices.Clone(s.untrustedSignature)
+	return bytes.Clone(s.untrustedSignature)
 }

--- a/manifest/oci.go
+++ b/manifest/oci.go
@@ -182,11 +182,12 @@ func getEncryptedMediaType(mediatype string) (string, error) {
 // getEncryptedMediaType will return the mediatype to its encrypted counterpart and return
 // an error if the mediatype does not support decryption
 func getDecryptedMediaType(mediatype string) (string, error) {
-	if !strings.HasSuffix(mediatype, "+encrypted") {
+	res, ok := strings.CutSuffix(mediatype, "+encrypted")
+	if !ok {
 		return "", fmt.Errorf("unsupported mediaType to decrypt: %v", mediatype)
 	}
 
-	return strings.TrimSuffix(mediatype, "+encrypted"), nil
+	return res, nil
 }
 
 // Serialize returns the manifest in a blob format.

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -190,7 +190,7 @@ func (o ostreeReader) Read(p []byte) (int, error) {
 	if count == 0 {
 		return 0, io.EOF
 	}
-	data := (*[1 << 30]byte)(unsafe.Pointer(C.g_bytes_get_data(b, nil)))[:count:count]
+	data := unsafe.Slice((*byte)(C.g_bytes_get_data(b, nil)), count)
 	copy(p, data)
 	return count, nil
 }

--- a/pkg/blobinfocache/internal/prioritize/prioritize_test.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize_test.go
@@ -21,27 +21,23 @@ const (
 )
 
 var (
-	// cssLiteral contains a non-trivial candidateSortState shared among several tests below.
-	cssLiteral = candidateSortState{
-		cs: []CandidateWithTime{
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A1"}, CompressorName: compressiontypes.XzAlgorithmName}, time.Unix(1, 0)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U2"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(1, 1)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A2"}, CompressorName: blobinfocache.Uncompressed}, time.Unix(1, 1)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P1"}, CompressorName: blobinfocache.UnknownCompression}, time.Unix(1, 0)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B1"}, CompressorName: compressiontypes.Bzip2AlgorithmName}, time.Unix(1, 1)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P2"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(1, 1)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B2"}, CompressorName: blobinfocache.Uncompressed}, time.Unix(2, 0)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U1"}, CompressorName: blobinfocache.UnknownCompression}, time.Unix(1, 0)},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
-			{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
-		},
-		primaryDigest:      digestCompressedPrimary,
-		uncompressedDigest: digestUncompressed,
+	// inputReplacementCandidates contains a non-trivial candidateSortState shared among several tests below.
+	inputReplacementCandidates = []CandidateWithTime{
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A1"}, CompressorName: compressiontypes.XzAlgorithmName}, time.Unix(1, 0)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U2"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(1, 1)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, Location: types.BICLocationReference{Opaque: "A2"}, CompressorName: blobinfocache.Uncompressed}, time.Unix(1, 1)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P1"}, CompressorName: blobinfocache.UnknownCompression}, time.Unix(1, 0)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B1"}, CompressorName: compressiontypes.Bzip2AlgorithmName}, time.Unix(1, 1)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P2"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(1, 1)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B2"}, CompressorName: blobinfocache.Uncompressed}, time.Unix(2, 0)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, Location: types.BICLocationReference{Opaque: "U1"}, CompressorName: blobinfocache.UnknownCompression}, time.Unix(1, 0)},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestUncompressed, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedA, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedB, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
+		{blobinfocache.BICReplacementCandidate2{Digest: digestCompressedPrimary, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression}, time.Time{}},
 	}
-	// cssExpectedReplacementCandidates is the fully-sorted, unlimited, result of prioritizing cssLiteral.
-	cssExpectedReplacementCandidates = []blobinfocache.BICReplacementCandidate2{
+	// expectedReplacementCandidates is the fully-sorted, unlimited, result of prioritizing inputReplacementCandidates.
+	expectedReplacementCandidates = []blobinfocache.BICReplacementCandidate2{
 		{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P2"}, CompressorName: compressiontypes.GzipAlgorithmName},
 		{Digest: digestCompressedPrimary, Location: types.BICLocationReference{Opaque: "P1"}, CompressorName: blobinfocache.UnknownCompression},
 		{Digest: digestCompressedB, Location: types.BICLocationReference{Opaque: "B2"}, CompressorName: blobinfocache.Uncompressed},
@@ -56,14 +52,6 @@ var (
 		{Digest: digestUncompressed, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}, CompressorName: blobinfocache.UnknownCompression},
 	}
 )
-
-func TestCandidateSortStateLen(t *testing.T) {
-	css := cssLiteral
-	assert.Equal(t, 12, css.Len())
-
-	css.cs = []CandidateWithTime{}
-	assert.Equal(t, 0, css.Len())
-}
 
 func TestCandidateSortStateLess(t *testing.T) {
 	type p struct {
@@ -83,25 +71,23 @@ func TestCandidateSortStateLess(t *testing.T) {
 	} {
 		for _, tms := range [][2]int64{{1, 2}, {2, 1}, {1, 1}} {
 			caseName := fmt.Sprintf("%s %v", c.name, tms)
+			c0 := CandidateWithTime{blobinfocache.BICReplacementCandidate2{Digest: c.d0, Location: types.BICLocationReference{Opaque: "L0"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(tms[0], 0)}
+			c1 := CandidateWithTime{blobinfocache.BICReplacementCandidate2{Digest: c.d1, Location: types.BICLocationReference{Opaque: "L1"}, CompressorName: compressiontypes.ZstdAlgorithmName}, time.Unix(tms[1], 0)}
 			css := candidateSortState{
-				cs: []CandidateWithTime{
-					{blobinfocache.BICReplacementCandidate2{Digest: c.d0, Location: types.BICLocationReference{Opaque: "L0"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(tms[0], 0)},
-					{blobinfocache.BICReplacementCandidate2{Digest: c.d1, Location: types.BICLocationReference{Opaque: "L1"}, CompressorName: compressiontypes.ZstdAlgorithmName}, time.Unix(tms[1], 0)},
-				},
 				primaryDigest:      digestCompressedPrimary,
 				uncompressedDigest: digestUncompressed,
 			}
-			assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
-			assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+			assert.Equal(t, c.res, css.compare(c0, c1), caseName)
+			assert.Equal(t, -c.res, css.compare(c1, c0), caseName)
 
 			if c.d0 != digestUncompressed && c.d1 != digestUncompressed {
 				css.uncompressedDigest = ""
-				assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
-				assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+				assert.Equal(t, c.res, css.compare(c0, c1), caseName)
+				assert.Equal(t, -c.res, css.compare(c1, c0), caseName)
 
 				css.uncompressedDigest = css.primaryDigest
-				assert.Equal(t, c.res < 0, css.Less(0, 1), caseName)
-				assert.Equal(t, c.res > 0, css.Less(1, 0), caseName)
+				assert.Equal(t, c.res, css.compare(c0, c1), caseName)
+				assert.Equal(t, -c.res, css.compare(c1, c0), caseName)
 			}
 		}
 	}
@@ -122,62 +108,42 @@ func TestCandidateSortStateLess(t *testing.T) {
 		{"any: t=1 == t=1, d=A < d=B", -1, p{digestCompressedA, 1}, p{digestCompressedB, 1}},
 		{"any: t=1 == t=1, d=A == d=A", 0, p{digestCompressedA, 1}, p{digestCompressedA, 1}},
 	} {
+		c0 := CandidateWithTime{blobinfocache.BICReplacementCandidate2{Digest: c.p0.d, Location: types.BICLocationReference{Opaque: "L0"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(c.p0.t, 0)}
+		c1 := CandidateWithTime{blobinfocache.BICReplacementCandidate2{Digest: c.p1.d, Location: types.BICLocationReference{Opaque: "L1"}, CompressorName: compressiontypes.ZstdAlgorithmName}, time.Unix(c.p1.t, 0)}
 		css := candidateSortState{
-			cs: []CandidateWithTime{
-				{blobinfocache.BICReplacementCandidate2{Digest: c.p0.d, Location: types.BICLocationReference{Opaque: "L0"}, CompressorName: compressiontypes.GzipAlgorithmName}, time.Unix(c.p0.t, 0)},
-				{blobinfocache.BICReplacementCandidate2{Digest: c.p1.d, Location: types.BICLocationReference{Opaque: "L1"}, CompressorName: compressiontypes.ZstdAlgorithmName}, time.Unix(c.p1.t, 0)},
-			},
 			primaryDigest:      digestCompressedPrimary,
 			uncompressedDigest: digestUncompressed,
 		}
-		assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
-		assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+		assert.Equal(t, c.res, css.compare(c0, c1), c.name)
+		assert.Equal(t, -c.res, css.compare(c1, c0), c.name)
 
 		if c.p0.d != digestUncompressed && c.p1.d != digestUncompressed {
 			css.uncompressedDigest = ""
-			assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
-			assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+			assert.Equal(t, c.res, css.compare(c0, c1), c.name)
+			assert.Equal(t, -c.res, css.compare(c1, c0), c.name)
 
 			css.uncompressedDigest = css.primaryDigest
-			assert.Equal(t, c.res < 0, css.Less(0, 1), c.name)
-			assert.Equal(t, c.res > 0, css.Less(1, 0), c.name)
+			assert.Equal(t, c.res, css.compare(c0, c1), c.name)
+			assert.Equal(t, -c.res, css.compare(c1, c0), c.name)
 		}
 	}
-}
-
-func TestCandidateSortStateSwap(t *testing.T) {
-	freshCSS := func() candidateSortState { // Return a deep copy of cssLiteral which is safe to modify.
-		res := cssLiteral
-		res.cs = slices.Clone(cssLiteral.cs)
-		return res
-	}
-
-	css := freshCSS()
-	css.Swap(0, 1)
-	assert.Equal(t, cssLiteral.cs[1], css.cs[0])
-	assert.Equal(t, cssLiteral.cs[0], css.cs[1])
-	assert.Equal(t, cssLiteral.cs[2], css.cs[2])
-
-	css = freshCSS()
-	css.Swap(1, 1)
-	assert.Equal(t, cssLiteral, css)
 }
 
 func TestDestructivelyPrioritizeReplacementCandidatesWithMax(t *testing.T) {
 	totalUnknownLocationCandidates := 4
 	for _, totalLimit := range []int{0, 1, replacementAttempts, 100, replacementUnknownLocationAttempts} {
 		for _, noLocationLimit := range []int{0, 1, replacementAttempts, 100, replacementUnknownLocationAttempts} {
-			totalKnownLocationCandidates := len(cssExpectedReplacementCandidates) - totalUnknownLocationCandidates
+			totalKnownLocationCandidates := len(expectedReplacementCandidates) - totalUnknownLocationCandidates
 			allowedUnknown := min(noLocationLimit, totalUnknownLocationCandidates)
 			expectedLen := min(totalKnownLocationCandidates+allowedUnknown, totalLimit)
-			res := destructivelyPrioritizeReplacementCandidatesWithMax(slices.Clone(cssLiteral.cs), digestCompressedPrimary, digestUncompressed, totalLimit, noLocationLimit)
-			assert.Equal(t, cssExpectedReplacementCandidates[:expectedLen], res)
+			res := destructivelyPrioritizeReplacementCandidatesWithMax(slices.Clone(inputReplacementCandidates), digestCompressedPrimary, digestUncompressed, totalLimit, noLocationLimit)
+			assert.Equal(t, expectedReplacementCandidates[:expectedLen], res)
 		}
 	}
 }
 
 func TestDestructivelyPrioritizeReplacementCandidates(t *testing.T) {
 	// Just a smoke test; we mostly rely on test coverage in TestCandidateSortStateLess
-	res := DestructivelyPrioritizeReplacementCandidates(slices.Clone(cssLiteral.cs), digestCompressedPrimary, digestUncompressed)
-	assert.Equal(t, cssExpectedReplacementCandidates[:replacementAttempts], res)
+	res := DestructivelyPrioritizeReplacementCandidates(slices.Clone(inputReplacementCandidates), digestCompressedPrimary, digestUncompressed)
+	assert.Equal(t, expectedReplacementCandidates[:replacementAttempts], res)
 }

--- a/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/pkg/tlsclientconfig/tlsclientconfig.go
@@ -55,9 +55,9 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			}
 			tlsc.RootCAs.AppendCertsFromPEM(data)
 		}
-		if strings.HasSuffix(f.Name(), ".cert") {
+		if base, ok := strings.CutSuffix(f.Name(), ".cert"); ok {
 			certName := f.Name()
-			keyName := certName[:len(certName)-5] + ".key"
+			keyName := base + ".key"
 			logrus.Debugf(" cert: %s", fullPath)
 			if !hasFile(fs, keyName) {
 				return fmt.Errorf("missing key %s for client certificate %s. Note that CA certificates should use the extension .crt", keyName, certName)
@@ -68,9 +68,9 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			}
 			tlsc.Certificates = append(slices.Clone(tlsc.Certificates), cert)
 		}
-		if strings.HasSuffix(f.Name(), ".key") {
+		if base, ok := strings.CutSuffix(f.Name(), ".key"); ok {
 			keyName := f.Name()
-			certName := keyName[:len(keyName)-4] + ".cert"
+			certName := base + ".cert"
 			logrus.Debugf(" key: %s", fullPath)
 			if !hasFile(fs, certName) {
 				return fmt.Errorf("missing client certificate %s for key %s", certName, keyName)

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // assert that crypto.PublicKey matches the on in certPEM.
@@ -136,7 +135,7 @@ func TestFulcioIssuerInCertificate(t *testing.T) {
 			extensions: []pkix.Extension{
 				{
 					Id:    certificate.OIDIssuerV2,
-					Value: append(slices.Clone(asn1MarshalTest(t, "https://", "utf8")), asn1MarshalTest(t, "example.com", "utf8")...),
+					Value: append(bytes.Clone(asn1MarshalTest(t, "https://", "utf8")), asn1MarshalTest(t, "example.com", "utf8")...),
 				},
 			},
 			errorFragment: "invalid ASN.1 in OIDC issuer v2 extension, trailing data",

--- a/signature/internal/sigstore_payload_test.go
+++ b/signature/internal/sigstore_payload_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -14,7 +15,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // A short-hand way to get a JSON object field value or panic. No error handling done, we know
@@ -284,7 +284,7 @@ func TestVerifySigstorePayload(t *testing.T) {
 	for _, invalidSig := range [][]byte{
 		{}, // Empty signature
 		[]byte("invalid signature"),
-		append(slices.Clone(validSignatureBytes), validSignatureBytes...),
+		append(bytes.Clone(validSignatureBytes), validSignatureBytes...),
 	} {
 		recorded = acceptanceData{}
 		res, err = VerifySigstorePayload(publicKey, sigstoreSig.UntrustedPayload(), base64.StdEncoding.EncodeToString(invalidSig), recordingRules)

--- a/signature/policy_config_test.go
+++ b/signature/policy_config_test.go
@@ -296,10 +296,10 @@ func addExtraJSONMember(t *testing.T, encoded []byte, name string, extra any) []
 	extraJSON, err := json.Marshal(extra)
 	require.NoError(t, err)
 
-	require.True(t, bytes.HasSuffix(encoded, []byte("}")))
-	preservedLen := len(encoded) - 1
+	preserved, ok := bytes.CutSuffix(encoded, []byte("}"))
+	require.True(t, ok)
 
-	res := bytes.Join([][]byte{encoded[:preservedLen], []byte(`,"`), []byte(name), []byte(`":`), extraJSON, []byte("}")}, nil)
+	res := bytes.Join([][]byte{preserved, []byte(`,"`), []byte(name), []byte(`":`), extraJSON, []byte("}")}, nil)
 	// Verify that the result is valid JSON, as a sanity check that we are actually triggering
 	// the “duplicate member” case in the caller.
 	var raw map[string]any

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -1189,7 +1189,7 @@ func (s *storageImageDestination) PutManifest(ctx context.Context, manifestBlob 
 	if err != nil {
 		return err
 	}
-	s.manifest = slices.Clone(manifestBlob)
+	s.manifest = bytes.Clone(manifestBlob)
 	s.manifestDigest = digest
 	return nil
 }


### PR DESCRIPTION
After https://github.com/containers/image/pull/2337 (notably https://github.com/go-openapi/swag/compare/v0.22.10...v0.23.0 ), we require Go 1.20 to build.

So, update to it formally, and take advantage of new standard library features.