### PR TITLE
Avoid a redundant function call

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -704,7 +704,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		canChangeLayerCompression := ic.src.CanChangeLayerCompression(srcInfo.MediaType)
 		logrus.Debugf("Checking if we can reuse blob %s: general substitution = %v, compression for MIME type %q = %v",
 			srcInfo.Digest, ic.canSubstituteBlobs, srcInfo.MediaType, canChangeLayerCompression)
-		canSubstitute := ic.canSubstituteBlobs && ic.src.CanChangeLayerCompression(srcInfo.MediaType)
+		canSubstitute := ic.canSubstituteBlobs && canChangeLayerCompression
 
 		var requiredCompression *compressiontypes.Algorithm
 		if ic.requireCompressionFormatMatch {

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -930,7 +930,6 @@ func (s *storageImageDestination) untrustedLayerDiffID(layerIndex int) (digest.D
 	// nothing is writing to s.manifest yet, or PutManifest has been called and s.manifest != nil.
 	// Either way this function does not need the protection of s.lock.
 	if s.manifest == nil {
-		logrus.Debugf("Skipping commit for layer %d, manifest not yet available", layerIndex)
 		return "", nil
 	}
 


### PR DESCRIPTION
This primarily ensures that we log and use the same value.

Should not change behavior.