### PR TITLE
Add proxy for dockerClient

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -907,6 +907,10 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 	}
 	tr := tlsclientconfig.NewTransport()
 	tr.TLSClientConfig = c.tlsClientConfig
+	// if set DockerProxyURL explicitly, use the DockerProxyURL instead of system proxy
+	if c.sys != nil && c.sys.DockerProxyURL != nil {
+		tr.Proxy = http.ProxyURL(c.sys.DockerProxyURL)
+	}
 	c.client = &http.Client{Transport: tr}
 
 	ping := func(scheme string) error {

--- a/types/types.go
+++ b/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -655,6 +656,8 @@ type SystemContext struct {
 	// Note that this requires writing blobs to temporary files, and takes more time than the default behavior,
 	// when the digest for a blob is unknown.
 	DockerRegistryPushPrecomputeDigests bool
+	// DockerProxyURL specifies proxy configuration schema (like socks5://username:password@ip:port)
+	DockerProxyURL *url.URL
 
 	// === docker/daemon.Transport overrides ===
 	// A directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
dockerClient will use http client to fetch manifest、blob and do some network request. Golang build-in http library  will use `HTTP_PROXY`、`HTTPS_PROXY` environment variables to config proxy for network. But the  environment variables cannot make flexible control of proxy behaviours. So I want to declare proxy configuration explicitly.