### PR TITLE
fix: handle error on Close() of writable objects

### DIFF
--- a/oci/layout/oci_delete.go
+++ b/oci/layout/oci_delete.go
@@ -159,7 +159,7 @@ func (ref ociReference) deleteReferenceFromIndex(referenceIndex int) error {
 	return saveJSON(ref.indexPath(), index)
 }
 
-func saveJSON(path string, content any) error {
+func saveJSON(path string, content any) (retErr error) {
 	// If the file already exists, get its mode to preserve it
 	var mode fs.FileMode
 	existingfi, err := os.Stat(path)
@@ -177,7 +177,13 @@ func saveJSON(path string, content any) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	// since we are writing to this file, make sure we handle errors
+	defer func() {
+		closeErr := file.Close()
+		if retErr == nil {
+			retErr = closeErr
+		}
+	}()
 
 	return json.NewEncoder(file).Encode(content)
 }

--- a/ostree/ostree_dest.go
+++ b/ostree/ostree_dest.go
@@ -143,16 +143,24 @@ func (d *ostreeImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 		return private.UploadedBlob{}, err
 	}
 
+	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
+
 	blobPath := filepath.Join(tmpDir, "content")
 	blobFile, err := os.Create(blobPath)
 	if err != nil {
 		return private.UploadedBlob{}, err
 	}
-	defer blobFile.Close()
-
-	digester, stream := putblobdigest.DigestIfCanonicalUnknown(stream, inputInfo)
-	// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
-	size, err := io.Copy(blobFile, stream)
+	size, err := func() (_ int64, retErr error) { // A scope for defer
+		// since we are writing to this file, make sure we handle errors
+		defer func() {
+			closeErr := blobFile.Close()
+			if retErr == nil {
+				retErr = closeErr
+			}
+		}()
+		// TODO: This can take quite some time, and should ideally be cancellable using ctx.Done().
+		return io.Copy(blobFile, stream)
+	}()
 	if err != nil {
 		return private.UploadedBlob{}, err
 	}
@@ -247,9 +255,15 @@ func (d *ostreeImageDestination) ostreeCommit(repo *otbuiltin.Repo, branch strin
 	return err
 }
 
-func generateTarSplitMetadata(output *bytes.Buffer, file string) (digest.Digest, int64, error) {
+func generateTarSplitMetadata(output *bytes.Buffer, file string) (_ digest.Digest, _ int64, retErr error) {
 	mfz := pgzip.NewWriter(output)
-	defer mfz.Close()
+	// since we are writing to this, make sure we handle errors
+	defer func() {
+		closeErr := mfz.Close()
+		if retErr == nil {
+			retErr = closeErr
+		}
+	}()
 	metaPacker := storage.NewJSONPacker(mfz)
 
 	stream, err := os.OpenFile(file, os.O_RDONLY, 0)

--- a/pkg/sysregistriesv2/shortnames.go
+++ b/pkg/sysregistriesv2/shortnames.go
@@ -134,7 +134,7 @@ func ResolveShortNameAlias(ctx *types.SystemContext, name string) (reference.Nam
 // editShortNameAlias loads the aliases.conf file and changes it. If value is
 // set, it adds the name-value pair as a new alias. Otherwise, it will remove
 // name from the config.
-func editShortNameAlias(ctx *types.SystemContext, name string, value *string) error {
+func editShortNameAlias(ctx *types.SystemContext, name string, value *string) (retErr error) {
 	if err := validateShortName(name); err != nil {
 		return err
 	}
@@ -178,7 +178,13 @@ func editShortNameAlias(ctx *types.SystemContext, name string, value *string) er
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	// since we are writing to this file, make sure we handle err on Close()
+	defer func() {
+		closeErr := f.Close()
+		if retErr == nil {
+			retErr = closeErr
+		}
+	}()
 
 	encoder := toml.NewEncoder(f)
 	return encoder.Encode(conf)


### PR DESCRIPTION
For objects (particularly files) that we write to, we should to check the return value of `f.Close()` and pass error back to the caller if this fails.

I recently read https://www.joeshaw.org/dont-defer-close-on-writable-files/ and while working on another PR in this repo I noticed that some some writable files had the `defer f.Close()` pattern, so I did a grep to find similar calls, and for cases involving writeable file, changed the defer function to capture the result of calling `Close()`, and if the `err` value of the parent is `nil`, then set it for the caller.

In this manner errors on close will be returned to the caller, but won't mask other errors if an error was already set.

This adjusts those to one of the patterns in that article, e.g.:

```golang
func doThing() (err error) {
	outFile, err := os.Create(dst)
	if err != nil {
		return err
	}

	// since we are writing to this file, make sure we handle errors
	defer func() {
		closeErr := outFile.Close()
		if err == nil {
			err = closeErr
		}
	}()

        .....
}
```