### PR TITLE
Release 5.32.2

### DIFF
--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -320,7 +320,9 @@ This requirement requires an image to be signed using a sigstore signature with 
 {
     "type":    "sigstoreSigned",
     "keyPath": "/path/to/local/public/key/file",
+    "keyPaths": ["/path/to/first/public/key/one", "/path/to/first/public/key/two"],
     "keyData": "base64-encoded-public-key-data",
+    "keyDatas": ["base64-encoded-public-key-one-data", "base64-encoded-public-key-two-data"]
     "fulcio": {
         "caPath": "/path/to/local/CA/file",
         "caData": "base64-encoded-CA-data",
@@ -332,10 +334,13 @@ This requirement requires an image to be signed using a sigstore signature with 
     "signedIdentity": identity_requirement
 }
 ```
-Exactly one of `keyPath`, `keyData` and `fulcio` must be present.
+Exactly one of `keyPath`, `keyPaths`, `keyData`, `keyDatas` and `fulcio` must be present.
 
 If `keyPath` or `keyData` is present, it contains a sigstore public key.
 Only signatures made by this key are accepted.
+
+If `keyPaths` or `keyDatas` is present, it contains sigstore public keys.
+Only signatures made by any key in the list are accepted.
 
 If `fulcio` is present, the signature must be based on a Fulcio-issued certificate.
 One of `caPath` and `caData` must be specified, containing the public key of the Fulcio instance.

--- a/docs/containers-policy.json.5.md
+++ b/docs/containers-policy.json.5.md
@@ -330,7 +330,9 @@ This requirement requires an image to be signed using a sigstore signature with 
         "subjectEmail", "expected-signing-user@example.com",
     },
     "rekorPublicKeyPath": "/path/to/local/public/key/file",
+    "rekorPublicKeyPaths": ["/path/to/local/public/key/one","/path/to/local/public/key/two"],
     "rekorPublicKeyData": "base64-encoded-public-key-data",
+    "rekorPublicKeyDatas": ["base64-encoded-public-key-one-data","base64-encoded-public-key-two-data"],
     "signedIdentity": identity_requirement
 }
 ```
@@ -348,13 +350,13 @@ Both `oidcIssuer` and `subjectEmail` are mandatory,
 exactly specifying the expected identity provider,
 and the identity of the user obtaining the Fulcio certificate.
 
-At most one of `rekorPublicKeyPath` and `rekorPublicKeyData` can be present;
+At most one of `rekorPublicKeyPath`, `rekorPublicKeyPaths`, `rekorPublicKeyData` and `rekorPublicKeyDatas` can be present;
 it is mandatory if `fulcio` is specified.
 If a Rekor public key is specified,
 the signature must have been uploaded to a Rekor server
 and the signature must contain an (offline-verifiable) “signed entry timestamp”
 proving the existence of the Rekor log record,
-signed by the provided public key.
+signed by one of the provided public keys.
 
 The `signedIdentity` field has the same semantics as in the `signedBy` requirement described above.
 Note that `cosign`-created signatures only contain a repository, so only `matchRepository` and `exactRepository` can be used to accept them (and that does not protect against substitution of a signed image with an unexpected tag).

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -195,10 +195,10 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	return untrustedCertificate.PublicKey, nil
 }
 
-func verifyRekorFulcio(rekorPublicKey *ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
+func verifyRekorFulcio(rekorPublicKeys []*ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
 	untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte, untrustedBase64Signature string,
 	untrustedPayloadBytes []byte) (crypto.PublicKey, error) {
-	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKey, untrustedRekorSET, untrustedCertificateBytes,
+	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKeys, untrustedRekorSET, untrustedCertificateBytes,
 		untrustedBase64Signature, untrustedPayloadBytes)
 	if err != nil {
 		return nil, err

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -442,6 +442,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	require.NoError(t, err)
 	rekorKeyECDSA, ok := rekorKey.(*ecdsa.PublicKey)
 	require.True(t, ok)
+	rekorKeysECDSA := []*ecdsa.PublicKey{rekorKeyECDSA}
 	setBytes, err := os.ReadFile("fixtures/rekor-set")
 	require.NoError(t, err)
 	sigBase64, err := os.ReadFile("fixtures/rekor-sig")
@@ -450,7 +451,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	require.NoError(t, err)
 
 	// Success
-	pk, err := verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err := verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "mitr@redhat.com",
@@ -459,7 +460,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	assertPublicKeyMatchesCert(t, certBytes, pk)
 
 	// Rekor failure
-	pk, err = verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err = verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "mitr@redhat.com",
@@ -468,7 +469,7 @@ func TestVerifyRekorFulcio(t *testing.T) {
 	assert.Nil(t, pk)
 
 	// Fulcio failure
-	pk, err = verifyRekorFulcio(rekorKeyECDSA, &fulcioTrustRoot{
+	pk, err = verifyRekorFulcio(rekorKeysECDSA, &fulcioTrustRoot{
 		caCertificates: caCertificates,
 		oidcIssuer:     "https://github.com/login/oauth",
 		subjectEmail:   "this-does-not-match@example.com",

--- a/signature/internal/rekor_set.go
+++ b/signature/internal/rekor_set.go
@@ -113,7 +113,7 @@ func (p UntrustedRekorPayload) MarshalJSON() ([]byte, error) {
 
 // VerifyRekorSET verifies that unverifiedRekorSET is correctly signed by publicKey and matches the rest of the data.
 // Returns bundle upload time on success.
-func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
+func VerifyRekorSET(publicKeys []*ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
 	// FIXME: Should the publicKey parameter hard-code ecdsa?
 
 	// == Parse SET bytes
@@ -130,7 +130,14 @@ func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unver
 		return time.Time{}, NewInvalidSignatureError(fmt.Sprintf("canonicalizing Rekor SET JSON: %v", err))
 	}
 	untrustedSETPayloadHash := sha256.Sum256(untrustedSETPayloadCanonicalBytes)
-	if !ecdsa.VerifyASN1(publicKey, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+	publicKeymatched := false
+	for _, pk := range publicKeys {
+		if ecdsa.VerifyASN1(pk, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+			publicKeymatched = true
+			break
+		}
+	}
+	if !publicKeymatched {
 		return time.Time{}, NewInvalidSignatureError("cryptographic signature verification of Rekor SET failed")
 	}
 

--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -171,24 +171,37 @@ type SigstorePayloadAcceptanceRules struct {
 	ValidateSignedDockerManifestDigest func(digest.Digest) error
 }
 
+// verifySigstorePayloadBlobSignature verifies unverifiedSignature of unverifiedPayload was correctly created
+// by publicKey.
+//
+// This is an internal implementation detail of VerifySigstorePayload and should have no other callers.
+// It is INSUFFICIENT alone to consider the signature acceptable.
+func verifySigstorePayloadBlobSignature(publicKey crypto.PublicKey, unverifiedPayload, unverifiedSignature []byte) error {
+	verifier, err := sigstoreSignature.LoadVerifier(publicKey, sigstoreHarcodedHashAlgorithm)
+	if err != nil {
+		return err
+	}
+
+	// github.com/sigstore/cosign/pkg/cosign.verifyOCISignature uses signatureoptions.WithContext(),
+	// which seems to be not used by anything. So we don’t bother.
+	if err := verifier.VerifySignature(bytes.NewReader(unverifiedSignature), bytes.NewReader(unverifiedPayload)); err != nil {
+		return NewInvalidSignatureError(fmt.Sprintf("cryptographic signature verification failed: %v", err))
+	}
+	return nil
+}
+
 // VerifySigstorePayload verifies unverifiedBase64Signature of unverifiedPayload was correctly created by publicKey, and that its principal components
 // match expected values, both as specified by rules, and returns it.
 // We return an *UntrustedSigstorePayload, although nothing actually uses it,
 // just to double-check against stupid typos.
 func VerifySigstorePayload(publicKey crypto.PublicKey, unverifiedPayload []byte, unverifiedBase64Signature string, rules SigstorePayloadAcceptanceRules) (*UntrustedSigstorePayload, error) {
-	verifier, err := sigstoreSignature.LoadVerifier(publicKey, sigstoreHarcodedHashAlgorithm)
-	if err != nil {
-		return nil, fmt.Errorf("creating verifier: %w", err)
-	}
-
 	unverifiedSignature, err := base64.StdEncoding.DecodeString(unverifiedBase64Signature)
 	if err != nil {
 		return nil, NewInvalidSignatureError(fmt.Sprintf("base64 decoding: %v", err))
 	}
-	// github.com/sigstore/cosign/pkg/cosign.verifyOCISignature uses signatureoptions.WithContext(),
-	// which seems to be not used by anything. So we don’t bother.
-	if err := verifier.VerifySignature(bytes.NewReader(unverifiedSignature), bytes.NewReader(unverifiedPayload)); err != nil {
-		return nil, NewInvalidSignatureError(fmt.Sprintf("cryptographic signature verification failed: %v", err))
+
+	if err := verifySigstorePayloadBlobSignature(publicKey, unverifiedPayload, unverifiedSignature); err != nil {
+		return nil, err
 	}
 
 	var unmatchedPayload UntrustedSigstorePayload

--- a/signature/internal/sigstore_payload.go
+++ b/signature/internal/sigstore_payload.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/containers/image/v5/version"
@@ -172,35 +173,60 @@ type SigstorePayloadAcceptanceRules struct {
 }
 
 // verifySigstorePayloadBlobSignature verifies unverifiedSignature of unverifiedPayload was correctly created
-// by publicKey.
+// by any of the public keys in publicKeys.
 //
 // This is an internal implementation detail of VerifySigstorePayload and should have no other callers.
 // It is INSUFFICIENT alone to consider the signature acceptable.
-func verifySigstorePayloadBlobSignature(publicKey crypto.PublicKey, unverifiedPayload, unverifiedSignature []byte) error {
-	verifier, err := sigstoreSignature.LoadVerifier(publicKey, sigstoreHarcodedHashAlgorithm)
-	if err != nil {
-		return err
+func verifySigstorePayloadBlobSignature(publicKeys []crypto.PublicKey, unverifiedPayload, unverifiedSignature []byte) error {
+	if len(publicKeys) == 0 {
+		return errors.New("Need at least one public key to verify the sigstore payload, but got 0")
 	}
 
-	// github.com/sigstore/cosign/pkg/cosign.verifyOCISignature uses signatureoptions.WithContext(),
-	// which seems to be not used by anything. So we don’t bother.
-	if err := verifier.VerifySignature(bytes.NewReader(unverifiedSignature), bytes.NewReader(unverifiedPayload)); err != nil {
-		return NewInvalidSignatureError(fmt.Sprintf("cryptographic signature verification failed: %v", err))
+	verifiers := make([]sigstoreSignature.Verifier, 0, len(publicKeys))
+	for _, key := range publicKeys {
+		// Failing to load a verifier indicates that something is really, really
+		// invalid about the public key; prefer to fail even if the signature might be
+		// valid with other keys, so that users fix their fallback keys before they need them.
+		// For that reason, we even initialize all verifiers before trying to validate the signature
+		// with any key.
+		verifier, err := sigstoreSignature.LoadVerifier(key, sigstoreHarcodedHashAlgorithm)
+		if err != nil {
+			return err
+		}
+		verifiers = append(verifiers, verifier)
 	}
-	return nil
+
+	var failures []string
+	for _, verifier := range verifiers {
+		// github.com/sigstore/cosign/pkg/cosign.verifyOCISignature uses signatureoptions.WithContext(),
+		// which seems to be not used by anything. So we don’t bother.
+		err := verifier.VerifySignature(bytes.NewReader(unverifiedSignature), bytes.NewReader(unverifiedPayload))
+		if err == nil {
+			return nil
+		}
+
+		failures = append(failures, err.Error())
+	}
+
+	if len(failures) == 0 {
+		// Coverage: We have checked there is at least one public key, any success causes an early return,
+		// and any failure adds an entry to failures => there must be at least one error.
+		return fmt.Errorf("Internal error: signature verification failed but no errors have been recorded")
+	}
+	return NewInvalidSignatureError("cryptographic signature verification failed: " + strings.Join(failures, ", "))
 }
 
-// VerifySigstorePayload verifies unverifiedBase64Signature of unverifiedPayload was correctly created by publicKey, and that its principal components
+// VerifySigstorePayload verifies unverifiedBase64Signature of unverifiedPayload was correctly created by any of the public keys in publicKeys, and that its principal components
 // match expected values, both as specified by rules, and returns it.
 // We return an *UntrustedSigstorePayload, although nothing actually uses it,
 // just to double-check against stupid typos.
-func VerifySigstorePayload(publicKey crypto.PublicKey, unverifiedPayload []byte, unverifiedBase64Signature string, rules SigstorePayloadAcceptanceRules) (*UntrustedSigstorePayload, error) {
+func VerifySigstorePayload(publicKeys []crypto.PublicKey, unverifiedPayload []byte, unverifiedBase64Signature string, rules SigstorePayloadAcceptanceRules) (*UntrustedSigstorePayload, error) {
 	unverifiedSignature, err := base64.StdEncoding.DecodeString(unverifiedBase64Signature)
 	if err != nil {
 		return nil, NewInvalidSignatureError(fmt.Sprintf("base64 decoding: %v", err))
 	}
 
-	if err := verifySigstorePayloadBlobSignature(publicKey, unverifiedPayload, unverifiedSignature); err != nil {
+	if err := verifySigstorePayloadBlobSignature(publicKeys, unverifiedPayload, unverifiedSignature); err != nil {
 		return nil, err
 	}
 

--- a/signature/internal/testdata/cosign2.pub
+++ b/signature/internal/testdata/cosign2.pub
@@ -1,0 +1,1 @@
+../../fixtures/cosign2.pub

--- a/signature/policy_config_sigstore.go
+++ b/signature/policy_config_sigstore.go
@@ -2,7 +2,6 @@ package signature
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/containers/image/v5/signature/internal"
@@ -15,7 +14,7 @@ type PRSigstoreSignedOption func(*prSigstoreSigned) error
 func PRSigstoreSignedWithKeyPath(keyPath string) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.KeyPath != "" {
-			return errors.New(`"keyPath" already specified`)
+			return InvalidPolicyFormatError(`"keyPath" already specified`)
 		}
 		pr.KeyPath = keyPath
 		return nil
@@ -26,7 +25,7 @@ func PRSigstoreSignedWithKeyPath(keyPath string) PRSigstoreSignedOption {
 func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.KeyData != nil {
-			return errors.New(`"keyData" already specified`)
+			return InvalidPolicyFormatError(`"keyData" already specified`)
 		}
 		pr.KeyData = keyData
 		return nil
@@ -37,7 +36,7 @@ func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 func PRSigstoreSignedWithFulcio(fulcio PRSigstoreSignedFulcio) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.Fulcio != nil {
-			return errors.New(`"fulcio" already specified`)
+			return InvalidPolicyFormatError(`"fulcio" already specified`)
 		}
 		pr.Fulcio = fulcio
 		return nil
@@ -48,7 +47,7 @@ func PRSigstoreSignedWithFulcio(fulcio PRSigstoreSignedFulcio) PRSigstoreSignedO
 func PRSigstoreSignedWithRekorPublicKeyPath(rekorPublicKeyPath string) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.RekorPublicKeyPath != "" {
-			return errors.New(`"rekorPublicKeyPath" already specified`)
+			return InvalidPolicyFormatError(`"rekorPublicKeyPath" already specified`)
 		}
 		pr.RekorPublicKeyPath = rekorPublicKeyPath
 		return nil
@@ -59,7 +58,7 @@ func PRSigstoreSignedWithRekorPublicKeyPath(rekorPublicKeyPath string) PRSigstor
 func PRSigstoreSignedWithRekorPublicKeyData(rekorPublicKeyData []byte) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.RekorPublicKeyData != nil {
-			return errors.New(`"rekorPublicKeyData" already specified`)
+			return InvalidPolicyFormatError(`"rekorPublicKeyData" already specified`)
 		}
 		pr.RekorPublicKeyData = rekorPublicKeyData
 		return nil
@@ -70,7 +69,7 @@ func PRSigstoreSignedWithRekorPublicKeyData(rekorPublicKeyData []byte) PRSigstor
 func PRSigstoreSignedWithSignedIdentity(signedIdentity PolicyReferenceMatch) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
 		if pr.SignedIdentity != nil {
-			return errors.New(`"signedIdentity" already specified`)
+			return InvalidPolicyFormatError(`"signedIdentity" already specified`)
 		}
 		pr.SignedIdentity = signedIdentity
 		return nil
@@ -221,7 +220,7 @@ type PRSigstoreSignedFulcioOption func(*prSigstoreSignedFulcio) error
 func PRSigstoreSignedFulcioWithCAPath(caPath string) PRSigstoreSignedFulcioOption {
 	return func(f *prSigstoreSignedFulcio) error {
 		if f.CAPath != "" {
-			return errors.New(`"caPath" already specified`)
+			return InvalidPolicyFormatError(`"caPath" already specified`)
 		}
 		f.CAPath = caPath
 		return nil
@@ -232,7 +231,7 @@ func PRSigstoreSignedFulcioWithCAPath(caPath string) PRSigstoreSignedFulcioOptio
 func PRSigstoreSignedFulcioWithCAData(caData []byte) PRSigstoreSignedFulcioOption {
 	return func(f *prSigstoreSignedFulcio) error {
 		if f.CAData != nil {
-			return errors.New(`"caData" already specified`)
+			return InvalidPolicyFormatError(`"caData" already specified`)
 		}
 		f.CAData = caData
 		return nil
@@ -243,7 +242,7 @@ func PRSigstoreSignedFulcioWithCAData(caData []byte) PRSigstoreSignedFulcioOptio
 func PRSigstoreSignedFulcioWithOIDCIssuer(oidcIssuer string) PRSigstoreSignedFulcioOption {
 	return func(f *prSigstoreSignedFulcio) error {
 		if f.OIDCIssuer != "" {
-			return errors.New(`"oidcIssuer" already specified`)
+			return InvalidPolicyFormatError(`"oidcIssuer" already specified`)
 		}
 		f.OIDCIssuer = oidcIssuer
 		return nil
@@ -254,7 +253,7 @@ func PRSigstoreSignedFulcioWithOIDCIssuer(oidcIssuer string) PRSigstoreSignedFul
 func PRSigstoreSignedFulcioWithSubjectEmail(subjectEmail string) PRSigstoreSignedFulcioOption {
 	return func(f *prSigstoreSignedFulcio) error {
 		if f.SubjectEmail != "" {
-			return errors.New(`"subjectEmail" already specified`)
+			return InvalidPolicyFormatError(`"subjectEmail" already specified`)
 		}
 		f.SubjectEmail = subjectEmail
 		return nil

--- a/signature/policy_config_sigstore.go
+++ b/signature/policy_config_sigstore.go
@@ -21,6 +21,20 @@ func PRSigstoreSignedWithKeyPath(keyPath string) PRSigstoreSignedOption {
 	}
 }
 
+// PRSigstoreSignedWithKeyPaths specifies a value for the "keyPaths" field when calling NewPRSigstoreSigned.
+func PRSigstoreSignedWithKeyPaths(keyPaths []string) PRSigstoreSignedOption {
+	return func(pr *prSigstoreSigned) error {
+		if pr.KeyPaths != nil {
+			return InvalidPolicyFormatError(`"keyPaths" already specified`)
+		}
+		if len(keyPaths) == 0 {
+			return InvalidPolicyFormatError(`"keyPaths" contains no entries`)
+		}
+		pr.KeyPaths = keyPaths
+		return nil
+	}
+}
+
 // PRSigstoreSignedWithKeyData specifies a value for the "keyData" field when calling NewPRSigstoreSigned.
 func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 	return func(pr *prSigstoreSigned) error {
@@ -28,6 +42,20 @@ func PRSigstoreSignedWithKeyData(keyData []byte) PRSigstoreSignedOption {
 			return InvalidPolicyFormatError(`"keyData" already specified`)
 		}
 		pr.KeyData = keyData
+		return nil
+	}
+}
+
+// PRSigstoreSignedWithKeyDatas specifies a value for the "keyDatas" field when calling NewPRSigstoreSigned.
+func PRSigstoreSignedWithKeyDatas(keyDatas [][]byte) PRSigstoreSignedOption {
+	return func(pr *prSigstoreSigned) error {
+		if pr.KeyDatas != nil {
+			return InvalidPolicyFormatError(`"keyDatas" already specified`)
+		}
+		if len(keyDatas) == 0 {
+			return InvalidPolicyFormatError(`"keyDatas" contains no entries`)
+		}
+		pr.KeyDatas = keyDatas
 		return nil
 	}
 }
@@ -91,14 +119,20 @@ func newPRSigstoreSigned(options ...PRSigstoreSignedOption) (*prSigstoreSigned, 
 	if res.KeyPath != "" {
 		keySources++
 	}
+	if res.KeyPaths != nil {
+		keySources++
+	}
 	if res.KeyData != nil {
+		keySources++
+	}
+	if res.KeyDatas != nil {
 		keySources++
 	}
 	if res.Fulcio != nil {
 		keySources++
 	}
 	if keySources != 1 {
-		return nil, InvalidPolicyFormatError("exactly one of keyPath, keyData and fulcio must be specified")
+		return nil, InvalidPolicyFormatError("exactly one of keyPath, keyPaths, keyData, keyDatas and fulcio must be specified")
 	}
 
 	if res.RekorPublicKeyPath != "" && res.RekorPublicKeyData != nil {
@@ -143,7 +177,7 @@ var _ json.Unmarshaler = (*prSigstoreSigned)(nil)
 func (pr *prSigstoreSigned) UnmarshalJSON(data []byte) error {
 	*pr = prSigstoreSigned{}
 	var tmp prSigstoreSigned
-	var gotKeyPath, gotKeyData, gotFulcio, gotRekorPublicKeyPath, gotRekorPublicKeyData bool
+	var gotKeyPath, gotKeyPaths, gotKeyData, gotKeyDatas, gotFulcio, gotRekorPublicKeyPath, gotRekorPublicKeyData bool
 	var fulcio prSigstoreSignedFulcio
 	var signedIdentity json.RawMessage
 	if err := internal.ParanoidUnmarshalJSONObject(data, func(key string) any {
@@ -153,9 +187,15 @@ func (pr *prSigstoreSigned) UnmarshalJSON(data []byte) error {
 		case "keyPath":
 			gotKeyPath = true
 			return &tmp.KeyPath
+		case "keyPaths":
+			gotKeyPaths = true
+			return &tmp.KeyPaths
 		case "keyData":
 			gotKeyData = true
 			return &tmp.KeyData
+		case "keyDatas":
+			gotKeyDatas = true
+			return &tmp.KeyDatas
 		case "fulcio":
 			gotFulcio = true
 			return &fulcio
@@ -191,8 +231,14 @@ func (pr *prSigstoreSigned) UnmarshalJSON(data []byte) error {
 	if gotKeyPath {
 		opts = append(opts, PRSigstoreSignedWithKeyPath(tmp.KeyPath))
 	}
+	if gotKeyPaths {
+		opts = append(opts, PRSigstoreSignedWithKeyPaths(tmp.KeyPaths))
+	}
 	if gotKeyData {
 		opts = append(opts, PRSigstoreSignedWithKeyData(tmp.KeyData))
+	}
+	if gotKeyDatas {
+		opts = append(opts, PRSigstoreSignedWithKeyDatas(tmp.KeyDatas))
 	}
 	if gotFulcio {
 		opts = append(opts, PRSigstoreSignedWithFulcio(&fulcio))

--- a/signature/policy_eval_sigstore.go
+++ b/signature/policy_eval_sigstore.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/private"
@@ -26,6 +27,7 @@ type configBytesSources struct {
 	path                      string   // …Path: a path to a file containing the data, or ""
 	paths                     []string // …Paths: paths to files containing the data, or nil
 	data                      []byte   // …Data: a single instance ofhe raw data, or nil
+	datas                     [][]byte // …Datas: the raw data, or nil // codespell:ignore datas
 }
 
 // loadBytesFromConfigSources ensures at most one of the sources in src is set,
@@ -55,6 +57,10 @@ func loadBytesFromConfigSources(src configBytesSources) ([][]byte, error) {
 	if src.data != nil {
 		sources++
 		data = [][]byte{src.data}
+	}
+	if src.datas != nil { // codespell:ignore datas
+		sources++
+		data = src.datas // codespell:ignore datas
 	}
 	if sources > 1 {
 		return nil, errors.New(src.inconsistencyErrorMessage)
@@ -93,7 +99,7 @@ func (f *prSigstoreSignedFulcio) prepareTrustRoot() (*fulcioTrustRoot, error) {
 
 // sigstoreSignedTrustRoot contains an already parsed version of the prSigstoreSigned policy
 type sigstoreSignedTrustRoot struct {
-	publicKey      crypto.PublicKey
+	publicKeys     []crypto.PublicKey
 	fulcio         *fulcioTrustRoot
 	rekorPublicKey *ecdsa.PublicKey
 }
@@ -102,24 +108,26 @@ func (pr *prSigstoreSigned) prepareTrustRoot() (*sigstoreSignedTrustRoot, error)
 	res := sigstoreSignedTrustRoot{}
 
 	publicKeyPEMs, err := loadBytesFromConfigSources(configBytesSources{
-		inconsistencyErrorMessage: `Internal inconsistency: both "keyPath" and "keyData" specified`,
+		inconsistencyErrorMessage: `Internal inconsistency: more than one of "keyPath", "keyPaths", "keyData", "keyDatas" specified`,
 		path:                      pr.KeyPath,
+		paths:                     pr.KeyPaths,
 		data:                      pr.KeyData,
+		datas:                     pr.KeyDatas, // codespell:ignore datas
 	})
 	if err != nil {
 		return nil, err
 	}
 	if publicKeyPEMs != nil {
-		if len(publicKeyPEMs) != 1 {
-			// Coverage: This should never happen, we only provide single-element sources
-			// to loadBytesFromConfigSources, and at most one is allowed.
-			return nil, errors.New(`Internal inconsistency: got more than one element in "keyPath" and "keyData"`)
+		for index, keyData := range publicKeyPEMs {
+			pk, err := cryptoutils.UnmarshalPEMToPublicKey(keyData)
+			if err != nil {
+				return nil, fmt.Errorf("parsing public key %d: %w", index+1, err)
+			}
+			res.publicKeys = append(res.publicKeys, pk)
 		}
-		pk, err := cryptoutils.UnmarshalPEMToPublicKey(publicKeyPEMs[0])
-		if err != nil {
-			return nil, fmt.Errorf("parsing public key: %w", err)
+		if len(res.publicKeys) == 0 {
+			return nil, errors.New(`Internal inconsistency: "keyPath", "keyPaths", "keyData" and "keyDatas" produced no public keys`)
 		}
-		res.publicKey = pk
 	}
 
 	if pr.Fulcio != nil {
@@ -179,34 +187,48 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 	}
 	untrustedPayload := sig.UntrustedPayload()
 
-	var publicKey crypto.PublicKey
+	var publicKeys []crypto.PublicKey
 	switch {
-	case trustRoot.publicKey != nil && trustRoot.fulcio != nil: // newPRSigstoreSigned rejects such combinations.
+	case trustRoot.publicKeys != nil && trustRoot.fulcio != nil: // newPRSigstoreSigned rejects such combinations.
 		return sarRejected, errors.New("Internal inconsistency: Both a public key and Fulcio CA specified")
-	case trustRoot.publicKey == nil && trustRoot.fulcio == nil: // newPRSigstoreSigned rejects such combinations.
+	case trustRoot.publicKeys == nil && trustRoot.fulcio == nil: // newPRSigstoreSigned rejects such combinations.
 		return sarRejected, errors.New("Internal inconsistency: Neither a public key nor a Fulcio CA specified")
 
-	case trustRoot.publicKey != nil:
+	case trustRoot.publicKeys != nil:
 		if trustRoot.rekorPublicKey != nil {
 			untrustedSET, ok := untrustedAnnotations[signature.SigstoreSETAnnotationKey]
 			if !ok { // For user convenience; passing an empty []byte to VerifyRekorSet should work.
 				return sarRejected, fmt.Errorf("missing %s annotation", signature.SigstoreSETAnnotationKey)
 			}
-			// We could use publicKeyPEM directly, but let’s re-marshal to avoid inconsistencies.
-			// FIXME: We could just generate DER instead of the full PEM text
-			recreatedPublicKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(trustRoot.publicKey)
-			if err != nil {
-				// Coverage: The key was loaded from a PEM format, so it’s unclear how this could fail.
-				// (PEM is not essential, MarshalPublicKeyToPEM can only fail if marshaling to ASN1.DER fails.)
-				return sarRejected, fmt.Errorf("re-marshaling public key to PEM: %w", err)
 
+			var rekorFailures []string
+			for _, candidatePublicKey := range trustRoot.publicKeys {
+				// We could use publicKeyPEM directly, but let’s re-marshal to avoid inconsistencies.
+				// FIXME: We could just generate DER instead of the full PEM text
+				recreatedPublicKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(candidatePublicKey)
+				if err != nil {
+					// Coverage: The key was loaded from a PEM format, so it’s unclear how this could fail.
+					// (PEM is not essential, MarshalPublicKeyToPEM can only fail if marshaling to ASN1.DER fails.)
+					return sarRejected, fmt.Errorf("re-marshaling public key to PEM: %w", err)
+				}
+				// We don’t care about the Rekor timestamp, just about log presence.
+				_, err = internal.VerifyRekorSET(trustRoot.rekorPublicKey, []byte(untrustedSET), recreatedPublicKeyPEM, untrustedBase64Signature, untrustedPayload)
+				if err == nil {
+					publicKeys = append(publicKeys, candidatePublicKey)
+					break // The SET can only accept one public key entry, so if we found one, the rest either doesn’t match or is a duplicate
+				}
+				rekorFailures = append(rekorFailures, err.Error())
 			}
-			// We don’t care about the Rekor timestamp, just about log presence.
-			if _, err := internal.VerifyRekorSET(trustRoot.rekorPublicKey, []byte(untrustedSET), recreatedPublicKeyPEM, untrustedBase64Signature, untrustedPayload); err != nil {
-				return sarRejected, err
+			if len(publicKeys) == 0 {
+				if len(rekorFailures) == 0 {
+					// Coverage: We have ensured that len(trustRoot.publicKeys) != 0, when nothing succeeds, there must be at least one failure.
+					return sarRejected, errors.New(`Internal inconsistency: Rekor SET did not match any key but we have no failures.`)
+				}
+				return sarRejected, internal.NewInvalidSignatureError(fmt.Sprintf("No public key verified against the RekorSET: %s", strings.Join(rekorFailures, ", ")))
 			}
+		} else {
+			publicKeys = trustRoot.publicKeys
 		}
-		publicKey = trustRoot.publicKey
 
 	case trustRoot.fulcio != nil:
 		if trustRoot.rekorPublicKey == nil { // newPRSigstoreSigned rejects such combinations.
@@ -229,14 +251,15 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 		if err != nil {
 			return sarRejected, err
 		}
-		publicKey = pk
+		publicKeys = []crypto.PublicKey{pk}
 	}
 
-	if publicKey == nil {
-		// Coverage: This should never happen, we have already excluded the possibility in the switch above.
+	if len(publicKeys) == 0 {
+		// Coverage: This should never happen, we ensured that trustRoot.publicKeys is non-empty if set,
+		// and we have already excluded the possibility in the switch above.
 		return sarRejected, fmt.Errorf("Internal inconsistency: publicKey not set before verifying sigstore payload")
 	}
-	signature, err := internal.VerifySigstorePayload(publicKey, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
+	signature, err := internal.VerifySigstorePayload(publicKeys, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
 		ValidateSignedDockerReference: func(ref string) error {
 			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
 				return PolicyRequirementError(fmt.Sprintf("Signature for identity %q is not accepted", ref))

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -74,7 +74,7 @@ type prSignedBy struct {
 
 	// KeyPath is a pathname to a local file containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyPaths if a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPaths []string `json:"keyPaths,omitempty"`
 	// KeyData contains the trusted key(s), base64-encoded. Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
@@ -111,13 +111,16 @@ type prSignedBaseLayer struct {
 type prSigstoreSigned struct {
 	prCommon
 
-	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	KeyPaths []string `json:"keyPaths,omitempty"`
+	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
-	// FIXME: Multiple public keys?
+	// KeyDatas is a set of trusted keys, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	KeyDatas [][]byte `json:"keyDatas,omitempty"`
 
-	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	// If Fulcio is specified, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well.
 	Fulcio PRSigstoreSignedFulcio `json:"fulcio,omitempty"`
 

--- a/signature/policy_types.go
+++ b/signature/policy_types.go
@@ -125,13 +125,21 @@ type prSigstoreSigned struct {
 	Fulcio PRSigstoreSignedFulcio `json:"fulcio,omitempty"`
 
 	// RekorPublicKeyPath is a pathname to local file containing a public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyPath string `json:"rekorPublicKeyPath,omitempty"`
+	// RekorPublicKeyPaths is a set of pathnames to local files, each containing a public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyPaths []string `json:"rekorPublicKeyPaths,omitempty"`
 	// RekorPublicKeyPath contain a base64-encoded public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyData []byte `json:"rekorPublicKeyData,omitempty"`
+	// RekorPublicKeyDatas each contain a base64-encoded public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyDatas [][]byte `json:"rekorPublicKeyDatas,omitempty"`
 
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.
 	// Defaults to "matchRepoDigestOrExact" if not specified.

--- a/signature/sigstore/generate_test.go
+++ b/signature/sigstore/generate_test.go
@@ -2,6 +2,7 @@ package sigstore
 
 import (
 	"context"
+	"crypto"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +45,7 @@ func TestGenerateKeyPair(t *testing.T) {
 	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey(keyPair.PublicKey)
 	require.NoError(t, err)
 
-	_, err = internal.VerifySigstorePayload(publicKey, sig.UntrustedPayload(),
+	_, err = internal.VerifySigstorePayload([]crypto.PublicKey{publicKey}, sig.UntrustedPayload(),
 		sig.UntrustedAnnotations()[signature.SigstoreSignatureAnnotationKey],
 		internal.SigstorePayloadAcceptanceRules{
 			ValidateSignedDockerReference: func(ref string) error {

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 32
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This backports #2524 and #2526 :

> This adds the ability to accept sigstore signatures signed by any key from a set of several (_huge thanks_ to @dcermak and @danishprakash for doing almost all the work), and Rekor log presence proofs signed by any key from a set of several keys.

Cc: @TomSweeneyRedHat 