### PR TITLE
[release-5.30] Release 5.30.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 30
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 30
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This fixes CVE-2024-3727 .

Digest values used throughout this library were not always validated. That allowed attackers to trigger, when pulling untrusted images, unexpected authenticated registry accesses on behalf of a victim user.

In less common uses of this library (using other transports or not using the `containers/image/v5/copy.Image` API), an attacker could also trigger local path traversals or crashes.
