### PR TITLE
Fix docker daemon on Windows trying to use https instead of http for named pipes

### DIFF
--- a/docker/daemon/client.go
+++ b/docker/daemon/client.go
@@ -48,6 +48,7 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	}
 	switch serverURL.Scheme {
 	case "unix": // Nothing
+	case "npipe": // Nothing
 	case "http":
 		hc := httpConfig()
 		opts = append(opts, dockerclient.WithHTTPClient(hc))


### PR DESCRIPTION
This corrects an issue where previously connections to the Docker daemon on Windows would attempt to add a TLS config, changing the scheme to https instead of http, and breaking the client.  This changes named pipes (returned as `npipe` by the docker client library) to mimic the behavior of unix sockets.

I tried to add tests for this case, but the base transport and scheme variables are not exposed from the docker client, so there wasn't a clear way to test this change.  I have tested this locally on a Windows machine, ensuring that accessing the daemon works after this change.