### PR TITLE
docs: registries.conf: mention Podman Machine

### DIFF
--- a/docs/containers-registries.conf.5.md
+++ b/docs/containers-registries.conf.5.md
@@ -11,6 +11,8 @@ file for container image registries. The file format is TOML.
 
 Container engines will use the `$HOME/.config/containers/registries.conf` if it exists, otherwise they will use `/etc/containers/registries.conf`
 
+If you are using Podman Machine (e.g., on MacOS or Windows), registries.conf is read on the server-side only.  Changing the configuration implies changing the files inside the Podman Machine which you can do via `podman machine ssh`.  Make sure to not add registries.conf to a non-root user's home directory and only configure the system-wide settings in `/etc/containers` to make sure the default settings of Podman Machine continue being applied.
+
 ### GLOBAL SETTINGS
 
 `unqualified-search-registries`


### PR DESCRIPTION
After a wild ride helping to configure a mirror for docker.io for Podman on the Mac, I feel we need to improve the docs a bit.

When running against a Podman Machine, registries.conf is read server-side only.  That means that mirrors need to be configured inside the virtual Linux machine.  In addition to that, things can start falling apart when adding a config to the HOME directory of the default non-root (core) users of tha machine.

That means mirrors should be configured globally in /etc/containers/registries.conf[.d].

@rhatdan @mtrmac PTAL