### PR TITLE
Add support for Docker HealthConfig.StartInterval (v25.0.0+)

### DIFF
--- a/manifest/docker_schema2.go
+++ b/manifest/docker_schema2.go
@@ -54,9 +54,10 @@ type Schema2HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	StartPeriod time.Duration `json:",omitempty"` // StartPeriod is the time to wait after starting before running the first check.
-	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod   time.Duration `json:",omitempty"` // StartPeriod is the time to wait after starting before running the first check.
+	StartInterval time.Duration `json:",omitempty"` // StartInterval is the time to wait between checks during the start period.
+	Interval      time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout       time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.


### PR DESCRIPTION
I'm trying to add support for Dockerfile HEALTHCHECK --start-interval param which has been added in Docker v25.0.0.
So I figured out I have to update this library as well.
The change is quite trivial but I couldn't say that I understand completely what I'm doing so feedback is appreciated.