### PR TITLE
release-5.32 Zstd backports

### DIFF
--- a/copy/compression.go
+++ b/copy/compression.go
@@ -351,7 +351,9 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			// with the same digest and both ZstdAlgorithmName and ZstdChunkedAlgorithmName , which causes warnings about
 			// inconsistent data to be logged.
 			c.blobInfoCache.RecordDigestCompressorData(uploadedInfo.Digest, internalblobinfocache.DigestCompressorData{
-				BaseVariantCompressor: d.uploadedCompressorName,
+				BaseVariantCompressor:      d.uploadedCompressorName,
+				SpecificVariantCompressor:  internalblobinfocache.UnknownCompression,
+				SpecificVariantAnnotations: nil,
 			})
 		}
 	}
@@ -361,7 +363,9 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 		// blob as is, or perhaps decompressed it; either way we don’t trust the TOC digest,
 		// so record neither the variant name, nor the TOC digest.
 		c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
-			BaseVariantCompressor: d.srcCompressorBaseVariantName,
+			BaseVariantCompressor:      d.srcCompressorBaseVariantName,
+			SpecificVariantCompressor:  internalblobinfocache.UnknownCompression,
+			SpecificVariantAnnotations: nil,
 		})
 	}
 	return nil

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -347,14 +347,18 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			// between zstd and zstd:chunked; so we could, in varying situations over time, call RecordDigestCompressorName
 			// with the same digest and both ZstdAlgorithmName and ZstdChunkedAlgorithmName , which causes warnings about
 			// inconsistent data to be logged.
-			c.blobInfoCache.RecordDigestCompressorName(uploadedInfo.Digest, d.uploadedCompressorName)
+			c.blobInfoCache.RecordDigestCompressorData(uploadedInfo.Digest, internalblobinfocache.DigestCompressorData{
+				BaseVariantCompressor: d.uploadedCompressorName,
+			})
 		}
 	}
 	if srcInfo.Digest != "" && srcInfo.Digest != uploadedInfo.Digest &&
 		d.srcCompressorName != internalblobinfocache.UnknownCompression {
 		if d.srcCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
 			// HACK: Don’t record zstd:chunked algorithms, see above.
-			c.blobInfoCache.RecordDigestCompressorName(srcInfo.Digest, d.srcCompressorName)
+			c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
+				BaseVariantCompressor: d.srcCompressorName,
+			})
 		}
 	}
 	return nil

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -52,6 +52,16 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 	}
 	stream.reader = reader
 
+	if decompressor != nil && format.Name() == compressiontypes.ZstdAlgorithmName {
+		tocDigest, err := chunkedToc.GetTOCDigest(srcInfo.Annotations)
+		if err != nil {
+			return bpDetectCompressionStepData{}, err
+		}
+		if tocDigest != nil {
+			format = compression.ZstdChunked
+		}
+
+	}
 	res := bpDetectCompressionStepData{
 		isCompressed: decompressor != nil,
 		format:       format,

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -71,13 +71,14 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 
 // bpCompressionStepData contains data that the copy pipeline needs about the compression step.
 type bpCompressionStepData struct {
-	operation                    bpcOperation                // What we are actually doing
-	uploadedOperation            types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
-	uploadedAlgorithm            *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
-	uploadedAnnotations          map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
-	srcCompressorBaseVariantName string                      // Compressor base variant name to record in the blob info cache for the source blob.
-	uploadedCompressorName       string                      // Compressor name to record in the blob info cache for the uploaded blob.
-	closers                      []io.Closer                 // Objects to close after the upload is done, if any.
+	operation                             bpcOperation                // What we are actually doing
+	uploadedOperation                     types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
+	uploadedAlgorithm                     *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
+	uploadedAnnotations                   map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
+	srcCompressorBaseVariantName          string                      // Compressor base variant name to record in the blob info cache for the source blob.
+	uploadedCompressorBaseVariantName     string                      // Compressor base variant name to record in the blob info cache for the uploaded blob.
+	uploadedCompressorSpecificVariantName string                      // Compressor specific variant name to record in the blob info cache for the uploaded blob.
+	closers                               []io.Closer                 // Objects to close after the upload is done, if any.
 }
 
 type bpcOperation int
@@ -129,11 +130,12 @@ func (ic *imageCopier) bpcPreserveEncrypted(stream *sourceStream, _ bpDetectComp
 		// We can’t do anything with an encrypted blob unless decrypted.
 		logrus.Debugf("Using original blob without modification for encrypted blob")
 		return &bpCompressionStepData{
-			operation:                    bpcOpPreserveOpaque,
-			uploadedOperation:            types.PreserveOriginal,
-			uploadedAlgorithm:            nil,
-			srcCompressorBaseVariantName: internalblobinfocache.UnknownCompression,
-			uploadedCompressorName:       internalblobinfocache.UnknownCompression,
+			operation:                             bpcOpPreserveOpaque,
+			uploadedOperation:                     types.PreserveOriginal,
+			uploadedAlgorithm:                     nil,
+			srcCompressorBaseVariantName:          internalblobinfocache.UnknownCompression,
+			uploadedCompressorBaseVariantName:     internalblobinfocache.UnknownCompression,
+			uploadedCompressorSpecificVariantName: internalblobinfocache.UnknownCompression,
 		}, nil
 	}
 	return nil, nil
@@ -157,14 +159,19 @@ func (ic *imageCopier) bpcCompressUncompressed(stream *sourceStream, detected bp
 			Digest: "",
 			Size:   -1,
 		}
+		specificVariantName := uploadedAlgorithm.Name()
+		if specificVariantName == uploadedAlgorithm.BaseVariantName() {
+			specificVariantName = internalblobinfocache.UnknownCompression
+		}
 		return &bpCompressionStepData{
-			operation:                    bpcOpCompressUncompressed,
-			uploadedOperation:            types.Compress,
-			uploadedAlgorithm:            uploadedAlgorithm,
-			uploadedAnnotations:          annotations,
-			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
-			uploadedCompressorName:       uploadedAlgorithm.Name(),
-			closers:                      []io.Closer{reader},
+			operation:                             bpcOpCompressUncompressed,
+			uploadedOperation:                     types.Compress,
+			uploadedAlgorithm:                     uploadedAlgorithm,
+			uploadedAnnotations:                   annotations,
+			srcCompressorBaseVariantName:          detected.srcCompressorBaseVariantName,
+			uploadedCompressorBaseVariantName:     uploadedAlgorithm.BaseVariantName(),
+			uploadedCompressorSpecificVariantName: specificVariantName,
+			closers:                               []io.Closer{reader},
 		}, nil
 	}
 	return nil, nil
@@ -197,15 +204,20 @@ func (ic *imageCopier) bpcRecompressCompressed(stream *sourceStream, detected bp
 			Digest: "",
 			Size:   -1,
 		}
+		specificVariantName := ic.compressionFormat.Name()
+		if specificVariantName == ic.compressionFormat.BaseVariantName() {
+			specificVariantName = internalblobinfocache.UnknownCompression
+		}
 		succeeded = true
 		return &bpCompressionStepData{
-			operation:                    bpcOpRecompressCompressed,
-			uploadedOperation:            types.PreserveOriginal,
-			uploadedAlgorithm:            ic.compressionFormat,
-			uploadedAnnotations:          annotations,
-			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
-			uploadedCompressorName:       ic.compressionFormat.Name(),
-			closers:                      []io.Closer{decompressed, recompressed},
+			operation:                             bpcOpRecompressCompressed,
+			uploadedOperation:                     types.PreserveOriginal,
+			uploadedAlgorithm:                     ic.compressionFormat,
+			uploadedAnnotations:                   annotations,
+			srcCompressorBaseVariantName:          detected.srcCompressorBaseVariantName,
+			uploadedCompressorBaseVariantName:     ic.compressionFormat.BaseVariantName(),
+			uploadedCompressorSpecificVariantName: specificVariantName,
+			closers:                               []io.Closer{decompressed, recompressed},
 		}, nil
 	}
 	return nil, nil
@@ -226,12 +238,13 @@ func (ic *imageCopier) bpcDecompressCompressed(stream *sourceStream, detected bp
 			Size:   -1,
 		}
 		return &bpCompressionStepData{
-			operation:                    bpcOpDecompressCompressed,
-			uploadedOperation:            types.Decompress,
-			uploadedAlgorithm:            nil,
-			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
-			uploadedCompressorName:       internalblobinfocache.Uncompressed,
-			closers:                      []io.Closer{s},
+			operation:                             bpcOpDecompressCompressed,
+			uploadedOperation:                     types.Decompress,
+			uploadedAlgorithm:                     nil,
+			srcCompressorBaseVariantName:          detected.srcCompressorBaseVariantName,
+			uploadedCompressorBaseVariantName:     internalblobinfocache.Uncompressed,
+			uploadedCompressorSpecificVariantName: internalblobinfocache.UnknownCompression,
+			closers:                               []io.Closer{s},
 		}, nil
 	}
 	return nil, nil
@@ -276,7 +289,8 @@ func (ic *imageCopier) bpcPreserveOriginal(_ *sourceStream, detected bpDetectCom
 		// We only record the base variant of the format on upload; we didn’t do anything with
 		// the TOC, we don’t know whether it matches the blob digest, so we don’t want to trigger
 		// reuse of any kind between the blob digest and the TOC digest.
-		uploadedCompressorName: detected.srcCompressorBaseVariantName,
+		uploadedCompressorBaseVariantName:     detected.srcCompressorBaseVariantName,
+		uploadedCompressorSpecificVariantName: internalblobinfocache.UnknownCompression,
 	}
 }
 
@@ -336,26 +350,16 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			return fmt.Errorf("Internal error: Unexpected d.operation value %#v", d.operation)
 		}
 	}
-	if d.srcCompressorBaseVariantName == "" || d.uploadedCompressorName == "" {
-		return fmt.Errorf("internal error: missing compressor names (src base: %q, uploaded: %q)",
-			d.srcCompressorBaseVariantName, d.uploadedCompressorName)
+	if d.srcCompressorBaseVariantName == "" || d.uploadedCompressorBaseVariantName == "" || d.uploadedCompressorSpecificVariantName == "" {
+		return fmt.Errorf("internal error: missing compressor names (src base: %q, uploaded base: %q, uploaded specific: %q)",
+			d.srcCompressorBaseVariantName, d.uploadedCompressorBaseVariantName, d.uploadedCompressorSpecificVariantName)
 	}
-	if d.uploadedCompressorName != internalblobinfocache.UnknownCompression {
-		if d.uploadedCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
-			// HACK: Don’t record zstd:chunked algorithms.
-			// There is already a similar hack in internal/imagedestination/impl/helpers.CandidateMatchesTryReusingBlobOptions,
-			// and that one prevents reusing zstd:chunked blobs, so recording the algorithm here would be mostly harmless.
-			//
-			// We skip that here anyway to work around the inability of blobPipelineDetectCompressionStep to differentiate
-			// between zstd and zstd:chunked; so we could, in varying situations over time, call RecordDigestCompressorName
-			// with the same digest and both ZstdAlgorithmName and ZstdChunkedAlgorithmName , which causes warnings about
-			// inconsistent data to be logged.
-			c.blobInfoCache.RecordDigestCompressorData(uploadedInfo.Digest, internalblobinfocache.DigestCompressorData{
-				BaseVariantCompressor:      d.uploadedCompressorName,
-				SpecificVariantCompressor:  internalblobinfocache.UnknownCompression,
-				SpecificVariantAnnotations: nil,
-			})
-		}
+	if d.uploadedCompressorBaseVariantName != internalblobinfocache.UnknownCompression {
+		c.blobInfoCache.RecordDigestCompressorData(uploadedInfo.Digest, internalblobinfocache.DigestCompressorData{
+			BaseVariantCompressor:      d.uploadedCompressorBaseVariantName,
+			SpecificVariantCompressor:  d.uploadedCompressorSpecificVariantName,
+			SpecificVariantAnnotations: d.uploadedAnnotations,
+		})
 	}
 	if srcInfo.Digest != "" && srcInfo.Digest != uploadedInfo.Digest &&
 		d.srcCompressorBaseVariantName != internalblobinfocache.UnknownCompression {

--- a/copy/compression.go
+++ b/copy/compression.go
@@ -35,10 +35,10 @@ var (
 
 // bpDetectCompressionStepData contains data that the copy pipeline needs about the “detect compression” step.
 type bpDetectCompressionStepData struct {
-	isCompressed      bool
-	format            compressiontypes.Algorithm        // Valid if isCompressed
-	decompressor      compressiontypes.DecompressorFunc // Valid if isCompressed
-	srcCompressorName string                            // Compressor name to possibly record in the blob info cache for the source blob.
+	isCompressed                 bool
+	format                       compressiontypes.Algorithm        // Valid if isCompressed
+	decompressor                 compressiontypes.DecompressorFunc // Valid if isCompressed
+	srcCompressorBaseVariantName string                            // Compressor name to possibly record in the blob info cache for the source blob.
 }
 
 // blobPipelineDetectCompressionStep updates *stream to detect its current compression format.
@@ -58,9 +58,9 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 		decompressor: decompressor,
 	}
 	if res.isCompressed {
-		res.srcCompressorName = format.Name()
+		res.srcCompressorBaseVariantName = format.BaseVariantName()
 	} else {
-		res.srcCompressorName = internalblobinfocache.Uncompressed
+		res.srcCompressorBaseVariantName = internalblobinfocache.Uncompressed
 	}
 
 	if expectedBaseFormat, known := expectedBaseCompressionFormats[stream.info.MediaType]; known && res.isCompressed && format.BaseVariantName() != expectedBaseFormat.Name() {
@@ -71,13 +71,13 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 
 // bpCompressionStepData contains data that the copy pipeline needs about the compression step.
 type bpCompressionStepData struct {
-	operation              bpcOperation                // What we are actually doing
-	uploadedOperation      types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
-	uploadedAlgorithm      *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
-	uploadedAnnotations    map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
-	srcCompressorName      string                      // Compressor name to record in the blob info cache for the source blob.
-	uploadedCompressorName string                      // Compressor name to record in the blob info cache for the uploaded blob.
-	closers                []io.Closer                 // Objects to close after the upload is done, if any.
+	operation                    bpcOperation                // What we are actually doing
+	uploadedOperation            types.LayerCompression      // Operation to use for updating the blob metadata (matching the end state, not necessarily what we do)
+	uploadedAlgorithm            *compressiontypes.Algorithm // An algorithm parameter for the compressionOperation edits.
+	uploadedAnnotations          map[string]string           // Compression-related annotations that should be set on the uploaded blob. WARNING: This is only set after the srcStream.reader is fully consumed.
+	srcCompressorBaseVariantName string                      // Compressor base variant name to record in the blob info cache for the source blob.
+	uploadedCompressorName       string                      // Compressor name to record in the blob info cache for the uploaded blob.
+	closers                      []io.Closer                 // Objects to close after the upload is done, if any.
 }
 
 type bpcOperation int
@@ -129,11 +129,11 @@ func (ic *imageCopier) bpcPreserveEncrypted(stream *sourceStream, _ bpDetectComp
 		// We can’t do anything with an encrypted blob unless decrypted.
 		logrus.Debugf("Using original blob without modification for encrypted blob")
 		return &bpCompressionStepData{
-			operation:              bpcOpPreserveOpaque,
-			uploadedOperation:      types.PreserveOriginal,
-			uploadedAlgorithm:      nil,
-			srcCompressorName:      internalblobinfocache.UnknownCompression,
-			uploadedCompressorName: internalblobinfocache.UnknownCompression,
+			operation:                    bpcOpPreserveOpaque,
+			uploadedOperation:            types.PreserveOriginal,
+			uploadedAlgorithm:            nil,
+			srcCompressorBaseVariantName: internalblobinfocache.UnknownCompression,
+			uploadedCompressorName:       internalblobinfocache.UnknownCompression,
 		}, nil
 	}
 	return nil, nil
@@ -158,13 +158,13 @@ func (ic *imageCopier) bpcCompressUncompressed(stream *sourceStream, detected bp
 			Size:   -1,
 		}
 		return &bpCompressionStepData{
-			operation:              bpcOpCompressUncompressed,
-			uploadedOperation:      types.Compress,
-			uploadedAlgorithm:      uploadedAlgorithm,
-			uploadedAnnotations:    annotations,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: uploadedAlgorithm.Name(),
-			closers:                []io.Closer{reader},
+			operation:                    bpcOpCompressUncompressed,
+			uploadedOperation:            types.Compress,
+			uploadedAlgorithm:            uploadedAlgorithm,
+			uploadedAnnotations:          annotations,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       uploadedAlgorithm.Name(),
+			closers:                      []io.Closer{reader},
 		}, nil
 	}
 	return nil, nil
@@ -199,13 +199,13 @@ func (ic *imageCopier) bpcRecompressCompressed(stream *sourceStream, detected bp
 		}
 		succeeded = true
 		return &bpCompressionStepData{
-			operation:              bpcOpRecompressCompressed,
-			uploadedOperation:      types.PreserveOriginal,
-			uploadedAlgorithm:      ic.compressionFormat,
-			uploadedAnnotations:    annotations,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: ic.compressionFormat.Name(),
-			closers:                []io.Closer{decompressed, recompressed},
+			operation:                    bpcOpRecompressCompressed,
+			uploadedOperation:            types.PreserveOriginal,
+			uploadedAlgorithm:            ic.compressionFormat,
+			uploadedAnnotations:          annotations,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       ic.compressionFormat.Name(),
+			closers:                      []io.Closer{decompressed, recompressed},
 		}, nil
 	}
 	return nil, nil
@@ -226,12 +226,12 @@ func (ic *imageCopier) bpcDecompressCompressed(stream *sourceStream, detected bp
 			Size:   -1,
 		}
 		return &bpCompressionStepData{
-			operation:              bpcOpDecompressCompressed,
-			uploadedOperation:      types.Decompress,
-			uploadedAlgorithm:      nil,
-			srcCompressorName:      detected.srcCompressorName,
-			uploadedCompressorName: internalblobinfocache.Uncompressed,
-			closers:                []io.Closer{s},
+			operation:                    bpcOpDecompressCompressed,
+			uploadedOperation:            types.Decompress,
+			uploadedAlgorithm:            nil,
+			srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+			uploadedCompressorName:       internalblobinfocache.Uncompressed,
+			closers:                      []io.Closer{s},
 		}, nil
 	}
 	return nil, nil
@@ -269,11 +269,14 @@ func (ic *imageCopier) bpcPreserveOriginal(_ *sourceStream, detected bpDetectCom
 		algorithm = nil
 	}
 	return &bpCompressionStepData{
-		operation:              bpcOp,
-		uploadedOperation:      uploadedOp,
-		uploadedAlgorithm:      algorithm,
-		srcCompressorName:      detected.srcCompressorName,
-		uploadedCompressorName: detected.srcCompressorName,
+		operation:                    bpcOp,
+		uploadedOperation:            uploadedOp,
+		uploadedAlgorithm:            algorithm,
+		srcCompressorBaseVariantName: detected.srcCompressorBaseVariantName,
+		// We only record the base variant of the format on upload; we didn’t do anything with
+		// the TOC, we don’t know whether it matches the blob digest, so we don’t want to trigger
+		// reuse of any kind between the blob digest and the TOC digest.
+		uploadedCompressorName: detected.srcCompressorBaseVariantName,
 	}
 }
 
@@ -333,9 +336,9 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 			return fmt.Errorf("Internal error: Unexpected d.operation value %#v", d.operation)
 		}
 	}
-	if d.srcCompressorName == "" || d.uploadedCompressorName == "" {
-		return fmt.Errorf("internal error: missing compressor names (src: %q, uploaded: %q)",
-			d.srcCompressorName, d.uploadedCompressorName)
+	if d.srcCompressorBaseVariantName == "" || d.uploadedCompressorName == "" {
+		return fmt.Errorf("internal error: missing compressor names (src base: %q, uploaded: %q)",
+			d.srcCompressorBaseVariantName, d.uploadedCompressorName)
 	}
 	if d.uploadedCompressorName != internalblobinfocache.UnknownCompression {
 		if d.uploadedCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
@@ -353,13 +356,13 @@ func (d *bpCompressionStepData) recordValidatedDigestData(c *copier, uploadedInf
 		}
 	}
 	if srcInfo.Digest != "" && srcInfo.Digest != uploadedInfo.Digest &&
-		d.srcCompressorName != internalblobinfocache.UnknownCompression {
-		if d.srcCompressorName != compressiontypes.ZstdChunkedAlgorithmName {
-			// HACK: Don’t record zstd:chunked algorithms, see above.
-			c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
-				BaseVariantCompressor: d.srcCompressorName,
-			})
-		}
+		d.srcCompressorBaseVariantName != internalblobinfocache.UnknownCompression {
+		// If the source is already using some TOC-dependent variant, we either copied the
+		// blob as is, or perhaps decompressed it; either way we don’t trust the TOC digest,
+		// so record neither the variant name, nor the TOC digest.
+		c.blobInfoCache.RecordDigestCompressorData(srcInfo.Digest, internalblobinfocache.DigestCompressorData{
+			BaseVariantCompressor: d.srcCompressorBaseVariantName,
+		})
 	}
 	return nil
 }

--- a/copy/single.go
+++ b/copy/single.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -888,21 +889,33 @@ func updatedBlobInfoFromReuse(inputInfo types.BlobInfo, reusedBlob private.Reuse
 	// Handling of compression, encryption, and the related MIME types and the like are all the responsibility
 	// of the generic code in this package.
 	res := types.BlobInfo{
-		Digest:               reusedBlob.Digest,
-		Size:                 reusedBlob.Size,
-		URLs:                 nil,                   // This _must_ be cleared if Digest changes; clear it in other cases as well, to preserve previous behavior.
-		Annotations:          inputInfo.Annotations, // FIXME: This should remove zstd:chunked annotations (but those annotations being left with incorrect values should not break pulls)
-		MediaType:            inputInfo.MediaType,   // Mostly irrelevant, MediaType is updated based on Compression*/CryptoOperation.
+		Digest: reusedBlob.Digest,
+		Size:   reusedBlob.Size,
+		URLs:   nil, // This _must_ be cleared if Digest changes; clear it in other cases as well, to preserve previous behavior.
+		// FIXME: This should remove zstd:chunked annotations IF the original was chunked and the new one isn’t
+		// (but those annotations being left with incorrect values should not break pulls).
+		Annotations:          maps.Clone(inputInfo.Annotations),
+		MediaType:            inputInfo.MediaType, // Mostly irrelevant, MediaType is updated based on Compression*/CryptoOperation.
 		CompressionOperation: reusedBlob.CompressionOperation,
 		CompressionAlgorithm: reusedBlob.CompressionAlgorithm,
 		CryptoOperation:      inputInfo.CryptoOperation, // Expected to be unset anyway.
 	}
 	// The transport is only expected to fill CompressionOperation and CompressionAlgorithm
-	// if the blob was substituted; otherwise, fill it in based
+	// if the blob was substituted; otherwise, it is optional, and if not set, fill it in based
 	// on what we know from the srcInfos we were given.
 	if reusedBlob.Digest == inputInfo.Digest {
-		res.CompressionOperation = inputInfo.CompressionOperation
-		res.CompressionAlgorithm = inputInfo.CompressionAlgorithm
+		if res.CompressionOperation == types.PreserveOriginal {
+			res.CompressionOperation = inputInfo.CompressionOperation
+		}
+		if res.CompressionAlgorithm == nil {
+			res.CompressionAlgorithm = inputInfo.CompressionAlgorithm
+		}
+	}
+	if len(reusedBlob.CompressionAnnotations) != 0 {
+		if res.Annotations == nil {
+			res.Annotations = map[string]string{}
+		}
+		maps.Copy(res.Annotations, reusedBlob.CompressionAnnotations)
 	}
 	return res
 }

--- a/copy/single.go
+++ b/copy/single.go
@@ -163,7 +163,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		if format == nil {
 			format = defaultCompressionFormat
 		}
-		if format.Name() == compression.ZstdChunked.Name() {
+		if format.Name() == compressiontypes.ZstdChunkedAlgorithmName {
 			if ic.requireCompressionFormatMatch {
 				return copySingleImageResult{}, errors.New("explicitly requested to combine zstd:chunked with encryption, which is not beneficial; use plain zstd instead")
 			}

--- a/copy/single_test.go
+++ b/copy/single_test.go
@@ -55,19 +55,39 @@ func TestUpdatedBlobInfoFromReuse(t *testing.T) {
 		},
 		{ // Reuse with substitution
 			reused: private.ReusedBlob{
-				Digest:               "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				Size:                 513543640,
-				CompressionOperation: types.Decompress,
-				CompressionAlgorithm: nil,
+				Digest:                 "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Size:                   513543640,
+				CompressionOperation:   types.Decompress,
+				CompressionAlgorithm:   nil,
+				CompressionAnnotations: map[string]string{"decompressed": "value"},
 			},
 			expected: types.BlobInfo{
 				Digest:               "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Size:                 513543640,
 				URLs:                 nil,
-				Annotations:          map[string]string{"test-annotation-2": "two"},
+				Annotations:          map[string]string{"test-annotation-2": "two", "decompressed": "value"},
 				MediaType:            imgspecv1.MediaTypeImageLayerGzip,
 				CompressionOperation: types.Decompress,
 				CompressionAlgorithm: nil,
+				// CryptoOperation is set to the zero value
+			},
+		},
+		{ // Reuse turning zstd into zstd:chunked
+			reused: private.ReusedBlob{
+				Digest:                 "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
+				Size:                   51354364,
+				CompressionOperation:   types.Compress,
+				CompressionAlgorithm:   &compression.ZstdChunked,
+				CompressionAnnotations: map[string]string{"zstd-toc": "value"},
+			},
+			expected: types.BlobInfo{
+				Digest:               "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb",
+				Size:                 51354364,
+				URLs:                 nil,
+				Annotations:          map[string]string{"test-annotation-2": "two", "zstd-toc": "value"},
+				MediaType:            imgspecv1.MediaTypeImageLayerGzip,
+				CompressionOperation: types.Compress,
+				CompressionAlgorithm: &compression.ZstdChunked,
 				// CryptoOperation is set to the zero value
 			},
 		},

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -332,6 +332,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		return false, private.ReusedBlob{}, errors.New("Can not check for a blob with unknown digest")
 	}
 
+	originalCandidateKnownToBeMissing := false
 	if impl.OriginalCandidateMatchesTryReusingBlobOptions(options) {
 		// First, check whether the blob happens to already exist at the destination.
 		haveBlob, reusedInfo, err := d.tryReusingExactBlob(ctx, info, options.Cache)
@@ -341,9 +342,17 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		if haveBlob {
 			return true, reusedInfo, nil
 		}
+		originalCandidateKnownToBeMissing = true
 	} else {
 		logrus.Debugf("Ignoring exact blob match, compression %s does not match required %s or MIME types %#v",
 			optionalCompressionName(options.OriginalCompression), optionalCompressionName(options.RequiredCompression), options.PossibleManifestFormats)
+		// We can get here with a blob detected to be zstd when the user wants a zstd:chunked.
+		// In that case we keep originalCandiateKnownToBeMissing = false, so that if we find
+		// a BIC entry for this blob, we do use that entry and return a zstd:chunked entry
+		// with the BIC’s annotations.
+		// This is not quite correct, it only works if the BIC also contains an acceptable _location_.
+		// Ideally, we could look up just the compression algorithm/annotations for info.digest,
+		// and use it even if no location candidate exists and the original dandidate is present.
 	}
 
 	// Then try reusing blobs from other locations.
@@ -387,7 +396,8 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 			// for it in the current repo.
 			candidateRepo = reference.TrimNamed(d.ref.ref)
 		}
-		if candidateRepo.Name() == d.ref.ref.Name() && candidate.Digest == info.Digest {
+		if originalCandidateKnownToBeMissing &&
+			candidateRepo.Name() == d.ref.ref.Name() && candidate.Digest == info.Digest {
 			logrus.Debug("... Already tried the primary destination")
 			continue
 		}
@@ -427,10 +437,12 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		options.Cache.RecordKnownLocation(d.ref.Transport(), bicTransportScope(d.ref), candidate.Digest, newBICLocationReference(d.ref))
 
 		return true, private.ReusedBlob{
-			Digest:               candidate.Digest,
-			Size:                 size,
-			CompressionOperation: candidate.CompressionOperation,
-			CompressionAlgorithm: candidate.CompressionAlgorithm}, nil
+			Digest:                 candidate.Digest,
+			Size:                   size,
+			CompressionOperation:   candidate.CompressionOperation,
+			CompressionAlgorithm:   candidate.CompressionAlgorithm,
+			CompressionAnnotations: candidate.CompressionAnnotations,
+		}, nil
 	}
 
 	return false, private.ReusedBlob{}, nil

--- a/internal/blobinfocache/blobinfocache.go
+++ b/internal/blobinfocache/blobinfocache.go
@@ -34,7 +34,7 @@ func (bic *v1OnlyBlobInfoCache) UncompressedDigestForTOC(tocDigest digest.Digest
 func (bic *v1OnlyBlobInfoCache) RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest) {
 }
 
-func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorData(anyDigest digest.Digest, data DigestCompressorData) {
 }
 
 func (bic *v1OnlyBlobInfoCache) CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, options CandidateLocations2Options) []BICReplacementCandidate2 {

--- a/internal/blobinfocache/blobinfocache.go
+++ b/internal/blobinfocache/blobinfocache.go
@@ -27,6 +27,13 @@ func (bic *v1OnlyBlobInfoCache) Open() {
 func (bic *v1OnlyBlobInfoCache) Close() {
 }
 
+func (bic *v1OnlyBlobInfoCache) UncompressedDigestForTOC(tocDigest digest.Digest) digest.Digest {
+	return ""
+}
+
+func (bic *v1OnlyBlobInfoCache) RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest) {
+}
+
 func (bic *v1OnlyBlobInfoCache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
 }
 

--- a/internal/blobinfocache/types.go
+++ b/internal/blobinfocache/types.go
@@ -35,17 +35,23 @@ type BlobInfoCache2 interface {
 	// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
 	RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest)
 
-	// RecordDigestCompressorName records a compressor for the blob with the specified digest,
-	// or Uncompressed or UnknownCompression.
-	// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
-	// digest just because some remote author claims so (e.g. because a manifest says so);
+	// RecordDigestCompressorData records data for the blob with the specified digest.
+	// WARNING: Only call this with LOCALLY VERIFIED data:
+	//   - don’t record a compressor for a digest just because some remote author claims so
+	//     (e.g. because a manifest says so);
 	// otherwise the cache could be poisoned and cause us to make incorrect edits to type
 	// information in a manifest.
-	RecordDigestCompressorName(anyDigest digest.Digest, compressorName string)
+	RecordDigestCompressorData(anyDigest digest.Digest, data DigestCompressorData)
 	// CandidateLocations2 returns a prioritized, limited, number of blobs and their locations (if known)
 	// that could possibly be reused within the specified (transport scope) (if they still
 	// exist, which is not guaranteed).
 	CandidateLocations2(transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest, options CandidateLocations2Options) []BICReplacementCandidate2
+}
+
+// DigestCompressorData is information known about how a blob is compressed.
+// (This is worded generically, but basically targeted at the zstd / zstd:chunked situation.)
+type DigestCompressorData struct {
+	BaseVariantCompressor string // A compressor’s base variant name, or Uncompressed or UnknownCompression.
 }
 
 // CandidateLocations2Options are used in CandidateLocations2.

--- a/internal/blobinfocache/types.go
+++ b/internal/blobinfocache/types.go
@@ -26,6 +26,15 @@ type BlobInfoCache2 interface {
 	// Close destroys state created by Open().
 	Close()
 
+	// UncompressedDigestForTOC returns an uncompressed digest corresponding to anyDigest.
+	// Returns "" if the uncompressed digest is unknown.
+	UncompressedDigestForTOC(tocDigest digest.Digest) digest.Digest
+	// RecordTOCUncompressedPair records that the tocDigest corresponds to uncompressed.
+	// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+	// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+	// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+	RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest)
+
 	// RecordDigestCompressorName records a compressor for the blob with the specified digest,
 	// or Uncompressed or UnknownCompression.
 	// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -76,6 +76,9 @@ func (w *wrapped) TryReusingBlobWithOptions(ctx context.Context, info types.Blob
 		Size:                 blob.Size,
 		CompressionOperation: blob.CompressionOperation,
 		CompressionAlgorithm: blob.CompressionAlgorithm,
+		// CompressionAnnotations could be set to blob.Annotations, but that may contain unrelated
+		// annotations, and we didn’t use the blob.Annotations field previously, so we’ll
+		// continue not using it.
 	}, nil
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -205,11 +205,6 @@ type ReuseConditions struct {
 // (which can be nil to represent uncompressed or unknown) matches reuseConditions.
 func CandidateCompressionMatchesReuseConditions(c ReuseConditions, candidateCompression *compressiontypes.Algorithm) bool {
 	if c.RequiredCompression != nil {
-		if c.RequiredCompression.Name() == compressiontypes.ZstdChunkedAlgorithmName {
-			// HACK: Never match when the caller asks for zstd:chunked, because we don’t record the annotations required to use the chunked blobs.
-			// The caller must re-compress to build those annotations.
-			return false
-		}
 		if candidateCompression == nil ||
 			(c.RequiredCompression.Name() != candidateCompression.Name() && c.RequiredCompression.Name() != candidateCompression.BaseVariantName()) {
 			return false

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -192,6 +192,9 @@ func TestCandidateCompressionMatchesReuseConditions(t *testing.T) {
 	}{
 		// RequiredCompression restrictions
 		{&compression.Zstd, nil, &compression.Zstd, true},
+		{&compression.Zstd, nil, &compression.ZstdChunked, true},
+		{&compression.ZstdChunked, nil, &compression.Zstd, false},
+		{&compression.ZstdChunked, nil, &compression.ZstdChunked, true},
 		{&compression.Gzip, nil, &compression.Zstd, false},
 		{&compression.Zstd, nil, nil, false},
 		{nil, nil, &compression.Zstd, true},

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -134,8 +134,13 @@ type ReusedBlob struct {
 	Size   int64         // Must be provided
 	// The following compression fields should be set when the reuse substitutes
 	// a differently-compressed blob.
+	// They may be set also to change from a base variant to a specific variant of an algorithm.
 	CompressionOperation types.LayerCompression // Compress/Decompress, matching the reused blob; PreserveOriginal if N/A
 	CompressionAlgorithm *compression.Algorithm // Algorithm if compressed, nil if decompressed or N/A
+
+	// Annotations that should be added, for CompressionAlgorithm. Note that they might need to be
+	// added even if the digest doesn’t change (if we found the annotations in a cache).
+	CompressionAnnotations map[string]string
 
 	MatchedByTOCDigest bool // Whether the layer was reused/matched by TOC digest. Used only for UI purposes.
 }

--- a/pkg/blobinfocache/internal/prioritize/prioritize_test.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize_test.go
@@ -168,22 +168,22 @@ func TestCandidateWithLocation(t *testing.T) {
 	loc := types.BICLocationReference{Opaque: "opaque"}
 	time := time.Now()
 	res := template.CandidateWithLocation(loc, time)
-	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
-	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
-	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
-	assert.Equal(t, false, res.Candidate.UnknownLocation)
-	assert.Equal(t, loc, res.Candidate.Location)
-	assert.Equal(t, time, res.LastSeen)
+	assert.Equal(t, digestCompressedPrimary, res.candidate.Digest)
+	assert.Equal(t, types.Compress, res.candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, false, res.candidate.UnknownLocation)
+	assert.Equal(t, loc, res.candidate.Location)
+	assert.Equal(t, time, res.lastSeen)
 }
 
 func TestCandidateWithUnknownLocation(t *testing.T) {
 	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
 	require.NotNil(t, template)
 	res := template.CandidateWithUnknownLocation()
-	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
-	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
-	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
-	assert.Equal(t, true, res.Candidate.UnknownLocation)
+	assert.Equal(t, digestCompressedPrimary, res.candidate.Digest)
+	assert.Equal(t, types.Compress, res.candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, true, res.candidate.UnknownLocation)
 }
 
 func TestCandidateSortStateLess(t *testing.T) {

--- a/pkg/blobinfocache/internal/prioritize/prioritize_test.go
+++ b/pkg/blobinfocache/internal/prioritize/prioritize_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/containers/image/v5/internal/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
+	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -52,6 +54,137 @@ var (
 		{Digest: digestUncompressed, UnknownLocation: true, Location: types.BICLocationReference{Opaque: ""}},
 	}
 )
+
+func TestCandidateTemplateWithCompression(t *testing.T) {
+	for _, c := range []struct {
+		name                string
+		requiredCompression *compressiontypes.Algorithm
+		compressor          string
+		v2Matches           bool
+		// if v2Matches:
+		v2Op   types.LayerCompression
+		v2Algo string
+	}{
+		{
+			name:                "unknown",
+			requiredCompression: nil,
+			compressor:          blobinfocache.UnknownCompression,
+			v2Matches:           false,
+		},
+		{
+			name:                "uncompressed",
+			requiredCompression: nil,
+			compressor:          blobinfocache.Uncompressed,
+			v2Matches:           true,
+			v2Op:                types.Decompress,
+			v2Algo:              "",
+		},
+		{
+			name:                "uncompressed, want gzip",
+			requiredCompression: &compression.Gzip,
+			compressor:          blobinfocache.Uncompressed,
+			v2Matches:           false,
+		},
+		{
+			name:                "gzip",
+			requiredCompression: nil,
+			compressor:          compressiontypes.GzipAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.GzipAlgorithmName,
+		},
+		{
+			name:                "gzip, want zstd",
+			requiredCompression: &compression.Zstd,
+			compressor:          compressiontypes.GzipAlgorithmName,
+			v2Matches:           false,
+		},
+		{
+			name:                "unknown base",
+			requiredCompression: nil,
+			compressor:          "this value is unknown",
+			v2Matches:           false,
+		},
+		{
+			name:                "zstd",
+			requiredCompression: nil,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.ZstdAlgorithmName,
+		},
+		{
+			name:                "zstd, want gzip",
+			requiredCompression: &compression.Gzip,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           false,
+		},
+		{
+			name:                "zstd, want zstd",
+			requiredCompression: &compression.Zstd,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           true,
+			v2Op:                types.Compress,
+			v2Algo:              compressiontypes.ZstdAlgorithmName,
+		},
+		{
+			name:                "zstd, want zstd:chunked",
+			requiredCompression: &compression.ZstdChunked,
+			compressor:          compressiontypes.ZstdAlgorithmName,
+			v2Matches:           false,
+		},
+	} {
+		res := CandidateTemplateWithCompression(nil, digestCompressedPrimary, c.compressor)
+		assert.Equal(t, &CandidateTemplate{
+			digest:               digestCompressedPrimary,
+			compressionOperation: types.PreserveOriginal,
+			compressionAlgorithm: nil,
+		}, res, c.name)
+
+		// These tests only use RequiredCompression in CandidateLocations2Options for clarity;
+		// CandidateCompressionMatchesReuseConditions should have its own tests of handling the full set of options.
+		res = CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{
+			RequiredCompression: c.requiredCompression,
+		}, digestCompressedPrimary, c.compressor)
+		if !c.v2Matches {
+			assert.Nil(t, res, c.name)
+		} else {
+			require.NotNil(t, res, c.name)
+			assert.Equal(t, digestCompressedPrimary, res.digest, c.name)
+			assert.Equal(t, c.v2Op, res.compressionOperation, c.name)
+			if c.v2Algo == "" {
+				assert.Nil(t, res.compressionAlgorithm, c.name)
+			} else {
+				require.NotNil(t, res.compressionAlgorithm, c.name)
+				assert.Equal(t, c.v2Algo, res.compressionAlgorithm.Name())
+			}
+		}
+	}
+}
+
+func TestCandidateWithLocation(t *testing.T) {
+	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
+	require.NotNil(t, template)
+	loc := types.BICLocationReference{Opaque: "opaque"}
+	time := time.Now()
+	res := template.CandidateWithLocation(loc, time)
+	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
+	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, false, res.Candidate.UnknownLocation)
+	assert.Equal(t, loc, res.Candidate.Location)
+	assert.Equal(t, time, res.LastSeen)
+}
+
+func TestCandidateWithUnknownLocation(t *testing.T) {
+	template := CandidateTemplateWithCompression(&blobinfocache.CandidateLocations2Options{}, digestCompressedPrimary, compressiontypes.ZstdAlgorithmName)
+	require.NotNil(t, template)
+	res := template.CandidateWithUnknownLocation()
+	assert.Equal(t, digestCompressedPrimary, res.Candidate.Digest)
+	assert.Equal(t, types.Compress, res.Candidate.CompressionOperation)
+	assert.Equal(t, compressiontypes.ZstdAlgorithmName, res.Candidate.CompressionAlgorithm.Name())
+	assert.Equal(t, true, res.Candidate.UnknownLocation)
+}
 
 func TestCandidateSortStateLess(t *testing.T) {
 	type p struct {

--- a/pkg/blobinfocache/internal/test/test.go
+++ b/pkg/blobinfocache/internal/test/test.go
@@ -314,7 +314,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// ----------------------------
 		// If a record exists with compression without Location then
 		// then return a record without location and with `UnknownLocation: true`
-		cache.RecordDigestCompressorName(digestUnknownLocation, compressiontypes.Bzip2AlgorithmName)
+		cache.RecordDigestCompressorData(digestUnknownLocation, blobinfocache.DigestCompressorData{
+			BaseVariantCompressor: compressiontypes.Bzip2AlgorithmName,
+		})
 		res = cache.CandidateLocations2(transport, scope, digestUnknownLocation, blobinfocache.CandidateLocations2Options{
 			CanSubstitute: true,
 		})
@@ -355,7 +357,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// that shouldn’t happen in real-world usage.
 		if scopeIndex != 0 {
 			for _, e := range digestNameSetPrioritization {
-				cache.RecordDigestCompressorName(e.d, blobinfocache.UnknownCompression)
+				cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+					BaseVariantCompressor: blobinfocache.UnknownCompression,
+				})
 			}
 		}
 
@@ -423,7 +427,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 
 		// Set the "known" compression values
 		for _, e := range digestNameSetPrioritization {
-			cache.RecordDigestCompressorName(e.d, e.m)
+			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+				BaseVariantCompressor: e.m,
+			})
 		}
 
 		// No substitutions allowed:
@@ -505,7 +511,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 			cache.RecordKnownLocation(transport, scope, e.d, types.BICLocationReference{Opaque: scopeName + e.n})
 		}
 		for _, e := range digestNameSetFiltering {
-			cache.RecordDigestCompressorName(e.d, e.m)
+			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
+				BaseVariantCompressor: e.m,
+			})
 		}
 
 		// No filtering

--- a/pkg/blobinfocache/internal/test/test.go
+++ b/pkg/blobinfocache/internal/test/test.go
@@ -422,7 +422,7 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		})
 		assertCandidatesMatch2(t, scopeName, []candidate{}, res)
 
-		// Tests of lookups / prioritization when compression is unknown
+		// Tests of lookups / prioritization when compression is known
 		// -------------------------------------------------------------
 
 		// Set the "known" compression values

--- a/pkg/blobinfocache/internal/test/test.go
+++ b/pkg/blobinfocache/internal/test/test.go
@@ -25,7 +25,7 @@ const (
 	compressorNameU           = blobinfocache.Uncompressed
 	compressorNameA           = compressiontypes.GzipAlgorithmName
 	compressorNameB           = compressiontypes.ZstdAlgorithmName
-	compressorNameCU          = compressiontypes.ZstdChunkedAlgorithmName
+	compressorNameCU          = compressiontypes.XzAlgorithmName
 
 	digestUnknownLocation       = digest.Digest("sha256:7777777777777777777777777777777777777777777777777777777777777777")
 	digestFilteringUncompressed = digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -150,6 +150,7 @@ func testGenericRecordKnownLocations(t *testing.T, cache blobinfocache.BlobInfoC
 type candidate struct {
 	d  digest.Digest
 	cn string
+	ca map[string]string
 	lr string
 }
 
@@ -194,11 +195,12 @@ func assertCandidatesMatch2(t *testing.T, scopeName string, expected []candidate
 			algo = &algo_
 		}
 		e[i] = blobinfocache.BICReplacementCandidate2{
-			Digest:               ev.d,
-			CompressionOperation: op,
-			CompressionAlgorithm: algo,
-			UnknownLocation:      false,
-			Location:             types.BICLocationReference{Opaque: scopeName + ev.lr},
+			Digest:                 ev.d,
+			CompressionOperation:   op,
+			CompressionAlgorithm:   algo,
+			CompressionAnnotations: ev.ca,
+			UnknownLocation:        false,
+			Location:               types.BICLocationReference{Opaque: scopeName + ev.lr},
 		}
 	}
 	assertCandidatesMatch2Native(t, e, actual)
@@ -283,14 +285,16 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		{"B", digestCompressedB, compressorNameB},
 		{"CU", digestCompressedUnrelated, compressorNameCU},
 	}
+	chunkedAnnotations := map[string]string{"a": "b"}
 	digestNameSetFiltering := []struct { // Used primarily to test filtering in CandidateLocations2Options
-		n string
-		d digest.Digest
-		m string
+		n              string
+		d              digest.Digest
+		base, specific string
+		annotations    map[string]string
 	}{
-		{"gzip", digestGzip, compressiontypes.GzipAlgorithmName},
-		{"zstd", digestZstd, compressiontypes.ZstdAlgorithmName},
-		{"zstdChunked", digestZstdChunked, compressiontypes.ZstdChunkedAlgorithmName},
+		{"gzip", digestGzip, compressiontypes.GzipAlgorithmName, blobinfocache.UnknownCompression, nil},
+		{"zstd", digestZstd, compressiontypes.ZstdAlgorithmName, blobinfocache.UnknownCompression, nil},
+		{"zstdChunked", digestZstdChunked, compressiontypes.ZstdAlgorithmName, compressiontypes.ZstdChunkedAlgorithmName, chunkedAnnotations},
 	}
 	for _, e := range digestNameSetFiltering { // digestFilteringUncompressed exists only to allow the three entries to be considered as candidates
 		cache.RecordDigestUncompressedPair(e.d, digestFilteringUncompressed)
@@ -315,7 +319,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// If a record exists with compression without Location then
 		// then return a record without location and with `UnknownLocation: true`
 		cache.RecordDigestCompressorData(digestUnknownLocation, blobinfocache.DigestCompressorData{
-			BaseVariantCompressor: compressiontypes.Bzip2AlgorithmName,
+			BaseVariantCompressor:      compressiontypes.Bzip2AlgorithmName,
+			SpecificVariantCompressor:  blobinfocache.UnknownCompression,
+			SpecificVariantAnnotations: nil,
 		})
 		res = cache.CandidateLocations2(transport, scope, digestUnknownLocation, blobinfocache.CandidateLocations2Options{
 			CanSubstitute: true,
@@ -358,7 +364,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		if scopeIndex != 0 {
 			for _, e := range digestNameSetPrioritization {
 				cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
-					BaseVariantCompressor: blobinfocache.UnknownCompression,
+					BaseVariantCompressor:      blobinfocache.UnknownCompression,
+					SpecificVariantCompressor:  blobinfocache.UnknownCompression,
+					SpecificVariantAnnotations: nil,
 				})
 			}
 		}
@@ -428,7 +436,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		// Set the "known" compression values
 		for _, e := range digestNameSetPrioritization {
 			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
-				BaseVariantCompressor: e.m,
+				BaseVariantCompressor:      e.m,
+				SpecificVariantCompressor:  blobinfocache.UnknownCompression,
+				SpecificVariantAnnotations: nil,
 			})
 		}
 
@@ -512,7 +522,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 		}
 		for _, e := range digestNameSetFiltering {
 			cache.RecordDigestCompressorData(e.d, blobinfocache.DigestCompressorData{
-				BaseVariantCompressor: e.m,
+				BaseVariantCompressor:      e.base,
+				SpecificVariantCompressor:  e.specific,
+				SpecificVariantAnnotations: e.annotations,
 			})
 		}
 
@@ -521,9 +533,9 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 			CanSubstitute: true,
 		})
 		assertCandidatesMatch2(t, scopeName, []candidate{ // Sorted in the reverse of digestNameSetFiltering order
-			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, lr: "zstdChunked"},
-			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, lr: "zstd"},
-			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, lr: "gzip"},
+			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, ca: chunkedAnnotations, lr: "zstdChunked"},
+			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, ca: nil, lr: "zstd"},
+			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, ca: nil, lr: "gzip"},
 		}, res)
 
 		// Manifest format filters
@@ -532,16 +544,16 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 			PossibleManifestFormats: []string{manifest.DockerV2Schema2MediaType},
 		})
 		assertCandidatesMatch2(t, scopeName, []candidate{
-			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, lr: "gzip"},
+			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, ca: nil, lr: "gzip"},
 		}, res)
 		res = cache.CandidateLocations2(transport, scope, digestFilteringUncompressed, blobinfocache.CandidateLocations2Options{
 			CanSubstitute:           true,
 			PossibleManifestFormats: []string{imgspecv1.MediaTypeImageManifest},
 		})
 		assertCandidatesMatch2(t, scopeName, []candidate{ // Sorted in the reverse of digestNameSetFiltering order
-			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, lr: "zstdChunked"},
-			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, lr: "zstd"},
-			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, lr: "gzip"},
+			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, ca: chunkedAnnotations, lr: "zstdChunked"},
+			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, ca: nil, lr: "zstd"},
+			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, ca: nil, lr: "gzip"},
 		}, res)
 
 		// Compression algorithm filters
@@ -550,21 +562,37 @@ func testGenericCandidateLocations2(t *testing.T, cache blobinfocache.BlobInfoCa
 			RequiredCompression: &compression.Gzip,
 		})
 		assertCandidatesMatch2(t, scopeName, []candidate{
-			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, lr: "gzip"},
+			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, ca: nil, lr: "gzip"},
 		}, res)
 		res = cache.CandidateLocations2(transport, scope, digestFilteringUncompressed, blobinfocache.CandidateLocations2Options{
 			CanSubstitute:       true,
 			RequiredCompression: &compression.ZstdChunked,
 		})
-		// Right now, zstd:chunked requests never match a candidate, see CandidateCompressionMatchesReuseConditions().
-		assertCandidatesMatch2(t, scopeName, []candidate{}, res)
+		assertCandidatesMatch2(t, scopeName, []candidate{
+			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, ca: chunkedAnnotations, lr: "zstdChunked"},
+		}, res)
 		res = cache.CandidateLocations2(transport, scope, digestFilteringUncompressed, blobinfocache.CandidateLocations2Options{
 			CanSubstitute:       true,
 			RequiredCompression: &compression.Zstd,
 		})
-		assertCandidatesMatch2(t, scopeName, []candidate{ // When the user asks for zstd, zstd:chunked candidates are also acceptable.
-			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, lr: "zstdChunked"},
-			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, lr: "zstd"},
+		assertCandidatesMatch2(t, scopeName, []candidate{ // When the user asks for zstd, zstd:chunked candidates are also acceptable, and include the chunked information.
+			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, ca: chunkedAnnotations, lr: "zstdChunked"},
+			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, ca: nil, lr: "zstd"},
+		}, res)
+
+		// After RecordDigestCompressorData with zstd:chunked details, a later call with zstd-only does not drop the chunked details.
+		cache.RecordDigestCompressorData(digestZstdChunked, blobinfocache.DigestCompressorData{
+			BaseVariantCompressor:      compressiontypes.ZstdAlgorithmName,
+			SpecificVariantCompressor:  blobinfocache.UnknownCompression,
+			SpecificVariantAnnotations: nil,
+		})
+		res = cache.CandidateLocations2(transport, scope, digestFilteringUncompressed, blobinfocache.CandidateLocations2Options{
+			CanSubstitute: true,
+		})
+		assertCandidatesMatch2(t, scopeName, []candidate{ // Sorted in the reverse of digestNameSetFiltering order
+			{d: digestZstdChunked, cn: compressiontypes.ZstdChunkedAlgorithmName, ca: chunkedAnnotations, lr: "zstdChunked"},
+			{d: digestZstd, cn: compressiontypes.ZstdAlgorithmName, ca: nil, lr: "zstd"},
+			{d: digestGzip, cn: compressiontypes.GzipAlgorithmName, ca: nil, lr: "gzip"},
 		}, res)
 	}
 }

--- a/pkg/blobinfocache/internal/test/test.go
+++ b/pkg/blobinfocache/internal/test/test.go
@@ -43,6 +43,8 @@ func GenericCache(t *testing.T, newTestCache func(t *testing.T) blobinfocache.Bl
 	}{
 		{"UncompressedDigest", testGenericUncompressedDigest},
 		{"RecordDigestUncompressedPair", testGenericRecordDigestUncompressedPair},
+		{"UncompressedDigestForTOC", testGenericUncompressedDigestForTOC},
+		{"RecordTOCUncompressedPair", testGenericRecordTOCUncompressedPair},
 		{"RecordKnownLocations", testGenericRecordKnownLocations},
 		{"CandidateLocations", testGenericCandidateLocations},
 		{"CandidateLocations2", testGenericCandidateLocations2},
@@ -96,6 +98,28 @@ func testGenericRecordDigestUncompressedPair(t *testing.T, cache blobinfocache.B
 		// Mapping an uncompressed digest to self
 		cache.RecordDigestUncompressedPair(digestUncompressed, digestUncompressed)
 		assert.Equal(t, digestUncompressed, cache.UncompressedDigest(digestUncompressed))
+	}
+}
+
+func testGenericUncompressedDigestForTOC(t *testing.T, cache blobinfocache.BlobInfoCache2) {
+	// Nothing is known.
+	assert.Equal(t, digest.Digest(""), cache.UncompressedDigestForTOC(digestUnknown))
+
+	cache.RecordTOCUncompressedPair(digestCompressedA, digestUncompressed)
+	cache.RecordTOCUncompressedPair(digestCompressedB, digestUncompressed)
+	// Known TOC→uncompressed mapping
+	assert.Equal(t, digestUncompressed, cache.UncompressedDigestForTOC(digestCompressedA))
+	assert.Equal(t, digestUncompressed, cache.UncompressedDigestForTOC(digestCompressedB))
+}
+
+func testGenericRecordTOCUncompressedPair(t *testing.T, cache blobinfocache.BlobInfoCache2) {
+	for i := 0; i < 2; i++ { // Record the same data twice to ensure redundant writes don’t break things.
+		// Known TOC→uncompressed mapping
+		cache.RecordTOCUncompressedPair(digestCompressedA, digestUncompressed)
+		assert.Equal(t, digestUncompressed, cache.UncompressedDigestForTOC(digestCompressedA))
+		// Two mappings to the same uncompressed digest
+		cache.RecordTOCUncompressedPair(digestCompressedB, digestUncompressed)
+		assert.Equal(t, digestUncompressed, cache.UncompressedDigestForTOC(digestCompressedB))
 	}
 }
 

--- a/pkg/blobinfocache/memory/memory.go
+++ b/pkg/blobinfocache/memory/memory.go
@@ -24,10 +24,11 @@ type locationKey struct {
 type cache struct {
 	mutex sync.Mutex
 	// The following fields can only be accessed with mutex held.
-	uncompressedDigests   map[digest.Digest]digest.Digest
-	digestsByUncompressed map[digest.Digest]*set.Set[digest.Digest]                // stores a set of digests for each uncompressed digest
-	knownLocations        map[locationKey]map[types.BICLocationReference]time.Time // stores last known existence time for each location reference
-	compressors           map[digest.Digest]string                                 // stores a compressor name, or blobinfocache.Uncompressed (not blobinfocache.UnknownCompression), for each digest
+	uncompressedDigests      map[digest.Digest]digest.Digest
+	uncompressedDigestsByTOC map[digest.Digest]digest.Digest
+	digestsByUncompressed    map[digest.Digest]*set.Set[digest.Digest]                // stores a set of digests for each uncompressed digest
+	knownLocations           map[locationKey]map[types.BICLocationReference]time.Time // stores last known existence time for each location reference
+	compressors              map[digest.Digest]string                                 // stores a compressor name, or blobinfocache.Uncompressed (not blobinfocache.UnknownCompression), for each digest
 }
 
 // New returns a BlobInfoCache implementation which is in-memory only.
@@ -44,10 +45,11 @@ func New() types.BlobInfoCache {
 
 func new2() *cache {
 	return &cache{
-		uncompressedDigests:   map[digest.Digest]digest.Digest{},
-		digestsByUncompressed: map[digest.Digest]*set.Set[digest.Digest]{},
-		knownLocations:        map[locationKey]map[types.BICLocationReference]time.Time{},
-		compressors:           map[digest.Digest]string{},
+		uncompressedDigests:      map[digest.Digest]digest.Digest{},
+		uncompressedDigestsByTOC: map[digest.Digest]digest.Digest{},
+		digestsByUncompressed:    map[digest.Digest]*set.Set[digest.Digest]{},
+		knownLocations:           map[locationKey]map[types.BICLocationReference]time.Time{},
+		compressors:              map[digest.Digest]string{},
 	}
 }
 
@@ -102,6 +104,30 @@ func (mem *cache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompre
 		mem.digestsByUncompressed[uncompressed] = anyDigestSet
 	}
 	anyDigestSet.Add(anyDigest)
+}
+
+// UncompressedDigestForTOC returns an uncompressed digest corresponding to anyDigest.
+// Returns "" if the uncompressed digest is unknown.
+func (mem *cache) UncompressedDigestForTOC(tocDigest digest.Digest) digest.Digest {
+	mem.mutex.Lock()
+	defer mem.mutex.Unlock()
+	if d, ok := mem.uncompressedDigestsByTOC[tocDigest]; ok {
+		return d
+	}
+	return ""
+}
+
+// RecordTOCUncompressedPair records that the tocDigest corresponds to uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (mem *cache) RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest) {
+	mem.mutex.Lock()
+	defer mem.mutex.Unlock()
+	if previous, ok := mem.uncompressedDigestsByTOC[tocDigest]; ok && previous != uncompressed {
+		logrus.Warnf("Uncompressed digest for blob with TOC %q previously recorded as %q, now %q", tocDigest, previous, uncompressed)
+	}
+	mem.uncompressedDigestsByTOC[tocDigest] = uncompressed
 }
 
 // RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,

--- a/pkg/blobinfocache/none/none.go
+++ b/pkg/blobinfocache/none/none.go
@@ -34,6 +34,19 @@ func (noCache) UncompressedDigest(anyDigest digest.Digest) digest.Digest {
 func (noCache) RecordDigestUncompressedPair(anyDigest digest.Digest, uncompressed digest.Digest) {
 }
 
+// UncompressedDigestForTOC returns an uncompressed digest corresponding to anyDigest.
+// Returns "" if the uncompressed digest is unknown.
+func (noCache) UncompressedDigestForTOC(tocDigest digest.Digest) digest.Digest {
+	return ""
+}
+
+// RecordTOCUncompressedPair records that the tocDigest corresponds to uncompressed.
+// WARNING: Only call this for LOCALLY VERIFIED data; don’t record a digest pair just because some remote author claims so (e.g.
+// because a manifest/config pair exists); otherwise the cache could be poisoned and allow substituting unexpected blobs.
+// (Eventually, the DiffIDs in image config could detect the substitution, but that may be too late, and not all image formats contain that data.)
+func (noCache) RecordTOCUncompressedPair(tocDigest digest.Digest, uncompressed digest.Digest) {
+}
+
 // RecordKnownLocation records that a blob with the specified digest exists within the specified (transport, scope) scope,
 // and can be reused given the opaque location data.
 func (noCache) RecordKnownLocation(transport types.ImageTransport, scope types.BICTransportScope, blobDigest digest.Digest, location types.BICLocationReference) {

--- a/pkg/blobinfocache/sqlite/sqlite.go
+++ b/pkg/blobinfocache/sqlite/sqlite.go
@@ -3,6 +3,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -303,6 +304,16 @@ func ensureDBHasCurrentSchema(db *sql.DB) error {
 				`uncompressedDigest	TEXT NOT NULL
 			)`,
 		},
+		{
+			"DigestSpecificVariantCompressors", // If changing the schema incompatibly, merge this with DigestCompressors.
+			`CREATE TABLE IF NOT EXISTS DigestSpecificVariantCompressors(` +
+				// index implied by PRIMARY KEY
+				`digest		TEXT PRIMARY KEY NOT NULL,` +
+				// The compressor is not `UnknownCompression`.
+				`specificVariantCompressor	TEXT NOT NULL,
+				specificVariantAnnotations	BLOB NOT NULL
+			)`,
+		},
 	}
 
 	_, err := dbTransaction(db, func(tx *sql.Tx) (void, error) {
@@ -461,6 +472,9 @@ func (sqc *cache) RecordKnownLocation(transport types.ImageTransport, scope type
 // WARNING: Only call this with LOCALLY VERIFIED data:
 //   - don’t record a compressor for a digest just because some remote author claims so
 //     (e.g. because a manifest says so);
+//   - don’t record the non-base variant or annotations if we are not _sure_ that the base variant
+//     and the blob’s digest match the non-base variant’s annotations (e.g. because we saw them
+//     in a manifest)
 //
 // otherwise the cache could be poisoned and cause us to make incorrect edits to type
 // information in a manifest.
@@ -468,19 +482,44 @@ func (sqc *cache) RecordDigestCompressorData(anyDigest digest.Digest, data blobi
 	_, _ = transaction(sqc, func(tx *sql.Tx) (void, error) {
 		previous, gotPrevious, err := querySingleValue[string](tx, "SELECT compressor FROM DigestCompressors WHERE digest = ?", anyDigest.String())
 		if err != nil {
-			return void{}, fmt.Errorf("looking for compressor of for %q", anyDigest)
+			return void{}, fmt.Errorf("looking for compressor of %q", anyDigest)
 		}
+		warned := false
 		if gotPrevious && previous != data.BaseVariantCompressor {
 			logrus.Warnf("Compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, previous, data.BaseVariantCompressor)
+			warned = true
 		}
 		if data.BaseVariantCompressor == blobinfocache.UnknownCompression {
 			if _, err := tx.Exec("DELETE FROM DigestCompressors WHERE digest = ?", anyDigest.String()); err != nil {
 				return void{}, fmt.Errorf("deleting compressor for digest %q: %w", anyDigest, err)
 			}
+			if _, err := tx.Exec("DELETE FROM DigestSpecificVariantCompressors WHERE digest = ?", anyDigest.String()); err != nil {
+				return void{}, fmt.Errorf("deleting specific variant compressor for digest %q: %w", anyDigest, err)
+			}
 		} else {
 			if _, err := tx.Exec("INSERT OR REPLACE INTO DigestCompressors(digest, compressor) VALUES (?, ?)",
 				anyDigest.String(), data.BaseVariantCompressor); err != nil {
 				return void{}, fmt.Errorf("recording compressor %q for %q: %w", data.BaseVariantCompressor, anyDigest, err)
+			}
+		}
+
+		if data.SpecificVariantCompressor != blobinfocache.UnknownCompression {
+			if !warned { // Don’t warn twice about the same digest
+				prevSVC, found, err := querySingleValue[string](tx, "SELECT specificVariantCompressor FROM DigestSpecificVariantCompressors WHERE digest = ?", anyDigest.String())
+				if err != nil {
+					return void{}, fmt.Errorf("looking for specific variant compressor of %q", anyDigest)
+				}
+				if found && data.SpecificVariantCompressor != prevSVC {
+					logrus.Warnf("Specific compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, prevSVC, data.SpecificVariantCompressor)
+				}
+			}
+			annotations, err := json.Marshal(data.SpecificVariantAnnotations)
+			if err != nil {
+				return void{}, err
+			}
+			if _, err := tx.Exec("INSERT OR REPLACE INTO DigestSpecificVariantCompressors(digest, specificVariantCompressor, specificVariantAnnotations) VALUES (?, ?, ?)",
+				anyDigest.String(), data.SpecificVariantCompressor, annotations); err != nil {
+				return void{}, fmt.Errorf("recording specific variant compressor %q/%q for %q: %w", data.SpecificVariantCompressor, annotations, anyDigest, err)
 			}
 		}
 		return void{}, nil
@@ -493,19 +532,32 @@ func (sqc *cache) RecordDigestCompressorData(anyDigest digest.Digest, data blobi
 // with unknown compression.
 func (sqc *cache) appendReplacementCandidates(candidates []prioritize.CandidateWithTime, tx *sql.Tx, transport types.ImageTransport, scope types.BICTransportScope, digest digest.Digest,
 	v2Options *blobinfocache.CandidateLocations2Options) ([]prioritize.CandidateWithTime, error) {
-	compressorName := blobinfocache.UnknownCompression
+	compressionData := blobinfocache.DigestCompressorData{
+		BaseVariantCompressor:      blobinfocache.UnknownCompression,
+		SpecificVariantCompressor:  blobinfocache.UnknownCompression,
+		SpecificVariantAnnotations: nil,
+	}
 	if v2Options != nil {
-		compressor, found, err := querySingleValue[string](tx, "SELECT compressor FROM DigestCompressors WHERE digest = ?", digest.String())
-		if err != nil {
-			return nil, fmt.Errorf("scanning compressorName: %w", err)
-		}
-		if found {
-			compressorName = compressor
+		var baseVariantCompressor string
+		var specificVariantCompressor sql.NullString
+		var annotationBytes []byte
+		switch err := tx.QueryRow("SELECT compressor, specificVariantCompressor, specificVariantAnnotations "+
+			"FROM DigestCompressors LEFT JOIN DigestSpecificVariantCompressors USING (digest) WHERE digest = ?", digest.String()).
+			Scan(&baseVariantCompressor, &specificVariantCompressor, &annotationBytes); {
+		case errors.Is(err, sql.ErrNoRows): // Do nothing
+		case err != nil:
+			return nil, fmt.Errorf("scanning compressor data: %w", err)
+		default:
+			compressionData.BaseVariantCompressor = baseVariantCompressor
+			if specificVariantCompressor.Valid && annotationBytes != nil {
+				compressionData.SpecificVariantCompressor = specificVariantCompressor.String
+				if err := json.Unmarshal(annotationBytes, &compressionData.SpecificVariantAnnotations); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
-	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, blobinfocache.DigestCompressorData{
-		BaseVariantCompressor: compressorName,
-	})
+	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, compressionData)
 	if template == nil {
 		return candidates, nil
 	}

--- a/pkg/blobinfocache/sqlite/sqlite.go
+++ b/pkg/blobinfocache/sqlite/sqlite.go
@@ -457,29 +457,30 @@ func (sqc *cache) RecordKnownLocation(transport types.ImageTransport, scope type
 	}) // FIXME? Log error (but throttle the log volume on repeated accesses)?
 }
 
-// RecordDigestCompressorName records a compressor for the blob with the specified digest,
-// or Uncompressed or UnknownCompression.
-// WARNING: Only call this with LOCALLY VERIFIED data; don’t record a compressor for a
-// digest just because some remote author claims so (e.g. because a manifest says so);
+// RecordDigestCompressorData records data for the blob with the specified digest.
+// WARNING: Only call this with LOCALLY VERIFIED data:
+//   - don’t record a compressor for a digest just because some remote author claims so
+//     (e.g. because a manifest says so);
+//
 // otherwise the cache could be poisoned and cause us to make incorrect edits to type
 // information in a manifest.
-func (sqc *cache) RecordDigestCompressorName(anyDigest digest.Digest, compressorName string) {
+func (sqc *cache) RecordDigestCompressorData(anyDigest digest.Digest, data blobinfocache.DigestCompressorData) {
 	_, _ = transaction(sqc, func(tx *sql.Tx) (void, error) {
 		previous, gotPrevious, err := querySingleValue[string](tx, "SELECT compressor FROM DigestCompressors WHERE digest = ?", anyDigest.String())
 		if err != nil {
 			return void{}, fmt.Errorf("looking for compressor of for %q", anyDigest)
 		}
-		if gotPrevious && previous != compressorName {
-			logrus.Warnf("Compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, previous, compressorName)
+		if gotPrevious && previous != data.BaseVariantCompressor {
+			logrus.Warnf("Compressor for blob with digest %s previously recorded as %s, now %s", anyDigest, previous, data.BaseVariantCompressor)
 		}
-		if compressorName == blobinfocache.UnknownCompression {
+		if data.BaseVariantCompressor == blobinfocache.UnknownCompression {
 			if _, err := tx.Exec("DELETE FROM DigestCompressors WHERE digest = ?", anyDigest.String()); err != nil {
 				return void{}, fmt.Errorf("deleting compressor for digest %q: %w", anyDigest, err)
 			}
 		} else {
 			if _, err := tx.Exec("INSERT OR REPLACE INTO DigestCompressors(digest, compressor) VALUES (?, ?)",
-				anyDigest.String(), compressorName); err != nil {
-				return void{}, fmt.Errorf("recording compressor %q for %q: %w", compressorName, anyDigest, err)
+				anyDigest.String(), data.BaseVariantCompressor); err != nil {
+				return void{}, fmt.Errorf("recording compressor %q for %q: %w", data.BaseVariantCompressor, anyDigest, err)
 			}
 		}
 		return void{}, nil
@@ -502,7 +503,9 @@ func (sqc *cache) appendReplacementCandidates(candidates []prioritize.CandidateW
 			compressorName = compressor
 		}
 	}
-	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, compressorName)
+	template := prioritize.CandidateTemplateWithCompression(v2Options, digest, blobinfocache.DigestCompressorData{
+		BaseVariantCompressor: compressorName,
+	})
 	if template == nil {
 		return candidates, nil
 	}

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -548,8 +548,10 @@ func reusedBlobFromLayerLookup(layers []storage.Layer, blobDigest digest.Digest,
 			}
 		} else if options.CanSubstitute && layers[0].UncompressedDigest != "" {
 			return true, private.ReusedBlob{
-				Digest: layers[0].UncompressedDigest,
-				Size:   layers[0].UncompressedSize,
+				Digest:               layers[0].UncompressedDigest,
+				Size:                 layers[0].UncompressedSize,
+				CompressionOperation: types.Decompress,
+				CompressionAlgorithm: nil,
 			}
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 32
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 32
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This is #2321 + #2503 + #2487 , backported to a newly-created `release-5.32` branch, along with a release bump to 5.32.1.

Alternatively, we could just tag `main` as a `5.32.1` without backporting: see https://github.com/containers/image/compare/main..mtrmac:5.32-zstd , the difference is a set of typo fixes and dependency updates. The dependency updates are probably unwanted, I’m not sure.

Cc: @TomSweeneyRedHat 