### PR TITLE
Support proxy environment for docker client

### DIFF
--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -80,6 +80,7 @@ func tlsConfig(sys *types.SystemContext) (*http.Client, error) {
 
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsc,
 		},
 		CheckRedirect: dockerclient.CheckRedirect,
@@ -89,6 +90,7 @@ func tlsConfig(sys *types.SystemContext) (*http.Client, error) {
 func httpConfig() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: nil,
 		},
 		CheckRedirect: dockerclient.CheckRedirect,


### PR DESCRIPTION
Proxy environment works fine with docker-cli:

```bash
> export http_proxy=http://my_proxy:8080
> export DOCKER_HOST=tcp://my_docker_host_through_proxy
> docker info
# Works fine
> docker image inspect foo:bar
# Works fine
```

But does not work with skopeo:

```bash
> export http_proxy=http://my_proxy:8080
> skopeo inspect --daemon-host http://my_docker_host_through_proxy docker-daemon:foo:bar
FATA[0000] Error parsing image name "docker-daemon:foo:bar": initializing docker engine client: unable to parse docker host `my_docker_host_through_proxy`
```

It's just an example, I need to copy image to the docker-daemon host in actual.

After this pull request was patched, skopeo also worked fine with the proxy environment.

> Note that: I used a plain HTTP connection with docker-daemon, so it should be `http://` in skepeo but `tcp://` in docker-cli.