### PR TITLE
Update the CI image, to match Skopeo's updated test code

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     SKOPEO_PR:
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c20250422t130822z-f42f41d13"
+    IMAGE_SUFFIX: "c20250721t181111z-f42f41d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
 
     # Container FQIN's (include bleeding-edge development-level container deps.)


### PR DESCRIPTION
This matches https://github.com/containers/skopeo/pull/2661 , without it, any Skopeo test is going to fail, as in https://github.com/containers/image/pull/2905/checks?check_run_id=46601934935

@lsm5 PTAL.