### PR TITLE
cirrus: save/restore golangci-lint cache for linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,6 +59,12 @@ validate_task:
         image_name: ${DEBIAN_CACHE_IMAGE_NAME}
     env:
         HOME: "/root"  # default unset, needed by golangci-lint.
+    golangci-lint_cache:
+        folder: /root/.cache/golangci-lint
+        reupload_on_changes: true
+        fingerprint_script:
+            - go version
+            - grep GOLANGCI_LINT_VERSION Makefile | head -1
     script: |
         git remote update
         make tools

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,5 +14,5 @@ linters:
   exclusions:
     presets:
       - comments
-      - common-false-positives
+      #      - common-false-positives
       - std-error-handling


### PR DESCRIPTION
This shaves off some time from golangci-lint run (unless either golangci-lint or go version changes).

The cache size is pretty small (a few MB).