### PR TITLE
storage: lookup top layer in mapped top layers too

### DIFF
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -1571,7 +1571,7 @@ func (s *storageImageDestination) CommitWithOptions(ctx context.Context, options
 		if err != nil {
 			return fmt.Errorf("reading image %q: %w", intendedID, err)
 		}
-		if img.TopLayer != lastLayer {
+		if img.TopLayer != lastLayer && !slices.Contains(img.MappedTopLayers, lastLayer) {
 			logrus.Debugf("error creating image: image with ID %q exists, but uses different layers", intendedID)
 			return fmt.Errorf("image with ID %q already exists, but uses a different top layer: %w", intendedID, storage.ErrDuplicateID)
 		}


### PR DESCRIPTION
when looking up for a different toplayer, consider also the mapped top layers as a mapped layer could become top layer and the previous top layer moved to the mapped layers

Related-to: https://github.com/containers/storage/pull/2285.