### PR TITLE
DO NOT MERGE: Switch to `go.yaml.in/yaml/v4`

### DIFF
--- a/docker/registries_d.go
+++ b/docker/registries_d.go
@@ -17,7 +17,7 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.

--- a/go.mod
+++ b/go.mod
@@ -37,11 +37,11 @@ require (
 	github.com/ulikunitz/xz v0.5.12
 	github.com/vbauerster/mpb/v8 v8.10.2
 	go.etcd.io/bbolt v1.4.2
+	go.yaml.in/yaml/v4 v4.0.0-20250730171608-926dd0b54a90
 	golang.org/x/crypto v0.40.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0
 	golang.org/x/term v0.33.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -122,4 +122,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/grpc v1.72.2 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
+go.yaml.in/yaml/v4 v4.0.0-20250730171608-926dd0b54a90 h1:PK8906uEqvjB6qgonTahH/ZBqrdIv/6mpysTotKxvL0=
+go.yaml.in/yaml/v4 v4.0.0-20250730171608-926dd0b54a90/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // restTLSClientConfig is a modified copy of k8s.io/kubernetes/pkg/client/restclient.TLSClientConfig.

--- a/openshift/openshift-copies_test.go
+++ b/openshift/openshift-copies_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const fixtureKubeConfigPath = "testdata/admin.kubeconfig"

--- a/pkg/cli/sigstore/params/sigstore.go
+++ b/pkg/cli/sigstore/params/sigstore.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // SigningParameterFile collects parameters used for creating sigstore signatures.


### PR DESCRIPTION
Replace unmaintained `gopkg.in/yaml.v3` . The direct replacement is `go.yaml.in/v3`, but that is documented to be limited to security fixes only; so, as long as we are making a change, switch directly to the primary maintained branch.

Fixes containers/container-libs#187 .

The `/v4` branch does not yet have a tagged release, so this should wait for https://github.com/yaml/go-yaml/issues/61 .

Filing this early primarily to record the outcome of the investigation. Other than direct c/image users, indirect dependencies on `gopkg.in/yaml` are:
- `github.com/containers/ocicrypt`, hopefully we can just update that
- `github.com/letsencrypt/boulder` has already restructured the package we use not to depend on YAML at all, so this will go away (but we can’t update yet, that would add a dependency on Go 1.24)
- `github.com/stretchr/testify` (is considering a migration, but anyway) is a test-only dependency, so it doesn’t affect the final binary.