### PR TITLE
[Additional Layer Store] Enable Additional Layer Store to perform registry authentication

### DIFF
--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -1,7 +1,9 @@
 package docker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 
@@ -161,6 +164,34 @@ func newImageSourceAttempt(ctx context.Context, sys *types.SystemContext, logica
 	if err := s.ensureManifestIsLoaded(ctx); err != nil {
 		client.Close()
 		return nil, err
+	}
+
+	if h, err := sysregistriesv2.AdditionalLayerStoreAuthHelper(endpointSys); err == nil && h != "" {
+		acf := map[string]struct {
+			Username      string `json:"username,omitempty"`
+			Password      string `json:"password,omitempty"`
+			IdentityToken string `json:"identityToken,omitempty"`
+		}{
+			physicalRef.ref.String(): {
+				Username:      client.auth.Username,
+				Password:      client.auth.Password,
+				IdentityToken: client.auth.IdentityToken,
+			},
+		}
+		acfD, err := json.Marshal(acf)
+		if err != nil {
+			logrus.Warnf("failed to marshal auth config: %v", err)
+		} else {
+			cmd := exec.Command(h)
+			cmd.Stdin = bytes.NewReader(acfD)
+			if err := cmd.Run(); err != nil {
+				var stderr string
+				if ee, ok := err.(*exec.ExitError); ok {
+					stderr = string(ee.Stderr)
+				}
+				logrus.Warnf("Failed to call additional-layer-store-auth-helper (stderr:%s): %v", stderr, err)
+			}
+		}
 	}
 	return s, nil
 }

--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -19,6 +19,12 @@ Container engines will use the `$HOME/.config/containers/registries.conf` if it 
 `credential-helpers`
 : An array of default credential helpers used as external credential stores.  Note that "containers-auth.json" is a reserved value to use auth files as specified in containers-auth.json(5).  The credential helpers are set to `["containers-auth.json"]` if none are specified.
 
+`additional-layer-store-auth-helper`
+: A string containing the helper binary name. This enables passing registry credentials to an
+  Additional Layer Store every time an image is read using the `docker://`
+  transport so that it can access private registries. See the 'Enabling Additional Layer Store to access to private registries' section below for
+  more details.
+
 ### NAMESPACED `[[registry]]` SETTINGS
 
 The bulk of the configuration is represented as an array of `[[registry]]`
@@ -253,6 +259,30 @@ Given the above, a pull of `example.com/foo/image:latest` will try:
 in order, and use the first one that exists.
 
 Note that a mirror is associated only with the current `[[registry]]` TOML table. If using the example above, pulling the image `registry.com/image:latest` will hence only reach out to `mirror.registry.com`, and the mirrors associated with `example.com/foo` will not be considered.
+
+### Enabling Additional Layer Store to access to private registries
+
+The `additional-layer-store-auth-helper` option enables passing registry
+credentials to an Additional Layer Store so that it can access private registries.
+
+When accessing a private registry via an Additional Layer Store, a helper binary needs to be provided. This helper binary is
+registered via the `additional-layer-store-auth-helper` option. Every time an image
+is read using the `docker://` transport, the specified helper binary is executed
+and receives registry credentials from stdin in the following format.
+
+```json
+{
+  "$image_reference": {
+    "username": "$username",
+    "password": "$password",
+    "identityToken": "$identityToken"
+  }
+}
+```
+
+The format of `$image_reference` is `$repo{:$tag|@$digest}`.
+
+Additional Layer Stores can use this helper binary to access the private registry.
 
 ## VERSION 1 FORMAT - DEPRECATED
 VERSION 1 format is still supported but it does not support

--- a/pkg/sysregistriesv2/system_registries_v2.go
+++ b/pkg/sysregistriesv2/system_registries_v2.go
@@ -248,6 +248,11 @@ type V2RegistriesConf struct {
 	// potentially use all unqualified-search registries
 	ShortNameMode string `toml:"short-name-mode"`
 
+	// AdditionalLayerStoreAuthHelper is a helper binary that receives
+	// registry credentials pass them to Additional Layer Store for
+	// registry authentication. These credentials are only collected when pulling (not pushing).
+	AdditionalLayerStoreAuthHelper string `toml:"additional-layer-store-auth-helper"`
+
 	shortNameAliasConf
 
 	// If you add any field, make sure to update Nonempty() below.
@@ -825,6 +830,16 @@ func CredentialHelpers(sys *types.SystemContext) ([]string, error) {
 	return config.partialV2.CredentialHelpers, nil
 }
 
+// AdditionalLayerStoreAuthHelper returns the helper for passing registry
+// credentials to Additional Layer Store.
+func AdditionalLayerStoreAuthHelper(sys *types.SystemContext) (string, error) {
+	config, err := getConfig(sys)
+	if err != nil {
+		return "", err
+	}
+	return config.partialV2.AdditionalLayerStoreAuthHelper, nil
+}
+
 // refMatchingSubdomainPrefix returns the length of ref
 // iff ref, which is a registry, repository namespace, repository or image reference (as formatted by
 // reference.Domain(), reference.Named.Name() or reference.Reference.String()
@@ -1049,6 +1064,11 @@ func (c *parsedConfig) updateWithConfigurationFrom(updates *parsedConfig) {
 	// We don’t maintain c.partialV2.ShortNameMode.
 	if updates.shortNameMode != types.ShortNameModeInvalid {
 		c.shortNameMode = updates.shortNameMode
+	}
+
+	// == Merge AdditionalLayerStoreAuthHelper:
+	if updates.partialV2.AdditionalLayerStoreAuthHelper != "" {
+		c.partialV2.AdditionalLayerStoreAuthHelper = updates.partialV2.AdditionalLayerStoreAuthHelper
 	}
 
 	// == Merge aliasCache:

--- a/pkg/sysregistriesv2/system_registries_v2_test.go
+++ b/pkg/sysregistriesv2/system_registries_v2_test.go
@@ -57,6 +57,7 @@ var v2RegistriesConfEmptyTestData = []struct {
 	{nonempty: true, hasSetField: true, v: V2RegistriesConf{CredentialHelpers: []string{"a"}}},
 	{nonempty: true, hasSetField: true, v: V2RegistriesConf{ShortNameMode: "enforcing"}},
 	{nonempty: true, hasSetField: true, v: V2RegistriesConf{shortNameAliasConf: shortNameAliasConf{Aliases: map[string]string{"a": "example.com/b"}}}},
+	{nonempty: true, hasSetField: true, v: V2RegistriesConf{AdditionalLayerStoreAuthHelper: "example"}},
 }
 
 func TestV2RegistriesConfNonempty(t *testing.T) {


### PR DESCRIPTION
Implements https://github.com/openshift/enhancements/pull/1600#issuecomment-2099607551

Currently, c/image doesn't share creds to Additional Layer Store so it requires additional configurations for registry authentication. And the current means of registry authentication for Additional Layer Store doesn't seem to meet requirements for the platform: https://github.com/openshift/enhancements/pull/1600#pullrequestreview-1990049051

This commit fixes that issue by allowing c/image directly sharing creds to Additional Layer Store. Additional Layer Store doesn't need to have its own logic to fetch registry creds but it can receive them from c/image.

Additional Layer Store needs to provide a helper binary that is executed from c/image. This helper binary is registered to c/image using registries.conf with the following field (`store-helper` can be any command name of the helper binary). It receives registry creds via stdin and Additional Layer Store can use that creds for registry authentication.

```
additional-layer-store-auth-helper = "store-helper"
```

An example draft implementation of the helper binary is `store-helper` of stargz-store: https://github.com/containerd/stargz-snapshotter/pull/1674
This binary is executed by c/image and receives the registry creds from stdin and shares them to stargz-store via the unix socket of stargz-store. Then stargz-store uses these creds for registry authentication.

c/image passes [`DockerAuthConfig`](https://github.com/containers/image/blob/984c624c4c9e07c79bcdbc49679ba2a781805303/types/types.go#L490-L500) structures with keying them with the image reference.

```json
{
  "image-reference": {
    "username": "username",
    "password": "password",
    "identitytoken": "identitytoken"
  }
}
```
