### PR TITLE
fix: typo err and grammar err

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -475,7 +475,7 @@ func (c *dockerClient) resolveRequestURL(path string) (*url.URL, error) {
 }
 
 // Checks if the auth headers in the response contain an indication of a failed
-// authorizdation because of an "insufficient_scope" error. If that's the case,
+// authorization because of an "insufficient_scope" error. If that's the case,
 // returns the required scope to be used for fetching a new token.
 func needsRetryWithUpdatedScope(res *http.Response) (bool, *authScope) {
 	if res.StatusCode == http.StatusUnauthorized {


### PR DESCRIPTION
I'm trying to set proxy for single-side image proxy(only for src-image or dest-image, maybe you can combine these two proxy options) and find some err,  fix it by the way