### PR TITLE
Actually record last retry time after reconnecting

### DIFF
--- a/docker/body_reader.go
+++ b/docker/body_reader.go
@@ -197,7 +197,7 @@ func (br *bodyReader) Read(p []byte) (int, error) {
 		consumedBody = true
 		br.body = res.Body
 		br.lastRetryOffset = br.offset
-		br.lastRetryTime = time.Time{}
+		br.lastRetryTime = time.Now()
 		return n, nil
 
 	default:


### PR DESCRIPTION
The code was incorrectly setting it to "never", meaning the `bodyReaderMSSinceLastRetry` heuristic was never triggered, and, in effect, we would _always_ reconnect on `io.ErrUnexpectedEOF` or `syscall.ECONNRESET` .

This corrects the code - but it might also make more network failures user-visible instead of silently retried.