### PR TITLE
Run golangci-lint with extra tags, fix found issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ validate: lint
 lint: EXTRA_TAGS=containers_image_docker_daemon_stub,containers_image_fulcio_stub,containers_image_openpgp,containers_image_rekor_stub,containers_image_storage_stub
 lint:
 	$(GOBIN)/golangci-lint run --build-tags "$(BUILDTAGS)"
-	$(GOBIN)/golangci-lint run --build-tags "$(EXTRA_TAGS)"
+	time $(GOBIN)/golangci-lint run --build-tags "$(EXTRA_TAGS)"
 
 # When this is running in CI, it will only check the CI commit range
 .PHONY: .gitvalidation

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,10 @@ validate: lint
 	@BUILDTAGS="$(BUILDTAGS)" hack/validate.sh
 
 .PHONY: lint
+lint: EXTRA_TAGS=containers_image_docker_daemon_stub,containers_image_fulcio_stub,containers_image_openpgp,containers_image_rekor_stub,containers_image_storage_stub
 lint:
 	$(GOBIN)/golangci-lint run --build-tags "$(BUILDTAGS)"
+	$(GOBIN)/golangci-lint run --build-tags "$(EXTRA_TAGS)"
 
 # When this is running in CI, it will only check the CI commit range
 .PHONY: .gitvalidation

--- a/signature/fulcio_cert.go
+++ b/signature/fulcio_cert.go
@@ -185,21 +185,6 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	return untrustedCertificate.PublicKey, nil
 }
 
-func parseLeafCertFromPEM(untrustedCertificateBytes []byte) (*x509.Certificate, error) {
-	untrustedLeafCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(untrustedCertificateBytes)
-	if err != nil {
-		return nil, internal.NewInvalidSignatureError(fmt.Sprintf("parsing leaf certificate: %v", err))
-	}
-	switch len(untrustedLeafCerts) {
-	case 0:
-		return nil, internal.NewInvalidSignatureError("no certificate found in signature certificate data")
-	case 1: // OK
-		return untrustedLeafCerts[0], nil
-	default:
-		return nil, internal.NewInvalidSignatureError("unexpected multiple certificates present in signature certificate data")
-	}
-}
-
 func verifyRekorFulcio(rekorPublicKeys []*ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
 	untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte, untrustedBase64Signature string,
 	untrustedPayloadBytes []byte) (crypto.PublicKey, error) {

--- a/signature/fulcio_cert_test.go
+++ b/signature/fulcio_cert_test.go
@@ -4,7 +4,6 @@ package signature
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -21,19 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// assert that crypto.PublicKey matches the on in certPEM.
-func assertPublicKeyMatchesCert(t *testing.T, certPEM []byte, pk crypto.PublicKey) {
-	pkInterface, ok := pk.(interface {
-		Equal(x crypto.PublicKey) bool
-	})
-	require.True(t, ok)
-	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(certPEM)
-	require.NoError(t, err)
-	require.Len(t, certs, 1)
-	equal := pkInterface.Equal(certs[0].PublicKey)
-	assert.True(t, equal)
-}
 
 func TestFulcioTrustRootValidate(t *testing.T) {
 	certs := x509.NewCertPool() // Empty is valid enough for our purposes.
@@ -210,25 +196,6 @@ func TestFulcioIssuerInCertificate(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestParseLeafCertsFromPEM(t *testing.T) {
-	fulcioCertBytes, err := os.ReadFile("fixtures/fulcio-cert")
-	require.NoError(t, err)
-	// Invalid leaf certificate
-	for _, c := range [][]byte{
-		[]byte("not a certificate"),
-		{},                               // Empty
-		bytes.Repeat(fulcioCertBytes, 2), // More than one certificate
-	} {
-		pk, err := parseLeafCertFromPEM(c)
-		assert.Error(t, err)
-		assert.Nil(t, pk)
-	}
-	// Valid leaf certificate
-	cert, err := parseLeafCertFromPEM(fulcioCertBytes)
-	require.NoError(t, err)
-	assert.NotNil(t, cert)
 }
 
 func TestFulcioTrustRootVerifyFulcioCertificateAtTime(t *testing.T) {

--- a/signature/mechanism_openpgp.go
+++ b/signature/mechanism_openpgp.go
@@ -147,7 +147,7 @@ func (m *openpgpSigningMechanism) Verify(unverifiedSignature []byte) (contents [
 		return nil, "", err
 	}
 	if md.SignatureError != nil {
-		return nil, "", fmt.Errorf("signature error: %v", md.SignatureError)
+		return nil, "", fmt.Errorf("signature error: %w", md.SignatureError)
 	}
 	if md.SignedBy == nil {
 		return nil, "", internal.NewInvalidSignatureError(fmt.Sprintf("Key not found for key ID %x in signature", md.SignedByKeyId))

--- a/signature/sigstore/rekor/leveled_logger.go
+++ b/signature/sigstore/rekor/leveled_logger.go
@@ -1,3 +1,5 @@
+//go:build !containers_image_rekor_stub
+
 package rekor
 
 import (

--- a/storage/storage_dest_test.go
+++ b/storage/storage_dest_test.go
@@ -1,3 +1,5 @@
+//go:build !containers_image_storage_stub
+
 package storage
 
 import (

--- a/storage/storage_src_test.go
+++ b/storage/storage_src_test.go
@@ -1,3 +1,5 @@
+//go:build !containers_image_storage_stub
+
 package storage
 
 import (


### PR DESCRIPTION
The idea is to run golangci-lint with flags that are not usually set, to catch some potential issue that are not caught otherwise. Surprisingly, it's not much (see the first 4 commits).