### PR TITLE
[release-5.34] Bump c/image to v5.34.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 34
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 3
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""


### PR DESCRIPTION
As the title says.  This will start the SIC dance to eventually solve: https://issues.redhat.com/browse/RHEL-85218 and https://issues.redhat.com/browse/RHEL-85218 up in Podman for the RHEL 9.6/10.0 ZeroDay.