### PR TITLE
Consistently use a string type for expectedLayerDiffIDFlag

### DIFF
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -930,7 +930,7 @@ func (s *storageImageDestination) createNewLayer(index int, layerDigest digest.D
 
 		flags := make(map[string]interface{})
 		if untrustedUncompressedDigest != "" {
-			flags[expectedLayerDiffIDFlag] = untrustedUncompressedDigest
+			flags[expectedLayerDiffIDFlag] = untrustedUncompressedDigest.String()
 			logrus.Debugf("Setting uncompressed digest to %q for layer %q", untrustedUncompressedDigest, newLayerID)
 		}
 


### PR DESCRIPTION
Might be a fix for https://github.com/containers/image/issues/2602 .