### PR TITLE
CI: run tests that need root as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ BUILD_TAGS_DARWIN_CROSS = containers_image_openpgp
 BUILDTAGS =
 BUILDFLAGS := -tags "$(BUILDTAGS)"
 
+# Extra flags passed to go test
+TESTFLAGS :=
+
 PACKAGES := $(shell go list $(BUILDFLAGS) ./...)
 SOURCE_DIRS = $(shell echo $(PACKAGES) | awk 'BEGIN{FS="/"; RS=" "}{print $$4}' | uniq)
 
@@ -86,7 +89,7 @@ clean:
 
 .PHONY: test
 test:
-	@go test $(BUILDFLAGS) -cover ./...
+	@go test $(BUILDFLAGS) $(TESTFLAGS) -cover ./...
 
 .PHONY: fmt
 fmt:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -46,7 +46,23 @@ _run_setup() {
 _run_image_tests() {
     req_env_vars GOPATH GOSRC
 
-    # Tests in this repo. are intended to run as a regular user.
+    # Hacky solution to find test that must be run as root.
+    # This looks for the ensureTestCanCreateImages() test function call and gets the
+    # function name where it is called via git grep,
+    # then trims the line to only show the actual function name and add "^$" around it
+    # since go test commands only accepts a single regex.
+    # Then join all names with "|" with paste to again build up a single regex string
+    # that matches all these names.
+    # With that we don't have to run everything twice and can just run the ones that
+    # actually need to be root.
+    # Note we must run git before we switch/chown to the user because it will error
+    # out otherwise since the file ownership doesn't match.
+    test_filter=$(git grep -h --show-function ensureTestCanCreateImages |
+                    sed -n 's/func \(Test[[:alnum:]]*\)(.*/^\1\$\$/p' |
+                    paste -sd "|" -)
+    showrun make test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-run '$test_filter'"
+
+    # Most tests in this repo are intended to run as a regular user.
     ROOTLESS_USER="testuser$RANDOM"
     msg "Setting up rootless user '$ROOTLESS_USER'"
     cd $GOSRC || exit 1

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -60,7 +60,7 @@ _run_image_tests() {
     test_filter=$(git grep -h --show-function ensureTestCanCreateImages |
                     sed -n 's/func \(Test[[:alnum:]]*\)(.*/^\1\$\$/p' |
                     paste -sd "|" -)
-    showrun make test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-run '$test_filter'"
+    showrun make test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-v -run '$test_filter'"
 
     # Most tests in this repo are intended to run as a regular user.
     ROOTLESS_USER="testuser$RANDOM"
@@ -96,7 +96,7 @@ _run_image_tests() {
     ssh-keyscan localhost > /root/.ssh/known_hosts \
 
     msg "Executing tests as $ROOTLESS_USER"
-    showrun ssh $ROOTLESS_USER@localhost make -C $GOSRC test "BUILDTAGS='$BUILDTAGS'"
+    showrun ssh $ROOTLESS_USER@localhost make -C $GOSRC test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-v"
 }
 
 req_env_vars GOSRC


### PR DESCRIPTION
This is a quick and dirty fix but should get the job done and ensures the tests are actually run by CI. The idea is simple to not waste resources we just look for the test names using
ensureTestCanCreateImages() to skip as rootless.