### PR TITLE
[crio-1.31] Fix layer reuse in schema1 images

### DIFF
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -515,7 +515,7 @@ func (s *storageImageDestination) tryReusingBlobAsPending(blobDigest digest.Dige
 				return false, private.ReusedBlob{}, fmt.Errorf(`looking for layers with digest %q: %w`, uncompressedDigest, err)
 			}
 			if found, reused := reusedBlobFromLayerLookup(layers, blobDigest, size, options); found {
-				s.lockProtected.blobDiffIDs[blobDigest] = uncompressedDigest
+				s.lockProtected.blobDiffIDs[reused.Digest] = uncompressedDigest
 				return true, reused, nil
 			}
 		}


### PR DESCRIPTION
reused.Digest is not always blobDigest, it might be uncompressedDigest; but we must have a blobDiffIDs entry for reused.Digest.