### PR TITLE
Use testify's ErrorAs to simplify tests a bit

### DIFF
--- a/docker/errors_test.go
+++ b/docker/errors_test.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"net/http"
 	"testing"
 
@@ -109,8 +108,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			errorCode:         &errcode.ErrorCodeUnknown,
 			fn: func(t *testing.T, err error) {
 				var e errcode.Error
-				ok := errors.As(err, &e)
-				require.True(t, ok)
+				require.ErrorAs(t, err, &e)
 				// Note: (skopeo inspect) is checking for this errcode.Error value
 				assert.Equal(t, errcode.Error{
 					Code:    errcode.ErrorCodeUnknown, // The NOT_FOUND value is not defined, and turns into Unknown
@@ -140,8 +138,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			errorCode:         &errcode.ErrorCodeUnknown,
 			fn: func(t *testing.T, err error) {
 				var e errcode.Error
-				ok := errors.As(err, &e)
-				require.True(t, ok)
+				require.ErrorAs(t, err, &e)
 				// isManifestUnknownError is checking for this
 				assert.Equal(t, errcode.Error{
 					Code:    errcode.ErrorCodeUnknown, // The 404 value is not defined, and turns into Unknown
@@ -166,8 +163,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			unwrappedErrorPtr: &unwrappedUnexpectedHTTPResponseError,
 			fn: func(t *testing.T, err error) {
 				var e *unexpectedHTTPResponseError
-				ok := errors.As(err, &e)
-				require.True(t, ok)
+				require.ErrorAs(t, err, &e)
 				// isManifestUnknownError is checking for this
 				assert.Equal(t, 404, e.StatusCode)
 				assert.Equal(t, []byte("Not found\r"), e.Response)
@@ -191,8 +187,7 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			errorCode:         &errcode.ErrorCodeUnknown,
 			fn: func(t *testing.T, err error) {
 				var e errcode.Error
-				ok := errors.As(err, &e)
-				require.True(t, ok)
+				require.ErrorAs(t, err, &e)
 				// isManifestUnknownError is checking for this
 				assert.Equal(t, errcode.Error{
 					Code:    errcode.ErrorCodeUnknown, // The NOT_FOUND value is not defined, and turns into Unknown
@@ -212,13 +207,11 @@ func TestRegistryHTTPResponseToError(t *testing.T) {
 			assert.IsType(t, c.errorType, err, c.name)
 		}
 		if c.unwrappedErrorPtr != nil {
-			found := errors.As(err, c.unwrappedErrorPtr)
-			assert.True(t, found, c.name)
+			assert.ErrorAs(t, err, c.unwrappedErrorPtr, c.name)
 		}
 		if c.errorCode != nil {
 			var ec errcode.ErrorCoder
-			ok := errors.As(err, &ec)
-			require.True(t, ok, c.name)
+			require.ErrorAs(t, err, &ec, c.name)
 			assert.Equal(t, *c.errorCode, ec.ErrorCode(), c.name)
 		}
 		if c.fn != nil {


### PR DESCRIPTION
Should not change (test) behavior, other than perhaps better test failure output.