### PR TITLE
Add field KeyPaths to prSigstoreSigned

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -316,11 +316,13 @@ used with `exactReference` or `exactRepository`.
 
 This requirement requires an image to be signed using a sigstore signature with an expected identity and key.
 
-```js
+```json
 {
     "type":    "sigstoreSigned",
     "keyPath": "/path/to/local/public/key/file",
+    "keyPaths": ["/path/to/first/public/key/one", "/path/to/first/public/key/two"],
     "keyData": "base64-encoded-public-key-data",
+    "keyDatas": ["base64-encoded-public-key-one-data", "base64-encoded-public-key-two-data"]
     "fulcio": {
         "caPath": "/path/to/local/CA/file",
         "caData": "base64-encoded-CA-data",
@@ -332,10 +334,13 @@ This requirement requires an image to be signed using a sigstore signature with 
     "signedIdentity": identity_requirement
 }
 ```
-Exactly one of `keyPath`, `keyData` and `fulcio` must be present.
+Exactly one of `keyPath`, `keyPaths`, `keyData`, `keyDatas` and `fulcio` must be present.
 
 If `keyPath` or `keyData` is present, it contains a sigstore public key.
 Only signatures made by this key are accepted.
+
+If `keyPaths` or `keyDatas` is present, it contains sigstore public keys that
+sign the images. Signatures from any key in the list is accepted.
 
 If `fulcio` is present, the signature must be based on a Fulcio-issued certificate.
 One of `caPath` and `caData` must be specified, containing the public key of the Fulcio instance.

--- a/signature/policy_config_sigstore.go
+++ b/signature/policy_config_sigstore.go
@@ -22,6 +22,17 @@ func PRSigstoreSignedWithKeyPath(keyPath string) PRSigstoreSignedOption {
 	}
 }
 
+// PRSigstoreSignedWithKeyPaths specifies a value for the "keyPaths" field when calling NewPRSigstoreSigned.
+func PRSigstoreSignedWithKeyPaths(keyPaths []string) PRSigstoreSignedOption {
+	return func(pr *prSigstoreSigned) error {
+		if pr.KeyPaths != nil {
+			return errors.New(`"keyPaths" already specified`)
+		}
+		pr.KeyPaths = keyPaths
+		return nil
+	}
+}
+
 // PRSigstoreSignedWithKeyData specifies a value for the "keyData" field when calling NewPRSigstoreSigned.
 func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
@@ -29,6 +40,17 @@ func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 			return errors.New(`"keyData" already specified`)
 		}
 		pr.KeyData = keyData
+		return nil
+	}
+}
+
+// PRSigstoreSignedWithKeyDatas specifies a value for the "keyDatas" field when calling NewPRSigstoreSigned.
+func PRSigstoreSignedWithKeyDatas(keyDatas [][]byte) PRSigstoreSignedOption {
+	return func(pr *prSigstoreSigned) error {
+		if pr.KeyDatas != nil {
+			return errors.New(`"keyDatas" already specified`)
+		}
+		pr.KeyDatas = keyDatas
 		return nil
 	}
 }
@@ -92,14 +114,21 @@ func newPRSigstoreSigned(options ...PRSigstoreSignedOption) (*prSigstoreSigned, 
 	if res.KeyPath != "" {
 		keySources++
 	}
+	if len(res.KeyPaths) > 0 {
+		keySources++
+	}
 	if res.KeyData != nil {
+		keySources++
+	}
+	if len(res.KeyDatas) > 0 {
 		keySources++
 	}
 	if res.Fulcio != nil {
 		keySources++
 	}
+
 	if keySources != 1 {
-		return nil, InvalidPolicyFormatError("exactly one of keyPath, keyData and fulcio must be specified")
+		return nil, InvalidPolicyFormatError("exactly one of keyPath, keyPaths, keyData, keyDatas and fulcio must be specified")
 	}
 
 	if res.RekorPublicKeyPath != "" && res.RekorPublicKeyData != nil {

--- a/signature/policy_eval.go
+++ b/signature/policy_eval.go
@@ -7,6 +7,7 @@ package signature
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 
 	"github.com/containers/image/v5/internal/private"
@@ -30,6 +31,12 @@ const (
 	sarRejected signatureAcceptanceResult = "sarRejected"
 	sarUnknown  signatureAcceptanceResult = "sarUnknown"
 )
+
+// signatureKeyAcceptanceResult is the principal value returned by isSignatureAccepted.
+type signatureKeyAcceptanceResult struct {
+	result signatureAcceptanceResult
+	pk     crypto.PublicKey
+}
 
 // PolicyRequirement is a rule which must be satisfied by at least one of the signatures of an image.
 // The type is public, but its definition is private.

--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -238,7 +238,7 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 		return sarRejected, fmt.Errorf("Internal inconsistency: publicKey not set before verifying sigstore payload")
 	}
 
-	signature, err := internal.VerifySigstorePayload(publicKeys, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
+	signature, signingKey, err := internal.VerifySigstorePayload(publicKeys, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
 		ValidateSignedDockerReference: func(ref string) error {
 			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
 				return PolicyRequirementError(fmt.Sprintf("Signature for identity %q is not accepted", ref))

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -74,7 +74,7 @@ type prSignedBy struct {
 
 	// KeyPath is a pathname to a local file containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyPaths if a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPaths []string `json:"keyPaths,omitempty"`
 	// KeyData contains the trusted key(s), base64-encoded. Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
@@ -111,11 +111,14 @@ type prSignedBaseLayer struct {
 type prSigstoreSigned struct {
 	prCommon
 
-	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas or Fulcio must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas or Fulcio must be specified.
+	KeyPaths []string `json:"keyPaths,omitempty"`
+	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas or Fulcio must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
-	// FIXME: Multiple public keys?
+	// KeyDatas is a set of trusted keys, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas or Fulcio must be specified.
+	KeyDatas [][]byte `json:"keyDatas,omitempty"`
 
 	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyData, Fulcio must be specified.
 	// If Fulcio is specified, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well.

--- a/signature/sigstore/generate_test.go
+++ b/signature/sigstore/generate_test.go
@@ -46,7 +46,7 @@ func TestGenerateKeyPair(t *testing.T) {
 	require.NoError(t, err)
 	publicKeys := []crypto.PublicKey{publicKey}
 
-	_, err = internal.VerifySigstorePayload(publicKeys, sig.UntrustedPayload(),
+	_, _, err = internal.VerifySigstorePayload(publicKeys, sig.UntrustedPayload(),
 		sig.UntrustedAnnotations()[signature.SigstoreSignatureAnnotationKey],
 		internal.SigstorePayloadAcceptanceRules{
 			ValidateSignedDockerReference: func(ref string) error {

--- a/signature/sigstore/generate_test.go
+++ b/signature/sigstore/generate_test.go
@@ -2,6 +2,7 @@ package sigstore
 
 import (
 	"context"
+	"crypto"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,8 +44,9 @@ func TestGenerateKeyPair(t *testing.T) {
 	// but that is private.
 	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey(keyPair.PublicKey)
 	require.NoError(t, err)
+	publicKeys := []crypto.PublicKey{publicKey}
 
-	_, err = internal.VerifySigstorePayload(publicKey, sig.UntrustedPayload(),
+	_, err = internal.VerifySigstorePayload(publicKeys, sig.UntrustedPayload(),
 		sig.UntrustedAnnotations()[signature.SigstoreSignatureAnnotationKey],
 		internal.SigstorePayloadAcceptanceRules{
 			ValidateSignedDockerReference: func(ref string) error {


### PR DESCRIPTION
The new field `KeyPaths` is taken directly from `/etc/containers/policy.json` and allows users to provide multiple signature keys to be used to verify images. Only one of the keys has to verify, thereby this mechanism allows us to have support seamless key rotation on a registry.

This fixes https://github.com/containers/image/issues/2319