### PR TITLE
Update to Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/image/v5
 
-go 1.22.8
+go 1.23.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates.
 // That generally means there should be no toolchain directive present.


### PR DESCRIPTION
This is a very minimal change, just to handle the version bump.

I intend to let Renovate do the dependency updates. And a separate PR to actually benefit from new language features will follow.