### PR TITLE
Restrict the root-only tests to ./storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BUILDFLAGS := -tags "$(BUILDTAGS)"
 
 # Extra flags passed to go test
 TESTFLAGS :=
+TEST_PACKAGES := ./...
 
 PACKAGES := $(shell go list $(BUILDFLAGS) ./...)
 SOURCE_DIRS = $(shell echo $(PACKAGES) | awk 'BEGIN{FS="/"; RS=" "}{print $$4}' | uniq)
@@ -89,7 +90,7 @@ clean:
 
 .PHONY: test
 test:
-	@go test $(BUILDFLAGS) $(TESTFLAGS) -cover ./...
+	@go test $(BUILDFLAGS) $(TESTFLAGS) -cover $(TEST_PACKAGES)
 
 .PHONY: fmt
 fmt:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -57,10 +57,10 @@ _run_image_tests() {
     # actually need to be root.
     # Note we must run git before we switch/chown to the user because it will error
     # out otherwise since the file ownership doesn't match.
-    test_filter=$(git grep -h --show-function ensureTestCanCreateImages |
+    test_filter=$(git grep -h --show-function ensureTestCanCreateImages ./storage |
                     sed -n 's/func \(Test[[:alnum:]]*\)(.*/^\1\$\$/p' |
                     paste -sd "|" -)
-    showrun make test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-v -run '$test_filter'"
+    showrun make test "BUILDTAGS='$BUILDTAGS'" "TESTFLAGS=-v -run '$test_filter'" TEST_PACKAGES=./storage
 
     # Most tests in this repo are intended to run as a regular user.
     ROOTLESS_USER="testuser$RANDOM"


### PR DESCRIPTION
The filter already assumes that subpackage, by grepping for a package-private function name, anyway.

Cc: @Luap99 