### PR TITLE
directory: simplify newImageDestination

### DIFF
--- a/directory/directory_transport.go
+++ b/directory/directory_transport.go
@@ -190,8 +190,3 @@ func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) 
 	}
 	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1)), nil
 }
-
-// versionPath returns a path for the version file within a directory using our conventions.
-func (ref dirReference) versionPath() string {
-	return filepath.Join(ref.path, "version")
-}

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -181,7 +181,7 @@ func TestReferenceNewImageSource(t *testing.T) {
 func TestReferenceNewImageDestination(t *testing.T) {
 	ref, _ := refToTempDir(t)
 	dest, err := ref.NewImageDestination(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer dest.Close()
 }
 

--- a/directory/directory_transport_test.go
+++ b/directory/directory_transport_test.go
@@ -243,10 +243,3 @@ func TestReferenceSignaturePath(t *testing.T) {
 	_, err = dirRef.signaturePath(0, &invalidDigest)
 	assert.Error(t, err)
 }
-
-func TestReferenceVersionPath(t *testing.T) {
-	ref, tmpDir := refToTempDir(t)
-	dirRef, ok := ref.(dirReference)
-	require.True(t, ok)
-	assert.Equal(t, tmpDir+"/version", dirRef.versionPath())
-}


### PR DESCRIPTION
Based on patches from #2512.

----

The current code is unnecessarily complicated:
 - it does unnecessary checks if a file/directory exists before opening it;
 - it uses three helper functions not used anywhere else;
 - directory contents is read twice.

Untangle all this, making the code simpler.

Also, move the logic of initializing a destination directory to a
separate function.
    
Now, since the logic of handing version file is now encapsulated in a
single function, remove versionPath method and const version, as well
as the corresponding test.
    
This also fixes the subtle issue of using ref.path for constructing the
version file path, but ref.resolvedPath for all other operations.