### PR TITLE
Use %w to wrap errors, enable errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,15 @@
 run:
   concurrency: 6
   timeout: 5m
+
+linters:
+  enable:
+    - errorlint
+
+linters-settings:
+  errorlint:
+    # See https://golangci-lint.run/usage/linters/#errorlint.
+    # Only allow warnings about not using %w.
+    errorf-multi: false
+    asserts: false
+    comparison: false

--- a/manifest/docker_schema1.go
+++ b/manifest/docker_schema1.go
@@ -318,20 +318,20 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	// Add the history and rootfs information.
 	rootfs, err := json.Marshal(rootFS)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding rootfs information %#v: %v", rootFS, err)
+		return nil, fmt.Errorf("error encoding rootfs information %#v: %w", rootFS, err)
 	}
 	rawRootfs := json.RawMessage(rootfs)
 	raw["rootfs"] = &rawRootfs
 	history, err := json.Marshal(convertedHistory)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding history information %#v: %v", convertedHistory, err)
+		return nil, fmt.Errorf("error encoding history information %#v: %w", convertedHistory, err)
 	}
 	rawHistory := json.RawMessage(history)
 	raw["history"] = &rawHistory
 	// Encode the result.
 	config, err = json.Marshal(raw)
 	if err != nil {
-		return nil, fmt.Errorf("error re-encoding compat image config %#v: %v", s1, err)
+		return nil, fmt.Errorf("error re-encoding compat image config %#v: %w", s1, err)
 	}
 	return config, nil
 }

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -365,7 +365,7 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdCluster) []err
 	if len(clusterInfo.CertificateAuthority) != 0 {
 		err := validateFileIsReadable(clusterInfo.CertificateAuthority)
 		if err != nil {
-			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
+			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %w", clusterInfo.CertificateAuthority, clusterName, err))
 		}
 	}
 
@@ -403,13 +403,13 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdAuthInfo) []error {
 		if len(authInfo.ClientCertificate) != 0 {
 			err := validateFileIsReadable(authInfo.ClientCertificate)
 			if err != nil {
-				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %w", authInfo.ClientCertificate, authInfoName, err))
 			}
 		}
 		if len(authInfo.ClientKey) != 0 {
 			err := validateFileIsReadable(authInfo.ClientKey)
 			if err != nil {
-				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %w", authInfo.ClientKey, authInfoName, err))
 			}
 		}
 	}

--- a/signature/policy_reference_match.go
+++ b/signature/policy_reference_match.go
@@ -136,7 +136,7 @@ func (prm *prmRemapIdentity) remapReferencePrefix(ref reference.Named) (referenc
 	newNamedRef := strings.Replace(refString, prm.Prefix, prm.SignedPrefix, 1)
 	newParsedRef, err := reference.ParseNamed(newNamedRef)
 	if err != nil {
-		return nil, fmt.Errorf(`error rewriting reference from %q to %q: %v`, refString, newNamedRef, err)
+		return nil, fmt.Errorf(`error rewriting reference from %q to %q: %w`, refString, newNamedRef, err)
 	}
 	return newParsedRef, nil
 }

--- a/storage/storage_reference.go
+++ b/storage/storage_reference.go
@@ -37,7 +37,7 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 	}
 	if id != "" {
 		if err := validateImageID(id); err != nil {
-			return nil, fmt.Errorf("invalid ID value %q: %v: %w", id, err, ErrInvalidReference)
+			return nil, fmt.Errorf("invalid ID value %q: %v: %w", id, err.Error(), ErrInvalidReference)
 		}
 	}
 	// We take a copy of the transport, which contains a pointer to the

--- a/tarball/tarball_src.go
+++ b/tarball/tarball_src.go
@@ -103,7 +103,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 		}
 		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
 		if _, err := io.Copy(io.Discard, reader); err != nil {
-			return nil, fmt.Errorf("error reading %q: %v", filename, err)
+			return nil, fmt.Errorf("error reading %q: %w", filename, err)
 		}
 		if uncompressed != nil {
 			uncompressed.Close()
@@ -152,7 +152,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	// Encode and digest the image configuration blob.
 	configBytes, err := json.Marshal(&config)
 	if err != nil {
-		return nil, fmt.Errorf("error generating configuration blob for %q: %v", strings.Join(r.filenames, separator), err)
+		return nil, fmt.Errorf("error generating configuration blob for %q: %w", strings.Join(r.filenames, separator), err)
 	}
 	configID := digest.Canonical.FromBytes(configBytes)
 	blobs[configID] = tarballBlob{
@@ -177,7 +177,7 @@ func (r *tarballReference) NewImageSource(ctx context.Context, sys *types.System
 	// Encode the manifest.
 	manifestBytes, err := json.Marshal(&manifest)
 	if err != nil {
-		return nil, fmt.Errorf("error generating manifest for %q: %v", strings.Join(r.filenames, separator), err)
+		return nil, fmt.Errorf("error generating manifest for %q: %w", strings.Join(r.filenames, separator), err)
 	}
 
 	// Return the image.

--- a/tarball/tarball_transport.go
+++ b/tarball/tarball_transport.go
@@ -38,13 +38,13 @@ func (t *tarballTransport) ParseReference(reference string) (types.ImageReferenc
 		if filename == "-" {
 			stdin, err = io.ReadAll(os.Stdin)
 			if err != nil {
-				return nil, fmt.Errorf("error buffering stdin: %v", err)
+				return nil, fmt.Errorf("error buffering stdin: %w", err)
 			}
 			continue
 		}
 		f, err := os.Open(filename)
 		if err != nil {
-			return nil, fmt.Errorf("error opening %q: %v", filename, err)
+			return nil, fmt.Errorf("error opening %q: %w", filename, err)
 		}
 		f.Close()
 	}


### PR DESCRIPTION
Based on patches from #2512, but much more conservative this time.

See individual commit descriptions for details.