### PR TITLE
Queue a partially-pulled layer for commit immediately after staging it

### DIFF
--- a/copy/single.go
+++ b/copy/single.go
@@ -812,6 +812,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}
 			uploadedBlob, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, private.PutBlobPartialOptions{
 				Cache:      ic.c.blobInfoCache,
+				EmptyLayer: emptyLayer,
 				LayerIndex: layerIndex,
 			})
 			if err == nil {

--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -118,6 +118,7 @@ type PutBlobOptions struct {
 // PutBlobPartialOptions are used in PutBlobPartial.
 type PutBlobPartialOptions struct {
 	Cache      blobinfocache.BlobInfoCache2 // Cache to use and/or update.
+	EmptyLayer bool                         // True if the blob is an "empty"/"throwaway" layer, and may not necessarily be physically represented.
 	LayerIndex int                          // A zero-based index of the layer within the image (PutBlobPartial is only called with layer-like blobs, not configs)
 }
 

--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -496,9 +496,12 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 
 	succeeded = true
 	return private.UploadedBlob{
-		Digest: blobDigest,
-		Size:   srcInfo.Size,
-	}, nil
+			Digest: blobDigest,
+			Size:   srcInfo.Size,
+		}, s.queueOrCommit(options.LayerIndex, addedLayerInfo{
+			digest:     blobDigest,
+			emptyLayer: options.EmptyLayer,
+		})
 }
 
 // TryReusingBlobWithOptions checks whether the transport already contains, or can efficiently reuse, a blob, and if so, applies it to the current destination


### PR DESCRIPTION
Don't block all other layer commits until all layers are downloaded / staged.

Fixes #2798 .

Marked as draft: Absolutely untested, filing early just to make this public.