### PR TITLE
Merge the `release-5.30` branch into `main`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 30
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
The latest tagged release as of this moment, 5.30.1 is on the `release-5.30` branch, behind `main`.

That means that dependency automation tries to move users who use a recent commit from of `main` back onto `5.30.1`, possibly dropping some features.

This merge lets the tools know that `main` “is a superset of” 5.30.1; users on `main` can then update to `main` after this PR is merged.