### PR TITLE
Add support for accepting multiple Rekor public keys

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -330,7 +330,9 @@ This requirement requires an image to be signed using a sigstore signature with 
         "subjectEmail", "expected-signing-user@example.com",
     },
     "rekorPublicKeyPath": "/path/to/local/public/key/file",
+    "rekorPublicKeyPaths": ["/path/to/local/public/key/one","/path/to/local/public/key/two"],
     "rekorPublicKeyData": "base64-encoded-public-key-data",
+    "rekorPublicKeyDatas": ["base64-encoded-public-key-one-data","base64-encoded-public-key-two-data"],
     "signedIdentity": identity_requirement
 }
 ```
@@ -348,13 +350,13 @@ Both `oidcIssuer` and `subjectEmail` are mandatory,
 exactly specifying the expected identity provider,
 and the identity of the user obtaining the Fulcio certificate.
 
-At most one of `rekorPublicKeyPath` and `rekorPublicKeyData` can be present;
+At most one of `rekorPublicKeyPath`, `rekorPublicKeyPaths`, `rekorPublicKeyData` and `rekorPublicKeyDatas` can be present;
 it is mandatory if `fulcio` is specified.
 If a Rekor public key is specified,
 the signature must have been uploaded to a Rekor server
 and the signature must contain an (offline-verifiable) “signed entry timestamp”
 proving the existence of the Rekor log record,
-signed by the provided public key.
+signed by one of the provided public keys.
 
 The `signedIdentity` field has the same semantics as in the `signedBy` requirement described above.
 Note that `cosign`-created signatures only contain a repository, so only `matchRepository` and `exactRepository` can be used to accept them (and that does not protect against substitution of a signed image with an unexpected tag).

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -195,10 +195,10 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	return untrustedCertificate.PublicKey, nil
 }
 
-func verifyRekorFulcio(rekorPublicKey *ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
+func verifyRekorFulcio(rekorPublicKeys []*ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
 	untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte, untrustedBase64Signature string,
 	untrustedPayloadBytes []byte) (crypto.PublicKey, error) {
-	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKey, untrustedRekorSET, untrustedCertificateBytes,
+	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKeys, untrustedRekorSET, untrustedCertificateBytes,
 		untrustedBase64Signature, untrustedPayloadBytes)
 	if err != nil {
 		return nil, err

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -442,6 +442,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	require.NoError(t, err)
 	rekorKeyECDSA, ok := rekorKey.(*ecdsa.PublicKey)
 	require.True(t, ok)
+	rekorKeysECDSA := []*ecdsa.PublicKey{rekorKeyECDSA}
 	setBytes, err := os.ReadFile("fixtures/rekor-set")
 	require.NoError(t, err)
 	sigBase64, err := os.ReadFile("fixtures/rekor-sig")
@@ -450,7 +451,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	require.NoError(t, err)
 
 	// Success
-	pk, err := verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err := verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "mitr@redhat.com",
@@ -459,7 +460,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	assertPublicKeyMatchesCert(t, certBytes, pk)
 
 	// Rekor failure
-	pk, err = verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err = verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "mitr@redhat.com",
@@ -468,7 +469,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	assert.Nil(t, pk)
 
 	// Fulcio failure
-	pk, err = verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err = verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "this-does-not-match@example.com",

--- a/signature/internal/rekor_set.go
+++ b/signature/internal/rekor_set.go
@@ -110,7 +110,7 @@ func (p UntrustedRekorPayload) MarshalJSON() ([]byte, error) {
 
 // VerifyRekorSET verifies that unverifiedRekorSET is correctly signed by publicKey and matches the rest of the data.
 // Returns bundle upload time on success.
-func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
+func VerifyRekorSET(publicKeys []*ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
 	// FIXME: Should the publicKey parameter hard-code ecdsa?
 
 	// == Parse SET bytes
@@ -127,7 +127,14 @@ func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unver
 		return time.Time{}, NewInvalidSignatureError(fmt.Sprintf("canonicalizing Rekor SET JSON: %v", err))
 	}
 	untrustedSETPayloadHash := sha256.Sum256(untrustedSETPayloadCanonicalBytes)
-	if !ecdsa.VerifyASN1(publicKey, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+	publicKeymatched := false
+	for _, pk := range publicKeys {
+		if ecdsa.VerifyASN1(pk, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+			publicKeymatched = true
+			break
+		}
+	}
+	if !publicKeymatched {
 		return time.Time{}, NewInvalidSignatureError("cryptographic signature verification of Rekor SET failed")
 	}
 

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -125,13 +125,21 @@ type prSigstoreSigned struct {
 	Fulcio PRSigstoreSignedFulcio `json:"fulcio,omitempty"`
 
 	// RekorPublicKeyPath is a pathname to local file containing a public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyPath string `json:"rekorPublicKeyPath,omitempty"`
+	// RekorPublicKeyPaths is a set of pathnames to local files, each containing a public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyPaths []string `json:"rekorPublicKeyPaths,omitempty"`
 	// RekorPublicKeyPath contain a base64-encoded public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyData []byte `json:"rekorPublicKeyData,omitempty"`
+	// RekorPublicKeyDatas each contain a base64-encoded public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyDatas [][]byte `json:"rekorPublicKeyDatas,omitempty"`
 
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.
 	// Defaults to "matchRepoDigestOrExact" if not specified.


### PR DESCRIPTION
Add `rekorPublicKeyPaths` and `rekorPublicKeyDatas` options to `policy.json`.

This is on top of unmerged #2524.

Note an outstanding design question on `…Datas`: https://github.com/containers/image/pull/2524#issuecomment-2294570712 .

<s>Currently not tested end-to-end in practice.</s>