### PR TITLE
Add a helper for formatting multiple errors

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/iolimits"
+	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/set"
 	"github.com/containers/image/v5/internal/useragent"
 	"github.com/containers/image/v5/manifest"
@@ -1011,11 +1012,7 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 	if remoteErrors == nil {
 		return nil, 0, nil // fallback to non-external blob
 	}
-	err := fmt.Errorf("failed fetching external blob from all urls: %w", remoteErrors[0])
-	for _, e := range remoteErrors[1:] {
-		err = fmt.Errorf("%s, %w", err, e)
-	}
-	return nil, 0, err
+	return nil, 0, fmt.Errorf("failed fetching external blob from all urls: %w", multierr.Format("", ", ", "", remoteErrors))
 }
 
 func getBlobSize(resp *http.Response) int64 {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/klauspost/compress v1.17.7
 	github.com/klauspost/pgzip v1.2.6
@@ -91,6 +90,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20230907030200-6d76a0f91e1e // indirect

--- a/internal/multierr/multierr.go
+++ b/internal/multierr/multierr.go
@@ -1,0 +1,34 @@
+package multierr
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Format creates an error value from the input array (which should not be empty)
+// If the input contains a single error value, it is returned as is.
+// If there are multiple, they are formatted as a multi-error (with Unwrap() []error) with the provided initial, separator, and ending strings.
+//
+// Typical usage:
+//
+//	var errs []error
+//	// …
+//	errs = append(errs, …)
+//	// …
+//	if errs != nil { return multierr.Format("Failures doing $FOO", "\n* ", "", errs)}
+func Format(first, middle, last string, errs []error) error {
+	switch len(errs) {
+	case 0:
+		return fmt.Errorf("internal error: multierr.Format called with 0 errors")
+	case 1:
+		return errs[0]
+	default:
+		// We have to do this — and this function only really exists — because fmt.Errorf(format, errs...) is invalid:
+		// []error is not a valid parameter to a function expecting []any
+		anyErrs := make([]any, 0, len(errs))
+		for _, e := range errs {
+			anyErrs = append(anyErrs, e)
+		}
+		return fmt.Errorf(first+"%w"+strings.Repeat(middle+"%w", len(errs)-1)+last, anyErrs...)
+	}
+}

--- a/internal/multierr/multierr_test.go
+++ b/internal/multierr/multierr_test.go
@@ -1,0 +1,39 @@
+package multierr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type errA struct{}
+
+func (errA) Error() string { return "A" }
+
+func TestFormat(t *testing.T) {
+	errB := errors.New("B")
+
+	// Single-item Format preserves the error type
+	res := Format("[", ",", "]", []error{errA{}})
+	assert.Equal(t, "A", res.Error())
+	var aTarget errA
+	assert.ErrorAs(t, res, &aTarget)
+
+	// Single-item Format preserves the error identity
+	res = Format("[", ",", "]", []error{errB})
+	assert.Equal(t, "B", res.Error())
+	assert.ErrorIs(t, res, errB)
+
+	// Multi-item Format preserves both
+	res = Format("[", ",", "]", []error{errA{}, errB})
+	assert.Equal(t, "[A,B]", res.Error())
+	assert.ErrorAs(t, res, &aTarget)
+	assert.ErrorIs(t, res, errB)
+
+	// This is invalid, but make sure we don’t misleadingly suceeed
+	res = Format("[", ",", "]", []error{})
+	assert.Error(t, res)
+	res = Format("[", ",", "]", nil)
+	assert.Error(t, res)
+}

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -298,7 +298,7 @@ func newShortNameAliasCache(path string, conf *shortNameAliasConf) (*shortNameAl
 		}
 	}
 	if len(errs) > 0 {
-		return nil, multierr.Format("", "\n: ", "", errs)
+		return nil, multierr.Format("", "\n", "", errs)
 	}
 	return &res, nil
 }

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/rootless"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
@@ -297,11 +298,7 @@ func newShortNameAliasCache(path string, conf *shortNameAliasConf) (*shortNameAl
 		}
 	}
 	if len(errs) > 0 {
-		err := errs[0]
-		for i := 1; i < len(errs); i++ {
-			err = fmt.Errorf("%v\n: %w", errs[i], err)
-		}
-		return nil, err
+		return nil, multierr.Format("", "\n: ", "", errs)
 	}
 	return &res, nil
 }

--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/manifest"
 	digest "github.com/opencontainers/go-digest"
@@ -134,12 +134,7 @@ func (pr *prSignedBy) isRunningImageAllowed(ctx context.Context, image private.U
 	case 1:
 		summary = rejections[0]
 	default:
-		var msgs []string
-		for _, e := range rejections {
-			msgs = append(msgs, e.Error())
-		}
-		summary = PolicyRequirementError(fmt.Sprintf("None of the signatures were accepted, reasons: %s",
-			strings.Join(msgs, "; ")))
+		summary = PolicyRequirementError(multierr.Format("None of the signatures were accepted, reasons: ", "; ", "", rejections).Error())
 	}
 	return false, summary
 }

--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/internal/signature"
 	"github.com/containers/image/v5/manifest"
@@ -270,12 +270,7 @@ func (pr *prSigstoreSigned) isRunningImageAllowed(ctx context.Context, image pri
 	case 1:
 		summary = rejections[0]
 	default:
-		var msgs []string
-		for _, e := range rejections {
-			msgs = append(msgs, e.Error())
-		}
-		summary = PolicyRequirementError(fmt.Sprintf("None of the signatures were accepted, reasons: %s",
-			strings.Join(msgs, "; ")))
+		summary = PolicyRequirementError(multierr.Format("None of the signatures were accepted, reasons: ", "; ", "", rejections).Error())
 	}
 	return false, summary
 }


### PR DESCRIPTION
As of Go 1.20, the standard library supposedly contains infrastructure for reporting multiple errors.

Sadly, that infrastructure is mostly unhelpful: `errors.Join` gives no control over formatting, and `fmt.Errorf` does not support a `[]error` input. So, introduce our own `multierr.Format`, and use it where possible.

Then remove the `go-multierror` dependency. The net result is not particularly better _code_, but at least we try to work with the standard library design.

(This was originally motivated just by trying to remove the `go-multierror` dependency in #2364, now that the standard library supposedly supports the feature.)

This might, in some cases, change whether the returned error matches `errors.{As,Is}`, mostly because the previous code for aggregating multiple errors was written before Go 1.20 made it possible for multiple errors to match. (Not that I know how the multi-matching design can ever be all that useful…)

See individual commit messages for details.