### PR TITLE
Test against a stable branch of Skopeo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ env:
     # Name of the ultimate destination branch for this CI run
     DEST_BRANCH: "main"
     # c/skopeo branch name which must work with this c/image branch
-    SKOPEO_CI_BRANCH: "main"
+    SKOPEO_CI_BRANCH: "release-1.16"
     # Use GO module mirror (reason unknown, travis did it this way)
     GOPROXY: https://proxy.golang.org
     # Overrides default location (/tmp/cirrus) for repo clone


### PR DESCRIPTION
The "main" branch of Skopeo now requires Go 1.22, and eventually will depend on new c/image APIs.