### PR TITLE
compression: uncap zstd decoder concurrency

### DIFF
--- a/pkg/compression/zstd.go
+++ b/pkg/compression/zstd.go
@@ -32,7 +32,7 @@ func (w *wrapperZstdDecoder) WriteTo(wr io.Writer) (int64, error) {
 }
 
 func zstdReader(buf io.Reader) (io.ReadCloser, error) {
-	decoder, err := zstd.NewReader(buf)
+	decoder, err := zstd.NewReader(buf, zstd.WithDecoderConcurrency(0))
 	return &wrapperZstdDecoder{decoder: decoder}, err
 }
 


### PR DESCRIPTION
Summary:
- uncap the plain zstd decoder pipeline concurrency
- use `zstd.WithDecoderConcurrency(0)` so decoder concurrency follows `GOMAXPROCS`

Validation:
- `CGO_ENABLED=0 go test ./pkg/compression/...`
