### PR TITLE
Support pulling Ollama [non-]OCI image

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -32,6 +32,27 @@ const (
 	DockerV2Schema2ForeignLayerMediaType = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for gzipped schema 2 foreign layers.
 	DockerV2Schema2ForeignLayerMediaTypeGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+
+	// OllamaImageLayerMediaTypePrefix is the prefix for Ollama image layer media types.
+	OllamaImageLayerMediaTypePrefix = "application/vnd.ollama.image."
+	// OllamaImageLayerMediaType is the media type used for Ollama image model layers.
+	OllamaImageModelLayerMediaType = OllamaImageLayerMediaTypePrefix + "model"
+	// OllamaImageAdapterLayerMediaType is the media type used for Ollama image adapter layers.
+	OllamaImageAdapterLayerMediaType = OllamaImageLayerMediaTypePrefix + "adapter"
+	// OllamaImageProjectorLayerMediaType is the media type used for Ollama image projector layers.
+	OllamaImageProjectorLayerMediaType = OllamaImageLayerMediaTypePrefix + "projector"
+	// OllamaImagePromptLayerMediaType is the media type used for Ollama image prompt layers.
+	OllamaImagePromptLayerMediaType = OllamaImageLayerMediaTypePrefix + "prompt"
+	// OllamaImageTemplateLayerMediaType is the media type used for Ollama image template layers.
+	OllamaImageTemplateLayerMediaType = OllamaImageLayerMediaTypePrefix + "template"
+	// OllamaImageSystemLayerMediaType is the media type used for Ollama image system layers.
+	OllamaImageSystemLayerMediaType = OllamaImageLayerMediaTypePrefix + "system"
+	// OllamaImageParamsLayerMediaType is the media type used for Ollama image params layers.
+	OllamaImageParamsLayerMediaType = OllamaImageLayerMediaTypePrefix + "params"
+	// OllamaImageMessagesLayerMediaType is the media type used for Ollama image messages layers.
+	OllamaImageMessagesLayerMediaType = OllamaImageLayerMediaTypePrefix + "messages"
+	// OllamaImageLicenseLayerMediaType is the media type used for Ollama image license layers.
+	OllamaImageLicenseLayerMediaType = OllamaImageLayerMediaTypePrefix + "license"
 )
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -32,6 +32,27 @@ const (
 	DockerV2Schema2ForeignLayerMediaType = manifest.DockerV2Schema2ForeignLayerMediaType
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for gzipped schema 2 foreign layers.
 	DockerV2Schema2ForeignLayerMediaTypeGzip = manifest.DockerV2Schema2ForeignLayerMediaTypeGzip
+
+	// OllamaImageLayerMediaTypePrefix is the prefix for all Ollama image layer media types.
+	OllamaImageLayerMediaTypePrefix = manifest.OllamaImageLayerMediaTypePrefix
+	// OllamaImageModelLayerMediaType is the media type used for model layers.
+	OllamaImageModelLayerMediaType = manifest.OllamaImageModelLayerMediaType
+	// OllamaImageAdapterLayerMediaType is the media type used for adapter layers.
+	OllamaImageAdapterLayerMediaType = manifest.OllamaImageAdapterLayerMediaType
+	// OllamaImageProjectorLayerMediaType is the media type used for projector layers.
+	OllamaImageProjectorLayerMediaType = manifest.OllamaImageProjectorLayerMediaType
+	// OllamaImagePromptLayerMediaType is the media type used for prompt layers.
+	OllamaImagePromptLayerMediaType = manifest.OllamaImagePromptLayerMediaType
+	//	OllamaImageTemplateLayerMediaType is the media type used for template layers.
+	OllamaImageTemplateLayerMediaType = manifest.OllamaImageTemplateLayerMediaType
+	// OllamaImageSystemLayerMediaType is the media type used for system layers.
+	OllamaImageSystemLayerMediaType = manifest.OllamaImageSystemLayerMediaType
+	// OllamaImageParamsLayerMediaType is the media type used for params layers.
+	OllamaImageParamsLayerMediaType = manifest.OllamaImageParamsLayerMediaType
+	// OllamaImageMessagesLayerMediaType is the media type used for messages layers.
+	OllamaImageMessagesLayerMediaType = manifest.OllamaImageMessagesLayerMediaType
+	// OllamaImageLicenseLayerMediaType is the media type used for license layers.
+	OllamaImageLicenseLayerMediaType = manifest.OllamaImageLicenseLayerMediaType
 )
 
 // NonImageArtifactError (detected via errors.As) is used when asking for an image-specific operation
@@ -42,6 +63,8 @@ type NonImageArtifactError = manifest.NonImageArtifactError
 func SupportedSchema2MediaType(m string) error {
 	switch m {
 	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed:
+		return nil
+	case OllamaImageModelLayerMediaType, OllamaImageAdapterLayerMediaType, OllamaImageProjectorLayerMediaType, OllamaImagePromptLayerMediaType, OllamaImageTemplateLayerMediaType, OllamaImageSystemLayerMediaType, OllamaImageParamsLayerMediaType, OllamaImageMessagesLayerMediaType, OllamaImageLicenseLayerMediaType:
 		return nil
 	default:
 		return fmt.Errorf("unsupported docker v2s2 media type: %q", m)


### PR DESCRIPTION
Background:

Kubernetes 1.31 introduced a new feature: [Read-Only Volumes Based on OCI Artifacts](https://kubernetes.io/blog/2024/08/16/kubernetes-1-31-image-volume-source/). I believe this feature could be very useful for deploying a dedicated model alongside [Ollama](https://github.com/ollama/ollama) in Kubernetes.

Ollama has introduced several new media types (e.g. application/vnd.ollama.image.model) for storing GGUF models, system prompts, and more. Each layer is essentially a file and does not need to be untarred.

This PR adds a new field, `layerFilename`, to `addedLayerInfo`, and the overlay driver will handle the layer creation separately.

[A separate PR](https://github.com/containers/storage/pull/2075) for `containers/storage` will be submitted later.

Please see the following logs for instructions on how to mount the Ollama image as a volume:

```bash
# Copied from testdata and added mounts information
❯ cat container.json
{
  "metadata": {
    "name": "podsandbox-sleep"
  },
  "image": {
    "image": "registry.docker.com/ollama/ollama:latest"
  },
  "command": [
    "/bin/sleep",
    "6000"
  ],
  "args": [
    "6000"
  ],
  "working_dir": "/",
  "envs": [
    {
      "key": "PATH",
      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    },
    {
      "key": "GLIBC_TUNABLES",
      "value": "glibc.pthread.rseq=0"
    }
  ],
  "annotations": {
    "pod": "podsandbox"
  },
  "log_path": "",
  "stdin": false,
  "stdin_once": false,
  "tty": false,
  "linux": {
    "security_context": {
      "namespace_options": {
        "pid": 1
      },
      "readonly_rootfs": false
    },
    "resources": {
      "cpu_period": 10000,
      "cpu_quota": 20000,
      "cpu_shares": 512,
      "oom_score_adj": 30,
      "memory_limit_in_bytes": 268435456
    }
  },
  "mounts": [
    {
      "host_path": "",
      "container_path": "/volume",
      "image": {
        "image": "registry.ollama.ai/library/tinyllama:latest"
      },
      "readonly": true
    }
  ]
}
# copied from testdata
❯ cat sandbox_config.json
{
        "metadata": {
                "name": "podsandbox1",
                "uid": "redhat-test-crio",
                "namespace": "redhat.test.crio",
                "attempt": 1
        },
        "hostname": "crictl_host",
        "log_directory": "",
        "dns_config": {
                "servers": [
                        "8.8.8.8"
                ]
        },
        "port_mappings": [],
        "resources": {
                "cpu": {
                        "limits": 3,
                        "requests": 2
                },
                "memory": {
                        "limits": 50000000,
                        "requests": 2000000
                }
        },
        "labels": {
                "group": "test"
        },
        "annotations": {
                "owner": "hmeng",
                "security.alpha.kubernetes.io/seccomp/pod": "unconfined",
                "com.example.test": "sandbox annotation"
        },
        "linux": {
                "cgroup_parent": "pod_123-456.slice",
                "security_context": {
                        "namespace_options": {
                                "network": 2,
                                "pid": 1,
                                "ipc": 0
                        },
                        "selinux_options": {
                                "user": "system_u",
                                "role": "system_r",
                                "type": "svirt_lxc_net_t",
                                "level": "s0:c4,c5"
                        }
                }
        }
}
❯ sudo crictl --timeout=200s --runtime-endpoint unix:///run/crio/crio.sock run ./container.json ./sandbox_config.json
INFO[0005] Pulling container image: registry.docker.com/ollama/ollama:latest 
INFO[0005] Pulling image registry.ollama.ai/library/tinyllama:latest to be mounted to container path: /volume 
7e437894449f6429799cc5ef236c4a4570a69e3769bf324bbf700045e383cae8
❯ sudo crictl --timeout=200s --runtime-endpoint unix:///run/crio/crio.sock ps
CONTAINER           IMAGE                                        CREATED             STATE               NAME                ATTEMPT             POD ID              POD
7e437894449f6       registry.docker.com/ollama/ollama:latest     8 seconds ago       Running             podsandbox-sleep    0                   4d1766fdf286b       unknown
❯ sudo crictl --timeout=200s --runtime-endpoint unix:///run/crio/crio.sock exec -it 7e437894449f6 bash
root@crictl_host:/# cd volume/
root@crictl_host:/volume# ls -l
total 622772
-rw-r--r-- 1 root root 637699456 Aug 26 08:32 model
-rw-r--r-- 1 root root        98 Aug 26 08:32 params
-rw-r--r-- 1 root root        31 Aug 26 08:32 system
-rw-r--r-- 1 root root        70 Aug 26 08:32 template
root@crictl_host:/volume# 
```