### PR TITLE
storage: cleanup staged layer if unused

### DIFF
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -171,9 +171,7 @@ func (s *storageImageDestination) Close() error {
 		al.Release()
 	}
 	for _, v := range s.lockProtected.diffOutputs {
-		if v.Target != "" {
-			_ = s.imageRef.transport.store.CleanupStagedLayer(v)
-		}
+		_ = s.imageRef.transport.store.CleanupStagedLayer(v)
 	}
 	return os.RemoveAll(s.directory)
 }


### PR DESCRIPTION
notify c/storage that the staged layer is not used and must be cleaned up on error.