### PR TITLE
zstd:chunked refactoring for early review

### DIFF
--- a/copy/compression.go
+++ b/copy/compression.go
@@ -347,14 +347,18 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			// between zstd and zstd:chunked; so we could, in varying situations over time, call RecordDigestCompressorName
 			// with the same digest and both ZstdAlgorithmName and ZstdChunkedAlgorithmName , which causes warnings about
 			// inconsistent data to be logged.
-			c.blobInfoCache.RecordDigestCompressorName(uploadedInfo.Digest, d.uploadedCompressorName)
+			c.blobInfoCache.RecordDigestCompressorData(uploadedInfo.Digest, internalblobinfocache.DigestCompressorData{
+				BaseVariantCompressor: d.uploadedCompressorName,
+			})
 		}
 	}
 	if srcInfo.Digest != "" && srcInfo.Digest != uploadedInfo.Digest &&
 		d.srcCompressorName != internalblobinfocache.UnknownCompression {
 		if d.srcCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
 			// HACK: Don’t record zstd:chunked algorithms, see above.
-			c.blobInfoCache.RecordDigestCompressorName(srcInfo.Digest, d.srcCompressorName)
+			c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
+				BaseVariantCompressor: d.srcCompressorName,
+			})
 		}
 	}
 	return nil

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -35,10 +35,10 @@ var (
 
 // bpDetectCompressionStepData contains data that the copy pipeline needs about the “detect compression” step.
 type bpDetectCompressionStepData struct {
-	isCompressed      bool
-	format            compressiontypes.Algorithm        // Valid if isCompressed
-	decompressor      compressiontypes.DecompressorFunc // Valid if isCompressed
-	srcCompressorName string                            // Compressor name to possibly record in the blob info cache for the source blob.
+	isCompressed                 bool
+	format                       compressiontypes.Algorithm        // Valid if isCompressed
+	decompressor                 compressiontypes.DecompressorFunc // Valid if isCompressed
+	srcCompressorBaseVariantName string                            // Compressor name to possibly record in the blob info cache for the source blob.
 }
 
 // blobPipelineDetectCompressionStep updates *stream to detect its current compression format.
@@ -58,9 +58,9 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 		decompressor: decompressor,
 	}
 	if res.isCompressed {
-		res.srcCompressorName = format.Name()
+		res.srcCompressorBaseVariantName = format.BaseVariantName()
 	} else {
-		res.srcCompressorName = internalblobinfocache.Uncompressed
+		res.srcCompressorBaseVariantName = internalblobinfocache.Uncompressed
 	}
 
 	if expectedBaseFormat, known := expectedBaseCompressionFormats[stream.info.MediaType]; known && res.isCompressed && format.BaseVariantName() != expectedBaseFormat.Name() {
@@ -71,13 +71,13 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 
 // bpCompressionStepData contains data that the copy pipeline needs about the compression step.
 type bpCompressionStepData struct {
-	operation              bpcOperation                // What we are actually doing
-	uploadedOperation      types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
-	uploadedAlgorithm      *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
-	uploadedAnnotations    map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
-	srcCompressorName      string                      // Compressor name to record in the blob info cache for the source blob.
-	uploadedCompressorName string                      // Compressor name to record in the blob info cache for the uploaded blob.
-	closers                []io.Closer                 // Objects to close after the upload is done, if any.
+	operation                    bpcOperation                // What we are actually doing
+	uploadedOperation            types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
+	uploadedAlgorithm            *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
+	uploadedAnnotations          map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
+	srcCompressorBaseVariantName string                      // Compressor base variant name to record in the blob info cache for the source blob.
+	uploadedCompressorName       string                      // Compressor name to record in the blob info cache for the uploaded blob.
+	closers                      []io.Closer                 // Objects to close after the upload is done, if any.
 }
 
 type bpcOperation int
@@ -129,11 +129,11 @@ func (ic *imageCopier) bpcPreserveEncrypted(stream *sourceStream, _ bpDetectComp
 		// We can’t do anything with an encrypted blob unless decrypted.
 		logrus.Debugf("Using original blob without modification for encrypted blob")
 		return &bpCompressionStepData{
-			operation:              bpcOpPreserveOpaque,
-			uploadedOperation:      types.PreserveOriginal,
-			uploadedAlgorithm:      nil,
-			srcCompressorName:      internalblobinfocache.UnknownCompression,
-			uploadedCompressorName: internalblobinfocache.UnknownCompression,
+			operation:                    bpcOpPreserveOpaque,
+			uploadedOperation:            types.PreserveOriginal,
+			uploadedAlgorithm:            nil,
+			srcCompressorBaseVariantName: internalblobinfocache.UnknownCompression,
+			uploadedCompressorName:       internalblobinfocache.UnknownCompression,
 		}, nil
 	}
 	return nil, nil
@@ -158,13 +158,13 @@ func (ic *imageCopier) bpcCompressUncompressed(stream *sourceStream, detected bp
 			Size:   -1,
 		}
 		return &bpCompressionStepData{
-			operation:              bpcOpCompressUncompressed,
-			uploadedOperation:      types.Compress,
-			uploadedAlgorithm:      uploadedAlgorithm,
-			uploadedAnnotations:    annotations,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: uploadedAlgorithm.Name(),
-			closers:                []io.Closer{reader},
+			operation:                    bpcOpCompressUncompressed,
+			uploadedOperation:            types.Compress,
+			uploadedAlgorithm:            uploadedAlgorithm,
+			uploadedAnnotations:          annotations,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       uploadedAlgorithm.Name(),
+			closers:                      []io.Closer{reader},
 		}, nil
 	}
 	return nil, nil
@@ -199,13 +199,13 @@ func (ic *imageCopier) bpcRecompressCompressed(stream *sourceStream, detected bp
 		}
 		succeeded = true
 		return &bpCompressionStepData{
-			operation:              bpcOpRecompressCompressed,
-			uploadedOperation:      types.PreserveOriginal,
-			uploadedAlgorithm:      ic.compressionFormat,
-			uploadedAnnotations:    annotations,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: ic.compressionFormat.Name(),
-			closers:                []io.Closer{decompressed, recompressed},
+			operation:                    bpcOpRecompressCompressed,
+			uploadedOperation:            types.PreserveOriginal,
+			uploadedAlgorithm:            ic.compressionFormat,
+			uploadedAnnotations:          annotations,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       ic.compressionFormat.Name(),
+			closers:                      []io.Closer{decompressed, recompressed},
 		}, nil
 	}
 	return nil, nil
@@ -226,12 +226,12 @@ func (ic *imageCopier) bpcDecompressCompressed(stream *sourceStream, detected bp
 			Size:   -1,
 		}
 		return &bpCompressionStepData{
-			operation:              bpcOpDecompressCompressed,
-			uploadedOperation:      types.Decompress,
-			uploadedAlgorithm:      nil,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: internalblobinfocache.Uncompressed,
-			closers:                []io.Closer{s},
+			operation:                    bpcOpDecompressCompressed,
+			uploadedOperation:            types.Decompress,
+			uploadedAlgorithm:            nil,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       internalblobinfocache.Uncompressed,
+			closers:                      []io.Closer{s},
 		}, nil
 	}
 	return nil, nil
@@ -269,11 +269,14 @@ func (ic *imageCopier) bpcPreserveOriginal(_ *sourceStream, detected bpDetectCom
 		algorithm = nil
 	}
 	return &bpCompressionStepData{
-		operation:              bpcOp,
-		uploadedOperation:      uploadedOp,
-		uploadedAlgorithm:      algorithm,
-		srcCompressorName:      detected.srcCompressorName,
-		uploadedCompressorName: detected.srcCompressorName,
+		operation:                    bpcOp,
+		uploadedOperation:            uploadedOp,
+		uploadedAlgorithm:            algorithm,
+		srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+		// We only record the base variant of the format on upload; we didn’t do anything with
+		// the TOC, we don’t know whether it matches the blob digest, so we don’t want to trigger
+		// reuse of any kind between the blob digest and the TOC digest.
+		uploadedCompressorName: detected.srcCompressorBaseVariantName,
 	}
 }
 
@@ -333,9 +336,9 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			return fmt.Errorf("Internal error: Unexpected d.operation value %#v", d.operation)
 		}
 	}
-	if d.srcCompressorName == "" || d.uploadedCompressorName == "" {
-		return fmt.Errorf("internal error: missing compressor names (src: %q, uploaded: %q)",
-			d.srcCompressorName, d.uploadedCompressorName)
+	if d.srcCompressorBaseVariantName == "" || d.uploadedCompressorName == "" {
+		return fmt.Errorf("internal error: missing compressor names (src base: %q, uploaded: %q)",
+			d.srcCompressorBaseVariantName, d.uploadedCompressorName)
 	}
 	if d.uploadedCompressorName != internalblobinfocache.UnknownCompression {
 		if d.uploadedCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
@@ -353,13 +356,13 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 		}
 	}
 	if srcInfo.Digest != "" && srcInfo.Digest != uploadedInfo.Digest &&
-		d.srcCompressorName != internalblobinfocache.UnknownCompression {
-		if d.srcCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
-			// HACK: Don’t record zstd:chunked algorithms, see above.
-			c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
-				BaseVariantCompressor: d.srcCompressorName,
-			})
-		}
+		d.srcCompressorBaseVariantName != internalblobinfocache.UnknownCompression {
+		// If the source is already using some TOC-dependent variant, we either copied the
+		// blob as is, or perhaps decompressed it; either way we don’t trust the TOC digest,
+		// so record neither the variant name, nor the TOC digest.
+		c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
+			BaseVariantCompressor: d.srcCompressorBaseVariantName,
+		})
 	}
 	return nil
 }

--- a/internal/blobinfocache/blobinfocache.go
+++ b/internal/blobinfocache/blobinfocache.go
@@ -34,7 +34,7 @@ func (bic *v1OnlyBlobInfoCache) UncompressedDigestForTOC(tocDigest digest.Digest
 func (bic *v1OnlyBlobInfoCache) RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest) {
 }
 
-func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorData(anyDigest digest.Digest, data DigestCompressorData) {
 }
 
 func (bic *v1OnlyBlobInfoCache) CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, options CandidateLocations2Options) []BICReplacementCandidate2 {

--- a/internal/blobinfocache/types.go
+++ b/internal/blobinfocache/types.go
@@ -35,17 +35,23 @@ type BlobInfoCache2 interface {
 	// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
 	RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest)
 
-	// RecordDigestCompressorName records a compressor for the blob with the specified digest,
-	// or Uncompressed or UnknownCompression.
-	// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
-	// digest just because some remote author claims so (e.g. because a manifest says so);
+	// RecordDigestCompressorData records data for the blob with the specified digest.
+	// WARNING: Only call this with LOCALLY VERIFIED data:
+	//   - don’t record a compressor for a digest just because some remote author claims so
+	//     (e.g. because a manifest says so);
 	// otherwise the cache could be poisoned and cause us to make incorrect edits to type
 	// information in a manifest.
-	RecordDigestCompressorName(anyDigest digest.Digest, compressorName string)
+	RecordDigestCompressorData(anyDigest digest.Digest, data DigestCompressorData)
 	// CandidateLocations2 returns a prioritized, limited, number of blobs and their locations (if known)
 	// that could possibly be reused within the specified (transport scope) (if they still
 	// exist, which is not guaranteed).
 	CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, options CandidateLocations2Options) []BICReplacementCandidate2
+}
+
+// DigestCompressorData is information known about how a blob is compressed.
+// (This is worded generically, but basically targeted at the zstd / zstd:chunked situation.)
+type DigestCompressorData struct {
+	BaseVariantCompressor string // A compressor’s base variant name, or Uncompressed or UnknownCompression.
 }
 
 // CandidateLocations2Options are used in CandidateLocations2.

--- a/pkg/blobinfocache/internal/prioritize/prioritize_test.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize_test.go
@@ -168,22 +168,22 @@ func TestCandidateWithLocation(t *testing.T) {
 	loc := types.BICLocationReference{Opaque: "opaque"}
 	time := time.Now()
 	res := template.CandidateWithLocation(loc, time)
-	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
-	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
-	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
-	assert.Equal(t, false, res.Candidate.UnknownLocation)
-	assert.Equal(t, loc, res.Candidate.Location)
-	assert.Equal(t, time, res.LastSeen)
+	assert.Equal(t, digestCompressedPrimary, res.candidate.Digest)
+	assert.Equal(t, types.Compress, res.candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, false, res.candidate.UnknownLocation)
+	assert.Equal(t, loc, res.candidate.Location)
+	assert.Equal(t, time, res.lastSeen)
 }
 
 func TestCandidateWithUnknownLocation(t *testing.T) {
 	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
 	require.NotNil(t, template)
 	res := template.CandidateWithUnknownLocation()
-	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
-	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
-	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
-	assert.Equal(t, true, res.Candidate.UnknownLocation)
+	assert.Equal(t, digestCompressedPrimary, res.candidate.Digest)
+	assert.Equal(t, types.Compress, res.candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, true, res.candidate.UnknownLocation)
 }
 
 func TestCandidateSortStateLess(t *testing.T) {

--- a/pkg/blobinfocache/internal/prioritize/prioritize_test.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
+	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -52,6 +54,137 @@ var (
 		{Digest: digestUncompressed, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}},
 	}
 )
+
+func TestCandidateTemplateWithCompression(t *testing.T) {
+	for _, c := range []struct {
+		name                string
+		requiredCompression *compressiontypes.Algorithm
+		compressor          string
+		v2Matches           bool
+		// if v2Matches:
+		v2Op   types.LayerCompression
+		v2Algo string
+	}{
+		{
+			name:                "unknown",
+			requiredCompression: nil,
+			compressor:          blobinfocache.UnknownCompression,
+			v2Matches:           false,
+		},
+		{
+			name:                "uncompressed",
+			requiredCompression: nil,
+			compressor:          blobinfocache.Uncompressed,
+			v2Matches:           true,
+			v2Op:                types.Decompress,
+			v2Algo:              "",
+		},
+		{
+			name:                "uncompressed, want gzip",
+			requiredCompression: &compression.Gzip,
+			compressor:          blobinfocache.Uncompressed,
+			v2Matches:           false,
+		},
+		{
+			name:                "gzip",
+			requiredCompression: nil,
+			compressor:          compressiontypes.GzipAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.GzipAlgorithmName,
+		},
+		{
+			name:                "gzip, want zstd",
+			requiredCompression: &compression.Zstd,
+			compressor:          compressiontypes.GzipAlgorithmName,
+			v2Matches:           false,
+		},
+		{
+			name:                "unknown base",
+			requiredCompression: nil,
+			compressor:          "this value is unknown",
+			v2Matches:           false,
+		},
+		{
+			name:                "zstd",
+			requiredCompression: nil,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.ZstdAlgorithmName,
+		},
+		{
+			name:                "zstd, want gzip",
+			requiredCompression: &compression.Gzip,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           false,
+		},
+		{
+			name:                "zstd, want zstd",
+			requiredCompression: &compression.Zstd,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.ZstdAlgorithmName,
+		},
+		{
+			name:                "zstd, want zstd:chunked",
+			requiredCompression: &compression.ZstdChunked,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           false,
+		},
+	} {
+		res := CandidateTemplateWithCompression(nil, digestCompressedPrimary, c.compressor)
+		assert.Equal(t, &CandidateTemplate{
+			digest:               digestCompressedPrimary,
+			compressionOperation: types.PreserveOriginal,
+			compressionAlgorithm: nil,
+		}, res, c.name)
+
+		// These tests only use RequiredCompression in CandidateLocations2Options for clarity;
+		// CandidateCompressionMatchesReuseConditions should have its own tests of handling the full set of options.
+		res = CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{
+			RequiredCompression: c.requiredCompression,
+		}, digestCompressedPrimary, c.compressor)
+		if !c.v2Matches {
+			assert.Nil(t, res, c.name)
+		} else {
+			require.NotNil(t, res, c.name)
+			assert.Equal(t, digestCompressedPrimary, res.digest, c.name)
+			assert.Equal(t, c.v2Op, res.compressionOperation, c.name)
+			if c.v2Algo == "" {
+				assert.Nil(t, res.compressionAlgorithm, c.name)
+			} else {
+				require.NotNil(t, res.compressionAlgorithm, c.name)
+				assert.Equal(t, c.v2Algo, res.compressionAlgorithm.Name())
+			}
+		}
+	}
+}
+
+func TestCandidateWithLocation(t *testing.T) {
+	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
+	require.NotNil(t, template)
+	loc := types.BICLocationReference{Opaque: "opaque"}
+	time := time.Now()
+	res := template.CandidateWithLocation(loc, time)
+	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
+	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, false, res.Candidate.UnknownLocation)
+	assert.Equal(t, loc, res.Candidate.Location)
+	assert.Equal(t, time, res.LastSeen)
+}
+
+func TestCandidateWithUnknownLocation(t *testing.T) {
+	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
+	require.NotNil(t, template)
+	res := template.CandidateWithUnknownLocation()
+	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
+	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, true, res.Candidate.UnknownLocation)
+}
 
 func TestCandidateSortStateLess(t *testing.T) {
 	type p struct {

--- a/pkg/blobinfocache/internal/test/test.go
+++ b/pkg/blobinfocache/internal/test/test.go
@@ -314,7 +314,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// ----------------------------
 		// If a record exists with compression without Location then
 		// then return a record without location and with `UnknownLocation: true`
-		cache.RecordDigestCompressorName(digestUnknownLocation, compressiontypes.Bzip2AlgorithmName)
+		cache.RecordDigestCompressorData(digestUnknownLocation, blobinfocache.DigestCompressorData{
+			BaseVariantCompressor: compressiontypes.Bzip2AlgorithmName,
+		})
 		res = cache.CandidateLocations2(transport, scope, digestUnknownLocation, blobinfocache.CandidateLocations2Options{
 			CanSubstitute: true,
 		})
@@ -355,7 +357,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// that shouldn’t happen in real-world usage.
 		if scopeIndex != 0 {
 			for _, e := range digestNameSetPrioritization {
-				cache.RecordDigestCompressorName(e.d, blobinfocache.UnknownCompression)
+				cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+					BaseVariantCompressor: blobinfocache.UnknownCompression,
+				})
 			}
 		}
 
@@ -423,7 +427,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 
 		// Set the "known" compression values
 		for _, e := range digestNameSetPrioritization {
-			cache.RecordDigestCompressorName(e.d, e.m)
+			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+				BaseVariantCompressor: e.m,
+			})
 		}
 
 		// No substitutions allowed:
@@ -505,7 +511,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 			cache.RecordKnownLocation(transport, scope, e.d, types.BICLocationReference{Opaque: scopeName + e.n})
 		}
 		for _, e := range digestNameSetFiltering {
-			cache.RecordDigestCompressorName(e.d, e.m)
+			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+				BaseVariantCompressor: e.m,
+			})
 		}
 
 		// No filtering

--- a/pkg/blobinfocache/sqlite/sqlite.go
+++ b/pkg/blobinfocache/sqlite/sqlite.go
@@ -457,29 +457,30 @@ func (sqc *cache) RecordKnownLocation(transport types.ImageTransport, scope type
 	}) // FIXME? Log error (but throttle the log volume on repeated accesses)?
 }
 
-// RecordDigestCompressorName records a compressor for the blob with the specified digest,
-// or Uncompressed or UnknownCompression.
-// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
-// digest just because some remote author claims so (e.g. because a manifest says so);
+// RecordDigestCompressorData records data for the blob with the specified digest.
+// WARNING: Only call this with LOCALLY VERIFIED data:
+//   - don’t record a compressor for a digest just because some remote author claims so
+//     (e.g. because a manifest says so);
+//
 // otherwise the cache could be poisoned and cause us to make incorrect edits to type
 // information in a manifest.
-func (sqc *cache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+func (sqc *cache) RecordDigestCompressorData(anyDigest digest.Digest, data blobinfocache.DigestCompressorData) {
 	_, _ = transaction(sqc, func(tx *sql.Tx) (void, error) {
 		previous, gotPrevious, err := querySingleValue[string](tx, "SELECT compressor FROM DigestCompressors WHERE digest = ?", anyDigest.String())
 		if err != nil {
 			return void{}, fmt.Errorf("looking for compressor of for %q", anyDigest)
 		}
-		if gotPrevious && previous != compressorName {
-			logrus.Warnf("Compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, previous, compressorName)
+		if gotPrevious && previous != data.BaseVariantCompressor {
+			logrus.Warnf("Compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, previous, data.BaseVariantCompressor)
 		}
-		if compressorName == blobinfocache.UnknownCompression {
+		if data.BaseVariantCompressor == blobinfocache.UnknownCompression {
 			if _, err := tx.Exec("DELETE FROM DigestCompressors WHERE digest = ?", anyDigest.String()); err != nil {
 				return void{}, fmt.Errorf("deleting compressor for digest %q: %w", anyDigest, err)
 			}
 		} else {
 			if _, err := tx.Exec("INSERT OR REPLACE INTO DigestCompressors(digest, compressor) VALUES (?, ?)",
-				anyDigest.String(), compressorName); err != nil {
-				return void{}, fmt.Errorf("recording compressor %q for %q: %w", compressorName, anyDigest, err)
+				anyDigest.String(), data.BaseVariantCompressor); err != nil {
+				return void{}, fmt.Errorf("recording compressor %q for %q: %w", data.BaseVariantCompressor, anyDigest, err)
 			}
 		}
 		return void{}, nil
@@ -502,7 +503,9 @@ func (sqc *cache) appendReplacementCandidates(candidates []prioritize.CandidateW
 			compressorName = compressor
 		}
 	}
-	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, compressorName)
+	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, blobinfocache.DigestCompressorData{
+		BaseVariantCompressor: compressorName,
+	})
 	if template == nil {
 		return candidates, nil
 	}

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -548,8 +548,10 @@ func reusedBlobFromLayerLookup(layers []storage.Layer, blobDigest digest.Digest,
 			}
 		} else if options.CanSubstitute && layers[0].UncompressedDigest != "" {
 			return true, private.ReusedBlob{
-				Digest: layers[0].UncompressedDigest,
-				Size:   layers[0].UncompressedSize,
+				Digest:               layers[0].UncompressedDigest,
+				Size:                 layers[0].UncompressedSize,
+				CompressionOperation: types.Decompress,
+				CompressionAlgorithm: nil,
 			}
 		}
 	}


### PR DESCRIPTION
This is a subset of #2487 , ready for review; it doesn’t make _that_ much sense separately, but I’m filing it early to allow earlier review / merging, and to decrease the size of the later review. See #2487 for more on how this is intended to be used.

This is:
- One mostly unrelated bug fix
- A set of refactoring of the BlobInfoCache implementations, so that compression matching decisions are centralized in a single place.
- A change to correctly use `BaseVariantName` instead of hard-coding a zstd:chunked exception.

@giuseppe PTAL.