### PR TITLE
Updated the `isSignatureAuthorAccepted` to use timeout to prevent indefinite hanging

### DIFF
--- a/signature/policy_eval_signedby.go
+++ b/signature/policy_eval_signedby.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/private"
@@ -40,7 +41,8 @@ func (pr *prSignedBy) isSignatureAuthorAccepted(ctx context.Context, image priva
 	}
 
 	// FIXME: move this to per-context initialization
-	mech, trustedIdentities, err := newEphemeralGPGSigningMechanism(data)
+	// Import the keys with a 60s timeout to avoid hanging indefinitely. see issues.redhat.com/browse/OCPBUGS-57893
+	mech, trustedIdentities, err := newEphemeralGPGSigningMechanismWithTimeout(data, 60*time.Second)
 	if err != nil {
 		return sarRejected, nil, err
 	}
@@ -113,4 +115,25 @@ func (pr *prSignedBy) isRunningImageAllowed(ctx context.Context, image private.U
 		summary = PolicyRequirementError(multierr.Format("None of the signatures were accepted, reasons: ", "; ", "", rejections).Error())
 	}
 	return false, summary
+}
+
+func newEphemeralGPGSigningMechanismWithTimeout(blobs [][]byte, timeout time.Duration) (signingMechanismWithPassphrase, []string, error) {
+	type result struct {
+		mech signingMechanismWithPassphrase
+		keys []string
+		err  error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		mech, keys, err := newEphemeralGPGSigningMechanism(blobs)
+		done <- result{mech, keys, err}
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return nil, nil, fmt.Errorf("GPG/OpenPGP key import timed out after %s", timeout)
+	case r := <-done:
+		return r.mech, r.keys, r.err
+	}
 }


### PR DESCRIPTION
Since the root cause of indefinite hanging during GPG verification operations (https://issues.redhat.com/browse/OCPBUGS-57893) 
is currently unknown, add a timeout workaround to mitigate the impact. This 
prevents CRI-O image pulls with signature verification from hanging 
indefinitely.