### PR TITLE
In pulls, compute DiffIDs earlier, and also for v2s2

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -109,7 +109,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		}
 	}
 
-	if err := checkImageDestinationForCurrentRuntime(ctx, c.options.DestinationCtx, src, c.dest); err != nil {
+	if err := prepareImageConfigForDest(ctx, c.options.DestinationCtx, src, c.dest); err != nil {
 		return copySingleImageResult{}, err
 	}
 
@@ -316,12 +316,15 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 	return res, nil
 }
 
-// checkImageDestinationForCurrentRuntime enforces dest.MustMatchRuntimeOS, if necessary.
-func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.SystemContext, src types.Image, dest types.ImageDestination) error {
+// prepareImageConfigForDest enforces dest.MustMatchRuntimeOS and handles dest.NoteOriginalOCIConfig, if necessary.
+func prepareImageConfigForDest(ctx context.Context, sys *types.SystemContext, src types.Image, dest private.ImageDestination) error {
+	ociConfig, configErr := src.OCIConfig(ctx)
+	// Do not fail on configErr here, this might be an artifact
+	// and maybe nothing needs this to be a container image and to process the config.
+
 	if dest.MustMatchRuntimeOS() {
-		c, err := src.OCIConfig(ctx)
-		if err != nil {
-			return fmt.Errorf("parsing image configuration: %w", err)
+		if configErr != nil {
+			return fmt.Errorf("parsing image configuration: %w", configErr)
 		}
 		wantedPlatforms := platform.WantedPlatforms(sys)
 
@@ -331,7 +334,7 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 			// For a transitional period, this might trigger warnings because the Variant
 			// field was added to OCI config only recently. If this turns out to be too noisy,
 			// revert this check to only look for (OS, Architecture).
-			if platform.MatchesPlatform(c.Platform, wantedPlatform) {
+			if platform.MatchesPlatform(ociConfig.Platform, wantedPlatform) {
 				match = true
 				break
 			}
@@ -339,9 +342,14 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 		}
 		if !match {
 			logrus.Infof("Image operating system mismatch: image uses OS %q+architecture %q+%q, expecting one of %q",
-				c.OS, c.Architecture, c.Variant, strings.Join(options.list, ", "))
+				ociConfig.OS, ociConfig.Architecture, ociConfig.Variant, strings.Join(options.list, ", "))
 		}
 	}
+
+	if err := dest.NoteOriginalOCIConfig(ociConfig, configErr); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/directory/directory_dest.go
+++ b/directory/directory_dest.go
@@ -29,6 +29,7 @@ var ErrNotContainerImageDir = errors.New("not a containers image directory, don'
 type dirImageDestination struct {
 	impl.Compat
 	impl.PropertyMethodsInitialize
+	stubs.IgnoresOriginalOCIConfig
 	stubs.NoPutBlobPartialInitialize
 	stubs.AlwaysSupportsSignatures
 

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -41,6 +41,7 @@ import (
 type dockerImageDestination struct {
 	impl.Compat
 	impl.PropertyMethodsInitialize
+	stubs.IgnoresOriginalOCIConfig
 	stubs.NoPutBlobPartialInitialize
 
 	ref dockerReference

--- a/docker/internal/tarfile/dest.go
+++ b/docker/internal/tarfile/dest.go
@@ -24,6 +24,7 @@ import (
 type Destination struct {
 	impl.Compat
 	impl.PropertyMethodsInitialize
+	stubs.IgnoresOriginalOCIConfig
 	stubs.NoPutBlobPartialInitialize
 	stubs.NoSignaturesInitialize
 

--- a/internal/imagedestination/stubs/original_oci_config.go
+++ b/internal/imagedestination/stubs/original_oci_config.go
@@ -1,0 +1,16 @@
+package stubs
+
+import (
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// IgnoresOriginalOCIConfig implements NoteOriginalOCIConfig() that does nothing.
+type IgnoresOriginalOCIConfig struct{}
+
+// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+// The destination can use it in its TryReusingBlob/PutBlob implementations
+// (otherwise it only obtains the final config after all layers are written).
+func (stub IgnoresOriginalOCIConfig) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error {
+	return nil
+}

--- a/internal/imagedestination/wrapper.go
+++ b/internal/imagedestination/wrapper.go
@@ -14,6 +14,7 @@ import (
 // wrapped provides the private.ImageDestination operations
 // for a destination that only implements types.ImageDestination
 type wrapped struct {
+	stubs.IgnoresOriginalOCIConfig
 	stubs.NoPutBlobPartialInitialize
 
 	types.ImageDestination

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -10,6 +10,7 @@ import (
 	compression "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageSourceInternalOnly is the part of private.ImageSource that is not
@@ -40,6 +41,12 @@ type ImageDestinationInternalOnly interface {
 	SupportsPutBlobPartial() bool
 	// FIXME: Add SupportsSignaturesWithFormat or something like that, to allow early failures
 	// on unsupported formats.
+
+	// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+	// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+	// The destination can use it in its TryReusingBlob/PutBlob implementations
+	// (otherwise it only obtains the final config after all layers are written).
+	NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error
 
 	// PutBlobWithOptions writes contents of stream and returns data representing the result.
 	// inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.

--- a/oci/archive/oci_dest.go
+++ b/oci/archive/oci_dest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -101,6 +102,14 @@ func (d *ociArchiveImageDestination) HasThreadSafePutBlob() bool {
 // SupportsPutBlobPartial returns true if PutBlobPartial is supported.
 func (d *ociArchiveImageDestination) SupportsPutBlobPartial() bool {
 	return d.unpackedDest.SupportsPutBlobPartial()
+}
+
+// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+// The destination can use it in its TryReusingBlob/PutBlob implementations
+// (otherwise it only obtains the final config after all layers are written).
+func (d *ociArchiveImageDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error {
+	return d.unpackedDest.NoteOriginalOCIConfig(ociConfig, configErr)
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/oci/layout/oci_dest.go
+++ b/oci/layout/oci_dest.go
@@ -27,6 +27,7 @@ import (
 type ociImageDestination struct {
 	impl.Compat
 	impl.PropertyMethodsInitialize
+	stubs.IgnoresOriginalOCIConfig
 	stubs.NoPutBlobPartialInitialize
 	stubs.NoSignaturesInitialize
 

--- a/openshift/openshift_dest.go
+++ b/openshift/openshift_dest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type openshiftImageDestination struct {
@@ -109,6 +110,14 @@ func (d *openshiftImageDestination) HasThreadSafePutBlob() bool {
 // SupportsPutBlobPartial returns true if PutBlobPartial is supported.
 func (d *openshiftImageDestination) SupportsPutBlobPartial() bool {
 	return d.docker.SupportsPutBlobPartial()
+}
+
+// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+// The destination can use it in its TryReusingBlob/PutBlob implementations
+// (otherwise it only obtains the final config after all layers are written).
+func (d *openshiftImageDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error {
+	return d.docker.NoteOriginalOCIConfig(ociConfig, configErr)
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/pkg/blobcache/dest.go
+++ b/pkg/blobcache/dest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/ioutils"
 	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -136,6 +137,14 @@ func (d *blobCacheDestination) saveStream(wg *sync.WaitGroup, decompressReader i
 
 func (d *blobCacheDestination) HasThreadSafePutBlob() bool {
 	return d.destination.HasThreadSafePutBlob()
+}
+
+// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+// The destination can use it in its TryReusingBlob/PutBlob implementations
+// (otherwise it only obtains the final config after all layers are written).
+func (d *blobCacheDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error {
+	return d.destination.NoteOriginalOCIConfig(ociConfig, configErr)
 }
 
 // PutBlobWithOptions writes contents of stream and returns data representing the result.

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -1242,7 +1242,7 @@ func (s *storageImageDestination) CommitWithOptions(ctx context.Context, options
 	}
 	// Set up to save the options.UnparsedToplevel's manifest if it differs from
 	// the per-platform one, which is saved below.
-	if len(toplevelManifest) != 0 && !bytes.Equal(toplevelManifest, s.manifest) {
+	if !bytes.Equal(toplevelManifest, s.manifest) {
 		manifestDigest, err := manifest.Digest(toplevelManifest)
 		if err != nil {
 			return fmt.Errorf("digesting top-level manifest: %w", err)

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -207,6 +207,14 @@ func (s *storageImageDestination) computeNextBlobCacheFile() string {
 	return filepath.Join(s.directory, fmt.Sprintf("%d", s.nextTempFileID.Add(1)))
 }
 
+// NoteOriginalOCIConfig provides the config of the image, as it exists on the source, BUT converted to OCI format,
+// or an error obtaining that value (e.g. if the image is an artifact and not a container image).
+// The destination can use it in its TryReusingBlob/PutBlob implementations
+// (otherwise it only obtains the final config after all layers are written).
+func (s *storageImageDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image, configErr error) error {
+	return nil
+}
+
 // PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.

--- a/storage/storage_src.go
+++ b/storage/storage_src.go
@@ -247,7 +247,7 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 		}
 		return blob, manifest.GuessMIMEType(blob), err
 	}
-	if len(s.cachedManifest) == 0 {
+	if s.cachedManifest == nil {
 		// The manifest is stored as a big data item.
 		// Prefer the manifest corresponding to the user-specified digest, if available.
 		if s.imageRef.named != nil {
@@ -267,7 +267,7 @@ func (s *storageImageSource) GetManifest(ctx context.Context, instanceDigest *di
 		}
 		// If the user did not specify a digest, or this is an old image stored before manifestBigDataKey was introduced, use the default manifest.
 		// Note that the manifest may not match the expected digest, and that is likely to fail eventually, e.g. in c/image/image/UnparsedImage.Manifest().
-		if len(s.cachedManifest) == 0 {
+		if s.cachedManifest == nil {
 			cachedBlob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, storage.ImageDigestBigDataKey)
 			if err != nil {
 				return nil, "", err


### PR DESCRIPTION
This is primarily motivated by preparing for the zstd:chunked logic, but potentially useful separately:
- Have the generic code provide the image config, and thus DiffIDs, at the start of the copy. Therefore we can start committing staged chunked layers immediately, we don’t have to wait for all of them to be staged. That might be a fairly significant performance benefit.
- Support obtaining DiffIDs from v2s2 images as well. Right now that only happens in theoretical corner cases; we will want to enforce that for all images in the future.
- (Some mostly-unrelated cleanups of handling of zero-length manifests.)

<s>At this point absolutely untested.</s>

Cc: @giuseppe , filing early to allow a preliminary review in case I have missed anything important.