### PR TITLE
Don't silently ignore errors determining size in TryReuseBlob

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -998,7 +998,12 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 			resp.Body.Close()
 			continue
 		}
-		return resp.Body, getBlobSize(resp), nil
+
+		size, err := getBlobSize(resp)
+		if err != nil {
+			size = -1
+		}
+		return resp.Body, size, nil
 	}
 	if remoteErrors == nil {
 		return nil, 0, nil // fallback to non-external blob
@@ -1006,12 +1011,20 @@ func (c *dockerClient) getExternalBlob(ctx context.Context, urls []string) (io.R
 	return nil, 0, fmt.Errorf("failed fetching external blob from all urls: %w", multierr.Format("", ", ", "", remoteErrors))
 }
 
-func getBlobSize(resp *http.Response) int64 {
-	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
-	if err != nil {
-		size = -1
+func getBlobSize(resp *http.Response) (int64, error) {
+	hdrs := resp.Header.Values("Content-Length")
+	if len(hdrs) == 0 {
+		return -1, errors.New(`Missing "Content-Length" header in response`)
 	}
-	return size
+	hdr := hdrs[0] // Equivalent to resp.Header.Get(…)
+	size, err := strconv.ParseInt(hdr, 10, 64)
+	if err != nil { // Go’s response reader should already reject such values.
+		return -1, err
+	}
+	if size < 0 { // '-' is not a valid character in Content-Length, so negative values are invalid. Go’s response reader should already reject such values.
+		return -1, fmt.Errorf(`Invalid negative "Content-Length" %q`, hdr)
+	}
+	return size, nil
 }
 
 // getBlob returns a stream for the specified blob in ref, and the blob’s size (or -1 if unknown).
@@ -1042,7 +1055,10 @@ func (c *dockerClient) getBlob(ctx context.Context, ref dockerReference, info ty
 		return nil, 0, fmt.Errorf("fetching blob: %w", err)
 	}
 	cache.RecordKnownLocation(ref.Transport(), bicTransportScope(ref), info.Digest, newBICLocationReference(ref))
-	blobSize := getBlobSize(res)
+	blobSize, err := getBlobSize(res)
+	if err != nil {
+		blobSize = -1
+	}
 
 	reconnectingReader, err := newBodyReader(ctx, c, path, res.Body)
 	if err != nil {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -243,8 +243,12 @@ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.
 	defer res.Body.Close()
 	switch res.StatusCode {
 	case http.StatusOK:
+		size, err := getBlobSize(res)
+		if err != nil {
+			return false, -1, fmt.Errorf("determining size of blob %s in %s: %w", digest, repo.Name(), err)
+		}
 		logrus.Debugf("... already exists")
-		return true, getBlobSize(res), nil
+		return true, size, nil
 	case http.StatusUnauthorized:
 		logrus.Debugf("... not authorized")
 		return false, -1, fmt.Errorf("checking whether a blob %s exists in %s: %w", digest, repo.Name(), registryHTTPResponseToError(res))


### PR DESCRIPTION
Returning the size required by the `TryReuseBlob`/`PutBlob` API; otherwise we could put `-1` into manifests.

- When looking for inexact matches, this will cause the matches to be skipped.
- When checking for an exact match, this will cause an upload failure; we don't have any other way to handle pre-existing blobs on the destination.

---

<s>For now, completely untested.</s>