### PR TITLE
ci: start skopeo tests earlier

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,8 +96,6 @@ test_task:
 test_skopeo_task:
     alias: test_skopeo
     only_if: *not_docs
-    depends_on:
-        - validate
     gce_instance:
         image_project: libpod-218412
         zone: "us-central1-f"


### PR DESCRIPTION
Currently, skopeo tests (which are the most time consuming, taking 13-15 minutes) wait on validate test (which takes ~4 minutes) to finish. As a result, total time to finish all tests is about 20 minutes.

Let's start skopeo tests early to improve overall time.

Here's a pic to illustrate:

![image](https://github.com/user-attachments/assets/cce4ac7e-acb4-4cee-b4b9-0ee98312b082)
