### PR TITLE
Improve the error message when MessageDetails.SignedBy == nil

### DIFF
--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containers/image/v5/signature/internal"
 	"github.com/containers/storage/pkg/homedir"
+
 	// This is a fallback code; the primary recommendation is to use the gpgme mechanism
 	// implementation, which is out-of-process and more appropriate for handling long-term private key material
 	// than any Go implementation.
@@ -150,7 +151,7 @@ func (m *openpgpSigningMechanism) Verify(unverifiedSignature []byte) (contents [
 		return nil, "", fmt.Errorf("signature error: %v", md.SignatureError)
 	}
 	if md.SignedBy == nil {
-		return nil, "", internal.NewInvalidSignatureError(fmt.Sprintf("Invalid GPG signature: %#v", md.Signature))
+		return nil, "", internal.NewInvalidSignatureError(fmt.Sprintf("Key not found for key ID %x in signature", md.SignedByKeyId))
 	}
 	if md.Signature != nil {
 		if md.Signature.SigLifetimeSecs != nil {


### PR DESCRIPTION
We already know that IsSigned is set; and SignedBy is the result of a lookup of SignedByKeyId , so log that value.

Currently we log MessageDetails.Signature, which will always be nil if SignedBy == nil; that's not particularly useful.

Reported in https://github.com/containers/skopeo/issues/2238 .