### PR TITLE
registry: remove ping v1

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -42,7 +42,6 @@ const (
 	dockerRegistry   = "registry-1.docker.io"
 
 	resolvedPingV2URL       = "%s://%s/v2/"
-	resolvedPingV1URL       = "%s://%s/v1/_ping"
 	tagsPath                = "/v2/%s/tags/list"
 	manifestPath            = "/v2/%s/manifests/%s"
 	blobsPath               = "/v2/%s/blobs/%s"
@@ -936,34 +935,6 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 	}
 	if err != nil {
 		err = fmt.Errorf("pinging container registry %s: %w", c.registry, err)
-		if c.sys != nil && c.sys.DockerDisableV1Ping {
-			return err
-		}
-		// best effort to understand if we're talking to a V1 registry
-		pingV1 := func(scheme string) bool {
-			pingURL, err := url.Parse(fmt.Sprintf(resolvedPingV1URL, scheme, c.registry))
-			if err != nil {
-				return false
-			}
-			resp, err := c.makeRequestToResolvedURL(ctx, http.MethodGet, pingURL, nil, nil, -1, noAuth, nil)
-			if err != nil {
-				logrus.Debugf("Ping %s err %s (%#v)", pingURL.Redacted(), err.Error(), err)
-				return false
-			}
-			defer resp.Body.Close()
-			logrus.Debugf("Ping %s status %d", pingURL.Redacted(), resp.StatusCode)
-			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-				return false
-			}
-			return true
-		}
-		isV1 := pingV1("https")
-		if !isV1 && c.tlsClientConfig.InsecureSkipVerify {
-			isV1 = pingV1("http")
-		}
-		if isV1 {
-			err = ErrV1NotSupported
-		}
 	}
 	return err
 }

--- a/docker/errors.go
+++ b/docker/errors.go
@@ -12,6 +12,7 @@ import (
 var (
 	// ErrV1NotSupported is returned when we're trying to talk to a
 	// docker V1 registry.
+	// Deprecated: The V1 container registry detection is no longer performed, so this error is never returned.
 	ErrV1NotSupported = errors.New("can't talk to a V1 container registry")
 	// ErrTooManyRequests is returned when the status code returned is 429
 	ErrTooManyRequests = errors.New("too many requests to registry")

--- a/types/types.go
+++ b/types/types.go
@@ -643,6 +643,7 @@ type SystemContext struct {
 	// if true, a V1 ping attempt isn't done to give users a better error. Default is false.
 	// Note that this field is used mainly to integrate containers/image into projectatomic/docker
 	// in order to not break any existing docker's integration tests.
+	// Deprecated: The V1 container registry detection is no longer performed, so setting this flag has no effect.
 	DockerDisableV1Ping bool
 	// If true, dockerImageDestination.SupportedManifestMIMETypes will omit the Schema1 media types from the supported list
 	DockerDisableDestSchema1MIMETypes bool


### PR DESCRIPTION
The ping v1 happens when the ping v2 fails, however, it causes the ping v2 error to be skipped and not output to the user. As result, when a registry has v1 and v2 enabled, and there are, for example, intermittent connectivity issues making the ping v2 fail, the user is presented with a misleading error saying "can't talk to V1 registry."

Since the only use of v1 is for the search API as a workaround for docker.io, and new container registries setups are very unlikely to be v1-only, there is little utility in keeping this v1 detection in the attempt to help the user realize their setup is v1-only, hence not compatible. On the contratry, it just presents the user with a misleading error in certain circumstances.