### PR TITLE
[release-5.34] Bump to v5.34.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 34
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""


### PR DESCRIPTION
Bumping to v5.34.1.  This will allow the BYOPKI functionality to be added to c/image in time for RHEL 9.6/10.0.  This came in via this PR: https://github.com/containers/image/pull/2725

Fixes: https://issues.redhat.com/browse/RHEL-79694, https://issues.redhat.com/browse/RHEL-79695