### PR TITLE
Do not error on Docker V2 images with zstd compression

### DIFF
--- a/copy/compression.go
+++ b/copy/compression.go
@@ -27,9 +27,10 @@ var (
 	// expectedBaseCompressionFormats is used to check if a blob with a specified media type is compressed
 	// using the algorithm that the media type says it should be compressed with
 	expectedBaseCompressionFormats = map[string]*compressiontypes.Algorithm{
-		imgspecv1.MediaTypeImageLayerGzip:      &compression.Gzip,
-		imgspecv1.MediaTypeImageLayerZstd:      &compression.Zstd,
-		manifest.DockerV2Schema2LayerMediaType: &compression.Gzip,
+		imgspecv1.MediaTypeImageLayerGzip:         &compression.Gzip,
+		imgspecv1.MediaTypeImageLayerZstd:         &compression.Zstd,
+		manifest.DockerV2Schema2LayerMediaType:    &compression.Gzip,
+		manifest.DockerV2SchemaLayerMediaTypeZstd: &compression.Zstd,
 	}
 )
 

--- a/internal/image/docker_schema2.go
+++ b/internal/image/docker_schema2.go
@@ -233,6 +233,8 @@ func (m *manifestSchema2) convertToManifestOCI1(ctx context.Context, _ *types.Ma
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayer
 		case manifest.DockerV2Schema2LayerMediaType:
 			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerGzip
+		case manifest.DockerV2SchemaLayerMediaTypeZstd:
+			layers[idx].MediaType = imgspecv1.MediaTypeImageLayerZstd
 		default:
 			return nil, fmt.Errorf("Unknown media type during manifest conversion: %q", m.m.LayersDescriptors[idx].MediaType)
 		}

--- a/internal/image/fixtures/schema2-invalid-media-type.json
+++ b/internal/image/fixtures/schema2-invalid-media-type.json
@@ -8,7 +8,7 @@
     },
     "layers": [
        {
-          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.zstd",
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.invalid",
           "size": 51354364,
           "digest": "sha256:6a5a5368e0c2d3e5909184fa28ddfd56072e7ff3ee9a945876f7eee5896ef5bb"
        },

--- a/internal/image/oci.go
+++ b/internal/image/oci.go
@@ -288,7 +288,7 @@ func (m *manifestOCI1) convertToManifestSchema2(_ context.Context, options *type
 		case imgspecv1.MediaTypeImageLayerGzip:
 			layers[idx].MediaType = manifest.DockerV2Schema2LayerMediaType
 		case imgspecv1.MediaTypeImageLayerZstd:
-			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not supported for docker images", layers[idx].MediaType)
+			return nil, fmt.Errorf("Error during manifest conversion: %q: zstd compression is not officially supported for docker images", layers[idx].MediaType)
 		case ociencspec.MediaTypeLayerEnc, ociencspec.MediaTypeLayerGzipEnc, ociencspec.MediaTypeLayerZstdEnc,
 			ociencspec.MediaTypeLayerNonDistributableEnc, ociencspec.MediaTypeLayerNonDistributableGzipEnc, ociencspec.MediaTypeLayerNonDistributableZstdEnc:
 			return nil, fmt.Errorf("during manifest conversion: encrypted layers (%q) are not supported in docker images", layers[idx].MediaType)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -26,6 +26,8 @@ const (
 	DockerV2Schema2LayerMediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 	// DockerV2SchemaLayerMediaTypeUncompressed is the mediaType used for uncompressed layers.
 	DockerV2SchemaLayerMediaTypeUncompressed = "application/vnd.docker.image.rootfs.diff.tar"
+	// DockerV2Schema2LayerMediaType is the MIME type used for schema 2 layers.
+	DockerV2SchemaLayerMediaTypeZstd = "application/vnd.docker.image.rootfs.diff.tar.zstd"
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list
 	DockerV2ListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for schema 2 foreign layers.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -27,6 +27,7 @@ const (
 	// DockerV2SchemaLayerMediaTypeUncompressed is the mediaType used for uncompressed layers.
 	DockerV2SchemaLayerMediaTypeUncompressed = manifest.DockerV2SchemaLayerMediaTypeUncompressed
 	// DockerV2SchemaLayerMediaTypeZstd is the mediaType used for zstd layers.
+	// Warning: This mediaType is not officially supported in https://github.com/distribution/distribution/blob/main/docs/content/spec/manifest-v2-2.md but some images may exhibit it. Support is partial.
 	DockerV2SchemaLayerMediaTypeZstd = manifest.DockerV2SchemaLayerMediaTypeZstd
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list
 	DockerV2ListMediaType = manifest.DockerV2ListMediaType

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -26,6 +26,8 @@ const (
 	DockerV2Schema2LayerMediaType = manifest.DockerV2Schema2LayerMediaType
 	// DockerV2SchemaLayerMediaTypeUncompressed is the mediaType used for uncompressed layers.
 	DockerV2SchemaLayerMediaTypeUncompressed = manifest.DockerV2SchemaLayerMediaTypeUncompressed
+	// DockerV2SchemaLayerMediaTypeZstd is the mediaType used for zstd layers.
+	DockerV2SchemaLayerMediaTypeZstd = manifest.DockerV2SchemaLayerMediaTypeZstd
 	// DockerV2ListMediaType MIME type represents Docker manifest schema 2 list
 	DockerV2ListMediaType = manifest.DockerV2ListMediaType
 	// DockerV2Schema2ForeignLayerMediaType is the MIME type used for schema 2 foreign layers.
@@ -41,7 +43,7 @@ type NonImageArtifactError = manifest.NonImageArtifactError
 // SupportedSchema2MediaType checks if the specified string is a supported Docker v2s2 media type.
 func SupportedSchema2MediaType(m string) error {
 	switch m {
-	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed:
+	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed, DockerV2SchemaLayerMediaTypeZstd:
 		return nil
 	default:
 		return fmt.Errorf("unsupported docker v2s2 media type: %q", m)


### PR DESCRIPTION
Some images are pushed to registries with `docker buildx` which, depending on the options, base images and others, can generate DockerV2 manifests that have layers compressed with Zstd. While inspecting at images in a repo, one such image would generate an error when queried via `skopeo inspect` or any tool based on `containers/image`. The error is:
```
FATA[0001] Error parsing manifest for image: unsupported docker v2s2 media type: "application/vnd.docker.image.rootfs.diff.tar.zstd"
```

It looks like if treated like an OCI zstd layer this is working as intended. I have tested this with `skopeo inspect` and `skopeo copy docker://some-docker-zstd-image dir:somewhere --dest-decompress` and it looks OK. What do you think?