### PR TITLE
Update stubs to match signature of actual methods

### DIFF
--- a/signature/fulcio_cert_stub.go
+++ b/signature/fulcio_cert_stub.go
@@ -20,7 +20,7 @@ func (f *fulcioTrustRoot) validate() error {
 	return errors.New("fulcio disabled at compile-time")
 }
 
-func verifyRekorFulcio(rekorPublicKey *ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
+func verifyRekorFulcio(rekorPublicKeys []*ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
 	untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte, untrustedBase64Signature string,
 	untrustedPayloadBytes []byte) (crypto.PublicKey, error) {
 	return nil, errors.New("fulcio disabled at compile-time")

--- a/signature/internal/rekor_set_stub.go
+++ b/signature/internal/rekor_set_stub.go
@@ -10,6 +10,6 @@ import (
 
 // VerifyRekorSET verifies that unverifiedRekorSET is correctly signed by publicKey and matches the rest of the data.
 // Returns bundle upload time on success.
-func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
+func VerifyRekorSET(publicKeys []*ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
 	return time.Time{}, NewInvalidSignatureError("rekor disabled at compile-time")
 }


### PR DESCRIPTION
#2526 has broken building v5.32.2 with the `containers_image_fulcio_stub` and `containers_image_rekor_stub` build tags, as the signatures for `verifyRekorFulcio()` and `VerifyRekorSET()` were updated without updating the corresponding stubs.

This PR updates the stubs to match