### PR TITLE
Export BuiltinDefaultPolicyPath

### DIFF
--- a/signature/policy_config.go
+++ b/signature/policy_config.go
@@ -32,7 +32,7 @@ import (
 // systemDefaultPolicyPath is the policy path used for DefaultPolicy().
 // You can override this at build time with
 // -ldflags '-X github.com/containers/image/v5/signature.systemDefaultPolicyPath=$your_path'
-var systemDefaultPolicyPath = builtinDefaultPolicyPath
+var systemDefaultPolicyPath = BuiltinDefaultPolicyPath
 
 // userPolicyFile is the path to the per user policy path.
 var userPolicyFile = filepath.FromSlash(".config/containers/policy.json")

--- a/signature/policy_paths_common.go
+++ b/signature/policy_paths_common.go
@@ -3,6 +3,6 @@
 
 package signature
 
-// builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
+// BuiltinDefaultPolicyPath is the policy path used for DefaultPolicy().
 // DO NOT change this, instead see systemDefaultPolicyPath above.
-const builtinDefaultPolicyPath = "/etc/containers/policy.json"
+const BuiltinDefaultPolicyPath = "/etc/containers/policy.json"

--- a/signature/policy_paths_freebsd.go
+++ b/signature/policy_paths_freebsd.go
@@ -3,6 +3,6 @@
 
 package signature
 
-// builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
+// BuiltinDefaultPolicyPath is the policy path used for DefaultPolicy().
 // DO NOT change this, instead see systemDefaultPolicyPath above.
-const builtinDefaultPolicyPath = "/usr/local/etc/containers/policy.json"
+const BuiltinDefaultPolicyPath = "/usr/local/etc/containers/policy.json"


### PR DESCRIPTION
This field is duplicated in containers/common/pkg/config and is being vendored into bindings, just because it is not exported from containers/image.