### PR TITLE
Add debugging for manifests when uploading to destinations.

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -358,6 +358,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		return nil, fmt.Errorf("committing the finished image: %w", err)
 	}
 
+	logrus.Debugf("Copied manifest(s): %q", string(copiedManifest))
 	return copiedManifest, nil
 }
 

--- a/copy/single.go
+++ b/copy/single.go
@@ -610,6 +610,8 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 	if instanceDigest != nil {
 		instanceDigest = &manifestDigest
 	}
+
+	logrus.Debugf("Manifest to be written to destination: %q", string(man))
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
 		logrus.Debugf("Error %v while writing manifest %q", err, string(man))
 		return nil, "", fmt.Errorf("writing manifest: %w", err)


### PR DESCRIPTION
Add optional logging for printing outgoing manifests.  This can greatly help in debugging anything that might alter a manifest either on wire or in the use case I just had, verifying a problem in local storage (verifying the outgoing manifests without having to watch pure HTTP calls, etc).