### PR TITLE
[release-5.29] blobinfocache: add function to delete the cache directory

### DIFF
--- a/pkg/blobinfocache/default.go
+++ b/pkg/blobinfocache/default.go
@@ -74,3 +74,15 @@ func DefaultCache(sys *types.SystemContext) types.BlobInfoCache {
 	logrus.Debugf("Using SQLite blob info cache at %s", path)
 	return cache
 }
+
+// CleanupDefaultCache removes the blob info cache directory.
+// It deletes the cache directory but it does not affect any file or memory buffer currently
+// in use.
+func CleanupDefaultCache(sys *types.SystemContext) error {
+	dir, err := blobInfoCacheDir(sys, rootless.GetRootlessEUID())
+	if err != nil {
+		// Mirror the DefaultCache behavior that does not fail in this case
+		return nil
+	}
+	return os.RemoveAll(dir)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 29
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 5
+	VersionPatch = 6
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
needed for: https://github.com/containers/podman/issues/22825

Addresses: https://issues.redhat.com/browse/ACCELFIX-268

This is for the noted accelerated customer fix, once merged, this will need to be vendored into Podman v4.9-rhel and further cherry-picking will need to go on there.