### PR TITLE
Move JSONFormatToInvalidSignatureError to an unconditionally-included file

### DIFF
--- a/signature/internal/errors.go
+++ b/signature/internal/errors.go
@@ -13,3 +13,12 @@ func (err InvalidSignatureError) Error() string {
 func NewInvalidSignatureError(msg string) InvalidSignatureError {
 	return InvalidSignatureError{msg: msg}
 }
+
+// JSONFormatToInvalidSignatureError converts JSONFormatError to InvalidSignatureError.
+// All other errors are returned as is.
+func JSONFormatToInvalidSignatureError(err error) error {
+	if formatErr, ok := err.(JSONFormatError); ok {
+		err = NewInvalidSignatureError(formatErr.Error())
+	}
+	return err
+}

--- a/signature/internal/rekor_set.go
+++ b/signature/internal/rekor_set.go
@@ -40,15 +40,6 @@ type UntrustedRekorPayload struct {
 // A compile-time check that UntrustedRekorSET implements json.Unmarshaler
 var _ json.Unmarshaler = (*UntrustedRekorSET)(nil)
 
-// JSONFormatToInvalidSignatureError converts JSONFormatError to InvalidSignatureError.
-// All other errors are returned as is.
-func JSONFormatToInvalidSignatureError(err error) error {
-	if formatErr, ok := err.(JSONFormatError); ok {
-		err = NewInvalidSignatureError(formatErr.Error())
-	}
-	return err
-}
-
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (s *UntrustedRekorSET) UnmarshalJSON(data []byte) error {
 	return JSONFormatToInvalidSignatureError(s.strictUnmarshalJSON(data))


### PR DESCRIPTION
otherwise:
```console
% go build -tags ' containers_image_fulcio_stub containers_image_rekor_stub' ./...
# github.com/containers/image/v5/signature/internal
signature/internal/sigstore_payload.go:83:9: undefined: JSONFormatToInvalidSignatureError
```