### PR TITLE
 copy: Don't print "skipped: 0.0b = 0.00%"

### DIFF
--- a/copy/progress_bars.go
+++ b/copy/progress_bars.go
@@ -24,13 +24,18 @@ func (c *copier) newProgressPool() *mpb.Progress {
 
 // customPartialBlobDecorFunc implements mpb.DecorFunc for the partial blobs retrieval progress bar
 func customPartialBlobDecorFunc(s decor.Statistics) string {
+	current := decor.SizeB1024(s.Current)
+	total := decor.SizeB1024(s.Total)
+	refill := decor.SizeB1024(s.Refill)
 	if s.Total == 0 {
-		pairFmt := "%.1f / %.1f (skipped: %.1f)"
-		return fmt.Sprintf(pairFmt, decor.SizeB1024(s.Current), decor.SizeB1024(s.Total), decor.SizeB1024(s.Refill))
+		return fmt.Sprintf("%.1f / %.1f (skipped: %.1f)", current, total, refill)
 	}
-	pairFmt := "%.1f / %.1f (skipped: %.1f = %.2f%%)"
+	// If we didn't do a partial fetch then let's not output a distracting ("skipped: 0.0b = 0.00%")
+	if s.Refill == 0 {
+		return fmt.Sprintf("%.1f / %.1f", current, total)
+	}
 	percentage := 100.0 * float64(s.Refill) / float64(s.Total)
-	return fmt.Sprintf(pairFmt, decor.SizeB1024(s.Current), decor.SizeB1024(s.Total), decor.SizeB1024(s.Refill), percentage)
+	return fmt.Sprintf("%.1f / %.1f (skipped: %.1f = %.2f%%)", current, total, refill, percentage)
 }
 
 // progressBar wraps a *mpb.Bar, allowing us to add extra state and methods.

--- a/copy/progress_bars_test.go
+++ b/copy/progress_bars_test.go
@@ -20,5 +20,5 @@ func TestCustomPartialBlobDecorFunc(t *testing.T) {
 	// Almost complete, but no reuse
 	s.Current = int64(float64(s.Total) * 0.95)
 	s.Refill = 0
-	assert.Equal(t, "7.5MiB / 7.9MiB (skipped: 0.0b = 0.00%)", customPartialBlobDecorFunc(s))
+	assert.Equal(t, "7.5MiB / 7.9MiB", customPartialBlobDecorFunc(s))
 }

--- a/copy/progress_bars_test.go
+++ b/copy/progress_bars_test.go
@@ -1,0 +1,24 @@
+package copy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+func TestCustomPartialBlobDecorFunc(t *testing.T) {
+	// A stub test
+	s := decor.Statistics{}
+	assert.Equal(t, "0.0b / 0.0b (skipped: 0.0b)", customPartialBlobDecorFunc(s))
+	// Partial pull in progress
+	s = decor.Statistics{}
+	s.Current = 1097653
+	s.Total = 8329917
+	s.Refill = 509722
+	assert.Equal(t, "1.0MiB / 7.9MiB (skipped: 497.8KiB = 6.12%)", customPartialBlobDecorFunc(s))
+	// Almost complete, but no reuse
+	s.Current = int64(float64(s.Total) * 0.95)
+	s.Refill = 0
+	assert.Equal(t, "7.5MiB / 7.9MiB (skipped: 0.0b = 0.00%)", customPartialBlobDecorFunc(s))
+}


### PR DESCRIPTION
copy: Add unit tests for progress output

Prep for more work.

Signed-off-by: Colin Walters <walters@verbum.org>

---

copy: Don't print "skipped: 0.0b = 0.00%"

I think this is just visually noisy. If we didn't do a partial
fetch then let's just not say anything about it.

Signed-off-by: Colin Walters <walters@verbum.org>

---