### PR TITLE
Losen the dependency on go-connections/tlsconfig

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -228,7 +228,12 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		registry = dockerRegistry
 	}
 	tlsClientConfig := &tls.Config{
-		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
+		// As of 2025-08, tlsconfig.ClientDefault() differs from Go 1.23 defaults only in CipherSuites;
+		// so, limit us to only using that value. If go-connections/tlsconfig changes its policy, we
+		// will want to consider that and make a decision whether to follow suit.
+		// There is some chance that eventually the Go default will be to require TLS 1.3, and that point
+		// we might want to drop the dependency on go-connections entirely.
+		CipherSuites: tlsconfig.ClientDefault().CipherSuites,
 	}
 
 	// It is undefined whether the host[:port] string for dockerHostname should be dockerHostname or dockerRegistry,

--- a/oci/layout/oci_src.go
+++ b/oci/layout/oci_src.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -50,7 +51,14 @@ type ociImageSource struct {
 // newImageSource returns an ImageSource for reading from an existing directory.
 func newImageSource(sys *types.SystemContext, ref ociReference) (private.ImageSource, error) {
 	tr := tlsclientconfig.NewTransport()
-	tr.TLSClientConfig = tlsconfig.ServerDefault()
+	tr.TLSClientConfig = &tls.Config{
+		// As of 2025-08, tlsconfig.ClientDefault() differs from Go 1.23 defaults only in CipherSuites;
+		// so, limit us to only using that value. If go-connections/tlsconfig changes its policy, we
+		// will want to consider that and make a decision whether to follow suit.
+		// There is some chance that eventually the Go default will be to require TLS 1.3, and that point
+		// we might want to drop the dependency on go-connections entirely.
+		CipherSuites: tlsconfig.ClientDefault().CipherSuites,
+	}
 
 	if sys != nil && sys.OCICertPath != "" {
 		if err := tlsclientconfig.SetupCertificates(sys.OCICertPath, tr.TLSClientConfig); err != nil {


### PR DESCRIPTION
As of `go-connections` 0.6.0, there is no difference between "server" and "client" configuration; so, take this opportunity to switch from "server" defaults in client contexts, which were used for an unknown reason.

Also, don't use the whole `tlsconfig.ClientDefault()`, to _slightly_ move into the direction of using the Go built-in defaults, and to get a _bit_ closer to getting out of the business of managing TLS policy.

The TLS configuration in `docker/daemon` continues to use the full `tlsconfig.Client()`, because that's (to an extent) consistent with the defaults of `github.com/docker/docker/client`.

Should not change behavior (but the update from `go-connections` 0.5.0 to 0.6.0 did change the list of accepted TLS 1.2 cipher suites).