### PR TITLE
Only upload sigstore signatures to the sigstore tag schema

### DIFF
--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -615,11 +615,11 @@ func (d *dockerImageDestination) PutSignaturesWithFormat(ctx context.Context, si
 		}
 		switch {
 		case d.c.supportsSignatures:
-			if err := d.putSignaturesToAPIExtension(ctx, signatures, *instanceDigest); err != nil {
+			if err := d.putSignaturesToAPIExtension(ctx, otherSignatures, *instanceDigest); err != nil {
 				return err
 			}
 		case d.c.signatureBase != nil:
-			if err := d.putSignaturesToLookaside(signatures, *instanceDigest); err != nil {
+			if err := d.putSignaturesToLookaside(otherSignatures, *instanceDigest); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
... not to registries with X-R-S-S (that would immediately fail, when uploading to such a registry, with no opt-out), and not to
 lookaside (that would _work_ if users set up lookaside).

Before this PR, _if the image had any non-sigstore signatures_, we would upload both the non-sigstore and sigstore signatures to lookaside.

@mheon @TomSweeneyRedHat PTAL. The bug has been that way for 2.5 years. I think the combination of required circumstances (an image must have both kinds of signatures, and the user must have configured lookaside, not use of sigstore tags, while somehow requiring sigstore signatures) makes it unlikely that users would rely on it, but I can’t quite rule it out.