### PR TITLE
[release-5.32] Fix the version number

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 33
+	VersionMinor = 32
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 2
 


### PR DESCRIPTION
We are on the 5.32 branch and the previous release was 5.32.1.

@TomSweeneyRedHat FYI: I’m afraid the just-created 5.32.1 calls itself 5.33.1.