### PR TITLE
CI: enable errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,7 @@
 run:
   concurrency: 6
   timeout: 5m
+
+linters:
+  enable:
+    - errorlint

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -200,11 +200,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	dest := imagedestination.FromPublic(publicDest)
 	defer func() {
 		if err := dest.Close(); err != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf(" (dest: %v): %w", err, retErr)
-			} else {
-				retErr = fmt.Errorf(" (dest: %v)", err)
-			}
+			retErr = errors.Join(retErr, fmt.Errorf("dest: %w", err))
 		}
 	}()
 
@@ -215,11 +211,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	rawSource := imagesource.FromPublic(publicRawSource)
 	defer func() {
 		if err := rawSource.Close(); err != nil {
-			if retErr != nil {
-				retErr = fmt.Errorf(" (src: %v): %w", err, retErr)
-			} else {
-				retErr = fmt.Errorf(" (src: %v)", err)
-			}
+			retErr = errors.Join(retErr, fmt.Errorf("src: %w", err))
 		}
 	}()
 

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -181,7 +181,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, _ := refToTempDir(t)
 	dest, err := ref.NewImageDestination(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer dest.Close()
 }
 

--- a/docker/archive/writer.go
+++ b/docker/archive/writer.go
@@ -34,7 +34,7 @@ func NewWriter(sys *types.SystemContext, path string) (*Writer, error) {
 	// only in a different way. Either way, it’s up to the user to not have two writers to the same path.)
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %q: %w", path, err)
+		return nil, err
 	}
 	succeeded := false
 	defer func() {

--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -165,7 +165,7 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 		}
 		res, err := br.c.makeRequest(br.ctx, http.MethodGet, br.path, headers, nil, v2Auth, nil)
 		if err != nil {
-			return n, fmt.Errorf("%w (while reconnecting: %v)", originalErr, err)
+			return n, fmt.Errorf("%w (while reconnecting: %w)", originalErr, err)
 		}
 		consumedBody := false
 		defer func() {
@@ -179,7 +179,7 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 			// The recipient of an invalid Content-Range MUST NOT attempt to recombine the received content with a stored representation.
 			first, last, completeLength, err := parseContentRange(res)
 			if err != nil {
-				return n, fmt.Errorf("%w (after reconnecting, invalid Content-Range header: %v)", originalErr, err)
+				return n, fmt.Errorf("%w (after reconnecting, invalid Content-Range header: %w)", originalErr, err)
 			}
 			// We don’t handle responses that start at an unrequested offset, nor responses that terminate before the end of the full blob.
 			if first != br.offset || (completeLength != -1 && last+1 != completeLength) {
@@ -190,7 +190,7 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 			return n, fmt.Errorf("%w (after reconnecting, server did not process a Range: header, status %d)", originalErr, http.StatusOK)
 		default:
 			err := registryHTTPResponseToError(res)
-			return n, fmt.Errorf("%w (after reconnecting, fetching blob: %v)", originalErr, err)
+			return n, fmt.Errorf("%w (after reconnecting, fetching blob: %w)", originalErr, err)
 		}
 
 		logrus.Debugf("Successfully reconnected to %s", redactedURL)

--- a/docker/distribution_error.go
+++ b/docker/distribution_error.go
@@ -99,7 +99,7 @@ func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 }
 
 func makeErrorList(err error) []error {
-	if errL, ok := err.(errcode.Errors); ok {
+	if errL, ok := err.(errcode.Errors); ok { //nolint:errorlint
 		return []error(errL)
 	}
 	return []error{err}
@@ -139,7 +139,7 @@ func handleErrorResponse(resp *http.Response) error {
 			}
 		}
 		err := parseHTTPErrorResponse(resp.StatusCode, resp.Body)
-		if uErr, ok := err.(*unexpectedHTTPResponseError); ok && resp.StatusCode == 401 {
+		if uErr, ok := err.(*unexpectedHTTPResponseError); ok && resp.StatusCode == 401 { //nolint:errorlint
 			return errcode.ErrorCodeUnauthorized.WithDetail(uErr.Response)
 		}
 		return err

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -186,7 +186,7 @@ func newImageSourceAttempt(ctx context.Context, sys *types.SystemContext, logica
 			cmd.Stdin = bytes.NewReader(acfD)
 			if err := cmd.Run(); err != nil {
 				var stderr string
-				if ee, ok := err.(*exec.ExitError); ok {
+				if ee, ok := err.(*exec.ExitError); ok { //nolint:errorlint
 					stderr = string(ee.Stderr)
 				}
 				logrus.Warnf("Failed to call additional-layer-store-auth-helper (stderr:%s): %v", stderr, err)
@@ -357,7 +357,7 @@ var multipartByteRangesRe = regexp.Delayed("multipart/byteranges; boundary=([A-Z
 func parseMediaType(contentType string) (string, map[string]string, error) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		if err == mime.ErrInvalidMediaParameter {
+		if err == mime.ErrInvalidMediaParameter { //nolint:errorlint // TODO remove this (https://github.com/polyfloyd/go-errorlint/pull/79).
 			// CloudFront returns an invalid MIME type, that contains an unquoted ":" in the boundary
 			// param, let's handle it here.
 			matches := multipartByteRangesRe.FindStringSubmatch(contentType)
@@ -798,7 +798,7 @@ func (n *bufferedNetworkReader) read(p []byte) (int, error) {
 	select {
 	case b = <-n.readyBuffer:
 		if b.err != nil {
-			if b.err != io.EOF {
+			if b.err != io.EOF { //nolint:errorlint
 				return b.len, b.err
 			}
 			n.gotEOF = true

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -56,7 +56,7 @@ func httpResponseToError(res *http.Response, context string) error {
 func registryHTTPResponseToError(res *http.Response) error {
 	err := handleErrorResponse(res)
 	// len(errs) == 0 should never be returned by handleErrorResponse; if it does, we don't modify it and let the caller report it as is.
-	if errs, ok := err.(errcode.Errors); ok && len(errs) > 0 {
+	if errs, ok := err.(errcode.Errors); ok && len(errs) > 0 { //nolint:errorlint
 		// The docker/distribution registry implementation almost never returns
 		// more than one error in the HTTP body; it seems there is only one
 		// possible instance, where the second error reports a cleanup failure
@@ -81,7 +81,7 @@ func registryHTTPResponseToError(res *http.Response) error {
 		}
 		err = errs[0]
 	}
-	switch e := err.(type) {
+	switch e := err.(type) { //nolint:errorlint
 	case *unexpectedHTTPResponseError:
 		response := string(e.Response)
 		if len(response) > 50 {

--- a/docker/internal/tarfile/reader.go
+++ b/docker/internal/tarfile/reader.go
@@ -30,7 +30,7 @@ type Reader struct {
 func NewReaderFromFile(sys *types.SystemContext, path string) (*Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %q: %w", path, err)
+		return nil, err
 	}
 	defer file.Close()
 

--- a/docker/reference/reference_test.go
+++ b/docker/reference/reference_test.go
@@ -182,7 +182,7 @@ func TestReferenceParse(t *testing.T) {
 		if testcase.err != nil {
 			if err == nil {
 				failf("missing expected error: %v", testcase.err)
-			} else if testcase.err != err {
+			} else if testcase.err != err { //nolint:errorlint
 				failf("mismatched error: got %v, expected %v", err, testcase.err)
 			}
 			continue
@@ -392,7 +392,7 @@ func TestSerialization(t *testing.T) {
 			if testcase.err == nil {
 				failf("error unmarshaling: %v", err)
 			}
-			if err != testcase.err {
+			if err != testcase.err { //nolint:errorlint
 				failf("wrong error, expected %v, got %v", testcase.err, err)
 			}
 
@@ -639,7 +639,7 @@ func TestParseNamed(t *testing.T) {
 		} else if err == nil && testcase.err != nil {
 			failf("parsing succeeded: expected error %v", testcase.err)
 			continue
-		} else if err != testcase.err {
+		} else if err != testcase.err { //nolint:errorlint
 			failf("unexpected error %v, expected %v", err, testcase.err)
 			continue
 		} else if err != nil {

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -318,20 +318,20 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	// Add the history and rootfs information.
 	rootfs, err := json.Marshal(rootFS)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding rootfs information %#v: %v", rootFS, err)
+		return nil, fmt.Errorf("error encoding rootfs information %#v: %w", rootFS, err)
 	}
 	rawRootfs := json.RawMessage(rootfs)
 	raw["rootfs"] = &rawRootfs
 	history, err := json.Marshal(convertedHistory)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding history information %#v: %v", convertedHistory, err)
+		return nil, fmt.Errorf("error encoding history information %#v: %w", convertedHistory, err)
 	}
 	rawHistory := json.RawMessage(history)
 	raw["history"] = &rawHistory
 	// Encode the result.
 	config, err = json.Marshal(raw)
 	if err != nil {
-		return nil, fmt.Errorf("error re-encoding compat image config %#v: %v", s1, err)
+		return nil, fmt.Errorf("error re-encoding compat image config %#v: %w", s1, err)
 	}
 	return config, nil
 }

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -365,7 +365,7 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdCluster) []err
 	if len(clusterInfo.CertificateAuthority) != 0 {
 		err := validateFileIsReadable(clusterInfo.CertificateAuthority)
 		if err != nil {
-			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
+			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %w", clusterInfo.CertificateAuthority, clusterName, err))
 		}
 	}
 
@@ -403,13 +403,13 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdAuthInfo) []error {
 		if len(authInfo.ClientCertificate) != 0 {
 			err := validateFileIsReadable(authInfo.ClientCertificate)
 			if err != nil {
-				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %w", authInfo.ClientCertificate, authInfoName, err))
 			}
 		}
 		if len(authInfo.ClientKey) != 0 {
 			err := validateFileIsReadable(authInfo.ClientKey)
 			if err != nil {
-				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %w", authInfo.ClientKey, authInfoName, err))
 			}
 		}
 	}

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -285,7 +285,7 @@ func (config *directClientConfig) ConfirmUsable() error {
 	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
 	// when direct client config is specified, and our only error is that no server is defined, we should
 	// return a standard "no config" error
-	if len(validationErrors) == 1 && validationErrors[0] == errEmptyCluster {
+	if len(validationErrors) == 1 && validationErrors[0] == errEmptyCluster { //nolint:errorlint
 		return newErrConfigurationInvalid([]error{errEmptyConfig})
 	}
 	return newErrConfigurationInvalid(validationErrors)

--- a/pkg/cli/sigstore/params/sigstore.go
+++ b/pkg/cli/sigstore/params/sigstore.go
@@ -64,7 +64,7 @@ func ParseFile(path string) (*SigningParameterFile, error) {
 	var res SigningParameterFile
 	source, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading %q: %w", path, err)
+		return nil, err
 	}
 	dec := yaml.NewDecoder(bytes.NewReader(source))
 	dec.KnownFields(true)

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -112,7 +112,7 @@ func DetectCompressionFormat(input io.Reader) (Algorithm, DecompressorFunc, io.R
 	buffer := [8]byte{}
 
 	n, err := io.ReadAtLeast(input, buffer[:], len(buffer))
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF { //nolint:errorlint // TODO remove this (https://github.com/polyfloyd/go-errorlint/pull/83).
 		// This is a “real” error. We could just ignore it this time, process the data we have, and hope that the source will report the same error again.
 		// Instead, fail immediately with the original error cause instead of a possibly secondary/misleading error returned later.
 		return Algorithm{}, nil, nil, err

--- a/sif/src.go
+++ b/sif/src.go
@@ -42,7 +42,7 @@ type sifImageSource struct {
 func getBlobInfo(path string) (digest.Digest, int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", -1, fmt.Errorf("opening %q for reading: %w", path, err)
+		return "", -1, err
 	}
 	defer f.Close()
 
@@ -186,7 +186,7 @@ func (s *sifImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache
 	case s.layerDigest:
 		reader, err := os.Open(s.layerFile)
 		if err != nil {
-			return nil, -1, fmt.Errorf("opening %q: %w", s.layerFile, err)
+			return nil, -1, err
 		}
 		return reader, s.layerSize, nil
 	default:

--- a/signature/internal/json.go
+++ b/signature/internal/json.go
@@ -61,7 +61,7 @@ func ParanoidUnmarshalJSONObject(data []byte, fieldResolver func(string) any) er
 			return JSONFormatError(err.Error())
 		}
 	}
-	if _, err := dec.Token(); err != io.EOF {
+	if _, err := dec.Token(); err != io.EOF { //nolint:errorlint // TODO remove this (https://github.com/polyfloyd/go-errorlint/pull/82).
 		return JSONFormatError("Unexpected data after JSON object")
 	}
 	return nil

--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -47,8 +47,10 @@ func NewUntrustedSigstorePayload(dockerManifestDigest digest.Digest, dockerRefer
 }
 
 // A compile-time check that UntrustedSigstorePayload and *UntrustedSigstorePayload implements json.Marshaler
-var _ json.Marshaler = UntrustedSigstorePayload{}
-var _ json.Marshaler = (*UntrustedSigstorePayload)(nil)
+var (
+	_ json.Marshaler = UntrustedSigstorePayload{}
+	_ json.Marshaler = (*UntrustedSigstorePayload)(nil)
+)
 
 // MarshalJSON implements the json.Marshaler interface.
 func (s UntrustedSigstorePayload) MarshalJSON() ([]byte, error) {
@@ -79,13 +81,7 @@ var _ json.Unmarshaler = (*UntrustedSigstorePayload)(nil)
 
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (s *UntrustedSigstorePayload) UnmarshalJSON(data []byte) error {
-	err := s.strictUnmarshalJSON(data)
-	if err != nil {
-		if formatErr, ok := err.(JSONFormatError); ok {
-			err = NewInvalidSignatureError(formatErr.Error())
-		}
-	}
-	return err
+	return ConvertFormatError(s.strictUnmarshalJSON(data))
 }
 
 // strictUnmarshalJSON is UnmarshalJSON, except that it may return the internal JSONFormatError error type.

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -136,7 +136,7 @@ func (prm *prmRemapIdentity) remapReferencePrefix(ref reference.Named) (referenc
 	newNamedRef := strings.Replace(refString, prm.Prefix, prm.SignedPrefix, 1)
 	newParsedRef, err := reference.ParseNamed(newNamedRef)
 	if err != nil {
-		return nil, fmt.Errorf(`error rewriting reference from %q to %q: %v`, refString, newNamedRef, err)
+		return nil, fmt.Errorf(`error rewriting reference from %q to %q: %w`, refString, newNamedRef, err)
 	}
 	return newParsedRef, nil
 }

--- a/signature/sigstore/signer.go
+++ b/signature/sigstore/signer.go
@@ -25,7 +25,7 @@ func WithPrivateKeyFile(file string, passphrase []byte) Option {
 
 		privateKeyPEM, err := os.ReadFile(file)
 		if err != nil {
-			return fmt.Errorf("reading private key from %s: %w", file, err)
+			return fmt.Errorf("reading private key: %w", err)
 		}
 		signerVerifier, err := loadPrivateKey(privateKeyPEM, passphrase)
 		if err != nil {

--- a/signature/simple.go
+++ b/signature/simple.go
@@ -105,13 +105,7 @@ var _ json.Unmarshaler = (*untrustedSignature)(nil)
 
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (s *untrustedSignature) UnmarshalJSON(data []byte) error {
-	err := s.strictUnmarshalJSON(data)
-	if err != nil {
-		if formatErr, ok := err.(internal.JSONFormatError); ok {
-			err = internal.NewInvalidSignatureError(formatErr.Error())
-		}
-	}
-	return err
+	return internal.ConvertFormatError(s.strictUnmarshalJSON(data))
 }
 
 // strictUnmarshalJSON is UnmarshalJSON, except that it may return the internal.JSONFormatError error type.

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -301,11 +301,10 @@ func (f *zstdFetcher) GetBlobAt(chunks []chunked.ImageSourceChunk) (chan io.Read
 		newChunks = append(newChunks, i)
 	}
 	rc, errs, err := f.chunkAccessor.GetBlobAt(f.ctx, f.blobInfo, newChunks)
-	if _, ok := err.(private.BadPartialRequestError); ok {
+	if _, ok := err.(private.BadPartialRequestError); ok { //nolint:errorlint
 		err = chunked.ErrBadRequest{}
 	}
 	return rc, errs, err
-
 }
 
 // PutBlobPartial attempts to create a blob using the data that is already present

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -37,7 +37,7 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 	}
 	if id != "" {
 		if err := validateImageID(id); err != nil {
-			return nil, fmt.Errorf("invalid ID value %q: %v: %w", id, err, ErrInvalidReference)
+			return nil, fmt.Errorf("invalid ID value %q: %w: %w", id, err, ErrInvalidReference)
 		}
 	}
 	// We take a copy of the transport, which contains a pointer to the

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -73,7 +73,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 			reader = file
 			fileinfo, err := file.Stat()
 			if err != nil {
-				return nil, fmt.Errorf("error reading size of %q: %w", filename, err)
+				return nil, err
 			}
 			blobTime = fileinfo.ModTime()
 			blob = tarballBlob{
@@ -103,7 +103,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		}
 		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 		if _, err := io.Copy(io.Discard, reader); err != nil {
-			return nil, fmt.Errorf("error reading %q: %v", filename, err)
+			return nil, fmt.Errorf("error reading %q: %w", filename, err)
 		}
 		if uncompressed != nil {
 			uncompressed.Close()
@@ -152,7 +152,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	// Encode and digest the image configuration blob.
 	configBytes, err := json.Marshal(&config)
 	if err != nil {
-		return nil, fmt.Errorf("error generating configuration blob for %q: %v", strings.Join(r.filenames, separator), err)
+		return nil, fmt.Errorf("error generating configuration blob for %q: %w", strings.Join(r.filenames, separator), err)
 	}
 	configID := digest.Canonical.FromBytes(configBytes)
 	blobs[configID] = tarballBlob{
@@ -177,7 +177,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	// Encode the manifest.
 	manifestBytes, err := json.Marshal(&manifest)
 	if err != nil {
-		return nil, fmt.Errorf("error generating manifest for %q: %v", strings.Join(r.filenames, separator), err)
+		return nil, fmt.Errorf("error generating manifest for %q: %w", strings.Join(r.filenames, separator), err)
 	}
 
 	// Return the image.

--- a/tarball/tarball_transport.go
+++ b/tarball/tarball_transport.go
@@ -38,13 +38,13 @@ func (t *tarballTransport) ParseReference(reference string) (types.ImageReferenc
 		if filename == "-" {
 			stdin, err = io.ReadAll(os.Stdin)
 			if err != nil {
-				return nil, fmt.Errorf("error buffering stdin: %v", err)
+				return nil, fmt.Errorf("error buffering stdin: %w", err)
 			}
 			continue
 		}
 		f, err := os.Open(filename)
 		if err != nil {
-			return nil, fmt.Errorf("error opening %q: %v", filename, err)
+			return nil, err
 		}
 		f.Close()
 	}


### PR DESCRIPTION
This improves error reporting and handling, whether it makes sense, enables errorlint, and silences some of its warnings.

See individual commits for details.