### PR TITLE
Fix CVE-2024-3727

### DIFF
--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -174,7 +174,10 @@ func (d *dirImageDestination) PutBlobWithOptions(ctx context.Context, stream io.
 		}
 	}
 
-	blobPath := d.ref.layerPath(blobDigest)
+	blobPath, err := d.ref.layerPath(blobDigest)
+	if err != nil {
+		return private.UploadedBlob{}, err
+	}
 	// need to explicitly close the file, since a rename won't otherwise not work on Windows
 	blobFile.Close()
 	explicitClosed = true
@@ -197,7 +200,10 @@ func (d *dirImageDestination) TryReusingBlobWithOptions(ctx context.Context, inf
 	if info.Digest == "" {
 		return false, private.ReusedBlob{}, fmt.Errorf("Can not check for a blob with unknown digest")
 	}
-	blobPath := d.ref.layerPath(info.Digest)
+	blobPath, err := d.ref.layerPath(info.Digest)
+	if err != nil {
+		return false, private.ReusedBlob{}, err
+	}
 	finfo, err := os.Stat(blobPath)
 	if err != nil && os.IsNotExist(err) {
 		return false, private.ReusedBlob{}, nil
@@ -217,7 +223,11 @@ func (d *dirImageDestination) TryReusingBlobWithOptions(ctx context.Context, inf
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dirImageDestination) PutManifest(ctx context.Context, manifest []byte, instanceDigest *digest.Digest) error {
-	return os.WriteFile(d.ref.manifestPath(instanceDigest), manifest, 0644)
+	path, err := d.ref.manifestPath(instanceDigest)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, manifest, 0644)
 }
 
 // PutSignaturesWithFormat writes a set of signatures to the destination.
@@ -230,7 +240,11 @@ func (d *dirImageDestination) PutSignaturesWithFormat(ctx context.Context, signa
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(d.ref.signaturePath(i, instanceDigest), blob, 0644); err != nil {
+		path, err := d.ref.signaturePath(i, instanceDigest)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, blob, 0644); err != nil {
 			return err
 		}
 	}

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -64,7 +64,7 @@ func TestGetPutManifest(t *testing.T) {
 func TestGetPutBlob(t *testing.T) {
 	computedBlob := []byte("test-blob")
 	providedBlob := []byte("provided-blob")
-	providedDigest := digest.Digest("sha256:provided-test-digest")
+	providedDigest := digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	ref, _ := refToTempDir(t)
 	cache := memory.New()
@@ -113,12 +113,13 @@ func (fn readerFromFunc) Read(p []byte) (int, error) {
 // TestPutBlobDigestFailure simulates behavior on digest verification failure.
 func TestPutBlobDigestFailure(t *testing.T) {
 	const digestErrorString = "Simulated digest error"
-	const blobDigest = digest.Digest("sha256:test-digest")
+	const blobDigest = digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	ref, _ := refToTempDir(t)
 	dirRef, ok := ref.(dirReference)
 	require.True(t, ok)
-	blobPath := dirRef.layerPath(blobDigest)
+	blobPath, err := dirRef.layerPath(blobDigest)
+	require.NoError(t, err)
 	cache := memory.New()
 
 	firstRead := true

--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -161,25 +161,34 @@ func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContex
 }
 
 // manifestPath returns a path for the manifest within a directory using our conventions.
-func (ref dirReference) manifestPath(instanceDigest *digest.Digest) string {
+func (ref dirReference) manifestPath(instanceDigest *digest.Digest) (string, error) {
 	if instanceDigest != nil {
-		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json")
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+			return "", err
+		}
+		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json"), nil
 	}
-	return filepath.Join(ref.path, "manifest.json")
+	return filepath.Join(ref.path, "manifest.json"), nil
 }
 
 // layerPath returns a path for a layer tarball within a directory using our conventions.
-func (ref dirReference) layerPath(digest digest.Digest) string {
+func (ref dirReference) layerPath(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+		return "", err
+	}
 	// FIXME: Should we keep the digest identification?
-	return filepath.Join(ref.path, digest.Encoded())
+	return filepath.Join(ref.path, digest.Encoded()), nil
 }
 
 // signaturePath returns a path for a signature within a directory using our conventions.
-func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) string {
+func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) (string, error) {
 	if instanceDigest != nil {
-		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1))
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+			return "", err
+		}
+		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1)), nil
 	}
-	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
+	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1)), nil
 }
 
 // versionPath returns a path for the version file within a directory using our conventions.

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -197,8 +197,15 @@ func TestReferenceManifestPath(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	dirRef, ok := ref.(dirReference)
 	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/manifest.json", dirRef.manifestPath(nil))
-	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".manifest.json", dirRef.manifestPath(&dhex))
+	res, err := dirRef.manifestPath(nil)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/manifest.json", res)
+	res, err = dirRef.manifestPath(&dhex)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".manifest.json", res)
+	invalidDigest := digest.Digest("sha256:../hello")
+	_, err = dirRef.manifestPath(&invalidDigest)
+	assert.Error(t, err)
 }
 
 func TestReferenceLayerPath(t *testing.T) {
@@ -207,7 +214,11 @@ func TestReferenceLayerPath(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	dirRef, ok := ref.(dirReference)
 	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/"+hex, dirRef.layerPath("sha256:"+hex))
+	res, err := dirRef.layerPath("sha256:" + hex)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/"+hex, res)
+	_, err = dirRef.layerPath(digest.Digest("sha256:../hello"))
+	assert.Error(t, err)
 }
 
 func TestReferenceSignaturePath(t *testing.T) {
@@ -216,10 +227,21 @@ func TestReferenceSignaturePath(t *testing.T) {
 	ref, tmpDir := refToTempDir(t)
 	dirRef, ok := ref.(dirReference)
 	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/signature-1", dirRef.signaturePath(0, nil))
-	assert.Equal(t, tmpDir+"/signature-10", dirRef.signaturePath(9, nil))
-	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-1", dirRef.signaturePath(0, &dhex))
-	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-10", dirRef.signaturePath(9, &dhex))
+	res, err := dirRef.signaturePath(0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/signature-1", res)
+	res, err = dirRef.signaturePath(9, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/signature-10", res)
+	res, err = dirRef.signaturePath(0, &dhex)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-1", res)
+	res, err = dirRef.signaturePath(9, &dhex)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-10", res)
+	invalidDigest := digest.Digest("sha256:../hello")
+	_, err = dirRef.signaturePath(0, &invalidDigest)
+	assert.Error(t, err)
 }
 
 func TestReferenceVersionPath(t *testing.T) {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -963,6 +963,8 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 	return c.detectPropertiesError
 }
 
+// fetchManifest fetches a manifest for (the repo of ref) + tagOrDigest.
+// The caller is responsible for ensuring tagOrDigest uses the expected format.
 func (c *dockerClient) fetchManifest(ctx context.Context, ref dockerReference, tagOrDigest string) ([]byte, string, error) {
 	path := fmt.Sprintf(manifestPath, reference.Path(ref.ref), tagOrDigest)
 	headers := map[string][]string{
@@ -1042,6 +1044,9 @@ func (c *dockerClient) getBlob(ctx context.Context, ref dockerReference, info ty
 		}
 	}
 
+	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
+		return nil, 0, err
+	}
 	path := fmt.Sprintf(blobsPath, reference.Path(ref.ref), info.Digest.String())
 	logrus.Debugf("Downloading %s", path)
 	res, err := c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
@@ -1105,7 +1110,10 @@ func isManifestUnknownError(err error) bool {
 // digest in ref.
 // It returns (nil, nil) if the manifest does not exist.
 func (c *dockerClient) getSigstoreAttachmentManifest(ctx context.Context, ref dockerReference, digest digest.Digest) (*manifest.OCI1, error) {
-	tag := sigstoreAttachmentTag(digest)
+	tag, err := sigstoreAttachmentTag(digest)
+	if err != nil {
+		return nil, err
+	}
 	sigstoreRef, err := reference.WithTag(reference.TrimNamed(ref.ref), tag)
 	if err != nil {
 		return nil, err
@@ -1138,6 +1146,9 @@ func (c *dockerClient) getSigstoreAttachmentManifest(ctx context.Context, ref do
 // getExtensionsSignatures returns signatures from the X-Registry-Supports-Signatures API extension,
 // using the original data structures.
 func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerReference, manifestDigest digest.Digest) (*extensionSignatureList, error) {
+	if err := manifestDigest.Validate(); err != nil { // Make sure manifestDigest.String() does not contain any unexpected characters
+		return nil, err
+	}
 	path := fmt.Sprintf(extensionsSignaturePath, reference.Path(ref.ref), manifestDigest)
 	res, err := c.makeRequest(ctx, http.MethodGet, path, nil, nil, v2Auth, nil)
 	if err != nil {
@@ -1161,8 +1172,11 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 }
 
 // sigstoreAttachmentTag returns a sigstore attachment tag for the specified digest.
-func sigstoreAttachmentTag(d digest.Digest) string {
-	return strings.Replace(d.String(), ":", "-", 1) + ".sig"
+func sigstoreAttachmentTag(d digest.Digest) (string, error) {
+	if err := d.Validate(); err != nil { // Make sure d.String() doesn’t contain any unexpected characters
+		return "", err
+	}
+	return strings.Replace(d.String(), ":", "-", 1) + ".sig", nil
 }
 
 // Close removes resources associated with an initialized dockerClient, if any.

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -88,7 +88,12 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 		if err = json.NewDecoder(res.Body).Decode(&tagsHolder); err != nil {
 			return nil, err
 		}
-		tags = append(tags, tagsHolder.Tags...)
+		for _, tag := range tagsHolder.Tags {
+			if _, err := reference.WithTag(dr.ref, tag); err != nil { // Ensure the tag does not contain unexpected values
+				return nil, fmt.Errorf("registry returned invalid tag %q: %w", tag, err)
+			}
+			tags = append(tags, tag)
+		}
 
 		link := res.Header.Get("Link")
 		if link == "" {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -624,9 +624,11 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 
 	// NOTE: Keep this in sync with docs/signature-protocols.md!
 	for i, signature := range signatures {
-		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
-		err := d.putOneSignature(sigURL, signature)
+		sigURL, err := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
 		if err != nil {
+			return err
+		}
+		if err := d.putOneSignature(sigURL, signature); err != nil {
 			return err
 		}
 	}
@@ -636,7 +638,10 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures []signature
 	// is enough for dockerImageSource to stop looking for other signatures, so that
 	// is sufficient.
 	for i := len(signatures); ; i++ {
-		sigURL := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(d.c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return err
+		}
 		missing, err := d.c.deleteOneSignature(sigURL)
 		if err != nil {
 			return err

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -230,6 +230,9 @@ func (d *dockerImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 // If the destination does not contain the blob, or it is unknown, blobExists ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
 func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScope *authScope) (bool, int64, error) {
+	if err := digest.Validate(); err != nil { // Make sure digest.String() does not contain any unexpected characters
+		return false, -1, err
+	}
 	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
 	logrus.Debugf("Checking %s", checkPath)
 	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
@@ -458,6 +461,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 		// particular instance.
 		refTail = instanceDigest.String()
 		// Double-check that the manifest we've been given matches the digest we've been given.
+		// This also validates the format of instanceDigest.
 		matches, err := manifest.MatchesDigest(m, *instanceDigest)
 		if err != nil {
 			return fmt.Errorf("digesting manifest in PutManifest: %w", err)
@@ -772,8 +776,12 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 	if err != nil {
 		return err
 	}
+	attachmentTag, err := sigstoreAttachmentTag(manifestDigest)
+	if err != nil {
+		return err
+	}
 	logrus.Debugf("Uploading sigstore attachment manifest")
-	return d.uploadManifest(ctx, manifestBlob, sigstoreAttachmentTag(manifestDigest))
+	return d.uploadManifest(ctx, manifestBlob, attachmentTag)
 }
 
 func layerMatchesSigstoreSignature(layer imgspecv1.Descriptor, mimeType string,
@@ -889,6 +897,7 @@ func (d *dockerImageDestination) putSignaturesToAPIExtension(ctx context.Context
 			return err
 		}
 
+		// manifestDigest is known to be valid because it was not rejected by getExtensionsSignatures above.
 		path := fmt.Sprintf(extensionsSignaturePath, reference.Path(d.ref.ref), manifestDigest.String())
 		res, err := d.c.makeRequest(ctx, http.MethodPut, path, nil, bytes.NewReader(body), v2Auth, nil)
 		if err != nil {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -462,7 +462,10 @@ func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context, inst
 			return nil, fmt.Errorf("server provided %d signatures, assuming that's unreasonable and a server error", maxLookasideSignatures)
 		}
 
-		sigURL := lookasideStorageURL(s.c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(s.c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return nil, err
+		}
 		signature, missing, err := s.getOneSignature(ctx, sigURL)
 		if err != nil {
 			return nil, err
@@ -660,7 +663,10 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 	}
 
 	for i := 0; ; i++ {
-		sigURL := lookasideStorageURL(c.signatureBase, manifestDigest, i)
+		sigURL, err := lookasideStorageURL(c.signatureBase, manifestDigest, i)
+		if err != nil {
+			return err
+		}
 		missing, err := c.deleteOneSignature(sigURL)
 		if err != nil {
 			return err

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -111,11 +111,19 @@ func (d *Destination) PutBlobWithOptions(ctx context.Context, stream io.Reader, 
 			return private.UploadedBlob{}, fmt.Errorf("reading Config file stream: %w", err)
 		}
 		d.config = buf
-		if err := d.archive.sendFileLocked(d.archive.configPath(inputInfo.Digest), inputInfo.Size, bytes.NewReader(buf)); err != nil {
+		configPath, err := d.archive.configPath(inputInfo.Digest)
+		if err != nil {
+			return private.UploadedBlob{}, err
+		}
+		if err := d.archive.sendFileLocked(configPath, inputInfo.Size, bytes.NewReader(buf)); err != nil {
 			return private.UploadedBlob{}, fmt.Errorf("writing Config file: %w", err)
 		}
 	} else {
-		if err := d.archive.sendFileLocked(d.archive.physicalLayerPath(inputInfo.Digest), inputInfo.Size, stream); err != nil {
+		layerPath, err := d.archive.physicalLayerPath(inputInfo.Digest)
+		if err != nil {
+			return private.UploadedBlob{}, err
+		}
+		if err := d.archive.sendFileLocked(layerPath, inputInfo.Size, stream); err != nil {
 			return private.UploadedBlob{}, err
 		}
 	}

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -142,6 +142,9 @@ func (w *Writer) writeLegacyMetadataLocked(layerDescriptors []manifest.Schema2De
 		}
 
 		// This chainID value matches the computation in docker/docker/layer.CreateChainID …
+		if err := l.Digest.Validate(); err != nil { // This should never fail on this code path, still: make sure the chainID computation is unambiguous.
+			return err
+		}
 		if chainID == "" {
 			chainID = l.Digest
 		} else {

--- a/docker/internal/tarfile/writer.go
+++ b/docker/internal/tarfile/writer.go
@@ -95,7 +95,10 @@ func (w *Writer) ensureSingleLegacyLayerLocked(layerID string, layerDigest diges
 	if !w.legacyLayers.Contains(layerID) {
 		// Create a symlink for the legacy format, where there is one subdirectory per layer ("image").
 		// See also the comment in physicalLayerPath.
-		physicalLayerPath := w.physicalLayerPath(layerDigest)
+		physicalLayerPath, err := w.physicalLayerPath(layerDigest)
+		if err != nil {
+			return err
+		}
 		if err := w.sendSymlinkLocked(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
 			return fmt.Errorf("creating layer symbolic link: %w", err)
 		}
@@ -204,12 +207,20 @@ func checkManifestItemsMatch(a, b *ManifestItem) error {
 func (w *Writer) ensureManifestItemLocked(layerDescriptors []manifest.Schema2Descriptor, configDigest digest.Digest, repoTags []reference.NamedTagged) error {
 	layerPaths := []string{}
 	for _, l := range layerDescriptors {
-		layerPaths = append(layerPaths, w.physicalLayerPath(l.Digest))
+		p, err := w.physicalLayerPath(l.Digest)
+		if err != nil {
+			return err
+		}
+		layerPaths = append(layerPaths, p)
 	}
 
 	var item *ManifestItem
+	configPath, err := w.configPath(configDigest)
+	if err != nil {
+		return err
+	}
 	newItem := ManifestItem{
-		Config:       w.configPath(configDigest),
+		Config:       configPath,
 		RepoTags:     []string{},
 		Layers:       layerPaths,
 		Parent:       "", // We don’t have this information
@@ -294,21 +305,27 @@ func (w *Writer) Close() error {
 // configPath returns a path we choose for storing a config with the specified digest.
 // NOTE: This is an internal implementation detail, not a format property, and can change
 // any time.
-func (w *Writer) configPath(configDigest digest.Digest) string {
-	return configDigest.Hex() + ".json"
+func (w *Writer) configPath(configDigest digest.Digest) (string, error) {
+	if err := configDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
+		return "", err
+	}
+	return configDigest.Hex() + ".json", nil
 }
 
 // physicalLayerPath returns a path we choose for storing a layer with the specified digest
 // (the actual path, i.e. a regular file, not a symlink that may be used in the legacy format).
 // NOTE: This is an internal implementation detail, not a format property, and can change
 // any time.
-func (w *Writer) physicalLayerPath(layerDigest digest.Digest) string {
+func (w *Writer) physicalLayerPath(layerDigest digest.Digest) (string, error) {
+	if err := layerDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in unexpected paths, so validate explicitly.
+		return "", err
+	}
 	// Note that this can't be e.g. filepath.Join(l.Digest.Hex(), legacyLayerFileName); due to the way
 	// writeLegacyMetadata constructs layer IDs differently from inputinfo.Digest values (as described
 	// inside it), most of the layers would end up in subdirectories alone without any metadata; (docker load)
 	// tries to load every subdirectory as an image and fails if the config is missing.  So, keep the layers
 	// in the root of the tarball.
-	return layerDigest.Hex() + ".tar"
+	return layerDigest.Hex() + ".tar", nil
 }
 
 type tarFI struct {

--- a/docker/registries_d.go
+++ b/docker/registries_d.go
@@ -287,8 +287,11 @@ func (ns registryNamespace) signatureTopLevel(write bool) string {
 // lookasideStorageURL returns an URL usable for accessing signature index in base with known manifestDigest.
 // base is not nil from the caller
 // NOTE: Keep this in sync with docs/signature-protocols.md!
-func lookasideStorageURL(base lookasideStorageBase, manifestDigest digest.Digest, index int) *url.URL {
+func lookasideStorageURL(base lookasideStorageBase, manifestDigest digest.Digest, index int) (*url.URL, error) {
+	if err := manifestDigest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, and could possibly result in a path with ../, so validate explicitly.
+		return nil, err
+	}
 	sigURL := *base
 	sigURL.Path = fmt.Sprintf("%s@%s=%s/signature-%d", sigURL.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
-	return &sigURL
+	return &sigURL, nil
 }

--- a/docker/registries_d_test.go
+++ b/docker/registries_d_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -320,9 +321,15 @@ func TestLookasideStorageURL(t *testing.T) {
 		require.NoError(t, err)
 		expectedURL, err := url.Parse(c.expected)
 		require.NoError(t, err)
-		res := lookasideStorageURL(baseURL, mdInput, c.index)
+		res, err := lookasideStorageURL(baseURL, mdInput, c.index)
+		require.NoError(t, err)
 		assert.Equal(t, expectedURL, res, c.expected)
 	}
+
+	baseURL, err := url.Parse("file:///tmp")
+	require.NoError(t, err)
+	_, err = lookasideStorageURL(baseURL, digest.Digest("sha256:../hello"), 0)
+	assert.Error(t, err)
 }
 
 func TestBuiltinDefaultLookasideStorageDir(t *testing.T) {

--- a/openshift/openshift_src.go
+++ b/openshift/openshift_src.go
@@ -109,6 +109,9 @@ func (s *openshiftImageSource) GetSignaturesWithFormat(ctx context.Context, inst
 		}
 		imageStreamImageName = s.imageStreamImageName
 	} else {
+		if err := instanceDigest.Validate(); err != nil { // Make sure instanceDigest.String() does not contain any unexpected characters
+			return nil, err
+		}
 		imageStreamImageName = instanceDigest.String()
 	}
 	image, err := s.client.getImage(ctx, imageStreamImageName)

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -347,6 +347,10 @@ func (d *ostreeImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		}
 		d.repo = repo
 	}
+
+	if err := info.Digest.Validate(); err != nil { // digest.Digest.Hex() panics on failure, so validate explicitly.
+		return false, private.ReusedBlob{}, err
+	}
 	branch := fmt.Sprintf("ociimage/%s", info.Digest.Hex())
 
 	found, data, err := readMetadata(d.repo, branch, "docker.uncompressed_digest")
@@ -472,12 +476,18 @@ func (d *ostreeImageDestination) Commit(context.Context, types.UnparsedImage) er
 		return nil
 	}
 	for _, layer := range d.schema.LayersDescriptors {
+		if err := layer.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return err
+		}
 		hash := layer.Digest.Hex()
 		if err = checkLayer(hash); err != nil {
 			return err
 		}
 	}
 	for _, layer := range d.schema.FSLayers {
+		if err := layer.BlobSum.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return err
+		}
 		hash := layer.BlobSum.Hex()
 		if err = checkLayer(hash); err != nil {
 			return err

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -286,7 +286,9 @@ func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, 
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *ostreeImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-
+	if err := info.Digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+		return nil, -1, err
+	}
 	blob := info.Digest.Hex()
 
 	// Ensure s.compressed is initialized.  It is build by LayerInfosForCopy.

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -1097,8 +1097,12 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		})
 	}
 	for instanceDigest, signatures := range s.signatureses {
+		key, err := signatureBigDataKey(instanceDigest)
+		if err != nil {
+			return err
+		}
 		options.BigData = append(options.BigData, storage.ImageBigDataOption{
-			Key:    signatureBigDataKey(instanceDigest),
+			Key:    key,
 			Data:   signatures,
 			Digest: digest.Canonical.FromBytes(signatures),
 		})

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -1069,8 +1069,12 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 		if err != nil {
 			return fmt.Errorf("digesting top-level manifest: %w", err)
 		}
+		key, err := manifestBigDataKey(manifestDigest)
+		if err != nil {
+			return err
+		}
 		options.BigData = append(options.BigData, storage.ImageBigDataOption{
-			Key:    manifestBigDataKey(manifestDigest),
+			Key:    key,
 			Data:   toplevelManifest,
 			Digest: manifestDigest,
 		})
@@ -1078,8 +1082,12 @@ func (s *storageImageDestination) Commit(ctx context.Context, unparsedToplevel t
 	// Set up to save the image's manifest.  Allow looking it up by digest by using the key convention defined by the Store.
 	// Record the manifest twice: using a digest-specific key to allow references to that specific digest instance,
 	// and using storage.ImageDigestBigDataKey for future users that don’t specify any digest and for compatibility with older readers.
+	key, err := manifestBigDataKey(s.manifestDigest)
+	if err != nil {
+		return err
+	}
 	options.BigData = append(options.BigData, storage.ImageBigDataOption{
-		Key:    manifestBigDataKey(s.manifestDigest),
+		Key:    key,
 		Data:   s.manifest,
 		Digest: s.manifestDigest,
 	})

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -27,8 +27,11 @@ func manifestBigDataKey(digest digest.Digest) string {
 
 // signatureBigDataKey returns a key suitable for recording the signatures associated with the manifest with the specified digest using storage.Store.ImageBigData and related functions.
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
-func signatureBigDataKey(digest digest.Digest) string {
-	return "signature-" + digest.Encoded()
+func signatureBigDataKey(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+		return "", err
+	}
+	return "signature-" + digest.Encoded(), nil
 }
 
 // storageImageMetadata is stored, as JSON, in storage.Image.Metadata

--- a/storage/storage_image.go
+++ b/storage/storage_image.go
@@ -21,8 +21,11 @@ var (
 // manifestBigDataKey returns a key suitable for recording a manifest with the specified digest using storage.Store.ImageBigData and related functions.
 // If a specific manifest digest is explicitly requested by the user, the key returned by this function should be used preferably;
 // for compatibility, if a manifest is not available under this key, check also storage.ImageDigestBigDataKey
-func manifestBigDataKey(digest digest.Digest) string {
-	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String()
+func manifestBigDataKey(digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil { // Make sure info.Digest.String() uses the expected format and does not collide with other BigData keys.
+		return "", err
+	}
+	return storage.ImageDigestManifestBigDataNamePrefix + "-" + digest.String(), nil
 }
 
 // signatureBigDataKey returns a key suitable for recording the signatures associated with the manifest with the specified digest using storage.Store.ImageBigData and related functions.

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -73,7 +73,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
 	// We don't need to care about storage.ImageDigestBigDataKey because
 	// manifests lists are only stored into storage by c/image versions
 	// that know about manifestBigDataKey, and only using that key.
-	key := manifestBigDataKey(manifestDigest)
+	key, err := manifestBigDataKey(manifestDigest)
+	if err != nil {
+		return false // This should never happen, manifestDigest comes from a reference.Digested, and that validates the format.
+	}
 	manifestBytes, err := store.ImageBigData(img.ID, key)
 	if err != nil {
 		return false
@@ -95,7 +98,10 @@ func multiArchImageMatchesSystemContext(store storage.Store, img *storage.Image,
 	if err != nil {
 		return false
 	}
-	key = manifestBigDataKey(chosenInstance)
+	key, err = manifestBigDataKey(chosenInstance)
+	if err != nil {
+		return false
+	}
 	_, err = store.ImageBigData(img.ID, key)
 	return err == nil // true if img.ID is based on chosenInstance.
 }

--- a/storage/storage_src.go
+++ b/storage/storage_src.go
@@ -237,7 +237,10 @@ func (s *storageImageSource) getBlobAndLayerID(digest digest.Digest, layers []st
 // GetManifest() reads the image's manifest.
 func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) (manifestBlob []byte, mimeType string, err error) {
 	if instanceDigest != nil {
-		key := manifestBigDataKey(*instanceDigest)
+		key, err := manifestBigDataKey(*instanceDigest)
+		if err != nil {
+			return nil, "", err
+		}
 		blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 		if err != nil {
 			return nil, "", fmt.Errorf("reading manifest for image instance %q: %w", *instanceDigest, err)
@@ -249,7 +252,10 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 		// Prefer the manifest corresponding to the user-specified digest, if available.
 		if s.imageRef.named != nil {
 			if digested, ok := s.imageRef.named.(reference.Digested); ok {
-				key := manifestBigDataKey(digested.Digest())
+				key, err := manifestBigDataKey(digested.Digest())
+				if err != nil {
+					return nil, "", err
+				}
 				blob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, key)
 				if err != nil && !os.IsNotExist(err) { // os.IsNotExist is true if the image exists but there is no data corresponding to key
 					return nil, "", err

--- a/storage/storage_src.go
+++ b/storage/storage_src.go
@@ -385,7 +385,14 @@ func (s *storageImageSource) GetSignaturesWithFormat(ctx context.Context, instan
 	instance := "default instance"
 	if instanceDigest != nil {
 		signatureSizes = s.metadata.SignaturesSizes[*instanceDigest]
-		key = signatureBigDataKey(*instanceDigest)
+		k, err := signatureBigDataKey(*instanceDigest)
+		if err != nil {
+			return nil, err
+		}
+		key = k
+		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, so validate explicitly.
+			return nil, err
+		}
 		instance = instanceDigest.Encoded()
 	}
 	if len(signatureSizes) > 0 {


### PR DESCRIPTION
Digest values used throughout this library were not always validated. That allowed attackers to trigger, when pulling untrusted images, unexpected authenticated registry accesses on behalf of a victim user.

In less common uses of this library (using other transports or not using the `containers/image/v5/copy.Image` API), an attacker could also trigger local path traversals or crashes.