### PR TITLE
Clean up obtaining bearer tokens for registries

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -89,9 +89,6 @@ type extensionSignatureList struct {
 // bearerToken records a cached token we can use to authenticate.
 type bearerToken struct {
 	token          string
-	AccessToken    string
-	ExpiresIn      int
-	IssuedAt       time.Time
 	expirationTime time.Time
 }
 
@@ -173,22 +170,20 @@ func newBearerTokenFromHTTPResponseBody(res *http.Response) (*bearerToken, error
 	}
 
 	bt := &bearerToken{
-		token:       token.Token,
-		AccessToken: token.AccessToken,
-		ExpiresIn:   token.ExpiresIn,
-		IssuedAt:    token.IssuedAt,
+		token: token.Token,
 	}
 	if bt.token == "" {
-		bt.token = bt.AccessToken
+		bt.token = token.AccessToken
 	}
-	if bt.ExpiresIn < minimumTokenLifetimeSeconds {
-		bt.ExpiresIn = minimumTokenLifetimeSeconds
-		logrus.Debugf("Increasing token expiration to: %d seconds", bt.ExpiresIn)
+
+	if token.ExpiresIn < minimumTokenLifetimeSeconds {
+		token.ExpiresIn = minimumTokenLifetimeSeconds
+		logrus.Debugf("Increasing token expiration to: %d seconds", token.ExpiresIn)
 	}
-	if bt.IssuedAt.IsZero() {
-		bt.IssuedAt = time.Now().UTC()
+	if token.IssuedAt.IsZero() {
+		token.IssuedAt = time.Now().UTC()
 	}
-	bt.expirationTime = bt.IssuedAt.Add(time.Duration(bt.ExpiresIn) * time.Second)
+	bt.expirationTime = token.IssuedAt.Add(time.Duration(token.ExpiresIn) * time.Second)
 	return bt, nil
 }
 

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -86,8 +86,9 @@ type extensionSignatureList struct {
 	Signatures []extensionSignature `json:"signatures"`
 }
 
+// bearerToken records a cached token we can use to authenticate.
 type bearerToken struct {
-	Token          string
+	token          string
 	AccessToken    string
 	ExpiresIn      int
 	IssuedAt       time.Time
@@ -172,13 +173,13 @@ func newBearerTokenFromHTTPResponseBody(res *http.Response) (*bearerToken, error
 	}
 
 	bt := &bearerToken{
-		Token:       token.Token,
+		token:       token.Token,
 		AccessToken: token.AccessToken,
 		ExpiresIn:   token.ExpiresIn,
 		IssuedAt:    token.IssuedAt,
 	}
-	if bt.Token == "" {
-		bt.Token = bt.AccessToken
+	if bt.token == "" {
+		bt.token = bt.AccessToken
 	}
 	if bt.ExpiresIn < minimumTokenLifetimeSeconds {
 		bt.ExpiresIn = minimumTokenLifetimeSeconds
@@ -799,7 +800,7 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 					token = *t
 					c.tokenCache.Store(cacheKey, token)
 				}
-				registryToken = token.Token
+				registryToken = token.token
 			}
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", registryToken))
 			return nil

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -145,7 +145,7 @@ func TestNewBearerTokenFromHTTPResponseBodyIssuedAtZero(t *testing.T) {
 	zeroTime := time.Time{}.Format(time.RFC3339)
 	now := time.Now()
 	tokenBlob := fmt.Sprintf(`{"token":"IAmAToken","expires_in":100,"issued_at":"%s"}`, zeroTime)
-	token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, string(tokenBlob)))
+	token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, tokenBlob))
 	require.NoError(t, err)
 	assert.False(t, token.IssuedAt.Before(now), "expected [%s] not to be before [%s]", token.IssuedAt, now)
 }

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -117,15 +117,15 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 		},
 		{ // "token"
 			input:    `{"token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)},
+			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)},
 		},
 		{ // "access_token"
 			input:    `{"access_token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{Token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)},
+			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0)},
 		},
 		{ // Small expiry
 			input:    `{"token":"IAmAToken","expires_in":1,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{Token: "IAmAToken", ExpiresIn: 60, IssuedAt: time.Unix(1514800802, 0)},
+			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 60, IssuedAt: time.Unix(1514800802, 0)},
 		},
 	} {
 		token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, c.input))
@@ -133,7 +133,7 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 			assert.Error(t, err, c.input)
 		} else {
 			require.NoError(t, err, c.input)
-			assert.Equal(t, c.expected.Token, token.Token, c.input)
+			assert.Equal(t, c.expected.token, token.token, c.input)
 			assert.Equal(t, c.expected.ExpiresIn, token.ExpiresIn, c.input)
 			assert.True(t, c.expected.IssuedAt.Equal(token.IssuedAt),
 				"expected [%s] to equal [%s], it did not", token.IssuedAt, c.expected.IssuedAt)

--- a/docker/docker_client_test.go
+++ b/docker/docker_client_test.go
@@ -117,15 +117,15 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 		},
 		{ // "token"
 			input:    `{"token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0), expirationTime: time.Unix(1514800802+100, 0)},
+			expected: &bearerToken{token: "IAmAToken", expirationTime: time.Unix(1514800802+100, 0)},
 		},
 		{ // "access_token"
 			input:    `{"access_token":"IAmAToken","expires_in":100,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 100, IssuedAt: time.Unix(1514800802, 0), expirationTime: time.Unix(1514800802+100, 0)},
+			expected: &bearerToken{token: "IAmAToken", expirationTime: time.Unix(1514800802+100, 0)},
 		},
 		{ // Small expiry
 			input:    `{"token":"IAmAToken","expires_in":1,"issued_at":"2018-01-01T10:00:02+00:00"}`,
-			expected: &bearerToken{token: "IAmAToken", ExpiresIn: 60, IssuedAt: time.Unix(1514800802, 0), expirationTime: time.Unix(1514800802+60, 0)},
+			expected: &bearerToken{token: "IAmAToken", expirationTime: time.Unix(1514800802+60, 0)},
 		},
 	} {
 		token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, c.input))
@@ -134,9 +134,6 @@ func TestNewBearerTokenFromHTTPResponseBody(t *testing.T) {
 		} else {
 			require.NoError(t, err, c.input)
 			assert.Equal(t, c.expected.token, token.token, c.input)
-			assert.Equal(t, c.expected.ExpiresIn, token.ExpiresIn, c.input)
-			assert.True(t, c.expected.IssuedAt.Equal(token.IssuedAt),
-				"expected [%s] to equal [%s], it did not", token.IssuedAt, c.expected.IssuedAt)
 			assert.True(t, c.expected.expirationTime.Equal(token.expirationTime),
 				"expected [%s] to equal [%s], it did not", token.expirationTime, c.expected.expirationTime)
 		}
@@ -149,7 +146,6 @@ func TestNewBearerTokenFromHTTPResponseBodyIssuedAtZero(t *testing.T) {
 	tokenBlob := fmt.Sprintf(`{"token":"IAmAToken","expires_in":100,"issued_at":"%s"}`, zeroTime)
 	token, err := newBearerTokenFromHTTPResponseBody(testTokenHTTPResponse(t, tokenBlob))
 	require.NoError(t, err)
-	assert.False(t, token.IssuedAt.Before(now), "expected [%s] not to be before [%s]", token.IssuedAt, now)
 	expectedExpiration := now.Add(time.Duration(100) * time.Second)
 	require.False(t, token.expirationTime.Before(expectedExpiration),
 		"expected [%s] not to be before [%s]", token.expirationTime, expectedExpiration)


### PR DESCRIPTION
This is a few refactors currently living in #1968, split for separate review and merging — without the substance of that feature.

The net effect of this PR is to decrease memory requirements a tiny bit, and to add make tests a tiny bit more relevant and decoupled.

See individual commit messages for details.