### PR TITLE
Add docker media types in OCI formats

### DIFF
--- a/oci/layout/fixtures/name_lookups/index.json
+++ b/oci/layout/fixtures/name_lookups/index.json
@@ -3,7 +3,7 @@
     "mediaType": "application/vnd.oci.image.index.v1+json",
     "manifests": [
         {
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "mediaType": "application/vnd.oci.image.index.v1+json",
             "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "size": 1,
             "annotations": {
@@ -19,17 +19,25 @@
             }
         },
         {
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
             "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
             "size": 3,
             "annotations": {
-                "org.opencontainers.image.ref.name": "invalid-mime"
+                "org.opencontainers.image.ref.name": "c"
+            }
+        },
+        {
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "size": 4,
+            "annotations": {
+                "org.opencontainers.image.ref.name": "d"
             }
         },
         {
             "mediaType": "x-completely-unknown",
-            "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-            "size": 4,
+            "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "size": 6,
             "annotations": {
                 "org.opencontainers.image.ref.name": "invalid-mime"
             }

--- a/oci/layout/oci_transport.go
+++ b/oci/layout/oci_transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/v5/directory/explicitfilepath"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/internal/image"
+	"github.com/containers/image/v5/internal/manifest"
 	"github.com/containers/image/v5/oci/internal"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
@@ -234,7 +235,7 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, int, erro
 		var unsupportedMIMETypes []string
 		for i, md := range index.Manifests {
 			if refName, ok := md.Annotations[imgspecv1.AnnotationRefName]; ok && refName == ref.image {
-				if md.MediaType == imgspecv1.MediaTypeImageManifest || md.MediaType == imgspecv1.MediaTypeImageIndex {
+				if md.MediaType == imgspecv1.MediaTypeImageManifest || md.MediaType == imgspecv1.MediaTypeImageIndex || md.MediaType == manifest.DockerV2Schema2MediaType || md.MediaType == manifest.DockerV2ListMediaType {
 					return md, i, nil
 				}
 				unsupportedMIMETypes = append(unsupportedMIMETypes, md.MediaType)

--- a/oci/layout/oci_transport_test.go
+++ b/oci/layout/oci_transport_test.go
@@ -53,7 +53,7 @@ func TestGetManifestDescriptor(t *testing.T) {
 			dir:   "fixtures/name_lookups",
 			image: "a",
 			expectedDescriptor: &imgspecv1.Descriptor{
-				MediaType:   "application/vnd.oci.image.manifest.v1+json",
+				MediaType:   "application/vnd.oci.image.index.v1+json",
 				Digest:      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Size:        1,
 				Annotations: map[string]string{"org.opencontainers.image.ref.name": "a"},
@@ -70,6 +70,28 @@ func TestGetManifestDescriptor(t *testing.T) {
 				Annotations: map[string]string{"org.opencontainers.image.ref.name": "b"},
 			},
 			expectedIndex: 1,
+		},
+		{ // A valid reference in a multi-manifest directory
+			dir:   "fixtures/name_lookups",
+			image: "c",
+			expectedDescriptor: &imgspecv1.Descriptor{
+				MediaType:   "application/vnd.docker.distribution.manifest.list.v2+json",
+				Digest:      "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				Size:        3,
+				Annotations: map[string]string{"org.opencontainers.image.ref.name": "c"},
+			},
+			expectedIndex: 2,
+		},
+		{ // A valid reference in a multi-manifest directory
+			dir:   "fixtures/name_lookups",
+			image: "d",
+			expectedDescriptor: &imgspecv1.Descriptor{
+				MediaType:   "application/vnd.docker.distribution.manifest.v2+json",
+				Digest:      "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+				Size:        4,
+				Annotations: map[string]string{"org.opencontainers.image.ref.name": "d"},
+			},
+			expectedIndex: 3,
 		},
 		{ // No entry found
 			dir:                "fixtures/name_lookups",

--- a/oci/layout/reader_test.go
+++ b/oci/layout/reader_test.go
@@ -35,14 +35,15 @@ func TestList(t *testing.T) {
 		},
 		{
 			path: "fixtures/name_lookups",
-			num:  4,
+			num:  5,
 			digests: []string{
 				"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 				"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+				"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 			},
-			names: map[int]string{0: "a", 1: "b", 2: "invalid-mime", 3: "invalid-mime"},
+			names: map[int]string{0: "a", 1: "b", 2: "c", 3: "d", 4: "invalid-mime"},
 		},
 	} {
 		results, err := List(test.path)


### PR DESCRIPTION
This pull request adds the docker media types when reading back OCI formats, along with the corresponding tests.  This is from running into cases where docker images were built with the docker media types.  To avoid having to convert all of the existing manifests so that the original types can be maintained, this code adds support for reading the docker specific formats since the OCI formats are backwards compatible with the docker formats (https://github.com/opencontainers/image-spec/blob/main/media-types.md).