### PR TITLE
[release-5.26] Bump c/image to v5.26.3 then to v5.26.4-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 26
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 3
+	VersionPatch = 4
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Bumping to v5.26.3, then v5.26.4-dev to address CVE-2024-3727