### PR TITLE
manifest: accept OCI media types in Docker schema2 manifests

### DIFF
--- a/manifest/docker_schema2_test.go
+++ b/manifest/docker_schema2_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,11 @@ func TestSupportedSchema2MediaType(t *testing.T) {
 		{DockerV2ListMediaType, false},
 		{DockerV2Schema2ForeignLayerMediaType, false},
 		{DockerV2Schema2ForeignLayerMediaTypeGzip, false},
+		{imgspecv1.MediaTypeImageConfig, false},
+		{imgspecv1.MediaTypeImageLayer, false},
+		{imgspecv1.MediaTypeImageLayerGzip, false},
+		{imgspecv1.MediaTypeImageLayerNonDistributable, false},     //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
+		{imgspecv1.MediaTypeImageLayerNonDistributableGzip, false}, //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
 		{"application/vnd.docker.image.rootfs.foreign.diff.unknown", true},
 	}
 	for _, d := range data {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -41,7 +41,12 @@ type NonImageArtifactError = manifest.NonImageArtifactError
 // SupportedSchema2MediaType checks if the specified string is a supported Docker v2s2 media type.
 func SupportedSchema2MediaType(m string) error {
 	switch m {
-	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed:
+	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed,
+		imgspecv1.MediaTypeImageConfig,
+		imgspecv1.MediaTypeImageLayer,
+		imgspecv1.MediaTypeImageLayerGzip,
+		imgspecv1.MediaTypeImageLayerNonDistributable,     //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
+		imgspecv1.MediaTypeImageLayerNonDistributableGzip: //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
 		return nil
 	default:
 		return fmt.Errorf("unsupported docker v2s2 media type: %q", m)


### PR DESCRIPTION
### What

Accept OCI image config and layer media types when validating Docker schema 2 manifests.

This allows `Schema2FromManifest` / `SupportedSchema2MediaType` to handle Docker schema2 manifests with OCI descriptor media types, including `application/vnd.oci.image.layer.v1.tar+gzip`.

### Why

Some registries return Docker schema2 manifests whose config/layer descriptors use OCI media types. Today those fail before copy/inspection can proceed, for example through `skopeo copy --all`:

```text
unsupported docker v2s2 media type: "application/vnd.oci.image.layer.v1.tar+gzip"
```

Fixes #2972.

### Testing

- Added `TestSupportedSchema2MediaType` coverage for OCI config/layer media types.
- Ran `gofmt` through `golang:1.24` container.
- Attempted `go test ./manifest -run TestSupportedSchema2MediaType -count=1 -v` in `golang:1.24`, but the container timed out while downloading Go dependencies before reaching test execution in this environment.
- Verified the same code path in a patched `skopeo v1.23.0` build during registry mirroring: manifests with OCI layer media types copied successfully after this change.
