### PR TITLE
[release-5.31]  Don't abort listing tags when we encounter a digest

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 31
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Cherry Pick https://github.com/containers/image/pull/2440 then bump to v5.31.1 and finally to v5.31.2-dev

