### PR TITLE
Drop the toolchain directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/containers/image/v5
 
 go 1.21.0
 
-toolchain go1.21.11
-
 require (
 	dario.cat/mergo v1.0.0
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Per previous consensus, we intentionally keep the toolchain at .0 so that the package does not interfere with toolchain update decisions.

Revert the tooolchain dependency from 1.21.11 to 1.21.0; then (go mod tidy) removed it entirely.