### PR TITLE
Two small lint updates

### DIFF
--- a/oci/internal/oci_util.go
+++ b/oci/internal/oci_util.go
@@ -98,7 +98,7 @@ func ValidateScope(scope string) error {
 }
 
 func validateScopeWindows(scope string) error {
-	matched, _ := regexp.Match(`^[a-zA-Z]:\\`, []byte(scope))
+	matched, _ := regexp.MatchString(`^[a-zA-Z]:\\`, scope)
 	if !matched {
 		return fmt.Errorf("Invalid scope '%s'. Must be an absolute path", scope)
 	}


### PR DESCRIPTION
… from browsing the output of `golangci-lint --enable-all`. =

(There are tons of other warnings, many outright unwanted, most stylistic and unimportant — I’m not claiming these are the 2 most important warnings, these are just the ones that stood out in the noise.)