### PR TITLE
.cirrus.yml: use skip, not only_if

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ validate_task:
     # The git-validation tool doesn't work well on branch or tag push,
     # under Cirrus-CI, due to challenges obtaining the starting commit ID.
     # Only do validation for PRs.
-    only_if: $CIRRUS_PR != ''
+    skip: $CIRRUS_PR == ''
     gce_instance: &debian_vm
         image_project: libpod-218412
         zone: "us-central1-f"
@@ -67,7 +67,7 @@ validate_task:
 
 
 cross_task:
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    skip: &docs $CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*'
     gce_instance: *debian_vm
     script: make cross
 
@@ -76,7 +76,7 @@ test_task:
     alias: test
     depends_on:
         - validate
-    only_if: *not_docs
+    skip: *docs
     gce_instance: *debian_vm
     matrix:
         - name: "Test"
@@ -95,7 +95,7 @@ test_task:
 #####
 test_skopeo_task:
     alias: test_skopeo
-    only_if: *not_docs
+    skip: *docs
     depends_on:
         - validate
     gce_instance:


### PR DESCRIPTION
Cirrus CI emits a bunch of warnings (shown as check annotations in GitHub UI), for example:

> .cirrus.yml#L75
> task "Test" depends on task "validate", but their only_if conditions are different

> .cirrus.yml#L96
> task "Skopeo Test" depends on task "validate", but their only_if conditions are different

> .cirrus.yml#L158
> task "Total Success" depends on task "validate", but their only_if conditions are different

According to Cirrus CI documentation [1], skip should be used to skip a task (and mark it as "passed") if it is not needed, whereas only_if marks the task as failed if the condition is not met.

Switch from using only_if to skip, and revert conditions.

Let's see if it works.

[1]: https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution
