### PR TITLE
Non-security digest.Digest use cleanups

### DIFF
--- a/docs/atomic-signature-embedded-json.json
+++ b/docs/atomic-signature-embedded-json.json
@@ -31,7 +31,8 @@
                     "additionalProperties": false,
                     "properties": {
                         "docker-manifest-digest": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern":"^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$"
                         }
                     }
                 },

--- a/ostree/ostree_src.go
+++ b/ostree/ostree_src.go
@@ -439,7 +439,10 @@ func (s *ostreeImageSource) LayerInfosForCopy(ctx context.Context, instanceDiges
 		if err != nil {
 			return nil, err
 		}
-		uncompressedDigest := digest.Digest(uncompressedDigestStr)
+		uncompressedDigest, err := digest.Parse(uncompressedDigestStr)
+		if err != nil {
+			return nil, err
+		}
 		blobInfo := types.BlobInfo{
 			Digest:    uncompressedDigest,
 			Size:      uncompressedSize,

--- a/pkg/blobcache/src.go
+++ b/pkg/blobcache/src.go
@@ -123,14 +123,11 @@ func (s *blobCacheSource) layerInfoForCopy(info types.BlobInfo) (types.BlobInfo,
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	var alternate string
 	switch s.reference.compress {
 	case types.Compress:
-		alternate = blobFile + compressedNote
-		replaceDigest, err = os.ReadFile(alternate)
+		replaceDigest, err = os.ReadFile(blobFile + compressedNote)
 	case types.Decompress:
-		alternate = blobFile + decompressedNote
-		replaceDigest, err = os.ReadFile(alternate)
+		replaceDigest, err = os.ReadFile(blobFile + decompressedNote)
 	}
 	if err != nil {
 		return info, nil
@@ -138,7 +135,7 @@ func (s *blobCacheSource) layerInfoForCopy(info types.BlobInfo) (types.BlobInfo,
 	if digest.Digest(replaceDigest).Validate() != nil {
 		return info, nil
 	}
-	alternate, err = s.reference.blobPath(digest.Digest(replaceDigest), false)
+	alternate, err := s.reference.blobPath(digest.Digest(replaceDigest), false)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}

--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -150,7 +150,11 @@ func (s *UntrustedSigstorePayload) strictUnmarshalJSON(data []byte) error {
 	}); err != nil {
 		return err
 	}
-	s.untrustedDockerManifestDigest = digest.Digest(digestString)
+	digestValue, err := digest.Parse(digestString)
+	if err != nil {
+		return NewInvalidSignatureError(fmt.Sprintf(`invalid docker-manifest-digest value %q: %v`, digestString, err))
+	}
+	s.untrustedDockerManifestDigest = digestValue
 
 	return ParanoidUnmarshalJSONObjectExactFields(identity, map[string]any{
 		"docker-reference": &s.untrustedDockerReference,

--- a/signature/simple.go
+++ b/signature/simple.go
@@ -173,7 +173,11 @@ func (s *untrustedSignature) strictUnmarshalJSON(data []byte) error {
 	}); err != nil {
 		return err
 	}
-	s.untrustedDockerManifestDigest = digest.Digest(digestString)
+	digestValue, err := digest.Parse(digestString)
+	if err != nil {
+		return internal.NewInvalidSignatureError(fmt.Sprintf(`invalid docker-manifest-digest value %q: %v`, digestString, err))
+	}
+	s.untrustedDockerManifestDigest = digestValue
 
 	return internal.ParanoidUnmarshalJSONObjectExactFields(identity, map[string]any{
 		"docker-reference": &s.untrustedDockerReference,


### PR DESCRIPTION
A set of cleanups around creating/validating `digest.Digest` values, in places where it should not be exploitable.

See individual commit messages for details.

A side effect of the code audit required by CVE-2024-3727 .