### PR TITLE
Move the repository to monorepo.

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -1,0 +1,15 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@9c18513d320d7b2c7185fb93396d0c664d5d8448
+      with:
+        comment: "This repository has been migrated to https://github.com/containers/container-libs. Please open your PR there."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/containers/image/v5.svg)](https://pkg.go.dev/github.com/containers/image/v5) [![Build Status](https://api.cirrus-ci.com/github/containers/image.svg)](https://cirrus-ci.com/github/containers/image)
 =
 
+> [!WARNING]
+> This package was moved; please update your references to use `go.podman.io/image/v5` instead.
+> New development of this project happens on https://github.com/containers/container-libs.
+> For more information, check https://blog.podman.io/2025/08/upcoming-migration-of-three-containers-repositories-to-monorepo/.
+
 `image` is a set of Go libraries aimed at working in various way with
 containers' images and container image registries.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use go.podman.io/image/v5 instead.
 module github.com/containers/image/v5
 
 go 1.23.3


### PR DESCRIPTION
This commit:
- mentions the monorepo in the README.MD.
- deprecates the module in favor of go.podman.io/image/v5.
- adds github workflow to auto-close newly created PRs.