### PR TITLE
copy: Allow copying images with signatures

### DIFF
--- a/copy/multiple.go
+++ b/copy/multiple.go
@@ -197,9 +197,6 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	// If we can, set to the empty string. If we can't, set to the reason why.
 	// Compare, and perhaps keep in sync with, the version in copySingleImage.
 	cannotModifyManifestListReason := ""
-	if len(sigs) > 0 {
-		cannotModifyManifestListReason = "Would invalidate signatures"
-	}
 	if destIsDigestedReference {
 		cannotModifyManifestListReason = "Destination specifies a digest"
 	}

--- a/copy/single.go
+++ b/copy/single.go
@@ -124,9 +124,6 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 	// If we can, set to the empty string. If we can't, set to the reason why.
 	// Compare, and perhaps keep in sync with, the version in copyMultipleImages.
 	cannotModifyManifestReason := ""
-	if len(sigs) > 0 {
-		cannotModifyManifestReason = "Would invalidate signatures"
-	}
 	if destIsDigestedReference {
 		cannotModifyManifestReason = "Destination specifies a digest"
 	}


### PR DESCRIPTION
This error path was taken even when the destination supports signatures. The call to `sourceSignatures()` will return an error when the destination does not support signatures, so an error should not be thrown when len(sigs) > 0.

---

I'm not totally sure of the implications of removing this error path, but I tested this with skopeo and I am able to copy an image with a signature after removing this if statement.

This would fix https://github.com/containers/bootc/issues/812