### PR TITLE
[release-5.31] Bump c/image to v5.31.1-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 31
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
I managed to set main to v5.31.1-dev rather than the release-5.31 branch.  I've corrected main with #2430 and this will correct the release-5.31 branch