### PR TITLE
Stop setting the btrfs_noversion build tag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,10 +81,10 @@ test_task:
     matrix:
         - name: "Test"
           env:
-              BUILDTAGS: 'btrfs_noversion'
+              BUILDTAGS: ''
         - name: "Test w/ opengpg"
           env:
-              BUILDTAGS: &withopengpg 'btrfs_noversion containers_image_openpgp'
+              BUILDTAGS: &withopengpg 'containers_image_openpgp'
     script: ${GOSRC}/${SCRIPT_BASE}/runner.sh image_tests
 
 
@@ -110,7 +110,7 @@ test_skopeo_task:
     matrix:
         - name: "Skopeo Test"
           env:
-              BUILDTAGS: 'btrfs_noversion'
+              BUILDTAGS: ''
         - name: "Skopeo Test w/ opengpg"
           env:
               BUILDTAGS: *withopengpg

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 BUILD_TAGS_WINDOWS_CROSS = containers_image_openpgp
 BUILD_TAGS_DARWIN_CROSS = containers_image_openpgp
 
-BUILDTAGS = btrfs_noversion
+BUILDTAGS =
 BUILDFLAGS := -tags "$(BUILDTAGS)"
 
 PACKAGES := $(shell go list $(BUILDFLAGS) ./...)

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -20,7 +20,7 @@ fi
 export "PATH=$PATH:$GOPATH/bin"
 
 _run_setup() {
-    req_env_vars SKOPEO_PATH SKOPEO_CI_BRANCH GOSRC BUILDTAGS
+    req_env_vars SKOPEO_PATH SKOPEO_CI_BRANCH GOSRC
 
     project_module=$(go list .)
 


### PR DESCRIPTION
It was removed in https://github.com/containers/storage/pull/2308 .