### PR TITLE
rekor: do not cancel http context

### DIFF
--- a/signature/sigstore/rekor/openapi_infra.go
+++ b/signature/sigstore/rekor/openapi_infra.go
@@ -28,9 +28,6 @@ import (
 
 // makeRequest makes a http request to the requested requestPath, and returns the received response.
 func (r *rekorClient) makeRequest(ctx context.Context, method, requestPath string, bodyContent any) (*http.Response, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	var body io.Reader
 	headers := http.Header{}
 


### PR DESCRIPTION
The context must be valid for the entire lifetime of the request including reading the body, as such it is invalid to return the body after cancelling the context, depending of if all the response data arrived already or not this then might fail.

To fix this simply do not cancel the context here, we could move the cancel() up to the caller function that processes the body. However as that one already closes the body there should be no need to cancel the context to end the request.

Fixes: #2936